### PR TITLE
Add roster builder search views for cfb-app

### DIFF
--- a/docs/SCHEMA_CONTRACT.md
+++ b/docs/SCHEMA_CONTRACT.md
@@ -98,6 +98,8 @@ eventually migrate to `api.*`.
 | `public.team_season_trajectory` | Deployed | Week-by-week trajectory |
 | `public.team_tempo_metrics` | Deployed | Tempo analysis |
 | `public.team_special_teams_sos` | Deployed | Special teams strength of schedule |
+| `public.transfer_portal_search` | Deployed | Transfer portal entries for roster builder search. Columns: season, first_name, last_name, position, origin, destination, stars, rating, transfer_date, eligibility |
+| `public.recruits_search` | Deployed | Recruiting class entries for roster builder search. Columns: id, athlete_id, year, name, position, height, weight, stars, rating, ranking, committed_to, school, city, state_province, country |
 
 ### RPCs (Functions)
 

--- a/src/schemas/public/010_roster_builder_views.sql
+++ b/src/schemas/public/010_roster_builder_views.sql
@@ -1,0 +1,53 @@
+-- Roster Builder search views
+-- Expose recruiting.recruits and recruiting.transfer_portal to PostgREST
+-- for the cfb-app "Armchair GM" roster builder feature.
+--
+-- These are lightweight wrappers with search-friendly column selections.
+-- See: cfb-app/docs/plans/2026-02-06-feat-roster-builder-armchair-gm-plan.md
+
+-- =============================================================================
+-- TRANSFER PORTAL SEARCH
+-- =============================================================================
+
+CREATE OR REPLACE VIEW public.transfer_portal_search AS
+SELECT
+    season,
+    first_name,
+    last_name,
+    "position",
+    origin,
+    destination,
+    stars,
+    rating,
+    transfer_date,
+    eligibility
+FROM recruiting.transfer_portal;
+
+COMMENT ON VIEW public.transfer_portal_search IS
+    'Transfer portal entries for roster builder search. Consumed by cfb-app.';
+
+-- =============================================================================
+-- RECRUITS SEARCH
+-- =============================================================================
+
+CREATE OR REPLACE VIEW public.recruits_search AS
+SELECT
+    id,
+    athlete_id,
+    year,
+    name,
+    "position",
+    height,
+    weight,
+    stars,
+    rating,
+    ranking,
+    committed_to,
+    school,
+    city,
+    state_province,
+    country
+FROM recruiting.recruits;
+
+COMMENT ON VIEW public.recruits_search IS
+    'Recruiting class entries for roster builder search. Consumed by cfb-app.';


### PR DESCRIPTION
## Summary
- Create `public.transfer_portal_search` and `public.recruits_search` views exposing recruiting schema data via PostgREST
- Views support the cfb-app "Armchair GM" roster builder feature (search/filter transfer portal and recruiting class players)
- Update `SCHEMA_CONTRACT.md` with both new views

## Details
- `transfer_portal_search`: 10 columns (season, first_name, last_name, position, origin, destination, stars, rating, transfer_date, eligibility) — 14,356 rows
- `recruits_search`: 15 columns (id, athlete_id, year, name, position, height, weight, stars, rating, ranking, committed_to, school, city, state_province, country) — 16,086 rows
- Both views already deployed to Supabase and verified via SQL queries

## Test plan
- [x] Verified `transfer_portal_search` returns data filtered by position and season
- [x] Verified `recruits_search` returns data filtered by year and stars
- [x] Supabase security advisors checked — no new issues (SECURITY_DEFINER matches existing pattern)
- [ ] After merge: run `supabase gen types typescript` in cfb-app to pick up new view types

🤖 Generated with [Claude Code](https://claude.com/claude-code)