### PR TITLE
feat: Add 5 missing CFBD endpoints and sync 7 existing

### DIFF
--- a/docs/plans/2026-01-31-cfb-scout-agent-design.md
+++ b/docs/plans/2026-01-31-cfb-scout-agent-design.md
@@ -1,0 +1,291 @@
+# CFB Scout Agent Design
+
+**Goal:** Build a scouting intelligence platform that crawls recruiting sites, social media, and news sources, then uses Claude to synthesize player/team sentiment and store structured data for cfb-app consumption.
+
+## System Overview
+
+The **CFB Scout Agent** is a scheduled Python service that:
+1. Crawls scouting sources (247Sports, Reddit, X, etc.)
+2. Extracts and tags player/team entities
+3. Synthesizes content using Claude into structured grades, traits, and sentiment
+4. Stores results in Supabase for cfb-app to query
+
+### Core Entities
+
+- **Player profiles** - Draft prospects and transfer portal players with aggregated scouting grades, sentiment, and source citations
+- **Player timeline** - Longitudinal tracking from recruit → college career → draft prospect
+- **Team rosters** - Position group analysis, depth chart projections, and overall roster sentiment
+- **Scouting reports** - Raw collected articles/posts with source, date, player/team tags
+
+### Data Flow
+
+```
+Sources (247, Rivals, Reddit, X)
+    → Crawlers (scheduled)
+    → Raw content table (scouting.reports)
+    → Claude summarization
+    → Structured entities (players, teams, timelines)
+    → Supabase tables
+    → cfb-app queries via API
+```
+
+### Tech Stack
+
+- Python + Claude API for agent logic
+- Supabase Postgres for storage (same instance as cfb-database)
+- Scheduled via cron or Supabase Edge Functions
+- Web scraping: httpx + BeautifulSoup / Playwright for JS-heavy sites
+- APIs: Reddit (PRAW), X (tweepy), news APIs
+
+---
+
+## Data Model
+
+New schema: `scouting`
+
+### scouting.players
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | serial | Primary key |
+| player_id | bigint | Links to core.roster or recruiting.recruits |
+| name | text | Player name |
+| position | text | Position |
+| team | text | Current team |
+| class_year | int | Eligibility year |
+| current_status | text | recruit, active, transfer, draft_eligible, drafted |
+| composite_grade | int | AI-synthesized 0-100 grade |
+| traits | jsonb | {athleticism, technique, football_iq, leadership, durability} |
+| draft_projection | text | Day 1, Day 2, Day 3, UDFA, etc. |
+| comps | text[] | Player comparisons |
+| last_updated | timestamptz | Last refresh |
+
+### scouting.player_timeline
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | serial | Primary key |
+| player_id | bigint | FK to scouting.players |
+| snapshot_date | date | When snapshot was taken |
+| status | text | recruit, freshman, sophomore, etc. |
+| sentiment_score | numeric | -1 to 1 |
+| grade_at_time | int | Grade at this point |
+| traits_at_time | jsonb | Traits snapshot |
+| key_narratives | text[] | "raw but explosive", "injury concerns" |
+| sources_count | int | Number of sources in this period |
+
+### scouting.reports
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | serial | Primary key |
+| source_url | text | Original URL |
+| source_name | text | 247Sports, Reddit, X, etc. |
+| published_at | timestamptz | When content was published |
+| crawled_at | timestamptz | When we crawled it |
+| content_type | text | article, social, forum |
+| player_ids | bigint[] | Tagged players |
+| team_ids | text[] | Tagged teams |
+| raw_text | text | Original content |
+| summary | text | Claude-generated summary |
+| sentiment_score | numeric | -1 to 1 |
+
+### scouting.team_rosters
+
+| Column | Type | Description |
+|--------|------|-------------|
+| team | text | Team name |
+| season | int | Season year |
+| position_groups | jsonb | Depth + sentiment per group |
+| overall_sentiment | numeric | -1 to 1 |
+| trajectory | text | improving, stable, declining |
+| key_storylines | text[] | Notable narratives |
+| last_updated | timestamptz | Last refresh |
+
+---
+
+## Sources & Crawlers
+
+### Tier 1 - High-value scouting sites (daily crawl)
+
+| Source | Content Type | Method | Notes |
+|--------|--------------|--------|-------|
+| 247Sports | Recruiting, scouting reports | Scrape | Player pages, team boards |
+| Rivals | Recruiting, player evals | Scrape | Similar structure to 247 |
+| On3 | NIL, transfer portal, recruiting | Scrape | Strong portal coverage |
+| ESPN | Draft rankings, scouting reports | Scrape | Insider content limited |
+| The Athletic | Deep-dive articles | Scrape | Paywall - may need subscription |
+
+### Tier 2 - Community sentiment (hourly for active topics)
+
+| Source | Content Type | Method | Notes |
+|--------|--------------|--------|-------|
+| Reddit | r/CFB, team subreddits | API (PRAW) | Great for fan sentiment, rumors |
+| X/Twitter | Insider accounts, beat writers | API (tweepy) | Real-time intel, requires paid tier |
+
+### Tier 3 - Supplementary (weekly)
+
+| Source | Content Type | Method | Notes |
+|--------|--------------|--------|-------|
+| Team blogs (SB Nation) | Team-specific analysis | RSS + scrape | Good for depth chart speculation |
+| Draft analysts | Draft grades | Scrape | Seasonal - ramps up Nov-April |
+
+### Crawler Architecture
+
+- Each source gets its own crawler module
+- Shared `BaseCrawler` class handles rate limiting, retries, deduplication
+- Content stored in `scouting.reports` with source tagging
+- Separate summarization job processes raw content → structured entities
+
+---
+
+## AI Processing Pipeline
+
+### Stage 1: Entity Extraction
+
+When raw content is crawled, Claude identifies:
+- Player names → matched to `core.roster` or `recruiting.recruits`
+- Teams mentioned
+- Content type (scouting report, rumor, opinion, news)
+
+### Stage 2: Player Summarization
+
+For each player with new content, Claude generates:
+
+```json
+{
+    "grade": 78,
+    "sentiment": 0.6,
+    "traits": {
+        "athleticism": {"score": 85, "trend": "stable"},
+        "technique": {"score": 70, "trend": "improving"},
+        "football_iq": {"score": 80, "trend": "stable"},
+        "leadership": {"score": 75, "trend": "unknown"},
+        "durability": {"score": 65, "trend": "concerning"}
+    },
+    "key_narratives": [
+        "Elite burst and acceleration",
+        "Route running has improved significantly since freshman year",
+        "Some concerns about contested catch ability"
+    ],
+    "draft_projection": "Day 2 (Rounds 2-3)",
+    "comps": ["Garrett Wilson", "Chris Olave"]
+}
+```
+
+### Stage 3: Team Roster Rollup
+
+Aggregate player data into position group assessments:
+
+```json
+{
+    "position_groups": {
+        "QB": {"depth": 2, "sentiment": 0.7, "outlook": "strong starter, thin backup"},
+        "WR": {"depth": 5, "sentiment": 0.8, "outlook": "deepest in conference"},
+        "OL": {"depth": 4, "sentiment": 0.3, "outlook": "concerning after 2 transfers out"}
+    },
+    "overall_sentiment": 0.6,
+    "trajectory": "improving",
+    "key_storylines": [
+        "QB competition resolved in favor of Smith",
+        "O-line depth is biggest question mark",
+        "Defensive backfield could be elite"
+    ]
+}
+```
+
+### Prompt Engineering
+
+Each summarization uses structured prompts with CFB-specific context:
+- Position-specific trait expectations
+- Conference strength adjustments
+- Historical context from player timeline
+- Consistent grading rubrics
+
+---
+
+## Project Structure
+
+Repository: `cfb-scout` (standalone under Development/personal)
+
+```
+cfb-scout/
+├── src/
+│   ├── crawlers/
+│   │   ├── base.py              # BaseCrawler with rate limiting, retries
+│   │   ├── recruiting/          # 247, Rivals, On3
+│   │   ├── social/              # Reddit, X
+│   │   └── news/                # ESPN, Athletic, blogs
+│   ├── processing/
+│   │   ├── entity_extraction.py
+│   │   ├── player_summarizer.py
+│   │   ├── team_rollup.py
+│   │   └── prompts/             # Structured prompts for Claude
+│   ├── storage/
+│   │   ├── models.py            # SQLAlchemy/Supabase models
+│   │   └── db.py                # Connection, upsert helpers
+│   └── scheduler/
+│       └── jobs.py              # Cron job definitions
+├── scripts/
+│   ├── run_crawl.py             # Manual crawl trigger
+│   └── backfill_player.py       # Seed historical data for a player
+├── tests/
+├── pyproject.toml
+└── README.md
+```
+
+---
+
+## Implementation Phases
+
+| Phase | Scope | Outcome |
+|-------|-------|---------|
+| **1** | Schema + Reddit crawler | Prove the loop: crawl → store → summarize → query |
+| **2** | 247Sports + player entity linking | Real scouting content, matched to existing roster data |
+| **3** | Player timeline + longitudinal tracking | Historical snapshots working |
+| **4** | Team roster rollups | Position group analysis |
+| **5** | X/Twitter + remaining sources | Full source coverage |
+| **6** | cfb-app integration | API endpoints for UI consumption |
+
+---
+
+## API Requirements (for cfb-app)
+
+The following endpoints/queries will be needed:
+
+- `GET /players/{id}` - Full player profile with current grade, traits, timeline
+- `GET /players/{id}/timeline` - Historical sentiment/grade progression
+- `GET /players?status=draft_eligible&position=WR` - Filter/search players
+- `GET /teams/{team}/roster?season=2025` - Team roster with position group analysis
+- `GET /reports?player_id={id}` - Raw scouting reports for a player
+
+These can be implemented as Supabase RPC functions or a thin API layer.
+
+---
+
+## Dependencies & Credentials Needed
+
+- **Anthropic API key** - Claude for summarization
+- **Reddit API credentials** - For PRAW
+- **X/Twitter API credentials** - Paid tier for search/stream
+- **Supabase connection** - Same as cfb-database
+- **Proxy service (optional)** - For scraping at scale without blocks
+
+---
+
+## Open Questions
+
+1. **Subscription access** - Do we have/want Athletic, 247 premium, etc.?
+2. **X API tier** - Basic ($100/mo) vs Pro ($5000/mo) - what level of Twitter access?
+3. **Crawl frequency** - Daily sufficient for most, or need real-time for portal/recruiting season?
+4. **Historical backfill** - Seed with current season only, or attempt historical scraping?
+
+---
+
+## Success Criteria
+
+Phase 1 is complete when:
+- [ ] Schema deployed to Supabase
+- [ ] Reddit crawler running on schedule
+- [ ] At least one player profile populated with sentiment data
+- [ ] Data queryable from Supabase dashboard

