### PR TITLE
Fix SECURITY INVOKER views by granting anon schema access

### DIFF
--- a/docs/solutions/database-issues/security-invoker-schema-grants.md
+++ b/docs/solutions/database-issues/security-invoker-schema-grants.md
@@ -1,0 +1,55 @@
+---
+title: "SECURITY INVOKER Requires Schema Grants for Cross-Schema Views"
+category: database-issues
+tags: [supabase, security, rls, security-invoker, permissions, postrgrest]
+module: public views
+symptom: "Views return 'permission denied for table X' after switching from SECURITY DEFINER to SECURITY INVOKER"
+root_cause: "SECURITY INVOKER views execute as the calling role (anon), which lacks USAGE/SELECT on underlying schemas"
+---
+
+# SECURITY INVOKER Requires Schema Grants for Cross-Schema Views
+
+## Problem
+
+After converting all 13 public schema views from `SECURITY DEFINER` to `SECURITY INVOKER` (to satisfy Supabase security linter), cfb-app broke with permission denied errors on most views.
+
+## Root Cause
+
+- `SECURITY DEFINER` views execute as the **view owner** (postgres superuser) — they can access any schema
+- `SECURITY INVOKER` views execute as the **calling role** (anon via PostgREST) — they can only access schemas the caller has USAGE + SELECT on
+- The `anon` role only had USAGE on `public`, `core`, and `marts` schemas
+- Views like `public.teams` read from `ref.teams` — anon had no access to `ref` schema
+- Views like `public.team_special_teams_sos` read from `ratings.*` — anon had no access to `ratings` schema
+
+## Fix
+
+Grant USAGE + SELECT on all data schemas to anon/authenticated, and REVOKE DML to maintain read-only:
+
+```sql
+GRANT USAGE ON SCHEMA ref TO anon, authenticated;
+GRANT SELECT ON ALL TABLES IN SCHEMA ref TO anon, authenticated;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON ALL TABLES IN SCHEMA ref FROM anon, authenticated;
+-- Repeat for: ratings, recruiting, stats, marts, core, api, analytics, betting, draft
+```
+
+## Testing Gotcha
+
+**Always test as the anon role, not as postgres superuser.** The Supabase MCP connection uses the postgres superuser role, which has access to everything. This masked the permission issue during initial testing.
+
+```sql
+-- WRONG: Tests as superuser (always works)
+SELECT * FROM public.teams LIMIT 1;
+
+-- RIGHT: Tests as anon (catches permission issues)
+SET ROLE anon;
+SELECT * FROM public.teams LIMIT 1;
+RESET ROLE;
+```
+
+## Prevention
+
+When switching any view to SECURITY INVOKER:
+1. List all schemas referenced by the view's query
+2. Verify the calling role (anon/authenticated) has USAGE on each schema
+3. Verify the calling role has SELECT on each referenced table
+4. Test with `SET ROLE anon` before deploying

--- a/src/schemas/migrations/grant_read_access_for_security_invoker.sql
+++ b/src/schemas/migrations/grant_read_access_for_security_invoker.sql
@@ -1,0 +1,43 @@
+-- Migration: grant_read_access_for_security_invoker
+-- Applied: 2026-02-07
+--
+-- Fix: After converting public views from SECURITY DEFINER to SECURITY INVOKER,
+-- the anon role could no longer read underlying tables in schemas it didn't have
+-- USAGE on. This grants USAGE + SELECT on all data schemas to anon/authenticated
+-- while revoking DML to maintain read-only access.
+
+-- Grant USAGE on all data schemas
+GRANT USAGE ON SCHEMA ref TO anon, authenticated;
+GRANT USAGE ON SCHEMA ratings TO anon, authenticated;
+GRANT USAGE ON SCHEMA recruiting TO anon, authenticated;
+GRANT USAGE ON SCHEMA stats TO anon, authenticated;
+GRANT USAGE ON SCHEMA marts TO anon, authenticated;
+GRANT USAGE ON SCHEMA core TO anon, authenticated;
+GRANT USAGE ON SCHEMA api TO anon, authenticated;
+GRANT USAGE ON SCHEMA analytics TO anon, authenticated;
+GRANT USAGE ON SCHEMA betting TO anon, authenticated;
+GRANT USAGE ON SCHEMA draft TO anon, authenticated;
+
+-- Grant SELECT on all tables in each schema
+GRANT SELECT ON ALL TABLES IN SCHEMA ref TO anon, authenticated;
+GRANT SELECT ON ALL TABLES IN SCHEMA ratings TO anon, authenticated;
+GRANT SELECT ON ALL TABLES IN SCHEMA recruiting TO anon, authenticated;
+GRANT SELECT ON ALL TABLES IN SCHEMA stats TO anon, authenticated;
+GRANT SELECT ON ALL TABLES IN SCHEMA marts TO anon, authenticated;
+GRANT SELECT ON ALL TABLES IN SCHEMA core TO anon, authenticated;
+GRANT SELECT ON ALL TABLES IN SCHEMA api TO anon, authenticated;
+GRANT SELECT ON ALL TABLES IN SCHEMA analytics TO anon, authenticated;
+GRANT SELECT ON ALL TABLES IN SCHEMA betting TO anon, authenticated;
+GRANT SELECT ON ALL TABLES IN SCHEMA draft TO anon, authenticated;
+
+-- Revoke DML on all newly exposed schemas (read-only database)
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON ALL TABLES IN SCHEMA ref FROM anon, authenticated;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON ALL TABLES IN SCHEMA ratings FROM anon, authenticated;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON ALL TABLES IN SCHEMA recruiting FROM anon, authenticated;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON ALL TABLES IN SCHEMA stats FROM anon, authenticated;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON ALL TABLES IN SCHEMA marts FROM anon, authenticated;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON ALL TABLES IN SCHEMA core FROM anon, authenticated;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON ALL TABLES IN SCHEMA api FROM anon, authenticated;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON ALL TABLES IN SCHEMA analytics FROM anon, authenticated;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON ALL TABLES IN SCHEMA betting FROM anon, authenticated;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON ALL TABLES IN SCHEMA draft FROM anon, authenticated;


### PR DESCRIPTION
## Summary
- SECURITY INVOKER views (from PR #8) broke cfb-app because anon role lacked USAGE/SELECT on underlying schemas (ref, ratings, recruiting, etc.)
- Applied migration `grant_read_access_for_security_invoker` granting read access + revoking DML on all data schemas
- Added solution doc for future reference

## Test plan
- [x] All 574 tests pass
- [x] Verified as anon: `public.teams`, `team_epa_season`, `api.team_detail`, `get_player_search` RPC all work
- [x] INSERT correctly blocked for anon on all schemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)