### PR TITLE
feat: analytics schema implementation (Phases 1-5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ Thumbs.db
 # Logs
 *.log
 logs/
+.worktrees/

--- a/docs/plans/2025-01-28-analytics-schema-design.md
+++ b/docs/plans/2025-01-28-analytics-schema-design.md
@@ -1,0 +1,413 @@
+# CFB Database Analytics Schema Design
+
+> Design document for expanded endpoint coverage, analytics-optimized schema, and ML extensions.
+> Created: 2025-01-28
+
+## Overview
+
+This design expands the CFB database from a data warehouse into a **comprehensive analytics platform** supporting:
+
+1. **Dashboards & reports** — pre-built visualizations, team pages, leaderboards
+2. **Interactive exploration** — filtering, comparisons, custom queries
+3. **Game-day / real-time** — live scores, win probability, play-by-play
+4. **Research tool** — deep dives, matchup analysis, player evaluation
+5. **Machine learning** — game prediction, spread modeling, play-call analysis
+
+## Architecture
+
+### Layered Schema Design
+
+| Layer | Schema | Purpose | Implementation | Refresh |
+|-------|--------|---------|----------------|---------|
+| **Raw** | `ref`, `core`, `stats`, `ratings`, `recruiting`, `betting`, `metrics` | Source of truth | Normalized tables | Pipeline loads |
+| **Marts** | `marts` | Pre-aggregated analytics | Materialized views | After pipeline + pg_cron |
+| **API** | `api` | App-friendly shapes | Regular views | Live (query-time) |
+| **Features** | `features` | ML-ready feature vectors | Materialized views | After pipeline |
+| **Predictions** | `predictions` | Model outputs | Tables | Model runs |
+| **Live** | `live` (future) | Real-time game data | Tables + Supabase realtime | WebSocket |
+
+### Why This Works for Supabase
+
+- PostgREST exposes views as API endpoints automatically
+- Materialized views = fast dashboard queries
+- Regular views = flexible, always-current joins
+- Realtime only works on tables (not mat views), so live data needs dedicated tables
+- RLS can gate access if user auth is added later
+
+---
+
+## Entity Model
+
+### Dimension Entities (the "nouns")
+
+| Entity | Table | Description |
+|--------|-------|-------------|
+| Team | `ref.teams` | Football programs (Alabama, Ohio State, etc.) |
+| Player | `core.rosters` | Individual athletes, linked to teams by season |
+| Coach | `ref.coaches` | Coaching staff |
+| Conference | `ref.conferences` | Organizational grouping |
+| Venue | `ref.venues` | Stadiums |
+| Position | `ref.positions` | Position reference with groupings |
+
+### Fact Entities (the "events/measurements")
+
+| Entity | Table | Grain |
+|--------|-------|-------|
+| Game | `core.games` | One row per game |
+| Drive | `core.drives` | One row per possession |
+| Play | `core.plays` | One row per snap (partitioned by season) |
+| Player Game Stats | `stats.player_game_stats` | Player × Game |
+| Player Season Stats | `stats.player_season_stats` | Player × Season |
+| Team Season Stats | `stats.team_season_stats` | Team × Season |
+| Ratings | `ratings.*` | Team × Season × Source |
+| Poll Rankings | `ratings.poll_rankings` | Team × Season × Week × Poll |
+| Recruiting | `recruiting.recruits` | Player × Commit |
+| Betting Lines | `betting.lines` | Game × Provider |
+
+### Key Relationships
+
+```
+Team (central hub)
+├── Conference (many-to-many over time)
+├── Players (via rosters, by season)
+├── Coaches (by season)
+├── Games (home/away)
+│   ├── Drives
+│   │   └── Plays
+│   └── Betting Lines
+├── Ratings (by season)
+├── Stats (by season)
+└── Recruiting (by class year)
+```
+
+---
+
+## Schema Details
+
+### Raw Layer Tables
+
+#### ref.teams (enriched)
+```sql
+id              bigint PRIMARY KEY
+school          text NOT NULL
+mascot          text
+abbreviation    text
+conference_id   bigint REFERENCES ref.conferences
+division        text                    -- "fbs", "fcs"
+color           text                    -- Primary hex
+alt_color       text                    -- Secondary hex
+logo_url        text
+```
+
+#### ref.positions (new)
+```sql
+id              text PRIMARY KEY        -- "QB", "RB", "WR"
+name            text                    -- "Quarterback"
+side            text                    -- "offense", "defense", "special_teams"
+position_group  text                    -- "passer", "rusher", "receiver", etc.
+```
+
+#### core.rosters (new — critical)
+```sql
+id              bigint                  -- CFBD player ID
+team_id         bigint REFERENCES ref.teams
+season          integer
+first_name      text
+last_name       text
+position        text
+height          integer                 -- inches
+weight          integer                 -- pounds
+year            integer                 -- 1=FR, 2=SO, etc.
+jersey          integer
+home_city       text
+home_state      text
+
+PRIMARY KEY (id, team_id, season)       -- Handles transfers
+```
+
+#### ratings.poll_rankings (new)
+```sql
+season              integer
+week                integer
+poll_type           text                -- "AP Top 25", "Coaches Poll", "CFP"
+team_id             bigint REFERENCES ref.teams
+rank                integer
+first_place_votes   integer
+points              integer
+
+PRIMARY KEY (season, week, poll_type, team_id)
+```
+
+#### stats.advanced_team_stats (wire existing config)
+```sql
+team_id             bigint REFERENCES ref.teams
+season              integer
+offense_ppa         numeric
+defense_ppa         numeric
+offense_success     numeric
+defense_success     numeric
+offense_explosiveness numeric
+defense_explosiveness numeric
+offense_power       numeric
+offense_stuff_rate  numeric
+offense_line_yards  numeric
+
+PRIMARY KEY (season, team_id)
+```
+
+#### metrics.wepa_team_season (new)
+```sql
+team_id             bigint REFERENCES ref.teams
+season              integer
+wepa_overall        numeric             -- Opponent-adjusted EPA
+wepa_passing        numeric
+wepa_rushing        numeric
+wepa_defense        numeric
+
+PRIMARY KEY (season, team_id)
+```
+
+---
+
+### Marts Layer (Materialized Views)
+
+#### marts.team_season_summary
+- **Grain:** Team × Season
+- **Metrics:** W-L, conf record, PPG, margin, SP+, Elo, FPI, recruiting rank, EPA
+- **Use:** Team pages, comparisons, trends
+
+#### marts.team_epa_season
+- **Grain:** Team × Season
+- **Metrics:** EPA/play, success rate, explosiveness, EPA tier, WEPA
+- **Use:** Advanced analytics, benchmarking
+
+#### marts.player_career
+- **Grain:** Player (career totals)
+- **Metrics:** Career stats, teams, seasons played, PPA
+- **Use:** Player pages, draft analysis
+
+#### marts.game_results
+- **Grain:** Game
+- **Metrics:** Score, spread result, EPA diff, win prob, ATS/OU result
+- **Use:** Game logs, betting analysis
+
+#### marts.situational_splits
+- **Grain:** Team × Season
+- **Metrics:**
+  - Down & distance: EPA by down, conversion rates, standard/passing downs
+  - Red zone: trips, TD rate, scoring rate, goal line
+  - Field position: backed up, own territory, scoring position
+  - Late & close: 2nd half within 16, 4th quarter one-score
+  - Two-minute drill
+  - Play type: rush/pass EPA, success rate, explosiveness, tendencies
+  - Power & stuff: power success, stuff rate, line yards
+- **Use:** Coaching analysis, tendencies, matchup prep
+
+#### marts.defensive_havoc
+- **Grain:** Team × Season
+- **Metrics:** Stuffs, sacks, INTs, forced fumbles, havoc rate, opp EPA
+- **Use:** Defensive analysis
+
+#### marts.scoring_opportunities
+- **Grain:** Team × Season
+- **Metrics:** Scoring rate, TD rate, points/drive, turnover rate
+- **Use:** Drive efficiency analysis
+
+#### marts.matchup_history
+- **Grain:** Team × Team
+- **Metrics:** H2H record, recent form, avg margin, series dates
+- **Use:** Matchup pages, rivalry analysis
+
+#### marts.recruiting_class
+- **Grain:** Team × Year
+- **Metrics:** National rank, star breakdown, blue chip ratio, position groups
+- **Use:** Recruiting analysis
+
+#### marts.coach_record
+- **Grain:** Coach × Team
+- **Metrics:** Tenure, W-L, win %, SP+ trajectory, recruiting avg
+- **Use:** Coaching analysis
+
+#### marts.conference_standings
+- **Grain:** Conference × Season × Team
+- **Metrics:** Conf record, overall record, conf rank
+- **Use:** Standings pages
+
+---
+
+### API Layer (Regular Views)
+
+| View | Purpose | Key Joins |
+|------|---------|-----------|
+| `api.team_detail` | Single team page | Current season + ratings + recruiting + coach |
+| `api.team_history` | Multi-season trends | Season summaries + EPA + recruiting |
+| `api.game_detail` | Single game page | Teams + betting + advanced stats + venue |
+| `api.player_detail` | Single player page | Career stats + current team + roster info |
+| `api.matchup` | Head-to-head comparison | Matchup history + current season context |
+| `api.leaderboard_teams` | Flexible leaderboards | Season summary + EPA + situational |
+
+---
+
+### ML Extensions
+
+#### features.team_game_features
+- **Grain:** Game × Team
+- **Features:**
+  - Target: won, margin, covered
+  - Context: is_home, neutral_site
+  - Rolling stats: points avg, margin avg, turnover margin (season-to-date)
+  - Efficiency: EPA/play, success rate, explosiveness
+  - Ratings: SP+, Elo, FPI, WEPA
+  - Situational: 3rd down rate, red zone rate, havoc rate
+  - Opponent mirror features
+  - Derived: sp_diff, elo_diff, epa_diff
+- **Critical:** All stats computed BEFORE each game (no data leakage)
+
+#### features.play_features
+- **Grain:** Play
+- **Features:** down, distance, yard_line, field_zone, score_diff, game_state, time pressure, team tendencies
+- **Use:** Play-call prediction
+
+#### predictions.game_predictions
+- **Storage:** Model outputs (win prob, spread prediction, picks)
+- **Calibration:** Post-game actual results for model evaluation
+
+#### predictions.model_registry
+- **Metadata:** Model versions, training windows, hyperparameters, performance metrics
+
+---
+
+## Endpoint Coverage Plan
+
+### Phase 1: Critical (blocks core functionality)
+
+| Endpoint | Table | Effort |
+|----------|-------|--------|
+| `/roster` | `core.rosters` | Medium |
+| `/rankings` | `ratings.poll_rankings` | Low |
+| `/games/players` | `stats.player_game_stats` | Medium |
+
+### Phase 2: High (enables key analytics)
+
+| Endpoint | Table | Effort |
+|----------|-------|--------|
+| `/stats/season/advanced` | `stats.advanced_team_stats` | Low (wire config) |
+| `/game/box/advanced` | `stats.game_advanced_stats` | Medium |
+| `/talent` | `recruiting.team_talent` | Low |
+| `/player/returning` | `stats.returning_production` | Low |
+| `/wepa/team/season` | `metrics.wepa_team_season` | Low |
+
+### Phase 3: Medium (enriches analysis)
+
+| Endpoint | Table | Effort |
+|----------|-------|--------|
+| `/ppa/games` | `metrics.ppa_games` | Low (wire config) |
+| `/ppa/players/games` | `metrics.ppa_players_games` | Low (wire config) |
+| `/metrics/wp` | `metrics.win_probability` | Medium (wire config) |
+| `/player/usage` | `stats.player_usage` | Low |
+| `/games/weather` | `core.game_weather` | Low |
+| `/games/media` | `core.game_media` | Low (wire config) |
+| `/recruiting/groups` | `recruiting.position_groups` | Low |
+
+### Phase 4: Nice-to-have
+
+- `/wepa/players/*` (3 endpoints)
+- `/records`
+- `/draft/positions`, `/draft/teams`
+- `/stats/categories`
+- `/calendar`
+
+### Phase 5: Real-time (future)
+
+- `/scoreboard`
+- `/live/plays`
+
+### API Budget Estimate
+
+| Endpoint | Call Pattern | Est. Calls |
+|----------|--------------|------------|
+| `/roster` | 130 teams × 22 years | ~2,860 |
+| `/rankings` | 22 years × ~17 weeks | ~374 |
+| `/games/players` | ~800 games/year × 22 years | ~17,600 |
+| `/game/box/advanced` | ~800 games/year × 22 years | ~17,600 |
+| Others | Various | ~5,000 |
+| **Total** | | **~45,000 calls** |
+
+Fits within 75k/month budget with room to spare.
+
+---
+
+## Utility Functions
+
+### Garbage Time Filter
+```sql
+CREATE OR REPLACE FUNCTION is_garbage_time(play core.plays)
+RETURNS boolean AS $$
+BEGIN
+    RETURN (
+        (play.period = 4 AND ABS(play.score_diff) > 28) OR
+        (play.period >= 3 AND ABS(play.score_diff) > 35)
+    );
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+```
+
+### EPA Benchmarks
+- Elite: EPA/play >= 0.16
+- Above avg: >= 0.05
+- Average: >= -0.05
+- Below avg: >= -0.15
+- Struggling: < -0.15
+
+---
+
+## Refresh Strategy
+
+| Layer | Trigger | Method |
+|-------|---------|--------|
+| Raw tables | Pipeline loads | dlt merge |
+| Marts (materialized views) | After pipeline | `REFRESH MATERIALIZED VIEW CONCURRENTLY` |
+| API views | N/A | Query-time (regular views) |
+| Feature views | After marts refresh | `REFRESH MATERIALIZED VIEW CONCURRENTLY` |
+
+Recommended: Use `pg_cron` (Supabase Pro) or external scheduler for mart refreshes.
+
+---
+
+## Frontend Stack Recommendation
+
+- **Framework:** React + Next.js
+- **Charting:** Recharts (simple) or Tremor (dashboard-focused)
+- **Data fetching:** Supabase client libraries
+- **Auth:** Supabase Auth (if needed)
+
+---
+
+## Implementation Phases
+
+| Phase | Focus | Deliverables |
+|-------|-------|--------------|
+| **1** | Endpoint coverage | Wire Phase 1-2 endpoints, backfill rosters/rankings |
+| **2** | Marts layer | Create all materialized views, refresh scripts |
+| **3** | API layer | Create all API views, test with Supabase client |
+| **4** | Features layer | ML feature views, training data exports |
+| **5** | App scaffold | Next.js app with team/game/player pages |
+| **6** | Advanced features | Predictions, real-time, betting analysis |
+
+---
+
+## Open Questions
+
+1. **Supabase tier:** Free vs Pro? Pro needed for pg_cron, more storage
+2. **Auth requirements:** Public data or user-gated?
+3. **Backfill priority:** Full history or recent years first?
+4. **Model deployment:** Where to run ML models (Supabase Edge Functions, external)?
+
+---
+
+## References
+
+- CFBD API: https://collegefootballdata.com
+- cfbfastR: https://cfbfastR.sportsdataverse.org
+- Supabase: https://supabase.com/docs
+- EPA/Success Rate research: various CFB analytics community sources

--- a/docs/plans/2025-01-28-analytics-schema-implementation.md
+++ b/docs/plans/2025-01-28-analytics-schema-implementation.md
@@ -1,0 +1,1073 @@
+# Analytics Schema Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Expand endpoint coverage, build analytics marts layer, and create app-friendly API views for a CFB analytics web application.
+
+**Architecture:** Layered schema (raw → marts → api → features) on Supabase Postgres. New endpoints loaded via dlt pipelines. Materialized views for pre-computed analytics. Regular views for API consumption via PostgREST.
+
+**Tech Stack:** Python 3.11+, dlt (dlthub), Supabase Postgres, SQL (materialized views, functions)
+
+---
+
+## Current State Summary
+
+**Loaded in Supabase:**
+- `ref.*`: conferences (106), teams (1,899), venues (837), coaches (1,790), play_types (49)
+- `core.*`: games (18,650), drives (183,603), plays (3,611,707 with PPA)
+- `stats.*`: team_season_stats (49,819), player_season_stats (131,268)
+- `ratings.*`: sp (800), elo (791), fpi (791), srs (1,258)
+- `recruiting.*`: recruits (16,086), team_recruiting (1,184), transfer_portal (14,356)
+- `betting.*`: lines (20,192)
+- `draft.*`: draft_picks (1,549)
+- `metrics.*`: ppa_teams (792), ppa_players_season (24,475), pregame_win_probability (5,080)
+
+**Known Issues:**
+- 3 variant columns need cleanup
+- No business indexes (only dlt's `_dlt_id`)
+- Teams reference conferences by name, not FK
+
+**Critical Gaps:**
+- No `core.rosters` (blocks player-team linkage)
+- No `ratings.poll_rankings` (AP/Coaches polls)
+- No advanced team stats, WEPA, or game-level player stats
+
+---
+
+## Phase 1: Endpoint Coverage (Pipeline Work)
+
+### Task 1.1: Add Roster Endpoint
+
+**Files:**
+- Create: `src/pipelines/sources/rosters.py`
+- Modify: `src/pipelines/config/endpoints.py`
+- Modify: `src/pipelines/run.py`
+- Test: `tests/test_sources/test_rosters.py`
+
+**Step 1: Write endpoint config**
+
+Add to `src/pipelines/config/endpoints.py`:
+
+```python
+EndpointConfig(
+    name="rosters",
+    path="/roster",
+    primary_key=["id", "team", "year"],
+    params={"team": None, "year": None},  # Required params
+    schema="core",
+    table_name="rosters",
+    write_disposition="merge",
+    year_range=(2004, 2026),
+)
+```
+
+**Step 2: Write the failing test**
+
+Create `tests/test_sources/test_rosters.py`:
+
+```python
+import pytest
+from unittest.mock import patch, MagicMock
+
+def test_rosters_resource_yields_players():
+    """Roster endpoint should yield player records with team/year context."""
+    from src.pipelines.sources.rosters import rosters_resource
+
+    mock_response = [
+        {"id": 12345, "first_name": "Jalen", "last_name": "Milroe", "position": "QB", "jersey": 4},
+        {"id": 12346, "first_name": "Ryan", "last_name": "Williams", "position": "WR", "jersey": 2},
+    ]
+
+    with patch("src.pipelines.sources.rosters.get_api_client") as mock_client:
+        mock_client.return_value.get.return_value = mock_response
+
+        results = list(rosters_resource(teams=["Alabama"], years=[2024]))
+
+        assert len(results) == 2
+        assert results[0]["id"] == 12345
+        assert results[0]["team"] == "Alabama"
+        assert results[0]["year"] == 2024
+
+
+def test_rosters_resource_iterates_teams_and_years():
+    """Should call API for each team/year combination."""
+    from src.pipelines.sources.rosters import rosters_resource
+
+    with patch("src.pipelines.sources.rosters.get_api_client") as mock_client:
+        mock_client.return_value.get.return_value = []
+
+        list(rosters_resource(teams=["Alabama", "Georgia"], years=[2023, 2024]))
+
+        # 2 teams x 2 years = 4 API calls
+        assert mock_client.return_value.get.call_count == 4
+```
+
+**Step 3: Run test to verify it fails**
+
+Run: `pytest tests/test_sources/test_rosters.py -v`
+Expected: FAIL with "No module named 'src.pipelines.sources.rosters'"
+
+**Step 4: Write the implementation**
+
+Create `src/pipelines/sources/rosters.py`:
+
+```python
+"""Roster data source - team rosters by season."""
+import dlt
+from typing import Iterator, List
+
+from src.pipelines.utils.api_client import get_api_client
+from src.pipelines.utils.rate_limiter import RateLimiter
+
+
+@dlt.resource(
+    name="rosters",
+    write_disposition="merge",
+    primary_key=["id", "team", "year"],
+)
+def rosters_resource(
+    teams: List[str],
+    years: List[int],
+    rate_limiter: RateLimiter = None,
+) -> Iterator[dict]:
+    """
+    Fetch team rosters for given teams and years.
+
+    Args:
+        teams: List of team names (e.g., ["Alabama", "Georgia"])
+        years: List of seasons (e.g., [2023, 2024])
+        rate_limiter: Optional rate limiter instance
+
+    Yields:
+        Player roster records with team/year context added
+    """
+    client = get_api_client()
+
+    for team in teams:
+        for year in years:
+            if rate_limiter:
+                rate_limiter.wait()
+
+            try:
+                players = client.get("/roster", params={"team": team, "year": year})
+
+                for player in players:
+                    # Add context fields
+                    player["team"] = team
+                    player["year"] = year
+                    yield player
+
+            except Exception as e:
+                print(f"Error fetching roster for {team} {year}: {e}")
+                continue
+
+
+@dlt.source(name="rosters")
+def rosters_source(
+    teams: List[str] = None,
+    years: List[int] = None,
+    rate_limiter: RateLimiter = None,
+):
+    """
+    Roster data source.
+
+    If teams not provided, fetches all FBS teams from ref.teams.
+    If years not provided, uses default year range.
+    """
+    from src.pipelines.utils.years import get_year_range
+
+    if years is None:
+        years = get_year_range(2004, 2026)
+
+    if teams is None:
+        # Load FBS teams from database or config
+        from src.pipelines.config.teams import get_fbs_teams
+        teams = get_fbs_teams()
+
+    return rosters_resource(teams=teams, years=years, rate_limiter=rate_limiter)
+```
+
+**Step 5: Run test to verify it passes**
+
+Run: `pytest tests/test_sources/test_rosters.py -v`
+Expected: PASS
+
+**Step 6: Wire into CLI**
+
+Modify `src/pipelines/run.py` to add rosters source:
+
+```python
+# In the source registry
+SOURCES = {
+    # ... existing sources
+    "rosters": rosters_source,
+}
+```
+
+**Step 7: Commit**
+
+```bash
+git add src/pipelines/sources/rosters.py tests/test_sources/test_rosters.py
+git add src/pipelines/config/endpoints.py src/pipelines/run.py
+git commit -m "feat: add roster endpoint for player-team linkage"
+```
+
+---
+
+### Task 1.2: Add Rankings Endpoint
+
+**Files:**
+- Create: `src/pipelines/sources/rankings.py`
+- Modify: `src/pipelines/config/endpoints.py`
+- Modify: `src/pipelines/run.py`
+- Test: `tests/test_sources/test_rankings.py`
+
+**Step 1: Write the failing test**
+
+Create `tests/test_sources/test_rankings.py`:
+
+```python
+import pytest
+from unittest.mock import patch
+
+def test_rankings_resource_yields_poll_data():
+    """Rankings endpoint should yield poll rankings by week."""
+    from src.pipelines.sources.rankings import rankings_resource
+
+    mock_response = [
+        {
+            "season": 2024,
+            "seasonType": "regular",
+            "week": 1,
+            "polls": [
+                {
+                    "poll": "AP Top 25",
+                    "ranks": [
+                        {"rank": 1, "school": "Georgia", "conference": "SEC", "firstPlaceVotes": 55, "points": 1550},
+                        {"rank": 2, "school": "Ohio State", "conference": "Big Ten", "firstPlaceVotes": 8, "points": 1492},
+                    ]
+                }
+            ]
+        }
+    ]
+
+    with patch("src.pipelines.sources.rankings.get_api_client") as mock_client:
+        mock_client.return_value.get.return_value = mock_response
+
+        results = list(rankings_resource(years=[2024]))
+
+        # Should flatten polls and ranks
+        assert len(results) >= 2
+        assert results[0]["season"] == 2024
+        assert results[0]["week"] == 1
+        assert results[0]["poll_type"] == "AP Top 25"
+        assert results[0]["rank"] == 1
+        assert results[0]["school"] == "Georgia"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_sources/test_rankings.py -v`
+Expected: FAIL
+
+**Step 3: Write the implementation**
+
+Create `src/pipelines/sources/rankings.py`:
+
+```python
+"""Rankings data source - AP/Coaches poll rankings by week."""
+import dlt
+from typing import Iterator, List
+
+from src.pipelines.utils.api_client import get_api_client
+from src.pipelines.utils.rate_limiter import RateLimiter
+
+
+@dlt.resource(
+    name="poll_rankings",
+    write_disposition="merge",
+    primary_key=["season", "week", "poll_type", "school"],
+)
+def rankings_resource(
+    years: List[int],
+    rate_limiter: RateLimiter = None,
+) -> Iterator[dict]:
+    """
+    Fetch poll rankings for given years.
+
+    Flattens the nested poll structure into individual rank records.
+    """
+    client = get_api_client()
+
+    for year in years:
+        if rate_limiter:
+            rate_limiter.wait()
+
+        try:
+            weeks_data = client.get("/rankings", params={"year": year})
+
+            for week_data in weeks_data:
+                season = week_data.get("season")
+                week = week_data.get("week")
+                season_type = week_data.get("seasonType")
+
+                for poll in week_data.get("polls", []):
+                    poll_type = poll.get("poll")
+
+                    for rank_entry in poll.get("ranks", []):
+                        yield {
+                            "season": season,
+                            "week": week,
+                            "season_type": season_type,
+                            "poll_type": poll_type,
+                            "rank": rank_entry.get("rank"),
+                            "school": rank_entry.get("school"),
+                            "conference": rank_entry.get("conference"),
+                            "first_place_votes": rank_entry.get("firstPlaceVotes"),
+                            "points": rank_entry.get("points"),
+                        }
+
+        except Exception as e:
+            print(f"Error fetching rankings for {year}: {e}")
+            continue
+
+
+@dlt.source(name="rankings")
+def rankings_source(years: List[int] = None, rate_limiter: RateLimiter = None):
+    """Rankings data source."""
+    from src.pipelines.utils.years import get_year_range
+
+    if years is None:
+        years = get_year_range(2004, 2026)
+
+    return rankings_resource(years=years, rate_limiter=rate_limiter)
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_sources/test_rankings.py -v`
+Expected: PASS
+
+**Step 5: Wire into CLI and commit**
+
+```bash
+git add src/pipelines/sources/rankings.py tests/test_sources/test_rankings.py
+git commit -m "feat: add rankings endpoint for poll data"
+```
+
+---
+
+### Task 1.3: Wire Existing CONFIG_ONLY Endpoints
+
+These endpoints have configs but aren't wired into their source functions.
+
+**Files:**
+- Modify: `src/pipelines/sources/stats.py` (advanced_team_stats)
+- Modify: `src/pipelines/sources/metrics.py` (ppa_games, ppa_players_games, win_probability)
+- Modify: `src/pipelines/sources/games.py` (game_media)
+- Test: Add tests for each
+
+**Step 1: Wire advanced_team_stats in stats.py**
+
+Find the `stats_source()` function and add `advanced_team_stats_resource` to the return list.
+
+**Step 2: Wire ppa_games, ppa_players_games, win_probability in metrics.py**
+
+Add these to `metrics_source()` return list.
+
+**Step 3: Wire game_media in games.py**
+
+Add to `games_source()` return list.
+
+**Step 4: Test each with --dry-run**
+
+```bash
+python -m src.pipelines.run --source stats --dry-run
+python -m src.pipelines.run --source metrics --dry-run
+python -m src.pipelines.run --source games --dry-run
+```
+
+**Step 5: Commit**
+
+```bash
+git add src/pipelines/sources/*.py
+git commit -m "feat: wire CONFIG_ONLY endpoints (advanced_stats, ppa_games, game_media)"
+```
+
+---
+
+### Task 1.4: Add WEPA Endpoint
+
+**Files:**
+- Create: `src/pipelines/sources/wepa.py`
+- Test: `tests/test_sources/test_wepa.py`
+
+**Step 1: Write test**
+
+```python
+def test_wepa_team_season_resource():
+    """WEPA endpoint should yield opponent-adjusted EPA by team/season."""
+    from src.pipelines.sources.wepa import wepa_team_season_resource
+
+    mock_response = [
+        {"team": "Alabama", "year": 2024, "offense": {"overall": 0.25}, "defense": {"overall": -0.15}},
+    ]
+
+    with patch("src.pipelines.sources.wepa.get_api_client") as mock_client:
+        mock_client.return_value.get.return_value = mock_response
+
+        results = list(wepa_team_season_resource(years=[2024]))
+
+        assert len(results) == 1
+        assert results[0]["team"] == "Alabama"
+        assert "offense__overall" in results[0] or results[0].get("offense", {}).get("overall")
+```
+
+**Step 2: Implement and wire**
+
+Similar pattern to rankings. Write disposition: merge. PK: (team, year).
+
+**Step 3: Commit**
+
+```bash
+git commit -m "feat: add WEPA endpoint for opponent-adjusted EPA"
+```
+
+---
+
+### Task 1.5: Add Team Talent Endpoint
+
+**Files:**
+- Modify: `src/pipelines/sources/recruiting.py`
+- Test: `tests/test_sources/test_recruiting.py`
+
+**Step 1: Add talent resource**
+
+```python
+@dlt.resource(
+    name="team_talent",
+    write_disposition="merge",
+    primary_key=["year", "school"],
+)
+def team_talent_resource(years: List[int], rate_limiter: RateLimiter = None):
+    """Fetch team talent composite scores."""
+    client = get_api_client()
+
+    for year in years:
+        if rate_limiter:
+            rate_limiter.wait()
+
+        data = client.get("/talent", params={"year": year})
+        for team in data:
+            team["year"] = year
+            yield team
+```
+
+**Step 2: Wire into recruiting_source and commit**
+
+---
+
+## Phase 2: Schema Hardening
+
+### Task 2.1: Create Utility Function for Garbage Time
+
+**Files:**
+- Create: `src/schemas/functions/is_garbage_time.sql`
+
+**Step 1: Write the SQL function**
+
+```sql
+-- Function to detect garbage time plays
+-- Garbage time: margin > 28 in 4th quarter, or > 35 in 3rd+
+CREATE OR REPLACE FUNCTION is_garbage_time(
+    period integer,
+    score_diff integer
+) RETURNS boolean AS $$
+BEGIN
+    RETURN (
+        (period = 4 AND ABS(COALESCE(score_diff, 0)) > 28) OR
+        (period >= 3 AND ABS(COALESCE(score_diff, 0)) > 35)
+    );
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+COMMENT ON FUNCTION is_garbage_time IS 'Returns true if play occurred in garbage time (blowout situations)';
+```
+
+**Step 2: Test locally**
+
+```sql
+SELECT is_garbage_time(4, 30);  -- true
+SELECT is_garbage_time(4, 14);  -- false
+SELECT is_garbage_time(3, 40);  -- true
+```
+
+**Step 3: Commit**
+
+```bash
+git add src/schemas/functions/
+git commit -m "feat: add is_garbage_time SQL function"
+```
+
+---
+
+### Task 2.2: Create Positions Reference Table
+
+**Files:**
+- Create: `src/schemas/014_positions.sql`
+
+**Step 1: Write the schema**
+
+```sql
+-- Position reference table for grouping
+CREATE TABLE IF NOT EXISTS ref.positions (
+    id text PRIMARY KEY,
+    name text NOT NULL,
+    side text NOT NULL CHECK (side IN ('offense', 'defense', 'special_teams')),
+    position_group text NOT NULL
+);
+
+INSERT INTO ref.positions (id, name, side, position_group) VALUES
+    ('QB', 'Quarterback', 'offense', 'passer'),
+    ('RB', 'Running Back', 'offense', 'rusher'),
+    ('FB', 'Fullback', 'offense', 'rusher'),
+    ('WR', 'Wide Receiver', 'offense', 'receiver'),
+    ('TE', 'Tight End', 'offense', 'receiver'),
+    ('OT', 'Offensive Tackle', 'offense', 'lineman'),
+    ('OG', 'Offensive Guard', 'offense', 'lineman'),
+    ('OC', 'Center', 'offense', 'lineman'),
+    ('OL', 'Offensive Line', 'offense', 'lineman'),
+    ('DE', 'Defensive End', 'defense', 'dline'),
+    ('DT', 'Defensive Tackle', 'defense', 'dline'),
+    ('DL', 'Defensive Line', 'defense', 'dline'),
+    ('EDGE', 'Edge Rusher', 'defense', 'dline'),
+    ('ILB', 'Inside Linebacker', 'defense', 'linebacker'),
+    ('OLB', 'Outside Linebacker', 'defense', 'linebacker'),
+    ('LB', 'Linebacker', 'defense', 'linebacker'),
+    ('CB', 'Cornerback', 'defense', 'db'),
+    ('S', 'Safety', 'defense', 'db'),
+    ('DB', 'Defensive Back', 'defense', 'db'),
+    ('K', 'Kicker', 'special_teams', 'specialist'),
+    ('P', 'Punter', 'special_teams', 'specialist'),
+    ('LS', 'Long Snapper', 'special_teams', 'specialist'),
+    ('ATH', 'Athlete', 'offense', 'athlete')
+ON CONFLICT (id) DO NOTHING;
+```
+
+**Step 2: Commit**
+
+```bash
+git commit -m "feat: add positions reference table"
+```
+
+---
+
+### Task 2.3: Add Score Diff Column to Plays
+
+The plays table needs `score_diff` for garbage time filtering. Currently has `offense_score` and `defense_score`.
+
+**Files:**
+- Create: `src/schemas/015_plays_score_diff.sql`
+
+**Step 1: Add computed column**
+
+```sql
+-- Add score_diff as a generated column
+ALTER TABLE core.plays
+ADD COLUMN IF NOT EXISTS score_diff integer
+GENERATED ALWAYS AS (offense_score - defense_score) STORED;
+
+-- Index for garbage time queries
+CREATE INDEX IF NOT EXISTS idx_plays_score_diff ON core.plays (score_diff);
+```
+
+**Step 2: Commit**
+
+```bash
+git commit -m "feat: add score_diff generated column to plays"
+```
+
+---
+
+## Phase 3: Marts Layer (Materialized Views)
+
+### Task 3.1: Create team_season_summary Mart
+
+**Files:**
+- Create: `src/schemas/marts/001_team_season_summary.sql`
+
+**Step 1: Write the materialized view**
+
+```sql
+-- Team season summary: record, scoring, ratings, recruiting
+CREATE SCHEMA IF NOT EXISTS marts;
+
+DROP MATERIALIZED VIEW IF EXISTS marts.team_season_summary CASCADE;
+
+CREATE MATERIALIZED VIEW marts.team_season_summary AS
+WITH game_results AS (
+    SELECT
+        CASE WHEN home_id = t.id THEN home_id ELSE away_id END AS team_id,
+        t.school,
+        g.season,
+        g.conference_game,
+        CASE
+            WHEN home_id = t.id AND home_points > away_points THEN 1
+            WHEN away_id = t.id AND away_points > home_points THEN 1
+            ELSE 0
+        END AS won,
+        CASE WHEN home_id = t.id THEN home_points ELSE away_points END AS points_for,
+        CASE WHEN home_id = t.id THEN away_points ELSE home_points END AS points_against
+    FROM core.games g
+    CROSS JOIN LATERAL (
+        SELECT id, school FROM ref.teams WHERE id IN (g.home_id, g.away_id)
+    ) t
+    WHERE g.completed = true
+)
+SELECT
+    gr.team_id,
+    gr.school,
+    t.conference,
+    gr.season,
+
+    -- Record
+    COUNT(*) AS games,
+    SUM(gr.won) AS wins,
+    COUNT(*) - SUM(gr.won) AS losses,
+
+    -- Conference record
+    SUM(gr.won) FILTER (WHERE gr.conference_game) AS conf_wins,
+    COUNT(*) FILTER (WHERE gr.conference_game) - SUM(gr.won) FILTER (WHERE gr.conference_game) AS conf_losses,
+
+    -- Scoring
+    ROUND(AVG(gr.points_for)::numeric, 1) AS ppg,
+    ROUND(AVG(gr.points_against)::numeric, 1) AS opp_ppg,
+    ROUND(AVG(gr.points_for - gr.points_against)::numeric, 1) AS avg_margin,
+
+    -- Ratings (joined)
+    sp.rating AS sp_rating,
+    sp.ranking AS sp_rank,
+    sp."offense__rating" AS sp_offense,
+    sp."defense__rating" AS sp_defense,
+    elo.elo,
+    fpi.fpi,
+
+    -- Recruiting
+    tr.rank AS recruiting_rank,
+    tr.points AS recruiting_points
+
+FROM game_results gr
+JOIN ref.teams t ON gr.team_id = t.id
+LEFT JOIN ratings.sp_ratings sp ON t.school = sp.team AND gr.season = sp.year
+LEFT JOIN ratings.elo_ratings elo ON t.school = elo.team AND gr.season = elo.year
+LEFT JOIN ratings.fpi_ratings fpi ON t.school = fpi.team AND gr.season = fpi.year
+LEFT JOIN recruiting.team_recruiting tr ON t.school = tr.team AND gr.season = tr.year
+GROUP BY
+    gr.team_id, gr.school, t.conference, gr.season,
+    sp.rating, sp.ranking, sp."offense__rating", sp."defense__rating",
+    elo.elo, fpi.fpi, tr.rank, tr.points;
+
+-- Required for REFRESH CONCURRENTLY
+CREATE UNIQUE INDEX ON marts.team_season_summary (team_id, season);
+
+-- Query indexes
+CREATE INDEX ON marts.team_season_summary (season);
+CREATE INDEX ON marts.team_season_summary (conference);
+CREATE INDEX ON marts.team_season_summary (sp_rank);
+```
+
+**Step 2: Test the view**
+
+```sql
+SELECT * FROM marts.team_season_summary
+WHERE school = 'Alabama' AND season = 2024;
+```
+
+**Step 3: Commit**
+
+```bash
+git commit -m "feat: add team_season_summary materialized view"
+```
+
+---
+
+### Task 3.2: Create _game_epa_calc Helper Mart
+
+**Files:**
+- Create: `src/schemas/marts/002_game_epa_calc.sql`
+
+**Step 1: Write the helper view**
+
+```sql
+-- Helper: EPA calculations per game/team (excluding garbage time)
+CREATE MATERIALIZED VIEW marts._game_epa_calc AS
+SELECT
+    p.game_id,
+    t.id AS team_id,
+
+    -- EPA/play (excluding garbage time)
+    ROUND(AVG(p.ppa) FILTER (
+        WHERE NOT is_garbage_time(p.period::integer, (p.offense_score - p.defense_score)::integer)
+    )::numeric, 4) AS epa_per_play,
+
+    -- Success rate: % of plays with positive EPA
+    ROUND(AVG(CASE WHEN p.ppa > 0 THEN 1.0 ELSE 0.0 END) FILTER (
+        WHERE NOT is_garbage_time(p.period::integer, (p.offense_score - p.defense_score)::integer)
+    )::numeric, 4) AS success_rate,
+
+    -- Explosiveness: avg EPA on successful plays only
+    ROUND(AVG(p.ppa) FILTER (
+        WHERE p.ppa > 0
+        AND NOT is_garbage_time(p.period::integer, (p.offense_score - p.defense_score)::integer)
+    )::numeric, 4) AS explosiveness,
+
+    -- Play counts
+    COUNT(*) FILTER (
+        WHERE NOT is_garbage_time(p.period::integer, (p.offense_score - p.defense_score)::integer)
+    ) AS plays_non_garbage,
+    COUNT(*) AS plays_total
+
+FROM core.plays p
+JOIN ref.teams t ON p.offense = t.school
+GROUP BY p.game_id, t.id;
+
+CREATE UNIQUE INDEX ON marts._game_epa_calc (game_id, team_id);
+```
+
+**Step 2: Commit**
+
+```bash
+git commit -m "feat: add _game_epa_calc helper materialized view"
+```
+
+---
+
+### Task 3.3: Create team_epa_season Mart
+
+**Files:**
+- Create: `src/schemas/marts/003_team_epa_season.sql`
+
+**Step 1: Write the view**
+
+```sql
+-- Team EPA season summary with benchmarks
+CREATE MATERIALIZED VIEW marts.team_epa_season AS
+SELECT
+    epa.team_id,
+    t.school,
+    g.season,
+
+    -- Aggregated EPA metrics
+    ROUND(AVG(epa.epa_per_play)::numeric, 4) AS epa_per_play,
+    ROUND(AVG(epa.success_rate)::numeric, 4) AS success_rate,
+    ROUND(AVG(epa.explosiveness)::numeric, 4) AS explosiveness,
+
+    -- EPA tier benchmark
+    CASE
+        WHEN AVG(epa.epa_per_play) >= 0.16 THEN 'elite'
+        WHEN AVG(epa.epa_per_play) >= 0.05 THEN 'above_avg'
+        WHEN AVG(epa.epa_per_play) >= -0.05 THEN 'average'
+        WHEN AVG(epa.epa_per_play) >= -0.15 THEN 'below_avg'
+        ELSE 'struggling'
+    END AS epa_tier,
+
+    SUM(epa.plays_non_garbage) AS total_plays
+
+FROM marts._game_epa_calc epa
+JOIN core.games g ON epa.game_id = g.id
+JOIN ref.teams t ON epa.team_id = t.id
+GROUP BY epa.team_id, t.school, g.season;
+
+CREATE UNIQUE INDEX ON marts.team_epa_season (team_id, season);
+CREATE INDEX ON marts.team_epa_season (season, epa_tier);
+```
+
+**Step 2: Commit**
+
+```bash
+git commit -m "feat: add team_epa_season materialized view"
+```
+
+---
+
+### Task 3.4: Create situational_splits Mart
+
+**Files:**
+- Create: `src/schemas/marts/004_situational_splits.sql`
+
+This is the expanded situational metrics view from the design. Include:
+- Down & distance splits
+- Red zone metrics
+- Field position metrics
+- Late & close
+- Two-minute drill
+- Play type efficiency
+- Power & stuff metrics
+
+**Step 1: Write the full view (see design document for complete SQL)**
+
+**Step 2: Commit**
+
+```bash
+git commit -m "feat: add situational_splits materialized view"
+```
+
+---
+
+### Task 3.5: Create Remaining Marts
+
+For each mart from the design document:
+- `marts.defensive_havoc`
+- `marts.scoring_opportunities`
+- `marts.game_results`
+- `marts.matchup_history`
+- `marts.recruiting_class`
+- `marts.coach_record`
+- `marts.conference_standings`
+
+Follow the same pattern:
+1. Create SQL file in `src/schemas/marts/`
+2. Include unique index for concurrent refresh
+3. Add query indexes
+4. Test with sample queries
+5. Commit
+
+---
+
+## Phase 4: API Views Layer
+
+### Task 4.1: Create team_detail API View
+
+**Files:**
+- Create: `src/schemas/api/001_team_detail.sql`
+
+**Step 1: Write the view**
+
+```sql
+CREATE SCHEMA IF NOT EXISTS api;
+
+CREATE OR REPLACE VIEW api.team_detail AS
+SELECT
+    t.id,
+    t.school,
+    t.mascot,
+    t.abbreviation,
+    t.color,
+    t.alternate_color AS alt_color,
+    logos.value AS logo_url,
+    t.conference,
+
+    -- Current season summary
+    tss.season AS current_season,
+    tss.wins,
+    tss.losses,
+    tss.conf_wins,
+    tss.conf_losses,
+    tss.ppg,
+    tss.opp_ppg,
+    tss.sp_rating,
+    tss.sp_rank,
+
+    -- EPA metrics
+    epa.epa_per_play,
+    epa.epa_tier,
+    epa.success_rate,
+
+    -- Recruiting
+    tss.recruiting_rank,
+    tss.recruiting_points
+
+FROM ref.teams t
+LEFT JOIN ref.teams__logos logos ON t._dlt_id = logos._dlt_parent_id AND logos._dlt_list_idx = 0
+LEFT JOIN LATERAL (
+    SELECT * FROM marts.team_season_summary
+    WHERE team_id = t.id
+    ORDER BY season DESC LIMIT 1
+) tss ON true
+LEFT JOIN LATERAL (
+    SELECT * FROM marts.team_epa_season
+    WHERE team_id = t.id
+    ORDER BY season DESC LIMIT 1
+) epa ON true;
+```
+
+**Step 2: Commit**
+
+```bash
+git commit -m "feat: add team_detail API view"
+```
+
+---
+
+### Task 4.2: Create Remaining API Views
+
+For each API view from the design:
+- `api.team_history`
+- `api.game_detail`
+- `api.player_detail` (depends on rosters being loaded)
+- `api.matchup`
+- `api.leaderboard_teams`
+
+---
+
+## Phase 5: Refresh Script
+
+### Task 5.1: Create Mart Refresh Script
+
+**Files:**
+- Create: `scripts/refresh_marts.py`
+
+**Step 1: Write the script**
+
+```python
+#!/usr/bin/env python3
+"""Refresh all materialized views in dependency order."""
+import os
+import psycopg2
+from datetime import datetime
+
+DATABASE_URL = os.environ.get("DATABASE_URL") or os.environ.get("SUPABASE_DB_URL")
+
+# Order matters: dependencies first
+MARTS = [
+    "marts._game_epa_calc",
+    "marts.team_season_summary",
+    "marts.team_epa_season",
+    "marts.situational_splits",
+    "marts.defensive_havoc",
+    "marts.scoring_opportunities",
+    "marts.game_results",
+    "marts.matchup_history",
+    "marts.recruiting_class",
+    "marts.coach_record",
+    "marts.conference_standings",
+]
+
+def refresh_marts(concurrently: bool = True):
+    """Refresh all materialized views."""
+    conn = psycopg2.connect(DATABASE_URL)
+    cur = conn.cursor()
+
+    refresh_type = "CONCURRENTLY" if concurrently else ""
+
+    for mart in MARTS:
+        print(f"[{datetime.now()}] Refreshing {mart}...")
+        try:
+            cur.execute(f"REFRESH MATERIALIZED VIEW {refresh_type} {mart}")
+            conn.commit()
+            print(f"  ✓ {mart} refreshed")
+        except Exception as e:
+            print(f"  ✗ {mart} failed: {e}")
+            conn.rollback()
+
+    cur.close()
+    conn.close()
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--no-concurrent", action="store_true", help="Don't use CONCURRENTLY")
+    args = parser.parse_args()
+
+    refresh_marts(concurrently=not args.no_concurrent)
+```
+
+**Step 2: Commit**
+
+```bash
+git commit -m "feat: add mart refresh script"
+```
+
+---
+
+## Phase 6: Backfill Data
+
+### Task 6.1: Backfill Rosters
+
+**Run:**
+```bash
+python -m src.pipelines.run --source rosters --years 2004 2005 2006 ... 2024
+```
+
+Note: This will make ~2,860 API calls (130 teams × 22 years). Budget allows.
+
+### Task 6.2: Backfill Rankings
+
+**Run:**
+```bash
+python -m src.pipelines.run --source rankings --years 2004 2005 ... 2024
+```
+
+### Task 6.3: Backfill Other Endpoints
+
+For each newly wired endpoint, run the backfill.
+
+### Task 6.4: Refresh All Marts
+
+**Run:**
+```bash
+python scripts/refresh_marts.py
+```
+
+---
+
+## Phase 7: Validation
+
+### Task 7.1: Validate Team Season Summary
+
+```sql
+-- Spot check Alabama 2024
+SELECT * FROM marts.team_season_summary
+WHERE school = 'Alabama' AND season = 2024;
+
+-- Should have wins, losses, ppg, sp_rating, etc.
+```
+
+### Task 7.2: Validate API Views
+
+```sql
+-- Test team detail
+SELECT * FROM api.team_detail WHERE school = 'Georgia';
+
+-- Test leaderboard
+SELECT school, epa_per_play, epa_tier
+FROM api.leaderboard_teams
+WHERE season = 2024
+ORDER BY epa_per_play DESC
+LIMIT 10;
+```
+
+### Task 7.3: Test from Supabase Client
+
+```typescript
+// In a test script or app
+const { data, error } = await supabase
+  .from('team_detail')
+  .select('*')
+  .eq('school', 'Alabama')
+  .single();
+
+console.log(data);
+```
+
+---
+
+## Summary
+
+| Phase | Tasks | Est. Commits |
+|-------|-------|--------------|
+| 1. Endpoint Coverage | 5 tasks | ~8 commits |
+| 2. Schema Hardening | 3 tasks | ~3 commits |
+| 3. Marts Layer | 5+ tasks | ~10 commits |
+| 4. API Views | 2+ tasks | ~5 commits |
+| 5. Refresh Script | 1 task | 1 commit |
+| 6. Backfill | 4 tasks | 0 commits (data only) |
+| 7. Validation | 3 tasks | 0 commits |
+
+**Total:** ~27 commits, organized into logical phases.
+
+Each phase can be demoed independently:
+- Phase 1: New data available in raw tables
+- Phase 2-3: Analytics queries work
+- Phase 4: API views available via PostgREST
+- Phase 5-6: Full data loaded and marts populated

--- a/scripts/refresh_marts.py
+++ b/scripts/refresh_marts.py
@@ -24,9 +24,18 @@ logger = logging.getLogger(__name__)
 # team_season_summary -> conference_standings (analytics)
 
 MARTS_VIEWS = [
+    # Core EPA views (order matters: _game_epa_calc first)
     "marts._game_epa_calc",
     "marts.team_season_summary",
     "marts.team_epa_season",
+    # Situational and play-level analysis
+    "marts.situational_splits",
+    "marts.defensive_havoc",
+    "marts.scoring_opportunities",
+    # Historical and reference
+    "marts.matchup_history",
+    "marts.recruiting_class",
+    "marts.coach_record",
 ]
 
 ANALYTICS_VIEWS = [

--- a/scripts/refresh_marts.py
+++ b/scripts/refresh_marts.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Refresh all materialized views in dependency order.
+
+Usage:
+    python scripts/refresh_marts.py                    # Refresh all marts
+    python scripts/refresh_marts.py --no-concurrent    # Without CONCURRENTLY (blocks reads)
+    python scripts/refresh_marts.py --schema marts     # Only marts schema
+    python scripts/refresh_marts.py --schema analytics # Only analytics schema
+    python scripts/refresh_marts.py --dry-run          # Print SQL without executing
+"""
+
+import argparse
+import logging
+import sys
+from datetime import datetime
+
+import dlt
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+# Order matters: dependencies must refresh first
+# _game_epa_calc -> team_epa_season
+# team_season_summary -> conference_standings (analytics)
+
+MARTS_VIEWS = [
+    "marts._game_epa_calc",
+    "marts.team_season_summary",
+    "marts.team_epa_season",
+]
+
+ANALYTICS_VIEWS = [
+    "analytics.team_season_summary",
+    "analytics.player_career_stats",
+    "analytics.conference_standings",  # Depends on team_season_summary
+    "analytics.team_recruiting_trend",
+    "analytics.game_results",
+]
+
+
+def get_db_url() -> str:
+    """Get database URL from dlt secrets or environment."""
+    try:
+        creds = dlt.secrets.get("destination.postgres.credentials")
+        if creds:
+            return str(creds)
+    except Exception:
+        pass
+
+    import os
+
+    url = os.environ.get("SUPABASE_DB_URL") or os.environ.get("DATABASE_URL")
+    if url:
+        return url
+
+    raise RuntimeError(
+        "No database URL found. Set destination.postgres.credentials in "
+        ".dlt/secrets.toml or SUPABASE_DB_URL environment variable."
+    )
+
+
+def refresh_view(view_name: str, conn, concurrently: bool, dry_run: bool) -> bool:
+    """Refresh a single materialized view. Returns True if successful."""
+    refresh_type = "CONCURRENTLY" if concurrently else ""
+    sql = f"REFRESH MATERIALIZED VIEW {refresh_type} {view_name}"
+
+    logger.info(f"{'[DRY RUN] ' if dry_run else ''}Refreshing {view_name}...")
+
+    if dry_run:
+        print(f"  {sql};")
+        return True
+
+    cursor = conn.cursor()
+    try:
+        start = datetime.now()
+        cursor.execute(sql)
+        conn.commit()
+        elapsed = (datetime.now() - start).total_seconds()
+        logger.info(f"  ✓ {view_name} refreshed ({elapsed:.2f}s)")
+        return True
+    except Exception as e:
+        conn.rollback()
+        logger.error(f"  ✗ {view_name} failed: {e}")
+        return False
+    finally:
+        cursor.close()
+
+
+def refresh_marts(
+    schema: str | None = None,
+    concurrently: bool = True,
+    dry_run: bool = False,
+) -> int:
+    """Refresh materialized views. Returns count of failures."""
+    # Build view list based on schema filter
+    views = []
+    if schema is None or schema == "marts":
+        views.extend(MARTS_VIEWS)
+    if schema is None or schema == "analytics":
+        views.extend(ANALYTICS_VIEWS)
+
+    if not views:
+        logger.error(f"No views found for schema: {schema}")
+        return 1
+
+    logger.info(f"Refreshing {len(views)} materialized view(s)")
+    if concurrently:
+        logger.info("Using CONCURRENTLY (reads not blocked)")
+    else:
+        logger.info("Not using CONCURRENTLY (reads blocked during refresh)")
+
+    if dry_run:
+        for view in views:
+            refresh_view(view, conn=None, concurrently=concurrently, dry_run=True)
+        return 0
+
+    import psycopg2
+
+    db_url = get_db_url()
+    conn = psycopg2.connect(db_url)
+
+    failures = 0
+    try:
+        for view in views:
+            if not refresh_view(view, conn, concurrently, dry_run):
+                failures += 1
+    finally:
+        conn.close()
+
+    if failures:
+        logger.warning(f"{failures} view(s) failed to refresh")
+    else:
+        logger.info("All views refreshed successfully")
+
+    return failures
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Refresh materialized views")
+    parser.add_argument(
+        "--no-concurrent",
+        action="store_true",
+        help="Don't use CONCURRENTLY (blocks reads during refresh)",
+    )
+    parser.add_argument(
+        "--schema",
+        choices=["marts", "analytics"],
+        help="Only refresh views in this schema",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print SQL without executing",
+    )
+    args = parser.parse_args()
+
+    failures = refresh_marts(
+        schema=args.schema,
+        concurrently=not args.no_concurrent,
+        dry_run=args.dry_run,
+    )
+    sys.exit(failures)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pipelines/sources/rosters.py
+++ b/src/pipelines/sources/rosters.py
@@ -1,0 +1,91 @@
+"""Roster data source - team rosters by season.
+
+Player roster data with team and year context.
+"""
+
+import logging
+from collections.abc import Iterator
+
+import dlt
+from dlt.sources import DltSource
+
+from ..config.years import YEAR_RANGES, get_current_season
+from ..utils.api_client import get_client
+from .base import make_request
+
+logger = logging.getLogger(__name__)
+
+
+@dlt.source(name="cfbd_rosters")
+def rosters_source(
+    teams: list[str] | None = None,
+    years: list[int] | None = None,
+    mode: str = "incremental",
+) -> DltSource:
+    """Source for roster data.
+
+    Args:
+        teams: List of team names. If None, requires explicit team list.
+        years: Specific years to load. If None, uses mode to determine years.
+        mode: "incremental" loads current season, "backfill" loads all historical.
+    """
+    if teams is None:
+        raise ValueError(
+            "teams parameter is required. Provide a list of team names, "
+            "e.g., teams=['Alabama', 'Georgia', 'Ohio State']"
+        )
+
+    if years is None:
+        if mode == "incremental":
+            years = [get_current_season()]
+        else:  # backfill
+            years = YEAR_RANGES["stats"].to_list()
+
+    return [
+        rosters_resource(teams=teams, years=years),
+    ]
+
+
+@dlt.resource(
+    name="rosters",
+    write_disposition="merge",
+    primary_key=["id", "team", "year"],
+)
+def rosters_resource(
+    teams: list[str],
+    years: list[int],
+) -> Iterator[dict]:
+    """Load team rosters for specified teams and years.
+
+    Args:
+        teams: List of team names (e.g., ["Alabama", "Georgia"])
+        years: List of seasons (e.g., [2023, 2024])
+
+    Yields:
+        Player roster records with team/year context added
+    """
+    client = get_client()
+    try:
+        for team in teams:
+            for year in years:
+                logger.info(f"Loading roster for {team} {year}...")
+
+                try:
+                    players = make_request(
+                        client,
+                        "/roster",
+                        params={"team": team, "year": year}
+                    )
+
+                    for player in players:
+                        # Add context fields for PK and querying
+                        player["team"] = team
+                        player["year"] = year
+                        yield player
+
+                except Exception as e:
+                    logger.warning(f"Error fetching roster for {team} {year}: {e}")
+                    continue
+
+    finally:
+        client.close()

--- a/src/pipelines/sources/wepa.py
+++ b/src/pipelines/sources/wepa.py
@@ -1,0 +1,174 @@
+"""WEPA (Wins-adjusted EPA) data sources - opponent-adjusted EPA metrics.
+
+These metrics adjust EPA for opponent strength, providing more accurate
+team and player efficiency comparisons.
+"""
+
+import logging
+from collections.abc import Iterator
+
+import dlt
+from dlt.sources import DltSource
+
+from ..config.years import YEAR_RANGES, get_current_season
+from ..utils.api_client import get_client
+from .base import make_request
+
+logger = logging.getLogger(__name__)
+
+
+@dlt.source(name="cfbd_wepa")
+def wepa_source(
+    years: list[int] | None = None,
+    mode: str = "incremental",
+) -> DltSource:
+    """Source for WEPA (opponent-adjusted EPA) data.
+
+    Args:
+        years: Specific years to load. If None, uses mode to determine years.
+        mode: "incremental" loads current season, "backfill" loads all historical.
+    """
+    if years is None:
+        if mode == "incremental":
+            years = [get_current_season()]
+        else:  # backfill
+            years = YEAR_RANGES["metrics"].to_list()
+
+    return [
+        wepa_team_season_resource(years),
+        wepa_players_passing_resource(years),
+        wepa_players_rushing_resource(years),
+        wepa_players_kicking_resource(years),
+    ]
+
+
+@dlt.resource(
+    name="wepa_team_season",
+    write_disposition="merge",
+    primary_key=["year", "team"],
+)
+def wepa_team_season_resource(years: list[int]) -> Iterator[dict]:
+    """Load team season WEPA (opponent-adjusted EPA) data.
+
+    Args:
+        years: List of years to load WEPA for
+
+    Yields:
+        Team season WEPA records with offense/defense breakdown
+    """
+    client = get_client()
+    try:
+        for year in years:
+            logger.info(f"Loading team WEPA for {year}...")
+
+            data = make_request(
+                client,
+                "/wepa/team/season",
+                params={"year": year}
+            )
+
+            for team in data:
+                team["year"] = year
+                yield team
+
+    finally:
+        client.close()
+
+
+@dlt.resource(
+    name="wepa_players_passing",
+    write_disposition="merge",
+    primary_key=["id", "year"],
+)
+def wepa_players_passing_resource(years: list[int]) -> Iterator[dict]:
+    """Load player passing WEPA data.
+
+    Args:
+        years: List of years to load WEPA for
+
+    Yields:
+        Player passing WEPA records
+    """
+    client = get_client()
+    try:
+        for year in years:
+            logger.info(f"Loading player passing WEPA for {year}...")
+
+            data = make_request(
+                client,
+                "/wepa/players/passing",
+                params={"year": year}
+            )
+
+            for player in data:
+                player["year"] = year
+                yield player
+
+    finally:
+        client.close()
+
+
+@dlt.resource(
+    name="wepa_players_rushing",
+    write_disposition="merge",
+    primary_key=["id", "year"],
+)
+def wepa_players_rushing_resource(years: list[int]) -> Iterator[dict]:
+    """Load player rushing WEPA data.
+
+    Args:
+        years: List of years to load WEPA for
+
+    Yields:
+        Player rushing WEPA records
+    """
+    client = get_client()
+    try:
+        for year in years:
+            logger.info(f"Loading player rushing WEPA for {year}...")
+
+            data = make_request(
+                client,
+                "/wepa/players/rushing",
+                params={"year": year}
+            )
+
+            for player in data:
+                player["year"] = year
+                yield player
+
+    finally:
+        client.close()
+
+
+@dlt.resource(
+    name="wepa_players_kicking",
+    write_disposition="merge",
+    primary_key=["id", "year"],
+)
+def wepa_players_kicking_resource(years: list[int]) -> Iterator[dict]:
+    """Load player kicking WEPA data.
+
+    Args:
+        years: List of years to load WEPA for
+
+    Yields:
+        Player kicking WEPA records
+    """
+    client = get_client()
+    try:
+        for year in years:
+            logger.info(f"Loading player kicking WEPA for {year}...")
+
+            data = make_request(
+                client,
+                "/wepa/players/kicking",
+                params={"year": year}
+            )
+
+            for player in data:
+                player["year"] = year
+                yield player
+
+    finally:
+        client.close()

--- a/src/schemas/014_positions.sql
+++ b/src/schemas/014_positions.sql
@@ -1,0 +1,60 @@
+-- Position reference table for grouping and analysis
+-- Maps position codes to human-readable names and categorizations
+
+CREATE TABLE IF NOT EXISTS ref.positions (
+    id text PRIMARY KEY,
+    name text NOT NULL,
+    side text NOT NULL CHECK (side IN ('offense', 'defense', 'special_teams')),
+    position_group text NOT NULL
+);
+
+COMMENT ON TABLE ref.positions IS 'Position reference table for categorization and grouping';
+COMMENT ON COLUMN ref.positions.id IS 'Position abbreviation (e.g., QB, RB, WR)';
+COMMENT ON COLUMN ref.positions.side IS 'Side of the ball: offense, defense, or special_teams';
+COMMENT ON COLUMN ref.positions.position_group IS 'Position grouping for aggregate analysis';
+
+INSERT INTO ref.positions (id, name, side, position_group) VALUES
+    -- Offense
+    ('QB', 'Quarterback', 'offense', 'passer'),
+    ('RB', 'Running Back', 'offense', 'rusher'),
+    ('FB', 'Fullback', 'offense', 'rusher'),
+    ('WR', 'Wide Receiver', 'offense', 'receiver'),
+    ('TE', 'Tight End', 'offense', 'receiver'),
+    ('OT', 'Offensive Tackle', 'offense', 'lineman'),
+    ('OG', 'Offensive Guard', 'offense', 'lineman'),
+    ('OC', 'Center', 'offense', 'lineman'),
+    ('OL', 'Offensive Line', 'offense', 'lineman'),
+    ('C', 'Center', 'offense', 'lineman'),
+
+    -- Defense
+    ('DE', 'Defensive End', 'defense', 'dline'),
+    ('DT', 'Defensive Tackle', 'defense', 'dline'),
+    ('NT', 'Nose Tackle', 'defense', 'dline'),
+    ('DL', 'Defensive Line', 'defense', 'dline'),
+    ('EDGE', 'Edge Rusher', 'defense', 'dline'),
+    ('ILB', 'Inside Linebacker', 'defense', 'linebacker'),
+    ('OLB', 'Outside Linebacker', 'defense', 'linebacker'),
+    ('MLB', 'Middle Linebacker', 'defense', 'linebacker'),
+    ('LB', 'Linebacker', 'defense', 'linebacker'),
+    ('CB', 'Cornerback', 'defense', 'db'),
+    ('FS', 'Free Safety', 'defense', 'db'),
+    ('SS', 'Strong Safety', 'defense', 'db'),
+    ('S', 'Safety', 'defense', 'db'),
+    ('DB', 'Defensive Back', 'defense', 'db'),
+
+    -- Special Teams
+    ('K', 'Kicker', 'special_teams', 'specialist'),
+    ('P', 'Punter', 'special_teams', 'specialist'),
+    ('LS', 'Long Snapper', 'special_teams', 'specialist'),
+    ('PR', 'Punt Returner', 'special_teams', 'returner'),
+    ('KR', 'Kick Returner', 'special_teams', 'returner'),
+
+    -- Multi-position
+    ('ATH', 'Athlete', 'offense', 'athlete'),
+    ('APB', 'All-Purpose Back', 'offense', 'rusher'),
+    ('H', 'H-Back', 'offense', 'receiver')
+ON CONFLICT (id) DO NOTHING;
+
+-- Index for position group queries
+CREATE INDEX IF NOT EXISTS idx_positions_side ON ref.positions (side);
+CREATE INDEX IF NOT EXISTS idx_positions_group ON ref.positions (position_group);

--- a/src/schemas/015_plays_score_diff.sql
+++ b/src/schemas/015_plays_score_diff.sql
@@ -1,0 +1,29 @@
+-- Add score_diff as a generated column for garbage time filtering
+-- This column is computed from offense_score - defense_score
+
+-- First check if column already exists before adding
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'core'
+          AND table_name = 'plays'
+          AND column_name = 'score_diff'
+    ) THEN
+        ALTER TABLE core.plays
+        ADD COLUMN score_diff integer
+        GENERATED ALWAYS AS (offense_score - defense_score) STORED;
+    END IF;
+END $$;
+
+-- Index for garbage time queries
+-- Uses partial index for efficient filtering on close games
+CREATE INDEX IF NOT EXISTS idx_plays_score_diff ON core.plays (score_diff);
+
+-- Index for non-garbage time plays (absolute value <= 28)
+-- This covers the majority of competitive plays
+CREATE INDEX IF NOT EXISTS idx_plays_competitive
+ON core.plays (game_id, period)
+WHERE ABS(offense_score - defense_score) <= 28;
+
+COMMENT ON COLUMN core.plays.score_diff IS 'Score differential from offense perspective (offense_score - defense_score). Positive = offense winning.';

--- a/src/schemas/api/001_team_detail.sql
+++ b/src/schemas/api/001_team_detail.sql
@@ -1,0 +1,62 @@
+-- Team detail API view
+-- Single team page data: current season + ratings + recruiting + EPA
+-- Exposed via PostgREST as /api/team_detail
+
+CREATE SCHEMA IF NOT EXISTS api;
+
+DROP VIEW IF EXISTS api.team_detail;
+
+CREATE VIEW api.team_detail AS
+SELECT
+    t.school,
+    t.mascot,
+    t.abbreviation,
+    t.color,
+    t.alt_color,
+    t.logos->0 AS logo_url,  -- First logo from JSONB array
+    t.conference,
+    t.classification,
+
+    -- Current season summary (most recent)
+    tss.season AS current_season,
+    tss.games,
+    tss.wins,
+    tss.losses,
+    tss.conf_wins,
+    tss.conf_losses,
+    tss.ppg,
+    tss.opp_ppg,
+    tss.avg_margin,
+
+    -- Ratings
+    tss.sp_rating,
+    tss.sp_rank,
+    tss.sp_offense,
+    tss.sp_defense,
+    tss.elo,
+    tss.fpi,
+
+    -- EPA metrics
+    epa.epa_per_play,
+    epa.epa_tier,
+    epa.success_rate,
+    epa.explosiveness,
+
+    -- Recruiting
+    tss.recruiting_rank,
+    tss.recruiting_points
+
+FROM ref.teams t
+LEFT JOIN LATERAL (
+    SELECT * FROM marts.team_season_summary
+    WHERE team = t.school
+    ORDER BY season DESC LIMIT 1
+) tss ON true
+LEFT JOIN LATERAL (
+    SELECT * FROM marts.team_epa_season
+    WHERE team = t.school
+    ORDER BY season DESC LIMIT 1
+) epa ON true
+WHERE t.classification = 'fbs';  -- Only FBS teams by default
+
+COMMENT ON VIEW api.team_detail IS 'Team page data with current season stats, ratings, and EPA metrics';

--- a/src/schemas/api/002_team_history.sql
+++ b/src/schemas/api/002_team_history.sql
@@ -1,0 +1,47 @@
+-- Team history API view
+-- Multi-season trends for a team
+-- Exposed via PostgREST as /api/team_history
+
+DROP VIEW IF EXISTS api.team_history;
+
+CREATE VIEW api.team_history AS
+SELECT
+    tss.team,
+    tss.season,
+    tss.conference,
+
+    -- Record
+    tss.games,
+    tss.wins,
+    tss.losses,
+    tss.conf_wins,
+    tss.conf_losses,
+
+    -- Scoring
+    tss.ppg,
+    tss.opp_ppg,
+    tss.avg_margin,
+
+    -- Ratings
+    tss.sp_rating,
+    tss.sp_rank,
+    tss.elo,
+    tss.fpi,
+
+    -- EPA (if available for that season)
+    epa.epa_per_play,
+    epa.epa_tier,
+    epa.success_rate,
+    epa.explosiveness,
+    epa.total_plays,
+
+    -- Recruiting
+    tss.recruiting_rank,
+    tss.recruiting_points
+
+FROM marts.team_season_summary tss
+LEFT JOIN marts.team_epa_season epa
+    ON epa.team = tss.team AND epa.season = tss.season
+ORDER BY tss.team, tss.season DESC;
+
+COMMENT ON VIEW api.team_history IS 'Multi-season team history with records, ratings, and EPA trends';

--- a/src/schemas/api/003_game_detail.sql
+++ b/src/schemas/api/003_game_detail.sql
@@ -1,0 +1,99 @@
+-- Game detail API view
+-- Single game page: teams, scores, betting, EPA, venue
+-- Exposed via PostgREST as /api/game_detail
+
+DROP VIEW IF EXISTS api.game_detail;
+
+CREATE VIEW api.game_detail AS
+WITH consensus_lines AS (
+    -- Pick 'consensus' provider first; fall back to first available
+    SELECT DISTINCT ON (game_id)
+        game_id,
+        spread,
+        over_under,
+        provider
+    FROM betting.lines
+    ORDER BY game_id, CASE WHEN provider = 'consensus' THEN 0 ELSE 1 END, provider
+)
+SELECT
+    g.id AS game_id,
+    g.season,
+    g.week,
+    g.season_type,
+    g.start_date,
+    g.start_time_tbd,
+    g.completed,
+    g.neutral_site,
+    g.conference_game,
+
+    -- Home team
+    g.home_team,
+    g.home_conference,
+    g.home_points,
+    g.home_pregame_elo,
+    home_epa.epa_per_play AS home_epa,
+    home_epa.success_rate AS home_success_rate,
+
+    -- Away team
+    g.away_team,
+    g.away_conference,
+    g.away_points,
+    g.away_pregame_elo,
+    away_epa.epa_per_play AS away_epa,
+    away_epa.success_rate AS away_success_rate,
+
+    -- Result
+    CASE
+        WHEN g.home_points > g.away_points THEN g.home_team
+        WHEN g.away_points > g.home_points THEN g.away_team
+        ELSE NULL
+    END AS winner,
+    ABS(g.home_points - g.away_points) AS point_diff,
+
+    -- Betting
+    cl.spread AS home_spread,
+    cl.over_under,
+    cl.provider AS line_provider,
+
+    -- Spread result (negative spread = home favored)
+    CASE
+        WHEN cl.spread IS NOT NULL AND g.completed THEN
+            CASE
+                WHEN (g.home_points - g.away_points) > (-1 * cl.spread) THEN 'home_covered'
+                WHEN (g.home_points - g.away_points) < (-1 * cl.spread) THEN 'away_covered'
+                ELSE 'push'
+            END
+        ELSE NULL
+    END AS spread_result,
+
+    -- Over/under result
+    CASE
+        WHEN cl.over_under IS NOT NULL AND g.completed THEN
+            CASE
+                WHEN (g.home_points + g.away_points) > cl.over_under THEN 'over'
+                WHEN (g.home_points + g.away_points) < cl.over_under THEN 'under'
+                ELSE 'push'
+            END
+        ELSE NULL
+    END AS ou_result,
+
+    -- Win probability
+    wp.home_win_probability AS pregame_home_win_prob,
+
+    -- Venue
+    g.venue,
+    g.venue_id,
+    g.attendance,
+
+    -- Excitement
+    g.excitement_index
+
+FROM core.games g
+LEFT JOIN consensus_lines cl ON cl.game_id = g.id
+LEFT JOIN metrics.pregame_win_probability wp ON wp.game_id = g.id
+LEFT JOIN marts._game_epa_calc home_epa
+    ON home_epa.game_id = g.id AND home_epa.team = g.home_team
+LEFT JOIN marts._game_epa_calc away_epa
+    ON away_epa.game_id = g.id AND away_epa.team = g.away_team;
+
+COMMENT ON VIEW api.game_detail IS 'Single game detail with teams, betting lines, EPA, and results';

--- a/src/schemas/api/004_matchup.sql
+++ b/src/schemas/api/004_matchup.sql
@@ -1,0 +1,113 @@
+-- Matchup API view
+-- Head-to-head comparison between two teams
+-- Query with: SELECT * FROM api.matchup WHERE team1 = 'Alabama' AND team2 = 'Georgia'
+-- Exposed via PostgREST as /api/matchup
+
+DROP VIEW IF EXISTS api.matchup;
+
+CREATE VIEW api.matchup AS
+WITH h2h_games AS (
+    -- All games between any two teams
+    SELECT
+        LEAST(home_team, away_team) AS team1,
+        GREATEST(home_team, away_team) AS team2,
+        season,
+        week,
+        start_date,
+        home_team,
+        away_team,
+        home_points,
+        away_points,
+        venue,
+        CASE
+            WHEN home_points > away_points THEN home_team
+            WHEN away_points > home_points THEN away_team
+            ELSE NULL
+        END AS winner
+    FROM core.games
+    WHERE completed = true
+),
+h2h_summary AS (
+    SELECT
+        team1,
+        team2,
+        COUNT(*) AS total_games,
+        SUM(CASE WHEN winner = team1 THEN 1 ELSE 0 END) AS team1_wins,
+        SUM(CASE WHEN winner = team2 THEN 1 ELSE 0 END) AS team2_wins,
+        SUM(CASE WHEN winner IS NULL THEN 1 ELSE 0 END) AS ties,
+        MIN(season) AS first_meeting,
+        MAX(season) AS last_meeting
+    FROM h2h_games
+    GROUP BY team1, team2
+),
+recent_games AS (
+    SELECT
+        team1,
+        team2,
+        ARRAY_AGG(
+            jsonb_build_object(
+                'season', season,
+                'winner', winner,
+                'home_team', home_team,
+                'home_points', home_points,
+                'away_points', away_points
+            ) ORDER BY season DESC
+        ) FILTER (WHERE season >= 2014) AS recent_results
+    FROM h2h_games
+    GROUP BY team1, team2
+)
+SELECT
+    h.team1,
+    h.team2,
+
+    -- Head-to-head record
+    h.total_games,
+    h.team1_wins,
+    h.team2_wins,
+    h.ties,
+    h.first_meeting,
+    h.last_meeting,
+
+    -- Recent results (last 10 years)
+    r.recent_results,
+
+    -- Team 1 current season
+    t1.season AS team1_season,
+    t1.wins AS team1_wins_season,
+    t1.losses AS team1_losses_season,
+    t1.sp_rank AS team1_sp_rank,
+    e1.epa_per_play AS team1_epa,
+    e1.epa_tier AS team1_epa_tier,
+
+    -- Team 2 current season
+    t2.season AS team2_season,
+    t2.wins AS team2_wins_season,
+    t2.losses AS team2_losses_season,
+    t2.sp_rank AS team2_sp_rank,
+    e2.epa_per_play AS team2_epa,
+    e2.epa_tier AS team2_epa_tier
+
+FROM h2h_summary h
+LEFT JOIN recent_games r ON r.team1 = h.team1 AND r.team2 = h.team2
+LEFT JOIN LATERAL (
+    SELECT * FROM marts.team_season_summary
+    WHERE team = h.team1
+    ORDER BY season DESC LIMIT 1
+) t1 ON true
+LEFT JOIN LATERAL (
+    SELECT * FROM marts.team_season_summary
+    WHERE team = h.team2
+    ORDER BY season DESC LIMIT 1
+) t2 ON true
+LEFT JOIN LATERAL (
+    SELECT * FROM marts.team_epa_season
+    WHERE team = h.team1
+    ORDER BY season DESC LIMIT 1
+) e1 ON true
+LEFT JOIN LATERAL (
+    SELECT * FROM marts.team_epa_season
+    WHERE team = h.team2
+    ORDER BY season DESC LIMIT 1
+) e2 ON true;
+
+COMMENT ON VIEW api.matchup IS 'Head-to-head matchup history and current season comparison';

--- a/src/schemas/api/005_leaderboard_teams.sql
+++ b/src/schemas/api/005_leaderboard_teams.sql
@@ -1,0 +1,56 @@
+-- Team leaderboard API view
+-- Flexible team rankings/leaderboards by season
+-- Query with filters: ?season=eq.2024&order=epa_per_play.desc
+-- Exposed via PostgREST as /api/leaderboard_teams
+
+DROP VIEW IF EXISTS api.leaderboard_teams;
+
+CREATE VIEW api.leaderboard_teams AS
+SELECT
+    tss.team,
+    tss.conference,
+    tss.season,
+
+    -- Record
+    tss.games,
+    tss.wins,
+    tss.losses,
+    ROUND(tss.wins::numeric / NULLIF(tss.games, 0), 3) AS win_pct,
+    tss.conf_wins,
+    tss.conf_losses,
+
+    -- Scoring
+    tss.ppg,
+    tss.opp_ppg,
+    tss.avg_margin,
+
+    -- Ratings
+    tss.sp_rating,
+    tss.sp_rank,
+    tss.sp_offense,
+    tss.sp_defense,
+    tss.elo,
+    tss.fpi,
+
+    -- EPA metrics
+    epa.epa_per_play,
+    epa.epa_tier,
+    epa.success_rate,
+    epa.explosiveness,
+    epa.total_plays,
+
+    -- Recruiting
+    tss.recruiting_rank,
+    tss.recruiting_points,
+
+    -- Computed rankings within season
+    RANK() OVER (PARTITION BY tss.season ORDER BY tss.wins DESC, tss.avg_margin DESC) AS wins_rank,
+    RANK() OVER (PARTITION BY tss.season ORDER BY tss.ppg DESC) AS ppg_rank,
+    RANK() OVER (PARTITION BY tss.season ORDER BY tss.opp_ppg ASC) AS defense_ppg_rank,
+    RANK() OVER (PARTITION BY tss.season ORDER BY epa.epa_per_play DESC NULLS LAST) AS epa_rank
+
+FROM marts.team_season_summary tss
+LEFT JOIN marts.team_epa_season epa
+    ON epa.team = tss.team AND epa.season = tss.season;
+
+COMMENT ON VIEW api.leaderboard_teams IS 'Team leaderboard with records, ratings, EPA, and computed rankings';

--- a/src/schemas/functions/is_garbage_time.sql
+++ b/src/schemas/functions/is_garbage_time.sql
@@ -1,0 +1,17 @@
+-- Function to detect garbage time plays
+-- Garbage time: margin > 28 in 4th quarter, or > 35 in 3rd+
+-- Used to filter out non-competitive plays in EPA calculations
+
+CREATE OR REPLACE FUNCTION is_garbage_time(
+    period integer,
+    score_diff integer
+) RETURNS boolean AS $$
+BEGIN
+    RETURN (
+        (period = 4 AND ABS(COALESCE(score_diff, 0)) > 28) OR
+        (period >= 3 AND ABS(COALESCE(score_diff, 0)) > 35)
+    );
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+COMMENT ON FUNCTION is_garbage_time IS 'Returns true if play occurred in garbage time (blowout situations where score diff > 28 in Q4 or > 35 in Q3+)';

--- a/src/schemas/marts/001_team_season_summary.sql
+++ b/src/schemas/marts/001_team_season_summary.sql
@@ -1,0 +1,131 @@
+-- Team season summary: record, scoring, ratings, recruiting
+-- Enhanced version with ratings and recruiting data joined
+-- Uses team name as primary join key (dlt schema pattern)
+
+CREATE SCHEMA IF NOT EXISTS marts;
+
+DROP MATERIALIZED VIEW IF EXISTS marts.team_season_summary CASCADE;
+
+CREATE MATERIALIZED VIEW marts.team_season_summary AS
+WITH home_games AS (
+    SELECT
+        season,
+        home_team AS team,
+        home_conference AS conference,
+        home_points AS points_for,
+        away_points AS points_against,
+        CASE WHEN home_points > away_points THEN 1 ELSE 0 END AS win,
+        CASE WHEN home_points < away_points THEN 1 ELSE 0 END AS loss,
+        CASE
+            WHEN home_conference IS NOT NULL
+                AND home_conference = away_conference THEN 1
+            ELSE 0
+        END AS is_conference_game,
+        CASE
+            WHEN home_conference IS NOT NULL
+                AND home_conference = away_conference
+                AND home_points > away_points THEN 1
+            ELSE 0
+        END AS conf_win,
+        CASE
+            WHEN home_conference IS NOT NULL
+                AND home_conference = away_conference
+                AND home_points < away_points THEN 1
+            ELSE 0
+        END AS conf_loss
+    FROM core.games
+    WHERE completed = true
+),
+away_games AS (
+    SELECT
+        season,
+        away_team AS team,
+        away_conference AS conference,
+        away_points AS points_for,
+        home_points AS points_against,
+        CASE WHEN away_points > home_points THEN 1 ELSE 0 END AS win,
+        CASE WHEN away_points < home_points THEN 1 ELSE 0 END AS loss,
+        CASE
+            WHEN away_conference IS NOT NULL
+                AND home_conference = away_conference THEN 1
+            ELSE 0
+        END AS is_conference_game,
+        CASE
+            WHEN away_conference IS NOT NULL
+                AND home_conference = away_conference
+                AND away_points > home_points THEN 1
+            ELSE 0
+        END AS conf_win,
+        CASE
+            WHEN away_conference IS NOT NULL
+                AND home_conference = away_conference
+                AND away_points < home_points THEN 1
+            ELSE 0
+        END AS conf_loss
+    FROM core.games
+    WHERE completed = true
+),
+all_games AS (
+    SELECT * FROM home_games
+    UNION ALL
+    SELECT * FROM away_games
+),
+team_records AS (
+    SELECT
+        season,
+        team,
+        MAX(conference) AS conference,
+        COUNT(*) AS games,
+        SUM(win) AS wins,
+        SUM(loss) AS losses,
+        SUM(conf_win) AS conf_wins,
+        SUM(conf_loss) AS conf_losses,
+        ROUND(AVG(points_for)::numeric, 1) AS ppg,
+        ROUND(AVG(points_against)::numeric, 1) AS opp_ppg,
+        ROUND(AVG(points_for - points_against)::numeric, 1) AS avg_margin
+    FROM all_games
+    GROUP BY season, team
+)
+SELECT
+    tr.team,
+    tr.conference,
+    tr.season,
+
+    -- Record
+    tr.games::int,
+    tr.wins::int,
+    tr.losses::int,
+    tr.conf_wins::int,
+    tr.conf_losses::int,
+
+    -- Scoring
+    tr.ppg,
+    tr.opp_ppg,
+    tr.avg_margin,
+
+    -- Ratings (joined from ratings schema)
+    sp.rating AS sp_rating,
+    sp.ranking AS sp_rank,
+    sp."offense__rating" AS sp_offense,
+    sp."defense__rating" AS sp_defense,
+    elo.elo,
+    fpi.fpi,
+
+    -- Recruiting
+    rec.rank AS recruiting_rank,
+    rec.points AS recruiting_points
+
+FROM team_records tr
+LEFT JOIN ratings.sp_ratings sp ON tr.team = sp.team AND tr.season = sp.year
+LEFT JOIN ratings.elo_ratings elo ON tr.team = elo.team AND tr.season = elo.year
+LEFT JOIN ratings.fpi_ratings fpi ON tr.team = fpi.team AND tr.season = fpi.year
+LEFT JOIN recruiting.team_recruiting rec ON tr.team = rec.team AND tr.season = rec.year;
+
+-- Required for REFRESH CONCURRENTLY
+CREATE UNIQUE INDEX ON marts.team_season_summary (team, season);
+
+-- Query indexes
+CREATE INDEX ON marts.team_season_summary (season);
+CREATE INDEX ON marts.team_season_summary (conference);
+CREATE INDEX ON marts.team_season_summary (sp_rank);
+CREATE INDEX ON marts.team_season_summary (wins DESC);

--- a/src/schemas/marts/002_game_epa_calc.sql
+++ b/src/schemas/marts/002_game_epa_calc.sql
@@ -1,0 +1,42 @@
+-- Helper: EPA calculations per game/team (excluding garbage time)
+-- This is a building block for team_epa_season and other EPA-based views
+-- Depends on: is_garbage_time() function from Phase 2
+
+DROP MATERIALIZED VIEW IF EXISTS marts._game_epa_calc CASCADE;
+
+CREATE MATERIALIZED VIEW marts._game_epa_calc AS
+SELECT
+    p.game_id,
+    p.offense AS team,
+
+    -- EPA/play (excluding garbage time)
+    ROUND(AVG(p.ppa) FILTER (
+        WHERE NOT is_garbage_time(p.period::integer, p.score_diff::integer)
+    )::numeric, 4) AS epa_per_play,
+
+    -- Success rate: % of plays with positive EPA (excluding garbage time)
+    ROUND(AVG(CASE WHEN p.ppa > 0 THEN 1.0 ELSE 0.0 END) FILTER (
+        WHERE NOT is_garbage_time(p.period::integer, p.score_diff::integer)
+    )::numeric, 4) AS success_rate,
+
+    -- Explosiveness: avg EPA on successful plays only (excluding garbage time)
+    ROUND(AVG(p.ppa) FILTER (
+        WHERE p.ppa > 0
+        AND NOT is_garbage_time(p.period::integer, p.score_diff::integer)
+    )::numeric, 4) AS explosiveness,
+
+    -- Play counts
+    COUNT(*) FILTER (
+        WHERE NOT is_garbage_time(p.period::integer, p.score_diff::integer)
+    ) AS plays_non_garbage,
+    COUNT(*) AS plays_total
+
+FROM core.plays p
+WHERE p.ppa IS NOT NULL  -- Only include plays with EPA values
+GROUP BY p.game_id, p.offense;
+
+-- Required for REFRESH CONCURRENTLY
+CREATE UNIQUE INDEX ON marts._game_epa_calc (game_id, team);
+
+-- Query indexes
+CREATE INDEX ON marts._game_epa_calc (team);

--- a/src/schemas/marts/003_team_epa_season.sql
+++ b/src/schemas/marts/003_team_epa_season.sql
@@ -1,0 +1,44 @@
+-- Team EPA season summary with benchmarks
+-- Aggregates game-level EPA from _game_epa_calc into season totals
+-- Depends on: marts._game_epa_calc
+
+DROP MATERIALIZED VIEW IF EXISTS marts.team_epa_season CASCADE;
+
+CREATE MATERIALIZED VIEW marts.team_epa_season AS
+SELECT
+    epa.team,
+    g.season,
+
+    -- Aggregated EPA metrics (averaged across games)
+    ROUND(AVG(epa.epa_per_play)::numeric, 4) AS epa_per_play,
+    ROUND(AVG(epa.success_rate)::numeric, 4) AS success_rate,
+    ROUND(AVG(epa.explosiveness)::numeric, 4) AS explosiveness,
+
+    -- EPA tier benchmark
+    -- Based on historical CFB EPA distributions:
+    -- Elite: >= 0.16, Above Avg: >= 0.05, Avg: >= -0.05, Below Avg: >= -0.15
+    CASE
+        WHEN AVG(epa.epa_per_play) >= 0.16 THEN 'elite'
+        WHEN AVG(epa.epa_per_play) >= 0.05 THEN 'above_avg'
+        WHEN AVG(epa.epa_per_play) >= -0.05 THEN 'average'
+        WHEN AVG(epa.epa_per_play) >= -0.15 THEN 'below_avg'
+        ELSE 'struggling'
+    END AS epa_tier,
+
+    -- Total plays (non-garbage time)
+    SUM(epa.plays_non_garbage)::bigint AS total_plays,
+
+    -- Game count
+    COUNT(*)::int AS games_played
+
+FROM marts._game_epa_calc epa
+JOIN core.games g ON epa.game_id = g.id
+GROUP BY epa.team, g.season;
+
+-- Required for REFRESH CONCURRENTLY
+CREATE UNIQUE INDEX ON marts.team_epa_season (team, season);
+
+-- Query indexes
+CREATE INDEX ON marts.team_epa_season (season);
+CREATE INDEX ON marts.team_epa_season (season, epa_tier);
+CREATE INDEX ON marts.team_epa_season (epa_per_play DESC);

--- a/src/schemas/marts/004_situational_splits.sql
+++ b/src/schemas/marts/004_situational_splits.sql
@@ -1,0 +1,155 @@
+-- Situational splits: EPA and efficiency by game situation
+-- Grain: Team × Season
+-- Includes: down/distance, red zone, field position, late & close, play type
+
+DROP MATERIALIZED VIEW IF EXISTS marts.situational_splits CASCADE;
+
+CREATE MATERIALIZED VIEW marts.situational_splits AS
+WITH play_situations AS (
+    SELECT
+        p.offense AS team,
+        g.season,
+        p.ppa,
+        p.play_type,
+        p.down,
+        p.distance,
+        p.yards_to_goal,
+        p.period,
+        p.clock_minutes,
+        p.clock_seconds,
+        p.score_diff,
+
+        -- Situation flags
+        NOT is_garbage_time(p.period::integer, p.score_diff::integer) AS is_competitive,
+
+        -- Down classifications
+        CASE
+            WHEN p.down = 1 THEN 'first'
+            WHEN p.down = 2 AND p.distance <= 4 THEN 'second_short'
+            WHEN p.down = 2 AND p.distance > 4 THEN 'second_long'
+            WHEN p.down = 3 AND p.distance <= 3 THEN 'third_short'
+            WHEN p.down = 3 AND p.distance BETWEEN 4 AND 7 THEN 'third_medium'
+            WHEN p.down = 3 AND p.distance > 7 THEN 'third_long'
+            WHEN p.down = 4 THEN 'fourth'
+            ELSE 'other'
+        END AS down_situation,
+
+        -- Standard vs passing downs (Connelly definition)
+        -- Passing down: 2nd & 8+, 3rd & 5+
+        CASE
+            WHEN (p.down = 2 AND p.distance >= 8) OR (p.down = 3 AND p.distance >= 5) THEN true
+            ELSE false
+        END AS is_passing_down,
+
+        -- Field position zones
+        CASE
+            WHEN p.yards_to_goal <= 20 THEN 'red_zone'
+            WHEN p.yards_to_goal <= 40 THEN 'scoring_position'
+            WHEN p.yards_to_goal >= 80 THEN 'backed_up'
+            ELSE 'between_20s'
+        END AS field_zone,
+
+        -- Late & close: 4th quarter, margin <= 8
+        CASE
+            WHEN p.period = 4 AND ABS(COALESCE(p.score_diff, 0)) <= 8 THEN true
+            ELSE false
+        END AS is_late_and_close,
+
+        -- Two-minute drill: last 2 mins of half
+        CASE
+            WHEN (p.period = 2 OR p.period = 4)
+                AND COALESCE(p.clock_minutes, 0) < 2 THEN true
+            ELSE false
+        END AS is_two_minute,
+
+        -- Play type classification
+        CASE
+            WHEN p.play_type ILIKE '%rush%' OR p.play_type ILIKE '%run%' THEN 'rush'
+            WHEN p.play_type ILIKE '%pass%' OR p.play_type ILIKE '%sack%' THEN 'pass'
+            ELSE 'other'
+        END AS play_category
+
+    FROM core.plays p
+    JOIN core.games g ON p.game_id = g.id
+    WHERE p.ppa IS NOT NULL
+)
+SELECT
+    team,
+    season,
+
+    -- === OVERALL (non-garbage time) ===
+    COUNT(*) FILTER (WHERE is_competitive) AS total_plays,
+    ROUND(AVG(ppa) FILTER (WHERE is_competitive)::numeric, 4) AS epa_per_play,
+    ROUND(AVG(CASE WHEN ppa > 0 THEN 1.0 ELSE 0.0 END) FILTER (WHERE is_competitive)::numeric, 4) AS success_rate,
+
+    -- === BY DOWN ===
+    -- First down
+    ROUND(AVG(ppa) FILTER (WHERE is_competitive AND down = 1)::numeric, 4) AS first_down_epa,
+    ROUND(AVG(CASE WHEN ppa > 0 THEN 1.0 ELSE 0.0 END) FILTER (WHERE is_competitive AND down = 1)::numeric, 4) AS first_down_success,
+
+    -- Second down
+    ROUND(AVG(ppa) FILTER (WHERE is_competitive AND down = 2)::numeric, 4) AS second_down_epa,
+    ROUND(AVG(CASE WHEN ppa > 0 THEN 1.0 ELSE 0.0 END) FILTER (WHERE is_competitive AND down = 2)::numeric, 4) AS second_down_success,
+
+    -- Third down
+    ROUND(AVG(ppa) FILTER (WHERE is_competitive AND down = 3)::numeric, 4) AS third_down_epa,
+    ROUND(AVG(CASE WHEN ppa > 0 THEN 1.0 ELSE 0.0 END) FILTER (WHERE is_competitive AND down = 3)::numeric, 4) AS third_down_success,
+    COUNT(*) FILTER (WHERE is_competitive AND down = 3) AS third_down_attempts,
+
+    -- Third down by distance
+    ROUND(AVG(CASE WHEN ppa > 0 THEN 1.0 ELSE 0.0 END) FILTER (WHERE is_competitive AND down_situation = 'third_short')::numeric, 4) AS third_short_success,
+    ROUND(AVG(CASE WHEN ppa > 0 THEN 1.0 ELSE 0.0 END) FILTER (WHERE is_competitive AND down_situation = 'third_medium')::numeric, 4) AS third_medium_success,
+    ROUND(AVG(CASE WHEN ppa > 0 THEN 1.0 ELSE 0.0 END) FILTER (WHERE is_competitive AND down_situation = 'third_long')::numeric, 4) AS third_long_success,
+
+    -- === STANDARD vs PASSING DOWNS ===
+    ROUND(AVG(ppa) FILTER (WHERE is_competitive AND NOT is_passing_down)::numeric, 4) AS standard_down_epa,
+    ROUND(AVG(ppa) FILTER (WHERE is_competitive AND is_passing_down)::numeric, 4) AS passing_down_epa,
+    ROUND(AVG(CASE WHEN ppa > 0 THEN 1.0 ELSE 0.0 END) FILTER (WHERE is_competitive AND NOT is_passing_down)::numeric, 4) AS standard_down_success,
+    ROUND(AVG(CASE WHEN ppa > 0 THEN 1.0 ELSE 0.0 END) FILTER (WHERE is_competitive AND is_passing_down)::numeric, 4) AS passing_down_success,
+
+    -- === RED ZONE ===
+    COUNT(*) FILTER (WHERE is_competitive AND field_zone = 'red_zone') AS red_zone_plays,
+    ROUND(AVG(ppa) FILTER (WHERE is_competitive AND field_zone = 'red_zone')::numeric, 4) AS red_zone_epa,
+    ROUND(AVG(CASE WHEN ppa > 0 THEN 1.0 ELSE 0.0 END) FILTER (WHERE is_competitive AND field_zone = 'red_zone')::numeric, 4) AS red_zone_success,
+
+    -- === FIELD POSITION ===
+    ROUND(AVG(ppa) FILTER (WHERE is_competitive AND field_zone = 'backed_up')::numeric, 4) AS backed_up_epa,
+    ROUND(AVG(ppa) FILTER (WHERE is_competitive AND field_zone = 'scoring_position')::numeric, 4) AS scoring_position_epa,
+
+    -- === LATE & CLOSE ===
+    COUNT(*) FILTER (WHERE is_competitive AND is_late_and_close) AS late_close_plays,
+    ROUND(AVG(ppa) FILTER (WHERE is_competitive AND is_late_and_close)::numeric, 4) AS late_close_epa,
+    ROUND(AVG(CASE WHEN ppa > 0 THEN 1.0 ELSE 0.0 END) FILTER (WHERE is_competitive AND is_late_and_close)::numeric, 4) AS late_close_success,
+
+    -- === TWO-MINUTE DRILL ===
+    COUNT(*) FILTER (WHERE is_competitive AND is_two_minute) AS two_minute_plays,
+    ROUND(AVG(ppa) FILTER (WHERE is_competitive AND is_two_minute)::numeric, 4) AS two_minute_epa,
+
+    -- === PLAY TYPE ===
+    -- Rush
+    COUNT(*) FILTER (WHERE is_competitive AND play_category = 'rush') AS rush_plays,
+    ROUND(AVG(ppa) FILTER (WHERE is_competitive AND play_category = 'rush')::numeric, 4) AS rush_epa,
+    ROUND(AVG(CASE WHEN ppa > 0 THEN 1.0 ELSE 0.0 END) FILTER (WHERE is_competitive AND play_category = 'rush')::numeric, 4) AS rush_success,
+
+    -- Pass
+    COUNT(*) FILTER (WHERE is_competitive AND play_category = 'pass') AS pass_plays,
+    ROUND(AVG(ppa) FILTER (WHERE is_competitive AND play_category = 'pass')::numeric, 4) AS pass_epa,
+    ROUND(AVG(CASE WHEN ppa > 0 THEN 1.0 ELSE 0.0 END) FILTER (WHERE is_competitive AND play_category = 'pass')::numeric, 4) AS pass_success,
+
+    -- Play calling tendency (rush rate)
+    ROUND(
+        COUNT(*) FILTER (WHERE is_competitive AND play_category = 'rush')::numeric /
+        NULLIF(COUNT(*) FILTER (WHERE is_competitive AND play_category IN ('rush', 'pass')), 0),
+        4
+    ) AS rush_rate
+
+FROM play_situations
+GROUP BY team, season;
+
+-- Required for REFRESH CONCURRENTLY
+CREATE UNIQUE INDEX ON marts.situational_splits (team, season);
+
+-- Query indexes
+CREATE INDEX ON marts.situational_splits (season);
+CREATE INDEX ON marts.situational_splits (third_down_success DESC);
+CREATE INDEX ON marts.situational_splits (red_zone_success DESC);

--- a/src/schemas/marts/005_defensive_havoc.sql
+++ b/src/schemas/marts/005_defensive_havoc.sql
@@ -1,0 +1,97 @@
+-- Defensive havoc metrics: disruptive plays and opponent EPA
+-- Grain: Team × Season (defensive perspective)
+-- Includes: stuffs, sacks, turnovers, havoc rate, opponent EPA
+
+DROP MATERIALIZED VIEW IF EXISTS marts.defensive_havoc CASCADE;
+
+CREATE MATERIALIZED VIEW marts.defensive_havoc AS
+WITH defensive_plays AS (
+    SELECT
+        p.defense AS team,
+        g.season,
+        p.ppa,
+        p.play_type,
+        p.yards_gained,
+
+        NOT is_garbage_time(p.period::integer, p.score_diff::integer) AS is_competitive,
+
+        -- Havoc plays (disruptive plays)
+        CASE
+            WHEN p.play_type ILIKE '%sack%' THEN true
+            WHEN p.play_type ILIKE '%interception%' THEN true
+            WHEN p.play_type ILIKE '%fumble%' AND p.play_type ILIKE '%lost%' THEN true
+            WHEN p.play_type ILIKE '%fumble recovery%' THEN true
+            ELSE false
+        END AS is_havoc,
+
+        -- Specific havoc types
+        CASE WHEN p.play_type ILIKE '%sack%' THEN 1 ELSE 0 END AS is_sack,
+        CASE WHEN p.play_type ILIKE '%interception%' THEN 1 ELSE 0 END AS is_interception,
+        CASE WHEN p.play_type ILIKE '%fumble%' THEN 1 ELSE 0 END AS is_fumble,
+
+        -- Stuff: rush for <= 0 yards
+        CASE
+            WHEN (p.play_type ILIKE '%rush%' OR p.play_type ILIKE '%run%')
+                AND COALESCE(p.yards_gained, 0) <= 0 THEN true
+            ELSE false
+        END AS is_stuff,
+
+        -- TFL: tackle for loss (any play for negative yards)
+        CASE WHEN COALESCE(p.yards_gained, 0) < 0 THEN true ELSE false END AS is_tfl
+
+    FROM core.plays p
+    JOIN core.games g ON p.game_id = g.id
+    WHERE p.defense IS NOT NULL
+)
+SELECT
+    team,
+    season,
+
+    -- Play counts
+    COUNT(*) FILTER (WHERE is_competitive) AS defensive_plays,
+
+    -- Opponent EPA (lower is better for defense)
+    ROUND(AVG(ppa) FILTER (WHERE is_competitive)::numeric, 4) AS opp_epa_per_play,
+    ROUND(AVG(CASE WHEN ppa > 0 THEN 1.0 ELSE 0.0 END) FILTER (WHERE is_competitive)::numeric, 4) AS opp_success_rate,
+
+    -- Havoc plays
+    SUM(CASE WHEN is_competitive AND is_havoc THEN 1 ELSE 0 END)::int AS havoc_plays,
+    ROUND(
+        SUM(CASE WHEN is_competitive AND is_havoc THEN 1 ELSE 0 END)::numeric /
+        NULLIF(COUNT(*) FILTER (WHERE is_competitive), 0),
+        4
+    ) AS havoc_rate,
+
+    -- Sacks
+    SUM(CASE WHEN is_competitive THEN is_sack ELSE 0 END)::int AS sacks,
+
+    -- Interceptions
+    SUM(CASE WHEN is_competitive THEN is_interception ELSE 0 END)::int AS interceptions,
+
+    -- Fumbles forced/recovered
+    SUM(CASE WHEN is_competitive THEN is_fumble ELSE 0 END)::int AS fumbles,
+
+    -- Total turnovers
+    SUM(CASE WHEN is_competitive THEN is_interception + is_fumble ELSE 0 END)::int AS turnovers_forced,
+
+    -- Stuffs (rushes for <= 0 yards)
+    SUM(CASE WHEN is_competitive AND is_stuff THEN 1 ELSE 0 END)::int AS stuffs,
+    ROUND(
+        SUM(CASE WHEN is_competitive AND is_stuff THEN 1 ELSE 0 END)::numeric /
+        NULLIF(COUNT(*) FILTER (WHERE is_competitive AND (play_type ILIKE '%rush%' OR play_type ILIKE '%run%')), 0),
+        4
+    ) AS stuff_rate,
+
+    -- TFLs
+    SUM(CASE WHEN is_competitive AND is_tfl THEN 1 ELSE 0 END)::int AS tfls
+
+FROM defensive_plays
+GROUP BY team, season;
+
+-- Required for REFRESH CONCURRENTLY
+CREATE UNIQUE INDEX ON marts.defensive_havoc (team, season);
+
+-- Query indexes
+CREATE INDEX ON marts.defensive_havoc (season);
+CREATE INDEX ON marts.defensive_havoc (havoc_rate DESC);
+CREATE INDEX ON marts.defensive_havoc (opp_epa_per_play ASC);

--- a/src/schemas/marts/006_scoring_opportunities.sql
+++ b/src/schemas/marts/006_scoring_opportunities.sql
@@ -1,0 +1,86 @@
+-- Scoring opportunities: drive efficiency and red zone conversion
+-- Grain: Team × Season
+-- Uses drives table for possession-level analysis
+
+DROP MATERIALIZED VIEW IF EXISTS marts.scoring_opportunities CASCADE;
+
+CREATE MATERIALIZED VIEW marts.scoring_opportunities AS
+SELECT
+    d.offense AS team,
+    d.season,
+
+    -- Drive counts
+    COUNT(*) AS total_drives,
+
+    -- Scoring drives
+    COUNT(*) FILTER (WHERE d.drive_result IN ('TD', 'FG', 'Touchdown', 'Field Goal')) AS scoring_drives,
+    ROUND(
+        COUNT(*) FILTER (WHERE d.drive_result IN ('TD', 'FG', 'Touchdown', 'Field Goal'))::numeric /
+        NULLIF(COUNT(*), 0),
+        4
+    ) AS scoring_rate,
+
+    -- Touchdown drives
+    COUNT(*) FILTER (WHERE d.drive_result IN ('TD', 'Touchdown')) AS td_drives,
+    ROUND(
+        COUNT(*) FILTER (WHERE d.drive_result IN ('TD', 'Touchdown'))::numeric /
+        NULLIF(COUNT(*), 0),
+        4
+    ) AS td_rate,
+
+    -- Points per drive (estimated: TD=7, FG=3)
+    ROUND(
+        (COUNT(*) FILTER (WHERE d.drive_result IN ('TD', 'Touchdown')) * 7.0 +
+         COUNT(*) FILTER (WHERE d.drive_result IN ('FG', 'Field Goal')) * 3.0) /
+        NULLIF(COUNT(*), 0),
+        3
+    ) AS points_per_drive,
+
+    -- Turnover drives
+    COUNT(*) FILTER (WHERE d.drive_result IN ('INT', 'FUMBLE', 'Interception', 'Fumble', 'Fumble Lost', 'Interception Return')) AS turnover_drives,
+    ROUND(
+        COUNT(*) FILTER (WHERE d.drive_result IN ('INT', 'FUMBLE', 'Interception', 'Fumble', 'Fumble Lost', 'Interception Return'))::numeric /
+        NULLIF(COUNT(*), 0),
+        4
+    ) AS turnover_rate,
+
+    -- Punt drives
+    COUNT(*) FILTER (WHERE d.drive_result IN ('PUNT', 'Punt')) AS punt_drives,
+    ROUND(
+        COUNT(*) FILTER (WHERE d.drive_result IN ('PUNT', 'Punt'))::numeric /
+        NULLIF(COUNT(*), 0),
+        4
+    ) AS punt_rate,
+
+    -- Average drive stats
+    ROUND(AVG(d.plays)::numeric, 1) AS avg_plays_per_drive,
+    ROUND(AVG(d.yards)::numeric, 1) AS avg_yards_per_drive,
+    ROUND(AVG(d.elapsed_minutes)::numeric, 2) AS avg_time_per_drive,
+
+    -- Red zone drives (started inside opponent 20)
+    COUNT(*) FILTER (WHERE d.start_yards_to_goal <= 20) AS red_zone_drives,
+    COUNT(*) FILTER (WHERE d.start_yards_to_goal <= 20 AND d.drive_result IN ('TD', 'FG', 'Touchdown', 'Field Goal')) AS red_zone_scores,
+    ROUND(
+        COUNT(*) FILTER (WHERE d.start_yards_to_goal <= 20 AND d.drive_result IN ('TD', 'FG', 'Touchdown', 'Field Goal'))::numeric /
+        NULLIF(COUNT(*) FILTER (WHERE d.start_yards_to_goal <= 20), 0),
+        4
+    ) AS red_zone_scoring_rate,
+
+    -- Red zone TD rate
+    ROUND(
+        COUNT(*) FILTER (WHERE d.start_yards_to_goal <= 20 AND d.drive_result IN ('TD', 'Touchdown'))::numeric /
+        NULLIF(COUNT(*) FILTER (WHERE d.start_yards_to_goal <= 20), 0),
+        4
+    ) AS red_zone_td_rate
+
+FROM core.drives d
+WHERE d.offense IS NOT NULL
+GROUP BY d.offense, d.season;
+
+-- Required for REFRESH CONCURRENTLY
+CREATE UNIQUE INDEX ON marts.scoring_opportunities (team, season);
+
+-- Query indexes
+CREATE INDEX ON marts.scoring_opportunities (season);
+CREATE INDEX ON marts.scoring_opportunities (points_per_drive DESC);
+CREATE INDEX ON marts.scoring_opportunities (scoring_rate DESC);

--- a/src/schemas/marts/007_matchup_history.sql
+++ b/src/schemas/marts/007_matchup_history.sql
@@ -1,0 +1,96 @@
+-- Matchup history: head-to-head records between teams
+-- Grain: Team1 × Team2 (alphabetically ordered for uniqueness)
+-- Includes: all-time record, recent form, avg margin
+
+DROP MATERIALIZED VIEW IF EXISTS marts.matchup_history CASCADE;
+
+CREATE MATERIALIZED VIEW marts.matchup_history AS
+WITH game_matchups AS (
+    SELECT
+        LEAST(home_team, away_team) AS team1,
+        GREATEST(home_team, away_team) AS team2,
+        season,
+        start_date,
+        home_team,
+        away_team,
+        home_points,
+        away_points,
+        venue,
+        CASE
+            WHEN home_points > away_points THEN home_team
+            WHEN away_points > home_points THEN away_team
+            ELSE NULL
+        END AS winner,
+        ABS(home_points - away_points) AS margin
+    FROM core.games
+    WHERE completed = true
+      AND home_points IS NOT NULL
+      AND away_points IS NOT NULL
+)
+SELECT
+    team1,
+    team2,
+
+    -- All-time record
+    COUNT(*) AS total_games,
+    SUM(CASE WHEN winner = team1 THEN 1 ELSE 0 END)::int AS team1_wins,
+    SUM(CASE WHEN winner = team2 THEN 1 ELSE 0 END)::int AS team2_wins,
+    SUM(CASE WHEN winner IS NULL THEN 1 ELSE 0 END)::int AS ties,
+
+    -- Series dates
+    MIN(season) AS first_meeting_year,
+    MAX(season) AS last_meeting_year,
+    MIN(start_date) AS first_meeting_date,
+    MAX(start_date) AS last_meeting_date,
+
+    -- Margins
+    ROUND(AVG(margin)::numeric, 1) AS avg_margin,
+    MAX(margin)::int AS largest_margin,
+
+    -- Team1 perspective stats
+    ROUND(AVG(
+        CASE
+            WHEN home_team = team1 THEN home_points - away_points
+            ELSE away_points - home_points
+        END
+    )::numeric, 1) AS team1_avg_margin,
+
+    SUM(
+        CASE
+            WHEN home_team = team1 THEN home_points
+            ELSE away_points
+        END
+    )::int AS team1_total_points,
+
+    SUM(
+        CASE
+            WHEN home_team = team2 THEN home_points
+            ELSE away_points
+        END
+    )::int AS team2_total_points,
+
+    -- Recent form (last 10 years)
+    SUM(CASE WHEN winner = team1 AND season >= 2015 THEN 1 ELSE 0 END)::int AS team1_wins_last_10yr,
+    SUM(CASE WHEN winner = team2 AND season >= 2015 THEN 1 ELSE 0 END)::int AS team2_wins_last_10yr,
+    COUNT(*) FILTER (WHERE season >= 2015)::int AS games_last_10yr,
+
+    -- Current streak (simplified: who won last game)
+    (
+        SELECT winner
+        FROM game_matchups gm2
+        WHERE gm2.team1 = game_matchups.team1
+          AND gm2.team2 = game_matchups.team2
+        ORDER BY start_date DESC
+        LIMIT 1
+    ) AS last_winner
+
+FROM game_matchups
+GROUP BY team1, team2;
+
+-- Required for REFRESH CONCURRENTLY
+CREATE UNIQUE INDEX ON marts.matchup_history (team1, team2);
+
+-- Query indexes
+CREATE INDEX ON marts.matchup_history (team1);
+CREATE INDEX ON marts.matchup_history (team2);
+CREATE INDEX ON marts.matchup_history (total_games DESC);

--- a/src/schemas/marts/008_recruiting_class.sql
+++ b/src/schemas/marts/008_recruiting_class.sql
@@ -1,0 +1,103 @@
+-- Recruiting class breakdown: star distribution and position groups
+-- Grain: Team × Year
+-- Includes: star counts, blue chip ratio, top positions
+
+DROP MATERIALIZED VIEW IF EXISTS marts.recruiting_class CASCADE;
+
+CREATE MATERIALIZED VIEW marts.recruiting_class AS
+WITH recruit_details AS (
+    SELECT
+        r.committed_to AS team,
+        r.year,
+        r.stars,
+        r.rating,
+        r.position,
+        r.ranking,
+        -- Position groupings
+        CASE
+            WHEN r.position IN ('QB') THEN 'qb'
+            WHEN r.position IN ('RB', 'FB', 'APB') THEN 'rb'
+            WHEN r.position IN ('WR', 'TE') THEN 'receiver'
+            WHEN r.position IN ('OT', 'OG', 'OC', 'OL') THEN 'oline'
+            WHEN r.position IN ('DE', 'DT', 'DL', 'EDGE', 'SDE', 'WDE') THEN 'dline'
+            WHEN r.position IN ('ILB', 'OLB', 'LB') THEN 'lb'
+            WHEN r.position IN ('CB', 'S', 'DB') THEN 'db'
+            WHEN r.position IN ('K', 'P', 'LS') THEN 'specialist'
+            ELSE 'ath'
+        END AS position_group
+    FROM recruiting.recruits r
+    WHERE r.committed_to IS NOT NULL
+),
+position_counts AS (
+    SELECT
+        team,
+        year,
+        position_group,
+        COUNT(*) AS cnt
+    FROM recruit_details
+    GROUP BY team, year, position_group
+),
+top_position AS (
+    SELECT DISTINCT ON (team, year)
+        team,
+        year,
+        position_group AS top_position_group
+    FROM position_counts
+    ORDER BY team, year, cnt DESC
+)
+SELECT
+    rd.team,
+    rd.year,
+
+    -- Team recruiting summary (from team_recruiting table)
+    tr.rank AS national_rank,
+    tr.points AS total_points,
+
+    -- Commit counts
+    COUNT(*) AS total_commits,
+
+    -- Star breakdown
+    COUNT(*) FILTER (WHERE rd.stars = 5)::int AS five_stars,
+    COUNT(*) FILTER (WHERE rd.stars = 4)::int AS four_stars,
+    COUNT(*) FILTER (WHERE rd.stars = 3)::int AS three_stars,
+    COUNT(*) FILTER (WHERE rd.stars = 2)::int AS two_stars,
+    COUNT(*) FILTER (WHERE rd.stars IS NULL OR rd.stars < 2)::int AS unrated,
+
+    -- Blue chip ratio (4* and 5* / total)
+    ROUND(
+        (COUNT(*) FILTER (WHERE rd.stars >= 4))::numeric /
+        NULLIF(COUNT(*), 0),
+        4
+    ) AS blue_chip_ratio,
+
+    -- Average rating
+    ROUND(AVG(rd.rating)::numeric, 4) AS avg_rating,
+    MAX(rd.rating) AS top_rating,
+
+    -- Best recruit rank
+    MIN(rd.ranking) FILTER (WHERE rd.ranking IS NOT NULL) AS best_recruit_rank,
+
+    -- Position group counts
+    COUNT(*) FILTER (WHERE position_group = 'qb')::int AS qb_commits,
+    COUNT(*) FILTER (WHERE position_group = 'rb')::int AS rb_commits,
+    COUNT(*) FILTER (WHERE position_group = 'receiver')::int AS receiver_commits,
+    COUNT(*) FILTER (WHERE position_group = 'oline')::int AS oline_commits,
+    COUNT(*) FILTER (WHERE position_group = 'dline')::int AS dline_commits,
+    COUNT(*) FILTER (WHERE position_group = 'lb')::int AS lb_commits,
+    COUNT(*) FILTER (WHERE position_group = 'db')::int AS db_commits,
+
+    -- Top position group
+    tp.top_position_group
+
+FROM recruit_details rd
+LEFT JOIN recruiting.team_recruiting tr ON tr.team = rd.team AND tr.year = rd.year
+LEFT JOIN top_position tp ON tp.team = rd.team AND tp.year = rd.year
+GROUP BY rd.team, rd.year, tr.rank, tr.points, tp.top_position_group;
+
+-- Required for REFRESH CONCURRENTLY
+CREATE UNIQUE INDEX ON marts.recruiting_class (team, year);
+
+-- Query indexes
+CREATE INDEX ON marts.recruiting_class (year);
+CREATE INDEX ON marts.recruiting_class (national_rank);
+CREATE INDEX ON marts.recruiting_class (blue_chip_ratio DESC);

--- a/src/schemas/marts/009_coach_record.sql
+++ b/src/schemas/marts/009_coach_record.sql
@@ -1,0 +1,90 @@
+-- Coach record: tenure and performance by team
+-- Grain: Coach × Team
+-- Note: ref.coaches stores seasons as JSONB array
+
+DROP MATERIALIZED VIEW IF EXISTS marts.coach_record CASCADE;
+
+CREATE MATERIALIZED VIEW marts.coach_record AS
+WITH coach_seasons AS (
+    -- Unnest the seasons JSONB array from coaches table
+    SELECT
+        c.first_name,
+        c.last_name,
+        c.first_name || ' ' || c.last_name AS coach_name,
+        s->>'school' AS team,
+        (s->>'year')::int AS season,
+        (s->>'games')::int AS games,
+        (s->>'wins')::int AS wins,
+        (s->>'losses')::int AS losses,
+        (s->>'ties')::int AS ties,
+        (s->>'preseason_rank')::int AS preseason_rank,
+        (s->>'postseason_rank')::int AS postseason_rank,
+        s->>'srs' AS srs,
+        s->>'sp_overall' AS sp_overall,
+        s->>'sp_offense' AS sp_offense,
+        s->>'sp_defense' AS sp_defense
+    FROM ref.coaches c,
+    LATERAL jsonb_array_elements(c.seasons) AS s
+    WHERE s->>'school' IS NOT NULL
+),
+coach_team_agg AS (
+    SELECT
+        coach_name,
+        first_name,
+        last_name,
+        team,
+        MIN(season) AS first_season,
+        MAX(season) AS last_season,
+        COUNT(DISTINCT season) AS seasons_at_team,
+        SUM(games) AS total_games,
+        SUM(wins) AS total_wins,
+        SUM(losses) AS total_losses,
+        SUM(COALESCE(ties, 0)) AS total_ties,
+        -- First and last season rankings
+        MIN(preseason_rank) FILTER (WHERE season = (SELECT MIN(season) FROM coach_seasons cs2 WHERE cs2.coach_name = coach_seasons.coach_name AND cs2.team = coach_seasons.team)) AS first_preseason_rank,
+        MIN(postseason_rank) FILTER (WHERE season = (SELECT MAX(season) FROM coach_seasons cs2 WHERE cs2.coach_name = coach_seasons.coach_name AND cs2.team = coach_seasons.team)) AS last_postseason_rank
+    FROM coach_seasons
+    GROUP BY coach_name, first_name, last_name, team
+)
+SELECT
+    cta.coach_name,
+    cta.first_name,
+    cta.last_name,
+    cta.team,
+    cta.first_season,
+    cta.last_season,
+    cta.seasons_at_team,
+
+    -- Record
+    cta.total_games,
+    cta.total_wins,
+    cta.total_losses,
+    cta.total_ties,
+
+    -- Win percentage
+    ROUND(
+        cta.total_wins::numeric /
+        NULLIF(cta.total_wins + cta.total_losses, 0),
+        4
+    ) AS win_pct,
+
+    -- Ranking trajectory
+    cta.first_preseason_rank,
+    cta.last_postseason_rank,
+
+    -- Average recruiting rank during tenure
+    ROUND(AVG(tr.rank)::numeric, 1) AS avg_recruiting_rank
+
+FROM coach_team_agg cta
+LEFT JOIN recruiting.team_recruiting tr
+    ON tr.team = cta.team
+    AND tr.year BETWEEN cta.first_season AND cta.last_season;
+
+-- Required for REFRESH CONCURRENTLY
+CREATE UNIQUE INDEX ON marts.coach_record (coach_name, team);
+
+-- Query indexes
+CREATE INDEX ON marts.coach_record (team);
+CREATE INDEX ON marts.coach_record (coach_name);
+CREATE INDEX ON marts.coach_record (win_pct DESC);
+CREATE INDEX ON marts.coach_record (total_wins DESC);

--- a/tests/test_sources/test_rosters.py
+++ b/tests/test_sources/test_rosters.py
@@ -1,0 +1,72 @@
+"""Tests for roster data source."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+def test_rosters_resource_yields_players():
+    """Roster endpoint should yield player records with team/year context."""
+    from src.pipelines.sources.rosters import rosters_resource
+
+    mock_response = [
+        {"id": 12345, "first_name": "Jalen", "last_name": "Milroe", "position": "QB", "jersey": 4},
+        {"id": 12346, "first_name": "Ryan", "last_name": "Williams", "position": "WR", "jersey": 2},
+    ]
+
+    with patch("src.pipelines.sources.rosters.get_client") as mock_get_client, \
+         patch("src.pipelines.sources.rosters.make_request") as mock_make_request:
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_make_request.return_value = mock_response
+
+        results = list(rosters_resource(teams=["Alabama"], years=[2024]))
+
+        assert len(results) == 2
+        assert results[0]["id"] == 12345
+        assert results[0]["team"] == "Alabama"
+        assert results[0]["year"] == 2024
+
+
+def test_rosters_resource_iterates_teams_and_years():
+    """Should call API for each team/year combination."""
+    from src.pipelines.sources.rosters import rosters_resource
+
+    with patch("src.pipelines.sources.rosters.get_client") as mock_get_client, \
+         patch("src.pipelines.sources.rosters.make_request") as mock_make_request:
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_make_request.return_value = []
+
+        list(rosters_resource(teams=["Alabama", "Georgia"], years=[2023, 2024]))
+
+        # 2 teams x 2 years = 4 API calls
+        assert mock_make_request.call_count == 4
+
+
+def test_rosters_resource_handles_empty_response():
+    """Should handle teams with no roster data gracefully."""
+    from src.pipelines.sources.rosters import rosters_resource
+
+    with patch("src.pipelines.sources.rosters.get_client") as mock_get_client, \
+         patch("src.pipelines.sources.rosters.make_request") as mock_make_request:
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_make_request.return_value = []
+
+        results = list(rosters_resource(teams=["Alabama"], years=[2024]))
+
+        assert len(results) == 0
+
+
+def test_rosters_source_returns_resource():
+    """Rosters source should return the rosters resource."""
+    from src.pipelines.sources.rosters import rosters_source
+
+    with patch("src.pipelines.sources.rosters.get_client") as mock_get_client:
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        source = rosters_source(teams=["Alabama"], years=[2024])
+
+        # Source should return a list containing the resource
+        assert source is not None

--- a/tests/test_sources/test_wepa.py
+++ b/tests/test_sources/test_wepa.py
@@ -1,0 +1,98 @@
+"""Tests for WEPA (opponent-adjusted EPA) data source."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+def test_wepa_team_season_resource_yields_data():
+    """WEPA endpoint should yield opponent-adjusted EPA by team/season."""
+    from src.pipelines.sources.wepa import wepa_team_season_resource
+
+    mock_response = [
+        {
+            "team": "Alabama",
+            "year": 2024,
+            "offense": {"overall": 0.25, "passing": 0.18, "rushing": 0.32},
+            "defense": {"overall": -0.15, "passing": -0.12, "rushing": -0.18},
+        },
+        {
+            "team": "Georgia",
+            "year": 2024,
+            "offense": {"overall": 0.22},
+            "defense": {"overall": -0.18},
+        },
+    ]
+
+    with patch("src.pipelines.sources.wepa.get_client") as mock_get_client, \
+         patch("src.pipelines.sources.wepa.make_request") as mock_make_request:
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_make_request.return_value = mock_response
+
+        results = list(wepa_team_season_resource(years=[2024]))
+
+        assert len(results) == 2
+        assert results[0]["team"] == "Alabama"
+        assert results[0]["year"] == 2024
+
+
+def test_wepa_team_season_iterates_years():
+    """Should call API for each year."""
+    from src.pipelines.sources.wepa import wepa_team_season_resource
+
+    with patch("src.pipelines.sources.wepa.get_client") as mock_get_client, \
+         patch("src.pipelines.sources.wepa.make_request") as mock_make_request:
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_make_request.return_value = []
+
+        list(wepa_team_season_resource(years=[2023, 2024]))
+
+        # Should call API twice (once per year)
+        assert mock_make_request.call_count == 2
+
+
+def test_wepa_players_passing_resource_yields_data():
+    """WEPA passing endpoint should yield player passing EPA."""
+    from src.pipelines.sources.wepa import wepa_players_passing_resource
+
+    mock_response = [
+        {
+            "id": 12345,
+            "name": "Jalen Milroe",
+            "team": "Alabama",
+            "overall": 0.28,
+        },
+    ]
+
+    with patch("src.pipelines.sources.wepa.get_client") as mock_get_client, \
+         patch("src.pipelines.sources.wepa.make_request") as mock_make_request:
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_make_request.return_value = mock_response
+
+        results = list(wepa_players_passing_resource(years=[2024]))
+
+        assert len(results) == 1
+        assert results[0]["id"] == 12345
+
+
+def test_wepa_source_returns_all_resources():
+    """WEPA source should return all WEPA resources."""
+    from src.pipelines.sources.wepa import wepa_source
+
+    with patch("src.pipelines.sources.wepa.get_client") as mock_get_client:
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        source = wepa_source(years=[2024])
+
+        # Source should return a DltSource with resources
+        assert source is not None
+        # Should have 4 resources: team_season, players_passing, players_rushing, players_kicking
+        resource_names = [r.name for r in source.resources.values()]
+        assert len(resource_names) == 4
+        assert "wepa_team_season" in resource_names
+        assert "wepa_players_passing" in resource_names
+        assert "wepa_players_rushing" in resource_names
+        assert "wepa_players_kicking" in resource_names


### PR DESCRIPTION
## Summary

- **Phase 1: Endpoint Coverage** - Added rosters and WEPA pipeline sources for player-team linkage and opponent-adjusted EPA
- **Phase 2: Schema Hardening** - Added `is_garbage_time()` function, positions reference table, and `score_diff` generated column on plays
- **Phase 3: Marts Layer** - Created 9 materialized views including `team_season_summary`, `team_epa_season`, `situational_splits`, `defensive_havoc`, `scoring_opportunities`, `matchup_history`, `recruiting_class`, and `coach_record`
- **Phase 4: API Views** - Added 5 PostgREST-friendly views: `team_detail`, `team_history`, `game_detail`, `matchup`, and `leaderboard_teams`
- **Phase 5: Refresh Script** - Added `scripts/refresh_marts.py` for dependency-ordered materialized view refresh

## Test Plan

- [x] All 270 tests pass
- [ ] Run Phase 6 backfill (rosters, rankings, WEPA data)
- [ ] Run Phase 7 validation queries against marts and API views