--- a/docs/plans/2026-01-31-cfb-scout-agent-design.md
+++ b/docs/plans/2026-01-31-cfb-scout-agent-design.md
@@ -108,20 +108,18 @@ New schema: `scouting`
 
 ### Tier 1 - High-value scouting sites (daily crawl)
 
-| Source | Content Type | Method | Notes |
-|--------|--------------|--------|-------|
-| 247Sports | Recruiting, scouting reports | Scrape | Player pages, team boards |
-| Rivals | Recruiting, player evals | Scrape | Similar structure to 247 |
-| On3 | NIL, transfer portal, recruiting | Scrape | Strong portal coverage |
-| ESPN | Draft rankings, scouting reports | Scrape | Insider content limited |
-| The Athletic | Deep-dive articles | Scrape | Paywall - may need subscription |
+| Source | Content Type | Method | Cost | Notes |
+|--------|--------------|--------|------|-------|
+| 247Sports | Recruiting, scouting reports | Scrape | Free tier | Player pages, team boards |
+| Rivals | Recruiting, player evals | Scrape | Free tier | Similar structure to 247 |
+| On3 | NIL, transfer portal, recruiting | Scrape | Free tier | Strong portal coverage, consider upgrade later |
+| PFF | Per-play grades, position rankings | Scrape | Free/~$40/mo | Objective film-based grades, complements sentiment |
 
 ### Tier 2 - Community sentiment (hourly for active topics)
 
-| Source | Content Type | Method | Notes |
-|--------|--------------|--------|-------|
-| Reddit | r/CFB, team subreddits | API (PRAW) | Great for fan sentiment, rumors |
-| X/Twitter | Insider accounts, beat writers | API (tweepy) | Real-time intel, requires paid tier |
+| Source | Content Type | Method | Cost | Notes |
+|--------|--------------|--------|------|-------|
+| Reddit | r/CFB, team subreddits | API (PRAW) | Free | Great for fan sentiment, rumors |
 
 ### Tier 3 - Supplementary (weekly)
 
@@ -129,6 +127,14 @@ New schema: `scouting`
 |--------|--------------|--------|-------|
 | Team blogs (SB Nation) | Team-specific analysis | RSS + scrape | Good for depth chart speculation |
 | Draft analysts | Draft grades | Scrape | Seasonal - ramps up Nov-April |
+| ESPN | Draft rankings, scouting reports | Scrape | Insider content limited |
+
+### Deferred Sources
+
+| Source | Reason | Revisit When |
+|--------|--------|--------------|
+| X/Twitter | Poor cost/value ($100/mo for limited access) | If Reddit + scouting sites leave gaps |
+| The Athletic | Paywall (~$8/mo) | If quality analysis needed |
 
 ### Crawler Architecture
 
@@ -242,9 +248,9 @@ cfb-scout/
 |-------|-------|---------|
 | **1** | Schema + Reddit crawler | Prove the loop: crawl → store → summarize → query |
 | **2** | 247Sports + player entity linking | Real scouting content, matched to existing roster data |
-| **3** | Player timeline + longitudinal tracking | Historical snapshots working |
-| **4** | Team roster rollups | Position group analysis |
-| **5** | X/Twitter + remaining sources | Full source coverage |
+| **3** | PFF grades integration | Objective performance data alongside sentiment |
+| **4** | Player timeline + longitudinal tracking | Historical snapshots working |
+| **5** | Team roster rollups | Position group analysis |
 | **6** | cfb-app integration | API endpoints for UI consumption |
 
 ---
@@ -266,19 +272,19 @@ These can be implemented as Supabase RPC functions or a thin API layer.
 ## Dependencies & Credentials Needed
 
 - **Anthropic API key** - Claude for summarization
-- **Reddit API credentials** - For PRAW
-- **X/Twitter API credentials** - Paid tier for search/stream
+- **Reddit API credentials** - For PRAW (free tier)
 - **Supabase connection** - Same as cfb-database
 - **Proxy service (optional)** - For scraping at scale without blocks
 
 ---
 
-## Open Questions
+## Decisions Made
 
-1. **Subscription access** - Do we have/want Athletic, 247 premium, etc.?
-2. **X API tier** - Basic ($100/mo) vs Pro ($5000/mo) - what level of Twitter access?
-3. **Crawl frequency** - Daily sufficient for most, or need real-time for portal/recruiting season?
-4. **Historical backfill** - Seed with current season only, or attempt historical scraping?
+1. **Premium access:** Start with free tiers for all sources. Consider On3 + Athletic (~$20-30/mo) later if gaps identified.
+2. **X/Twitter:** Skip for now - poor cost/value ratio. Reddit + scouting sites provide 80% of signal.
+3. **PFF:** Added as key source for objective, film-based player grades.
+4. **Backfill scope:** Active roster players only (~11,000 total, focus on ~3,000 key contributors). Pull recruiting history from existing `recruiting.recruits` table, scrape current-season scouting content only.
+5. **Crawl frequency:** Daily for scouting sites, hourly for Reddit during active periods.
 
 ---
 

--- a/docs/plans/2026-01-31-cfb-scout-phase1-implementation.md
+++ b/docs/plans/2026-01-31-cfb-scout-phase1-implementation.md
@@ -1,0 +1,1272 @@
+# CFB Scout Agent Phase 1 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build the foundational crawl → store → summarize → query loop using Reddit as the first data source.
+
+**Architecture:** Python project with PRAW for Reddit API, Claude for summarization, and Supabase Postgres for storage. Scheduled crawling stores raw content, then a separate summarization job processes it into structured player/team data.
+
+**Tech Stack:** Python 3.12, PRAW (Reddit API), Anthropic SDK (Claude), psycopg2/SQLAlchemy, httpx
+
+---
+
+## Task 1: Create Project Scaffold
+
+**Files:**
+- Create: `/Users/robstover/Development/personal/cfb-scout/pyproject.toml`
+- Create: `/Users/robstover/Development/personal/cfb-scout/src/__init__.py`
+- Create: `/Users/robstover/Development/personal/cfb-scout/src/config.py`
+- Create: `/Users/robstover/Development/personal/cfb-scout/.env.example`
+
+**Step 1: Create project directory structure**
+
+```bash
+mkdir -p /Users/robstover/Development/personal/cfb-scout/{src/{crawlers,processing,storage},tests,scripts}
+touch /Users/robstover/Development/personal/cfb-scout/src/__init__.py
+touch /Users/robstover/Development/personal/cfb-scout/src/crawlers/__init__.py
+touch /Users/robstover/Development/personal/cfb-scout/src/processing/__init__.py
+touch /Users/robstover/Development/personal/cfb-scout/src/storage/__init__.py
+touch /Users/robstover/Development/personal/cfb-scout/tests/__init__.py
+```
+
+**Step 2: Create pyproject.toml**
+
+```toml
+[project]
+name = "cfb-scout"
+version = "0.1.0"
+description = "CFB scouting intelligence agent"
+requires-python = ">=3.12"
+dependencies = [
+    "praw>=7.7.0",
+    "anthropic>=0.18.0",
+    "psycopg2-binary>=2.9.9",
+    "httpx>=0.27.0",
+    "python-dotenv>=1.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+    "ruff>=0.3.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+```
+
+**Step 3: Create config.py**
+
+```python
+"""Configuration management for CFB Scout."""
+
+import os
+from dataclasses import dataclass
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+@dataclass(frozen=True)
+class Config:
+    """Application configuration."""
+
+    # Supabase
+    database_url: str
+
+    # Reddit
+    reddit_client_id: str
+    reddit_client_secret: str
+    reddit_user_agent: str
+
+    # Anthropic
+    anthropic_api_key: str
+
+    @classmethod
+    def from_env(cls) -> "Config":
+        """Load configuration from environment variables."""
+        return cls(
+            database_url=os.environ["DATABASE_URL"],
+            reddit_client_id=os.environ["REDDIT_CLIENT_ID"],
+            reddit_client_secret=os.environ["REDDIT_CLIENT_SECRET"],
+            reddit_user_agent=os.environ.get("REDDIT_USER_AGENT", "cfb-scout:v0.1.0"),
+            anthropic_api_key=os.environ["ANTHROPIC_API_KEY"],
+        )
+
+
+def get_config() -> Config:
+    """Get application configuration."""
+    return Config.from_env()
+```
+
+**Step 4: Create .env.example**
+
+```bash
+# Supabase (same as cfb-database)
+DATABASE_URL=postgres://postgres:xxx@db.xxx.supabase.co:5432/postgres
+
+# Reddit API (https://www.reddit.com/prefs/apps)
+REDDIT_CLIENT_ID=your_client_id
+REDDIT_CLIENT_SECRET=your_client_secret
+REDDIT_USER_AGENT=cfb-scout:v0.1.0
+
+# Anthropic
+ANTHROPIC_API_KEY=your_api_key
+```
+
+**Step 5: Initialize git and commit**
+
+```bash
+cd /Users/robstover/Development/personal/cfb-scout
+git init
+cp .env.example .env
+echo ".env" >> .gitignore
+echo "__pycache__" >> .gitignore
+echo "*.pyc" >> .gitignore
+echo ".venv" >> .gitignore
+git add .
+git commit -m "feat: initialize cfb-scout project scaffold"
+```
+
+---
+
+## Task 2: Deploy Scouting Schema to Supabase
+
+**Files:**
+- Create: `/Users/robstover/Development/personal/cfb-scout/src/storage/schema.sql`
+
+**Step 1: Create schema SQL file**
+
+```sql
+-- CFB Scout Schema
+-- Deploy to Supabase using SQL Editor or migration tool
+
+CREATE SCHEMA IF NOT EXISTS scouting;
+
+-- Raw crawled content
+CREATE TABLE IF NOT EXISTS scouting.reports (
+    id SERIAL PRIMARY KEY,
+    source_url TEXT NOT NULL,
+    source_name TEXT NOT NULL,
+    published_at TIMESTAMPTZ,
+    crawled_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    content_type TEXT NOT NULL CHECK (content_type IN ('article', 'social', 'forum')),
+    player_ids BIGINT[] DEFAULT '{}',
+    team_ids TEXT[] DEFAULT '{}',
+    raw_text TEXT NOT NULL,
+    summary TEXT,
+    sentiment_score NUMERIC(3,2) CHECK (sentiment_score BETWEEN -1 AND 1),
+    processed_at TIMESTAMPTZ,
+    UNIQUE (source_url)
+);
+
+CREATE INDEX idx_reports_source ON scouting.reports (source_name);
+CREATE INDEX idx_reports_crawled ON scouting.reports (crawled_at DESC);
+CREATE INDEX idx_reports_unprocessed ON scouting.reports (id) WHERE processed_at IS NULL;
+CREATE INDEX idx_reports_players ON scouting.reports USING GIN (player_ids);
+CREATE INDEX idx_reports_teams ON scouting.reports USING GIN (team_ids);
+
+-- Player scouting profiles
+CREATE TABLE IF NOT EXISTS scouting.players (
+    id SERIAL PRIMARY KEY,
+    roster_player_id BIGINT,  -- Links to core.roster.id
+    recruit_id BIGINT,        -- Links to recruiting.recruits.id
+    name TEXT NOT NULL,
+    position TEXT,
+    team TEXT,
+    class_year INT,
+    current_status TEXT CHECK (current_status IN ('recruit', 'active', 'transfer', 'draft_eligible', 'drafted')),
+    composite_grade INT CHECK (composite_grade BETWEEN 0 AND 100),
+    traits JSONB DEFAULT '{}',
+    draft_projection TEXT,
+    comps TEXT[] DEFAULT '{}',
+    last_updated TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (name, team, class_year)
+);
+
+CREATE INDEX idx_players_team ON scouting.players (team);
+CREATE INDEX idx_players_status ON scouting.players (current_status);
+CREATE INDEX idx_players_grade ON scouting.players (composite_grade DESC NULLS LAST);
+
+-- Player timeline for longitudinal tracking
+CREATE TABLE IF NOT EXISTS scouting.player_timeline (
+    id SERIAL PRIMARY KEY,
+    player_id INT NOT NULL REFERENCES scouting.players(id) ON DELETE CASCADE,
+    snapshot_date DATE NOT NULL,
+    status TEXT,
+    sentiment_score NUMERIC(3,2),
+    grade_at_time INT,
+    traits_at_time JSONB,
+    key_narratives TEXT[] DEFAULT '{}',
+    sources_count INT DEFAULT 0,
+    UNIQUE (player_id, snapshot_date)
+);
+
+CREATE INDEX idx_timeline_player ON scouting.player_timeline (player_id);
+CREATE INDEX idx_timeline_date ON scouting.player_timeline (snapshot_date DESC);
+
+-- Team roster analysis
+CREATE TABLE IF NOT EXISTS scouting.team_rosters (
+    id SERIAL PRIMARY KEY,
+    team TEXT NOT NULL,
+    season INT NOT NULL,
+    position_groups JSONB DEFAULT '{}',
+    overall_sentiment NUMERIC(3,2),
+    trajectory TEXT CHECK (trajectory IN ('improving', 'stable', 'declining')),
+    key_storylines TEXT[] DEFAULT '{}',
+    last_updated TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (team, season)
+);
+
+CREATE INDEX idx_team_rosters_team ON scouting.team_rosters (team);
+CREATE INDEX idx_team_rosters_season ON scouting.team_rosters (season DESC);
+
+-- Crawl job tracking
+CREATE TABLE IF NOT EXISTS scouting.crawl_jobs (
+    id SERIAL PRIMARY KEY,
+    source_name TEXT NOT NULL,
+    started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    completed_at TIMESTAMPTZ,
+    status TEXT NOT NULL DEFAULT 'running' CHECK (status IN ('running', 'completed', 'failed')),
+    records_crawled INT DEFAULT 0,
+    records_new INT DEFAULT 0,
+    error_message TEXT
+);
+
+CREATE INDEX idx_crawl_jobs_source ON scouting.crawl_jobs (source_name, started_at DESC);
+```
+
+**Step 2: Deploy schema to Supabase**
+
+Run in Supabase SQL Editor or via psql:
+```bash
+cd /Users/robstover/Development/personal/cfb-scout
+psql "postgres://postgres:sittar-3fIzgy-horkak@db.ibobsbwlewpqslkqbrjd.supabase.co:5432/postgres" -f src/storage/schema.sql
+```
+
+Expected: Schema created successfully, no errors.
+
+**Step 3: Verify tables exist**
+
+```sql
+SELECT table_name FROM information_schema.tables WHERE table_schema = 'scouting';
+```
+
+Expected: reports, players, player_timeline, team_rosters, crawl_jobs
+
+**Step 4: Commit**
+
+```bash
+git add src/storage/schema.sql
+git commit -m "feat: add scouting schema for Supabase"
+```
+
+---
+
+## Task 3: Create Database Connection Module
+
+**Files:**
+- Create: `/Users/robstover/Development/personal/cfb-scout/src/storage/db.py`
+- Create: `/Users/robstover/Development/personal/cfb-scout/tests/test_db.py`
+
+**Step 1: Write the failing test**
+
+```python
+# tests/test_db.py
+"""Tests for database connection."""
+
+import pytest
+from src.storage.db import get_connection, insert_report, get_unprocessed_reports
+
+
+def test_get_connection_returns_connection():
+    """Test that we can connect to the database."""
+    conn = get_connection()
+    assert conn is not None
+    cur = conn.cursor()
+    cur.execute("SELECT 1")
+    result = cur.fetchone()
+    assert result[0] == 1
+    conn.close()
+
+
+def test_insert_report_creates_record():
+    """Test that we can insert a report."""
+    conn = get_connection()
+
+    report_id = insert_report(
+        conn,
+        source_url="https://reddit.com/r/CFB/test123",
+        source_name="reddit",
+        content_type="forum",
+        raw_text="Test content about Texas football",
+        team_ids=["Texas"],
+    )
+
+    assert report_id is not None
+    assert report_id > 0
+
+    # Clean up
+    cur = conn.cursor()
+    cur.execute("DELETE FROM scouting.reports WHERE id = %s", (report_id,))
+    conn.commit()
+    conn.close()
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd /Users/robstover/Development/personal/cfb-scout
+python -m pytest tests/test_db.py -v
+```
+
+Expected: FAIL with "ModuleNotFoundError: No module named 'src.storage.db'"
+
+**Step 3: Write minimal implementation**
+
+```python
+# src/storage/db.py
+"""Database connection and operations for CFB Scout."""
+
+import os
+from contextlib import contextmanager
+from typing import Iterator
+
+import psycopg2
+from psycopg2.extensions import connection
+
+
+def get_connection() -> connection:
+    """Get a database connection."""
+    database_url = os.environ.get("DATABASE_URL")
+    if not database_url:
+        raise ValueError("DATABASE_URL environment variable not set")
+    return psycopg2.connect(database_url)
+
+
+@contextmanager
+def get_db() -> Iterator[connection]:
+    """Context manager for database connections."""
+    conn = get_connection()
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def insert_report(
+    conn: connection,
+    source_url: str,
+    source_name: str,
+    content_type: str,
+    raw_text: str,
+    player_ids: list[int] | None = None,
+    team_ids: list[str] | None = None,
+    published_at: str | None = None,
+) -> int:
+    """Insert a scouting report and return its ID.
+
+    Uses ON CONFLICT to handle duplicates (same URL).
+    """
+    cur = conn.cursor()
+    cur.execute(
+        """
+        INSERT INTO scouting.reports
+            (source_url, source_name, content_type, raw_text, player_ids, team_ids, published_at)
+        VALUES (%s, %s, %s, %s, %s, %s, %s)
+        ON CONFLICT (source_url) DO UPDATE SET
+            raw_text = EXCLUDED.raw_text,
+            crawled_at = NOW()
+        RETURNING id
+        """,
+        (
+            source_url,
+            source_name,
+            content_type,
+            raw_text,
+            player_ids or [],
+            team_ids or [],
+            published_at,
+        ),
+    )
+    report_id = cur.fetchone()[0]
+    conn.commit()
+    return report_id
+
+
+def get_unprocessed_reports(conn: connection, limit: int = 100) -> list[dict]:
+    """Get reports that haven't been processed yet."""
+    cur = conn.cursor()
+    cur.execute(
+        """
+        SELECT id, source_url, source_name, content_type, raw_text, player_ids, team_ids
+        FROM scouting.reports
+        WHERE processed_at IS NULL
+        ORDER BY crawled_at ASC
+        LIMIT %s
+        """,
+        (limit,),
+    )
+    columns = [desc[0] for desc in cur.description]
+    return [dict(zip(columns, row)) for row in cur.fetchall()]
+
+
+def mark_report_processed(
+    conn: connection,
+    report_id: int,
+    summary: str | None = None,
+    sentiment_score: float | None = None,
+    player_ids: list[int] | None = None,
+    team_ids: list[str] | None = None,
+) -> None:
+    """Mark a report as processed with optional extracted data."""
+    cur = conn.cursor()
+    cur.execute(
+        """
+        UPDATE scouting.reports
+        SET processed_at = NOW(),
+            summary = COALESCE(%s, summary),
+            sentiment_score = COALESCE(%s, sentiment_score),
+            player_ids = COALESCE(%s, player_ids),
+            team_ids = COALESCE(%s, team_ids)
+        WHERE id = %s
+        """,
+        (summary, sentiment_score, player_ids, team_ids, report_id),
+    )
+    conn.commit()
+```
+
+**Step 4: Set up environment and run test**
+
+```bash
+# Create .env with real credentials
+cp .env.example .env
+# Edit .env with actual DATABASE_URL
+
+# Create venv and install
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+
+# Run tests
+python -m pytest tests/test_db.py -v
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/storage/db.py tests/test_db.py
+git commit -m "feat: add database connection module with report operations"
+```
+
+---
+
+## Task 4: Create Reddit Crawler
+
+**Files:**
+- Create: `/Users/robstover/Development/personal/cfb-scout/src/crawlers/base.py`
+- Create: `/Users/robstover/Development/personal/cfb-scout/src/crawlers/reddit.py`
+- Create: `/Users/robstover/Development/personal/cfb-scout/tests/test_reddit_crawler.py`
+
+**Step 1: Create base crawler class**
+
+```python
+# src/crawlers/base.py
+"""Base crawler class with common functionality."""
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CrawlResult:
+    """Result of a crawl operation."""
+    source_name: str
+    records_crawled: int
+    records_new: int
+    errors: list[str]
+    started_at: datetime
+    completed_at: datetime
+
+
+class BaseCrawler(ABC):
+    """Base class for all crawlers."""
+
+    source_name: str = "unknown"
+
+    @abstractmethod
+    def crawl(self) -> CrawlResult:
+        """Execute the crawl and return results."""
+        pass
+
+    def log_start(self) -> datetime:
+        """Log crawl start."""
+        started = datetime.now()
+        logger.info(f"Starting {self.source_name} crawl at {started}")
+        return started
+
+    def log_complete(self, result: CrawlResult) -> None:
+        """Log crawl completion."""
+        logger.info(
+            f"Completed {self.source_name} crawl: "
+            f"{result.records_new} new / {result.records_crawled} total"
+        )
+```
+
+**Step 2: Write failing test for Reddit crawler**
+
+```python
+# tests/test_reddit_crawler.py
+"""Tests for Reddit crawler."""
+
+import pytest
+from unittest.mock import Mock, patch
+
+from src.crawlers.reddit import RedditCrawler, extract_team_mentions
+
+
+def test_extract_team_mentions_finds_teams():
+    """Test that team mentions are extracted from text."""
+    text = "Texas is looking strong this year. Ohio State will be tough to beat."
+    teams = extract_team_mentions(text)
+    assert "Texas" in teams
+    assert "Ohio State" in teams
+
+
+def test_extract_team_mentions_handles_variations():
+    """Test that team name variations are handled."""
+    text = "The Longhorns are playing the Buckeyes this weekend."
+    teams = extract_team_mentions(text)
+    assert "Texas" in teams
+    assert "Ohio State" in teams
+
+
+def test_reddit_crawler_parses_submission():
+    """Test that Reddit submissions are parsed correctly."""
+    crawler = RedditCrawler(subreddits=["CFB"])
+
+    mock_submission = Mock()
+    mock_submission.id = "abc123"
+    mock_submission.title = "Texas QB situation looking good"
+    mock_submission.selftext = "After spring practice, the QB room is stacked."
+    mock_submission.url = "https://reddit.com/r/CFB/comments/abc123"
+    mock_submission.created_utc = 1706745600.0
+    mock_submission.score = 150
+
+    result = crawler._parse_submission(mock_submission)
+
+    assert result["source_url"] == "https://reddit.com/r/CFB/comments/abc123"
+    assert result["content_type"] == "forum"
+    assert "Texas" in result["raw_text"]
+    assert "Texas" in result["team_ids"]
+```
+
+**Step 3: Run test to verify it fails**
+
+```bash
+python -m pytest tests/test_reddit_crawler.py -v
+```
+
+Expected: FAIL with "ModuleNotFoundError"
+
+**Step 4: Write Reddit crawler implementation**
+
+```python
+# src/crawlers/reddit.py
+"""Reddit crawler for r/CFB and team subreddits."""
+
+import logging
+import os
+import re
+from datetime import datetime, timezone
+
+import praw
+from praw.models import Submission
+
+from .base import BaseCrawler, CrawlResult
+from ..storage.db import get_connection, insert_report
+
+logger = logging.getLogger(__name__)
+
+# Team name mappings (common variations)
+TEAM_ALIASES = {
+    "longhorns": "Texas",
+    "horns": "Texas",
+    "buckeyes": "Ohio State",
+    "osu": "Ohio State",
+    "bucks": "Ohio State",
+    "dawgs": "Georgia",
+    "bulldogs": "Georgia",
+    "uga": "Georgia",
+    "tide": "Alabama",
+    "bama": "Alabama",
+    "crimson tide": "Alabama",
+    "wolverines": "Michigan",
+    "umich": "Michigan",
+    "tigers": "LSU",  # Could also be Clemson, Auburn - context needed
+    "sooners": "Oklahoma",
+    "ou": "Oklahoma",
+    "aggies": "Texas A&M",
+    "tamu": "Texas A&M",
+    "nittany lions": "Penn State",
+    "psu": "Penn State",
+    "ducks": "Oregon",
+    "trojans": "USC",
+    "irish": "Notre Dame",
+    "nd": "Notre Dame",
+    "gators": "Florida",
+    "uf": "Florida",
+    "seminoles": "Florida State",
+    "fsu": "Florida State",
+    "hurricanes": "Miami",
+    "canes": "Miami",
+}
+
+# Canonical team names to look for
+FBS_TEAMS = [
+    "Alabama", "Arizona", "Arizona State", "Arkansas", "Auburn",
+    "Baylor", "BYU", "California", "Cincinnati", "Clemson",
+    "Colorado", "Duke", "Florida", "Florida State", "Georgia",
+    "Georgia Tech", "Houston", "Illinois", "Indiana", "Iowa",
+    "Iowa State", "Kansas", "Kansas State", "Kentucky", "Louisville",
+    "LSU", "Maryland", "Memphis", "Miami", "Michigan",
+    "Michigan State", "Minnesota", "Mississippi State", "Missouri", "Nebraska",
+    "North Carolina", "NC State", "Notre Dame", "Ohio State", "Oklahoma",
+    "Oklahoma State", "Ole Miss", "Oregon", "Oregon State", "Penn State",
+    "Pittsburgh", "Purdue", "Rutgers", "SMU", "South Carolina",
+    "Stanford", "Syracuse", "TCU", "Tennessee", "Texas",
+    "Texas A&M", "Texas Tech", "UCF", "UCLA", "USC",
+    "Utah", "Vanderbilt", "Virginia", "Virginia Tech", "Wake Forest",
+    "Washington", "Washington State", "West Virginia", "Wisconsin",
+]
+
+
+def extract_team_mentions(text: str) -> list[str]:
+    """Extract team mentions from text.
+
+    Looks for canonical team names and common aliases.
+    """
+    text_lower = text.lower()
+    teams_found = set()
+
+    # Check aliases first
+    for alias, canonical in TEAM_ALIASES.items():
+        if re.search(rf'\b{re.escape(alias)}\b', text_lower):
+            teams_found.add(canonical)
+
+    # Check canonical names
+    for team in FBS_TEAMS:
+        if re.search(rf'\b{re.escape(team.lower())}\b', text_lower):
+            teams_found.add(team)
+
+    return list(teams_found)
+
+
+class RedditCrawler(BaseCrawler):
+    """Crawler for Reddit CFB content."""
+
+    source_name = "reddit"
+
+    def __init__(
+        self,
+        subreddits: list[str] | None = None,
+        post_limit: int = 100,
+    ):
+        """Initialize Reddit crawler.
+
+        Args:
+            subreddits: List of subreddits to crawl. Defaults to ["CFB"].
+            post_limit: Max posts to fetch per subreddit.
+        """
+        self.subreddits = subreddits or ["CFB"]
+        self.post_limit = post_limit
+        self._reddit = None
+
+    @property
+    def reddit(self) -> praw.Reddit:
+        """Lazy-load Reddit client."""
+        if self._reddit is None:
+            self._reddit = praw.Reddit(
+                client_id=os.environ["REDDIT_CLIENT_ID"],
+                client_secret=os.environ["REDDIT_CLIENT_SECRET"],
+                user_agent=os.environ.get("REDDIT_USER_AGENT", "cfb-scout:v0.1.0"),
+            )
+        return self._reddit
+
+    def _parse_submission(self, submission: Submission) -> dict:
+        """Parse a Reddit submission into report format."""
+        # Combine title and body
+        raw_text = f"{submission.title}\n\n{submission.selftext or ''}"
+
+        # Extract teams mentioned
+        team_ids = extract_team_mentions(raw_text)
+
+        # Convert timestamp
+        published_at = datetime.fromtimestamp(
+            submission.created_utc, tz=timezone.utc
+        ).isoformat()
+
+        return {
+            "source_url": f"https://reddit.com{submission.permalink}",
+            "source_name": self.source_name,
+            "content_type": "forum",
+            "raw_text": raw_text,
+            "team_ids": team_ids,
+            "published_at": published_at,
+        }
+
+    def crawl(self) -> CrawlResult:
+        """Crawl configured subreddits for CFB content."""
+        started = self.log_start()
+        errors = []
+        records_crawled = 0
+        records_new = 0
+
+        conn = get_connection()
+
+        try:
+            for subreddit_name in self.subreddits:
+                logger.info(f"Crawling r/{subreddit_name}")
+                subreddit = self.reddit.subreddit(subreddit_name)
+
+                # Get hot posts
+                for submission in subreddit.hot(limit=self.post_limit):
+                    try:
+                        parsed = self._parse_submission(submission)
+                        records_crawled += 1
+
+                        # Only store if it mentions a team
+                        if parsed["team_ids"]:
+                            report_id = insert_report(conn, **parsed)
+                            if report_id:
+                                records_new += 1
+
+                    except Exception as e:
+                        errors.append(f"Error parsing {submission.id}: {e}")
+                        logger.warning(f"Error parsing submission: {e}")
+
+        finally:
+            conn.close()
+
+        completed = datetime.now()
+        result = CrawlResult(
+            source_name=self.source_name,
+            records_crawled=records_crawled,
+            records_new=records_new,
+            errors=errors,
+            started_at=started,
+            completed_at=completed,
+        )
+
+        self.log_complete(result)
+        return result
+```
+
+**Step 5: Run tests**
+
+```bash
+python -m pytest tests/test_reddit_crawler.py -v
+```
+
+Expected: PASS
+
+**Step 6: Commit**
+
+```bash
+git add src/crawlers/base.py src/crawlers/reddit.py tests/test_reddit_crawler.py
+git commit -m "feat: add Reddit crawler with team mention extraction"
+```
+
+---
+
+## Task 5: Create Claude Summarization Module
+
+**Files:**
+- Create: `/Users/robstover/Development/personal/cfb-scout/src/processing/summarizer.py`
+- Create: `/Users/robstover/Development/personal/cfb-scout/tests/test_summarizer.py`
+
+**Step 1: Write failing test**
+
+```python
+# tests/test_summarizer.py
+"""Tests for Claude summarization."""
+
+import pytest
+from unittest.mock import Mock, patch
+
+from src.processing.summarizer import extract_sentiment, summarize_report
+
+
+def test_extract_sentiment_positive():
+    """Test sentiment extraction for positive content."""
+    text = "Texas looks amazing this year. The offense is explosive and the defense is elite."
+    sentiment = extract_sentiment(text)
+    assert sentiment > 0.3  # Clearly positive
+
+
+def test_extract_sentiment_negative():
+    """Test sentiment extraction for negative content."""
+    text = "Ohio State is struggling. The injuries are piling up and morale is low."
+    sentiment = extract_sentiment(text)
+    assert sentiment < -0.3  # Clearly negative
+
+
+def test_extract_sentiment_neutral():
+    """Test sentiment extraction for neutral content."""
+    text = "The game is scheduled for Saturday at 3pm. Weather looks clear."
+    sentiment = extract_sentiment(text)
+    assert -0.3 <= sentiment <= 0.3  # Neutral range
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+python -m pytest tests/test_summarizer.py -v
+```
+
+Expected: FAIL
+
+**Step 3: Write summarizer implementation**
+
+```python
+# src/processing/summarizer.py
+"""Claude-powered summarization for scouting content."""
+
+import json
+import logging
+import os
+from typing import TypedDict
+
+import anthropic
+
+logger = logging.getLogger(__name__)
+
+
+class SummaryResult(TypedDict):
+    """Result of summarization."""
+    summary: str
+    sentiment_score: float
+    player_mentions: list[str]
+    team_mentions: list[str]
+    key_topics: list[str]
+
+
+def get_client() -> anthropic.Anthropic:
+    """Get Anthropic client."""
+    return anthropic.Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
+
+
+def extract_sentiment(text: str) -> float:
+    """Extract sentiment score from text using Claude.
+
+    Returns a score from -1 (very negative) to 1 (very positive).
+    """
+    client = get_client()
+
+    response = client.messages.create(
+        model="claude-3-haiku-20240307",  # Fast/cheap for simple tasks
+        max_tokens=50,
+        messages=[
+            {
+                "role": "user",
+                "content": f"""Analyze the sentiment of this college football text.
+Return ONLY a number between -1.0 (very negative) and 1.0 (very positive).
+
+Text: {text[:1000]}
+
+Sentiment score:"""
+            }
+        ],
+    )
+
+    try:
+        score = float(response.content[0].text.strip())
+        return max(-1.0, min(1.0, score))  # Clamp to valid range
+    except (ValueError, IndexError):
+        logger.warning(f"Failed to parse sentiment: {response.content}")
+        return 0.0
+
+
+def summarize_report(text: str, team_context: list[str] | None = None) -> SummaryResult:
+    """Summarize a scouting report using Claude.
+
+    Args:
+        text: The raw report text.
+        team_context: Optional list of teams mentioned for context.
+
+    Returns:
+        SummaryResult with summary, sentiment, and extracted entities.
+    """
+    client = get_client()
+
+    context = ""
+    if team_context:
+        context = f"Teams mentioned: {', '.join(team_context)}\n\n"
+
+    response = client.messages.create(
+        model="claude-3-haiku-20240307",
+        max_tokens=500,
+        messages=[
+            {
+                "role": "user",
+                "content": f"""Analyze this college football content and extract key information.
+
+{context}Text:
+{text[:2000]}
+
+Respond with JSON only:
+{{
+    "summary": "2-3 sentence summary of the key points",
+    "sentiment_score": <float from -1.0 to 1.0>,
+    "player_mentions": ["list", "of", "player", "names"],
+    "team_mentions": ["list", "of", "team", "names"],
+    "key_topics": ["recruiting", "transfer_portal", "injury", "performance", etc.]
+}}"""
+            }
+        ],
+    )
+
+    try:
+        # Extract JSON from response
+        response_text = response.content[0].text.strip()
+        # Handle potential markdown code blocks
+        if response_text.startswith("```"):
+            response_text = response_text.split("```")[1]
+            if response_text.startswith("json"):
+                response_text = response_text[4:]
+
+        result = json.loads(response_text)
+        return SummaryResult(
+            summary=result.get("summary", ""),
+            sentiment_score=float(result.get("sentiment_score", 0)),
+            player_mentions=result.get("player_mentions", []),
+            team_mentions=result.get("team_mentions", []),
+            key_topics=result.get("key_topics", []),
+        )
+    except (json.JSONDecodeError, KeyError) as e:
+        logger.warning(f"Failed to parse summary response: {e}")
+        return SummaryResult(
+            summary="",
+            sentiment_score=0.0,
+            player_mentions=[],
+            team_mentions=[],
+            key_topics=[],
+        )
+```
+
+**Step 4: Run tests**
+
+```bash
+python -m pytest tests/test_summarizer.py -v
+```
+
+Expected: PASS (requires valid ANTHROPIC_API_KEY in .env)
+
+**Step 5: Commit**
+
+```bash
+git add src/processing/summarizer.py tests/test_summarizer.py
+git commit -m "feat: add Claude-powered summarization module"
+```
+
+---
+
+## Task 6: Create Processing Pipeline
+
+**Files:**
+- Create: `/Users/robstover/Development/personal/cfb-scout/src/processing/pipeline.py`
+- Create: `/Users/robstover/Development/personal/cfb-scout/scripts/run_pipeline.py`
+
+**Step 1: Create processing pipeline**
+
+```python
+# src/processing/pipeline.py
+"""Processing pipeline to summarize crawled reports."""
+
+import logging
+from datetime import datetime
+
+from ..storage.db import get_connection, get_unprocessed_reports, mark_report_processed
+from .summarizer import summarize_report
+
+logger = logging.getLogger(__name__)
+
+
+def process_reports(batch_size: int = 50) -> dict:
+    """Process unprocessed reports through Claude summarization.
+
+    Args:
+        batch_size: Number of reports to process in this run.
+
+    Returns:
+        Dict with processing stats.
+    """
+    conn = get_connection()
+
+    try:
+        reports = get_unprocessed_reports(conn, limit=batch_size)
+        logger.info(f"Found {len(reports)} unprocessed reports")
+
+        processed = 0
+        errors = 0
+
+        for report in reports:
+            try:
+                result = summarize_report(
+                    text=report["raw_text"],
+                    team_context=report["team_ids"],
+                )
+
+                mark_report_processed(
+                    conn,
+                    report_id=report["id"],
+                    summary=result["summary"],
+                    sentiment_score=result["sentiment_score"],
+                )
+
+                processed += 1
+                logger.debug(f"Processed report {report['id']}")
+
+            except Exception as e:
+                errors += 1
+                logger.error(f"Error processing report {report['id']}: {e}")
+
+        return {
+            "total": len(reports),
+            "processed": processed,
+            "errors": errors,
+            "timestamp": datetime.now().isoformat(),
+        }
+
+    finally:
+        conn.close()
+```
+
+**Step 2: Create run script**
+
+```python
+#!/usr/bin/env python3
+# scripts/run_pipeline.py
+"""Run the CFB Scout pipeline."""
+
+import argparse
+import logging
+import sys
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from src.crawlers.reddit import RedditCrawler
+from src.processing.pipeline import process_reports
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run CFB Scout pipeline")
+    parser.add_argument(
+        "--crawl",
+        action="store_true",
+        help="Run Reddit crawler",
+    )
+    parser.add_argument(
+        "--process",
+        action="store_true",
+        help="Process unprocessed reports",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Run full pipeline (crawl + process)",
+    )
+    parser.add_argument(
+        "--subreddits",
+        nargs="+",
+        default=["CFB"],
+        help="Subreddits to crawl (default: CFB)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        help="Max posts to crawl per subreddit",
+    )
+
+    args = parser.parse_args()
+
+    if not any([args.crawl, args.process, args.all]):
+        parser.print_help()
+        sys.exit(1)
+
+    if args.crawl or args.all:
+        logger.info("Starting Reddit crawl...")
+        crawler = RedditCrawler(
+            subreddits=args.subreddits,
+            post_limit=args.limit,
+        )
+        result = crawler.crawl()
+        logger.info(f"Crawl complete: {result.records_new} new records")
+
+    if args.process or args.all:
+        logger.info("Processing reports...")
+        result = process_reports()
+        logger.info(f"Processing complete: {result['processed']}/{result['total']} reports")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+**Step 3: Make script executable and test**
+
+```bash
+chmod +x scripts/run_pipeline.py
+
+# Test crawl only
+python scripts/run_pipeline.py --crawl --limit 10
+
+# Test process only
+python scripts/run_pipeline.py --process
+
+# Test full pipeline
+python scripts/run_pipeline.py --all --limit 10
+```
+
+Expected: Pipeline runs successfully, reports crawled and processed.
+
+**Step 4: Commit**
+
+```bash
+git add src/processing/pipeline.py scripts/run_pipeline.py
+git commit -m "feat: add processing pipeline and CLI runner"
+```
+
+---
+
+## Task 7: Verify End-to-End and Document
+
+**Files:**
+- Create: `/Users/robstover/Development/personal/cfb-scout/README.md`
+
+**Step 1: Run full pipeline test**
+
+```bash
+cd /Users/robstover/Development/personal/cfb-scout
+source .venv/bin/activate
+
+# Run full pipeline
+python scripts/run_pipeline.py --all --subreddits CFB LonghornNation --limit 25
+```
+
+**Step 2: Verify data in Supabase**
+
+```sql
+-- Check reports were crawled
+SELECT COUNT(*), source_name FROM scouting.reports GROUP BY source_name;
+
+-- Check some were processed
+SELECT COUNT(*) FROM scouting.reports WHERE processed_at IS NOT NULL;
+
+-- View a processed report
+SELECT source_url, team_ids, summary, sentiment_score
+FROM scouting.reports
+WHERE processed_at IS NOT NULL
+LIMIT 5;
+```
+
+**Step 3: Create README**
+
+```markdown
+# CFB Scout
+
+AI-powered college football scouting intelligence agent.
+
+## Setup
+
+1. Create virtual environment:
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
+   pip install -e ".[dev]"
+   ```
+
+2. Configure environment:
+   ```bash
+   cp .env.example .env
+   # Edit .env with your credentials
+   ```
+
+3. Deploy schema (first time only):
+   ```bash
+   psql "$DATABASE_URL" -f src/storage/schema.sql
+   ```
+
+## Usage
+
+```bash
+# Crawl Reddit
+python scripts/run_pipeline.py --crawl --subreddits CFB LonghornNation
+
+# Process unprocessed reports
+python scripts/run_pipeline.py --process
+
+# Run full pipeline
+python scripts/run_pipeline.py --all
+```
+
+## Testing
+
+```bash
+pytest tests/ -v
+```
+
+## Project Structure
+
+```
+cfb-scout/
+├── src/
+│   ├── crawlers/       # Data source crawlers
+│   ├── processing/     # Claude summarization
+│   └── storage/        # Database operations
+├── scripts/            # CLI tools
+└── tests/              # Test suite
+```
+```
+
+**Step 4: Final commit**
+
+```bash
+git add README.md
+git commit -m "docs: add README with setup and usage instructions"
+```
+
+---
+
+## Success Criteria Checklist
+
+- [ ] Schema deployed to Supabase (`scouting.*` tables exist)
+- [ ] Reddit crawler running (`python scripts/run_pipeline.py --crawl` succeeds)
+- [ ] Reports stored with team tags (`SELECT * FROM scouting.reports LIMIT 5`)
+- [ ] Claude summarization working (`processed_at IS NOT NULL` for some reports)
+- [ ] End-to-end pipeline runs (`--all` flag works)
+- [ ] Tests pass (`pytest tests/ -v`)

--- a/docs/plans/2026-01-31-ratings-backfill-design.md
+++ b/docs/plans/2026-01-31-ratings-backfill-design.md
@@ -1,0 +1,82 @@
+# Ratings Backfill Design
+
+**Goal:** Expand ratings coverage from 2020-2025 to 2004-2025 for all rating types.
+
+## Current State
+
+| Table | Rows | Coverage |
+|-------|------|----------|
+| sp_ratings | 800 | 2020-2025 |
+| elo_ratings | 791 | 2020-2025 |
+| fpi_ratings | 791 | 2020-2025 |
+| srs_ratings | 1,258 | 2020-2025 |
+| sp_conference_ratings | 0 | (table missing) |
+
+## API Availability
+
+Tested API endpoints for historical data:
+
+| Rating | Earliest Year | Notes |
+|--------|---------------|-------|
+| SP+ | 2004 | Full coverage |
+| Elo | 2004 | Full coverage |
+| SRS | 2004 | Full coverage |
+| FPI | 2005 | No data for 2004 |
+| SP+ Conference | 2004 | Not yet tested |
+
+## Implementation
+
+### Step 1: Update Year Range Config
+
+File: `src/pipelines/config/years.py`
+
+```python
+# Change from:
+"ratings": YearRange(start=2015, end=2026),
+
+# To:
+"ratings": YearRange(start=2004, end=2026),
+```
+
+### Step 2: Run Backfill
+
+```bash
+cd /Users/robstover/Development/personal/cfb-database
+python -m src.pipelines.run --source ratings --mode backfill --years 2004 2005 2006 2007 2008 2009 2010 2011 2012 2013 2014 2015 2016 2017 2018 2019
+```
+
+### Step 3: Verify Coverage
+
+```sql
+SELECT 'sp_ratings' as tbl, COUNT(*), MIN(year), MAX(year) FROM ratings.sp_ratings
+UNION ALL SELECT 'elo_ratings', COUNT(*), MIN(year), MAX(year) FROM ratings.elo_ratings
+UNION ALL SELECT 'srs_ratings', COUNT(*), MIN(year), MAX(year) FROM ratings.srs_ratings
+UNION ALL SELECT 'fpi_ratings', COUNT(*), MIN(year), MAX(year) FROM ratings.fpi_ratings
+UNION ALL SELECT 'sp_conference_ratings', COUNT(*), MIN(year), MAX(year) FROM ratings.sp_conference_ratings;
+```
+
+## Expected Outcome
+
+| Table | Est. Rows | Coverage |
+|-------|-----------|----------|
+| sp_ratings | ~2,800 | 2004-2025 |
+| elo_ratings | ~2,800 | 2004-2025 |
+| fpi_ratings | ~2,600 | 2005-2025 |
+| srs_ratings | ~4,000 | 2004-2025 |
+| sp_conference_ratings | ~200 | 2004-2025 |
+
+## API Cost
+
+- 4 rating endpoints × 16 years = 64 calls
+- Plus sp_conference_ratings: +16 calls
+- **Total: ~80 API calls**
+
+## Error Handling
+
+- FPI 2004 returns empty - code handles gracefully (yields nothing)
+- Existing merge disposition ensures idempotent loads
+- No schema changes needed - dlt handles table creation
+
+## Rollback
+
+If issues occur, data is additive (merge disposition). No rollback needed - existing 2020-2025 data remains intact.

--- a/docs/plans/2026-02-05-api-completion-sprint.md
+++ b/docs/plans/2026-02-05-api-completion-sprint.md
@@ -1,0 +1,205 @@
+---
+title: API Completion Sprint
+type: feature
+date: 2026-02-05
+status: ready
+---
+
+# API Completion Sprint
+
+## Overview
+
+Add the 5 remaining CFBD API endpoints to achieve complete API coverage, and sync the endpoints config with tables that are already loaded but not tracked in config.
+
+## Current State
+
+**CFBD API:** 61 endpoints
+**Configured:** 44 endpoints
+**Actually loaded:** 51 endpoints (some loaded but not in config)
+**Truly missing:** 5 endpoints
+
+### Already Loaded (not in config)
+
+These tables exist in the database but aren't tracked in `endpoints.py`:
+
+| Table | Schema | Rows |
+|-------|--------|------|
+| wepa_team_season | metrics | 1,587 |
+| wepa_players_passing | metrics | 2,313 |
+| wepa_players_rushing | metrics | 4,975 |
+| wepa_players_kicking | metrics | 1,732 |
+| ppa_teams | metrics | 1,566 |
+| pregame_win_probability | metrics | 10,073 |
+| advanced_team_stats | stats | 2,887 |
+
+### Missing Endpoints
+
+| Endpoint | Table Name | Schema | Primary Key |
+|----------|------------|--------|-------------|
+| `/plays/stats` | play_stats | stats | game_id, play_id, athlete_id, stat_type |
+| `/plays/stats/types` | play_stat_types | ref | id |
+| `/stats/game/havoc` | game_havoc | stats | game_id, team |
+| `/teams/ats` | team_ats | betting | year, team_id |
+| `/metrics/fg/ep` | fg_expected_points | metrics | distance |
+
+## Implementation Tasks
+
+### Task 1: Add New Endpoint Configs
+
+Add 5 new `EndpointConfig` entries to `src/pipelines/config/endpoints.py`:
+
+```python
+# In STATS_ENDPOINTS
+"play_stats": EndpointConfig(
+    path="/plays/stats",
+    table_name="play_stats",
+    primary_key=["game_id", "play_id", "athlete_id", "stat_type"],
+    schema="stats",
+    write_disposition="merge",
+),
+"game_havoc": EndpointConfig(
+    path="/stats/game/havoc",
+    table_name="game_havoc",
+    primary_key=["game_id", "team"],
+    schema="stats",
+    write_disposition="merge",
+),
+
+# In REFERENCE_ENDPOINTS
+"play_stat_types": EndpointConfig(
+    path="/plays/stats/types",
+    table_name="play_stat_types",
+    primary_key=["id"],
+    schema="ref",
+    write_disposition="merge",
+),
+
+# In BETTING_ENDPOINTS
+"team_ats": EndpointConfig(
+    path="/teams/ats",
+    table_name="team_ats",
+    primary_key=["year", "team_id"],
+    schema="betting",
+    write_disposition="merge",
+),
+
+# In METRICS_ENDPOINTS
+"fg_expected_points": EndpointConfig(
+    path="/metrics/fg/ep",
+    table_name="fg_expected_points",
+    primary_key=["distance"],
+    schema="metrics",
+    write_disposition="merge",
+),
+```
+
+### Task 2: Add Tests
+
+Add PK validation tests to `tests/test_endpoints_config.py`:
+
+```python
+def test_play_stats_pk(self):
+    """play_stats needs composite PK for player-play associations."""
+    config = STATS_ENDPOINTS["play_stats"]
+    assert config.primary_key == ["game_id", "play_id", "athlete_id", "stat_type"]
+
+def test_game_havoc_pk(self):
+    """game_havoc needs game_id + team composite PK."""
+    config = STATS_ENDPOINTS["game_havoc"]
+    assert config.primary_key == ["game_id", "team"]
+
+def test_team_ats_pk(self):
+    """team_ats needs year + team_id composite PK."""
+    config = BETTING_ENDPOINTS["team_ats"]
+    assert config.primary_key == ["year", "team_id"]
+```
+
+### Task 3: Sync Existing Endpoints
+
+Add config entries for tables that are already loaded but not tracked:
+
+```python
+# In METRICS_ENDPOINTS (already have source files, just need config tracking)
+"wepa_team_season": EndpointConfig(
+    path="/wepa/team/season",
+    table_name="wepa_team_season",
+    primary_key=["year", "team"],
+    schema="metrics",
+    write_disposition="merge",
+),
+"wepa_players_passing": EndpointConfig(
+    path="/wepa/players/passing",
+    table_name="wepa_players_passing",
+    primary_key=["id", "year"],
+    schema="metrics",
+    write_disposition="merge",
+),
+# ... etc for remaining WEPA endpoints
+
+"ppa_teams": EndpointConfig(
+    path="/ppa/teams",
+    table_name="ppa_teams",
+    primary_key=["season", "team"],
+    schema="metrics",
+    write_disposition="merge",
+),
+"pregame_win_probability": EndpointConfig(
+    path="/metrics/wp/pregame",
+    table_name="pregame_win_probability",
+    primary_key=["season", "week", "team"],
+    schema="metrics",
+    write_disposition="merge",
+),
+
+# In STATS_ENDPOINTS
+"advanced_team_stats": EndpointConfig(
+    path="/stats/season/advanced",
+    table_name="advanced_team_stats",
+    primary_key=["season", "team"],
+    schema="stats",
+    write_disposition="merge",
+),
+```
+
+### Task 4: Run Initial Backfill
+
+```bash
+# Load reference table first (no year param)
+python -m src.pipelines.run --source reference --endpoint play_stat_types
+
+# Load year-iterated endpoints
+python -m src.pipelines.run --source stats --endpoint play_stats --mode backfill
+python -m src.pipelines.run --source stats --endpoint game_havoc --mode backfill
+python -m src.pipelines.run --source betting --endpoint team_ats --mode backfill
+python -m src.pipelines.run --source metrics --endpoint fg_expected_points --mode backfill
+```
+
+## Acceptance Criteria
+
+- [ ] 5 new endpoints added to `endpoints.py`
+- [ ] 7 existing endpoints synced in config
+- [ ] Tests pass (`pytest tests/test_endpoints_config.py`)
+- [ ] All 5 new tables created in database with data
+- [ ] Row counts documented
+
+## Verification Query
+
+```sql
+SELECT 'play_stats' as table_name, COUNT(*) FROM stats.play_stats
+UNION ALL SELECT 'play_stat_types', COUNT(*) FROM ref.play_stat_types
+UNION ALL SELECT 'game_havoc', COUNT(*) FROM stats.game_havoc
+UNION ALL SELECT 'team_ats', COUNT(*) FROM betting.team_ats
+UNION ALL SELECT 'fg_expected_points', COUNT(*) FROM metrics.fg_expected_points;
+```
+
+## API Call Budget
+
+**Estimated calls:** ~100 (20 years × 5 endpoints)
+**Monthly limit:** 1,000 calls
+**Status:** Well within budget
+
+## Notes
+
+- `play_stats` will be the largest table - contains player-level associations for every play
+- `fg_expected_points` is a small reference-style table (distance → expected points)
+- `play_stat_types` is a static reference table, load once

--- a/docs/plans/2026-02-05-api-completion-sprint.md
+++ b/docs/plans/2026-02-05-api-completion-sprint.md
@@ -176,11 +176,35 @@ python -m src.pipelines.run --source metrics --endpoint fg_expected_points --mod
 
 ## Acceptance Criteria
 
-- [ ] 5 new endpoints added to `endpoints.py`
-- [ ] 7 existing endpoints synced in config
-- [ ] Tests pass (`pytest tests/test_endpoints_config.py`)
-- [ ] All 5 new tables created in database with data
-- [ ] Row counts documented
+- [x] 5 new endpoints added to `endpoints.py`
+- [x] 7 existing endpoints synced in config
+- [x] Tests pass (`pytest tests/test_endpoints_config.py`)
+- [x] All 5 new tables created in database with data
+- [x] Row counts documented
+
+## Results (2026-02-05)
+
+### New Tables Created
+
+| Table | Schema | Rows |
+|-------|--------|------|
+| play_stats | stats | 4,000 (2024-2025 only) |
+| play_stat_types | ref | 26 |
+| game_havoc | stats | 11,577 |
+| team_ats | betting | 1,363 |
+| fg_expected_points | metrics | 100 |
+
+### Synced Tables Verified
+
+| Table | Schema | Rows |
+|-------|--------|------|
+| wepa_team_season | metrics | 1,587 |
+| wepa_players_passing | metrics | 2,313 |
+| wepa_players_rushing | metrics | 4,975 |
+| wepa_players_kicking | metrics | 1,732 |
+| ppa_teams | metrics | 1,566 |
+| pregame_win_probability | metrics | 10,073 |
+| advanced_team_stats | stats | 2,887 |
 
 ## Verification Query
 

--- a/scripts/load_new_endpoints.py
+++ b/scripts/load_new_endpoints.py
@@ -1,0 +1,89 @@
+"""Load the 5 new endpoints added in API completion sprint."""
+
+import dlt
+from src.pipelines.sources.metrics import fg_expected_points_resource
+from src.pipelines.sources.betting import team_ats_resource
+from src.pipelines.sources.stats import play_stats_resource, game_havoc_resource
+from src.pipelines.config.years import YEAR_RANGES
+
+# Use a limited year range for initial testing (recent years with more data availability)
+TEST_YEARS = [2020, 2021, 2022, 2023, 2024, 2025]
+
+def load_fg_expected_points():
+    """Load fg_expected_points (static lookup)."""
+    pipeline = dlt.pipeline(
+        pipeline_name="cfbd_fg_ep",
+        destination="postgres",
+        dataset_name="metrics",
+    )
+    print("\n=== Loading fg_expected_points (static lookup) ===")
+    info = pipeline.run(fg_expected_points_resource())
+    print(f"Load info: {info}")
+    return info
+
+def load_team_ats(years):
+    """Load team_ats for specified years."""
+    pipeline = dlt.pipeline(
+        pipeline_name="cfbd_team_ats",
+        destination="postgres",
+        dataset_name="betting",
+    )
+    print(f"\n=== Loading team_ats for years {years} ===")
+    info = pipeline.run(team_ats_resource(years))
+    print(f"Load info: {info}")
+    return info
+
+def load_play_stats(years):
+    """Load play_stats for specified years (large table!)."""
+    pipeline = dlt.pipeline(
+        pipeline_name="cfbd_play_stats",
+        destination="postgres",
+        dataset_name="stats",
+    )
+    print(f"\n=== Loading play_stats for years {years} ===")
+    info = pipeline.run(play_stats_resource(years))
+    print(f"Load info: {info}")
+    return info
+
+def load_game_havoc(years):
+    """Load game_havoc for specified years."""
+    pipeline = dlt.pipeline(
+        pipeline_name="cfbd_game_havoc",
+        destination="postgres",
+        dataset_name="stats",
+    )
+    print(f"\n=== Loading game_havoc for years {years} ===")
+    info = pipeline.run(game_havoc_resource(years))
+    print(f"Load info: {info}")
+    return info
+
+if __name__ == "__main__":
+    import sys
+    
+    if len(sys.argv) > 1:
+        endpoint = sys.argv[1]
+        if endpoint == "fg_expected_points":
+            load_fg_expected_points()
+        elif endpoint == "team_ats":
+            years = [int(y) for y in sys.argv[2:]] if len(sys.argv) > 2 else TEST_YEARS
+            load_team_ats(years)
+        elif endpoint == "play_stats":
+            years = [int(y) for y in sys.argv[2:]] if len(sys.argv) > 2 else TEST_YEARS
+            load_play_stats(years)
+        elif endpoint == "game_havoc":
+            years = [int(y) for y in sys.argv[2:]] if len(sys.argv) > 2 else TEST_YEARS
+            load_game_havoc(years)
+        else:
+            print(f"Unknown endpoint: {endpoint}")
+            print("Usage: python scripts/load_new_endpoints.py <endpoint> [years...]")
+            print("Endpoints: fg_expected_points, team_ats, play_stats, game_havoc")
+            sys.exit(1)
+    else:
+        # Load all new endpoints
+        print("Loading all new endpoints...")
+        load_fg_expected_points()
+        load_team_ats(TEST_YEARS)
+        load_game_havoc(TEST_YEARS)
+        # play_stats is large - load separately
+        print("\nNote: play_stats is a large table. Run separately with:")
+        print("  python scripts/load_new_endpoints.py play_stats 2024 2025")

--- a/scripts/load_play_stat_types.py
+++ b/scripts/load_play_stat_types.py
@@ -1,0 +1,14 @@
+"""Load just the play_stat_types reference table."""
+
+import dlt
+from src.pipelines.sources.reference import play_stat_types_resource
+
+pipeline = dlt.pipeline(
+    pipeline_name="cfbd_play_stat_types",
+    destination="postgres",
+    dataset_name="ref",
+)
+
+print("Loading play_stat_types...")
+info = pipeline.run(play_stat_types_resource())
+print(f"Load info: {info}")

--- a/scripts/refresh_marts.py
+++ b/scripts/refresh_marts.py
@@ -42,6 +42,8 @@ MARTS_VIEWS = [
     "marts.matchup_history",
     "marts.recruiting_class",
     "marts.coach_record",
+    # Tempo metrics (depends on team_epa_season)
+    "marts.team_tempo_metrics",
 ]
 
 ANALYTICS_VIEWS = [

--- a/src/pipelines/config/endpoints.py
+++ b/src/pipelines/config/endpoints.py
@@ -90,6 +90,13 @@ REFERENCE_ENDPOINTS = {
         schema="ref",
         write_disposition="merge",
     ),
+    "play_stat_types": EndpointConfig(
+        path="/plays/stats/types",
+        table_name="play_stat_types",
+        primary_key=["id"],
+        schema="ref",
+        write_disposition="merge",
+    ),
 }
 
 # Core game data endpoints (year-iterated, merge)
@@ -210,6 +217,27 @@ STATS_ENDPOINTS = {
         schema="stats",
         write_disposition="merge",
     ),
+    "play_stats": EndpointConfig(
+        path="/plays/stats",
+        table_name="play_stats",
+        primary_key=["game_id", "play_id", "athlete_id", "stat_type"],
+        schema="stats",
+        write_disposition="merge",
+    ),
+    "game_havoc": EndpointConfig(
+        path="/stats/game/havoc",
+        table_name="game_havoc",
+        primary_key=["game_id", "team"],
+        schema="stats",
+        write_disposition="merge",
+    ),
+    "advanced_team_stats": EndpointConfig(
+        path="/stats/season/advanced",
+        table_name="advanced_team_stats",
+        primary_key=["season", "team"],
+        schema="stats",
+        write_disposition="merge",
+    ),
 }
 
 # Ratings endpoints (year-iterated, merge)
@@ -299,6 +327,13 @@ BETTING_ENDPOINTS = {
         schema="betting",
         write_disposition="merge",
     ),
+    "team_ats": EndpointConfig(
+        path="/teams/ats",
+        table_name="team_ats",
+        primary_key=["year", "team_id"],
+        schema="betting",
+        write_disposition="merge",
+    ),
 }
 
 # Draft endpoints (year-iterated, merge)
@@ -346,6 +381,56 @@ METRICS_ENDPOINTS = {
         path="/ppa/predicted",
         table_name="ppa_predicted",
         primary_key=["down", "distance"],
+        schema="metrics",
+        write_disposition="merge",
+    ),
+    "fg_expected_points": EndpointConfig(
+        path="/metrics/fg/ep",
+        table_name="fg_expected_points",
+        primary_key=["distance"],
+        schema="metrics",
+        write_disposition="merge",
+    ),
+    # WEPA endpoints (already loaded, now tracked in config)
+    "wepa_team_season": EndpointConfig(
+        path="/wepa/team/season",
+        table_name="wepa_team_season",
+        primary_key=["year", "team"],
+        schema="metrics",
+        write_disposition="merge",
+    ),
+    "wepa_players_passing": EndpointConfig(
+        path="/wepa/players/passing",
+        table_name="wepa_players_passing",
+        primary_key=["id", "year"],
+        schema="metrics",
+        write_disposition="merge",
+    ),
+    "wepa_players_rushing": EndpointConfig(
+        path="/wepa/players/rushing",
+        table_name="wepa_players_rushing",
+        primary_key=["id", "year"],
+        schema="metrics",
+        write_disposition="merge",
+    ),
+    "wepa_players_kicking": EndpointConfig(
+        path="/wepa/players/kicking",
+        table_name="wepa_players_kicking",
+        primary_key=["id", "year"],
+        schema="metrics",
+        write_disposition="merge",
+    ),
+    "ppa_teams": EndpointConfig(
+        path="/ppa/teams",
+        table_name="ppa_teams",
+        primary_key=["season", "team"],
+        schema="metrics",
+        write_disposition="merge",
+    ),
+    "pregame_win_probability": EndpointConfig(
+        path="/metrics/wp/pregame",
+        table_name="pregame_win_probability",
+        primary_key=["season", "game_id"],
         schema="metrics",
         write_disposition="merge",
     ),

--- a/src/pipelines/config/years.py
+++ b/src/pipelines/config/years.py
@@ -39,8 +39,8 @@ YEAR_RANGES = {
     # Most stats available from 2004
     "stats": YearRange(start=2004, end=2026),
 
-    # Advanced ratings from 2015
-    "ratings": YearRange(start=2015, end=2026),
+    # Advanced ratings from 2004 (FPI starts 2005)
+    "ratings": YearRange(start=2004, end=2026),
 
     # Recruiting from 2000
     "recruiting": YearRange(start=2000, end=2026),

--- a/src/pipelines/sources/reference.py
+++ b/src/pipelines/sources/reference.py
@@ -16,7 +16,7 @@ def reference_source() -> DltSource:
     """Source for all reference/dimension data.
 
     Includes: conferences, teams, teams_fbs, venues, coaches, play_types,
-              draft_positions, draft_teams, stat_categories, calendar
+              play_stat_types, draft_positions, draft_teams, stat_categories, calendar
     """
     return [
         conferences_resource(),
@@ -25,6 +25,7 @@ def reference_source() -> DltSource:
         venues_resource(),
         coaches_resource(),
         play_types_resource(),
+        play_stat_types_resource(),
         draft_positions_resource(),
         draft_teams_resource(),
         stat_categories_resource(),
@@ -120,6 +121,21 @@ def teams_fbs_resource():
     client = get_client()
     try:
         data = make_request(client, "/teams/fbs")
+        yield from data
+    finally:
+        client.close()
+
+
+@dlt.resource(
+    name="play_stat_types",
+    write_disposition="merge",
+    primary_key="id",
+)
+def play_stat_types_resource():
+    """Load play stat type definitions."""
+    client = get_client()
+    try:
+        data = make_request(client, "/plays/stats/types")
         yield from data
     finally:
         client.close()

--- a/src/schemas/marts/019_team_tempo_metrics.sql
+++ b/src/schemas/marts/019_team_tempo_metrics.sql
@@ -1,0 +1,63 @@
+-- Team Tempo Metrics
+-- Grain: Team × Season
+-- Purpose: Tempo (plays per game) for scatter plot visualization
+
+DROP MATERIALIZED VIEW IF EXISTS marts.team_tempo_metrics CASCADE;
+
+CREATE MATERIALIZED VIEW marts.team_tempo_metrics AS
+WITH game_plays AS (
+    SELECT
+        p.season,
+        p.offense AS team,
+        g.id AS game_id,
+        COUNT(*) AS plays
+    FROM core.plays p
+    JOIN core.games g ON p.game_id = g.id
+    WHERE g.season >= 2014
+      AND p.play_type NOT IN ('Timeout', 'End Period', 'End of Half', 'End of Game', 'Kickoff')
+      -- Exclude garbage time
+      AND NOT (
+          (p.period = 4 AND ABS(COALESCE(p.score_diff, 0)) > 28) OR
+          (p.period >= 3 AND ABS(COALESCE(p.score_diff, 0)) > 35)
+      )
+    GROUP BY p.season, p.offense, g.id
+),
+team_tempo AS (
+    SELECT
+        season,
+        team,
+        COUNT(DISTINCT game_id) AS games,
+        SUM(plays) AS total_plays,
+        ROUND(AVG(plays)::numeric, 1) AS plays_per_game,
+        CASE
+            WHEN AVG(plays) >= 75 THEN 'up_tempo'
+            WHEN AVG(plays) >= 65 THEN 'balanced'
+            ELSE 'slow'
+        END AS tempo_tier
+    FROM game_plays
+    GROUP BY season, team
+)
+SELECT
+    t.season,
+    t.team,
+    t.games,
+    t.total_plays,
+    t.plays_per_game,
+    t.tempo_tier,
+    e.epa_per_play,
+    e.success_rate,
+    e.explosiveness
+FROM team_tempo t
+LEFT JOIN marts.team_epa_season e
+    ON t.season = e.season AND t.team = e.team
+WHERE t.games >= 5;
+
+-- Required for REFRESH CONCURRENTLY
+CREATE UNIQUE INDEX ON marts.team_tempo_metrics (season, team);
+
+-- Query optimization
+CREATE INDEX ON marts.team_tempo_metrics (season);
+CREATE INDEX ON marts.team_tempo_metrics (tempo_tier);
+
+COMMENT ON MATERIALIZED VIEW marts.team_tempo_metrics IS
+'Team tempo metrics joining plays per game with EPA. Grain: team × season.';

--- a/tests/test_endpoints_config.py
+++ b/tests/test_endpoints_config.py
@@ -99,6 +99,70 @@ class TestPrimaryKeyIntegrity:
         pk = DRAFT_ENDPOINTS["picks"].primary_key
         assert pk == ["year", "overall"]
 
+    def test_play_stats_pk(self):
+        """play_stats needs composite PK for player-play associations."""
+        config = STATS_ENDPOINTS["play_stats"]
+        assert config.primary_key == ["game_id", "play_id", "athlete_id", "stat_type"]
+
+    def test_game_havoc_pk(self):
+        """game_havoc needs game_id + team composite PK."""
+        config = STATS_ENDPOINTS["game_havoc"]
+        assert config.primary_key == ["game_id", "team"]
+
+    def test_team_ats_pk(self):
+        """team_ats needs year + team_id composite PK."""
+        config = BETTING_ENDPOINTS["team_ats"]
+        assert config.primary_key == ["year", "team_id"]
+
+    def test_play_stat_types_pk(self):
+        """play_stat_types is reference table with id PK."""
+        config = REFERENCE_ENDPOINTS["play_stat_types"]
+        assert config.primary_key == ["id"]
+
+    def test_fg_expected_points_pk(self):
+        """fg_expected_points is keyed by distance."""
+        config = METRICS_ENDPOINTS["fg_expected_points"]
+        assert config.primary_key == ["distance"]
+
+
+class TestSyncedEndpointPKs:
+    """Verify PKs for endpoints that existed but weren't in config."""
+
+    def test_wepa_team_season_pk(self):
+        """wepa_team_season keyed by year + team."""
+        config = METRICS_ENDPOINTS["wepa_team_season"]
+        assert config.primary_key == ["year", "team"]
+
+    def test_wepa_players_passing_pk(self):
+        """wepa_players_passing keyed by id + year."""
+        config = METRICS_ENDPOINTS["wepa_players_passing"]
+        assert config.primary_key == ["id", "year"]
+
+    def test_wepa_players_rushing_pk(self):
+        """wepa_players_rushing keyed by id + year."""
+        config = METRICS_ENDPOINTS["wepa_players_rushing"]
+        assert config.primary_key == ["id", "year"]
+
+    def test_wepa_players_kicking_pk(self):
+        """wepa_players_kicking keyed by id + year."""
+        config = METRICS_ENDPOINTS["wepa_players_kicking"]
+        assert config.primary_key == ["id", "year"]
+
+    def test_ppa_teams_pk(self):
+        """ppa_teams keyed by season + team."""
+        config = METRICS_ENDPOINTS["ppa_teams"]
+        assert config.primary_key == ["season", "team"]
+
+    def test_pregame_win_probability_pk(self):
+        """pregame_win_probability keyed by season + game_id."""
+        config = METRICS_ENDPOINTS["pregame_win_probability"]
+        assert config.primary_key == ["season", "game_id"]
+
+    def test_advanced_team_stats_pk(self):
+        """advanced_team_stats keyed by season + team."""
+        config = STATS_ENDPOINTS["advanced_team_stats"]
+        assert config.primary_key == ["season", "team"]
+
 
 class TestPrimaryKeyFieldsAreStrings:
     """PK fields should be simple string column names, not nested/complex types."""


### PR DESCRIPTION
## Summary

Complete CFBD API coverage by adding the 5 remaining endpoints and syncing 7 endpoints that were loaded but not tracked in config.

### New Endpoints Added
- **play_stats** (stats): Player-level associations for each play (4,000 rows for 2024-2025)
- **play_stat_types** (ref): Reference table for stat type definitions (26 rows)
- **game_havoc** (stats): Game-level havoc statistics - TFLs, PBUs, etc. (11,577 rows)
- **team_ats** (betting): Team against-the-spread records (1,363 rows)
- **fg_expected_points** (metrics): Field goal expected points by distance (100 rows)

### Synced Existing Endpoints
These tables existed but weren't tracked in `endpoints.py`:
- wepa_team_season, wepa_players_passing/rushing/kicking
- ppa_teams, pregame_win_probability, advanced_team_stats

## Changes
- Added EndpointConfig entries for all 12 endpoints
- Added dlt resources to appropriate source files
- Added PK validation tests (301 tests total)
- Created utility scripts for loading new endpoints
- Documented results in sprint plan

## Test Plan
- [x] All 301 endpoint config tests pass
- [x] New tables created in database with data
- [x] Row counts verified via SQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)