### PR TITLE
2026 season readiness: daily automation, critical fixes, docs refresh

### DIFF
--- a/.dlt/config.toml
+++ b/.dlt/config.toml
@@ -26,17 +26,6 @@ file_max_items = 2000
 # CFBD API base URL
 base_url = "https://api.collegefootballdata.com"
 
-# Rate limiting (Tier 3: 75,000 calls/month)
+# Monthly API budget (Tier 3: 75,000 calls/month), read by get_rate_limiter().
+# Year ranges live in src/pipelines/config/years.py (single source of truth).
 monthly_budget = 75000
-calls_per_second = 10
-
-# Year ranges by data type
-[sources.cfbd.year_ranges]
-games = { start = 1869, end = 2026 }
-plays = { start = 2004, end = 2026 }
-stats = { start = 2004, end = 2026 }
-ratings = { start = 2015, end = 2026 }
-recruiting = { start = 2000, end = 2026 }
-betting = { start = 2013, end = 2026 }
-draft = { start = 2000, end = 2026 }
-metrics = { start = 2014, end = 2026 }

--- a/.github/workflows/daily-load.yml
+++ b/.github/workflows/daily-load.yml
@@ -1,0 +1,97 @@
+name: Daily Season Load
+
+# Loads the current season from the CFBD API, refreshes marts, and verifies
+# the load. Runs year-round: portal windows (Jan/Apr), signing days (Dec/Feb),
+# the NFL draft (Apr), and the coaching carousel all mutate off-season data.
+#
+# Requires repo secrets:
+#   CFBD_API_KEY     - collegefootballdata.com API key
+#   SUPABASE_DB_URL  - Supabase SESSION pooler URL (IPv4; the transaction
+#                      pooler rejects the statement_timeout startup option
+#                      that refresh_marts.py appends)
+#
+# The rate limiter's JSON state resets every run (ephemeral runner). That is
+# accepted: a full daily season load is ~730 estimated calls, ~22K/month worst
+# case against the 75K monthly budget.
+
+on:
+  schedule:
+    - cron: "0 10 * * *" # 10:00 UTC ~ 6:00 AM ET, after all games (incl. Hawaii) complete
+  workflow_dispatch:
+    inputs:
+      season:
+        description: "Season year (default: current season)"
+        required: false
+        type: string
+
+concurrency:
+  group: daily-season-load
+  cancel-in-progress: false # never kill a mid-merge load; a queued run waits
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  PYTHON_VERSION: "3.11"
+  SOURCES__CFBD__API_KEY: ${{ secrets.CFBD_API_KEY }}
+  SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+
+jobs:
+  load:
+    name: Load season, refresh marts, verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+      - run: pip install -e .
+      - name: Set dlt destination credentials
+        # dlt requires the postgres:// scheme (see .dlt/secrets.toml.example)
+        run: echo "DESTINATION__POSTGRES__CREDENTIALS=$(printf '%s' "$SUPABASE_DB_URL" | sed 's/^postgresql:/postgres:/')" >> "$GITHUB_ENV"
+      - name: Load season data (includes mart refresh)
+        run: |
+          if [ -n "${{ inputs.season }}" ]; then
+            python scripts/load_season.py --season "${{ inputs.season }}" --weekly
+          else
+            python scripts/load_season.py --weekly
+          fi
+      - name: Verify load
+        run: |
+          if [ -n "${{ inputs.season }}" ]; then
+            python scripts/verify_load.py --season "${{ inputs.season }}"
+          else
+            python scripts/verify_load.py
+          fi
+      - name: Open or update failure issue
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = "Daily season load failing";
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const { data } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+            });
+            const existing = data.find((i) => i.title === title);
+            const body = `Run failed: ${runUrl} (${new Date().toISOString()})`;
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+              });
+            }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,17 +53,24 @@ The database uses multiple Postgres schemas organized by data domain:
 | `draft` | NFL draft data | picks, positions |
 | `metrics` | Advanced metrics | PPA, win probability |
 | `analytics` | Computed analytics | EPA, style profiles |
-| `marts` | Materialized views (19) | Denormalized, query-optimized |
-| `api` | API view layer (7) | Contract surface for cfb-app/cfb-scout |
-| `public` | Convenience views/RPCs (8) | Downstream consumer interface |
+| `marts` | Materialized views (27) | Denormalized, query-optimized |
+| `api` | API view layer (18) | Contract surface for cfb-app/cfb-scout |
+| `public` | Convenience views/RPCs (12) | Downstream consumer interface |
 
 ### Marts System
 
-19 materialized views in the `marts` schema provide denormalized, query-optimized data. Refresh via:
+27 materialized views in the `marts` schema provide denormalized, query-optimized data (plus the plain view `analytics.data_quality_dashboard`). Refresh via:
 ```bash
 python scripts/refresh_marts.py        # Refresh all marts
 ```
 Or use the `refresh_all_marts()` RPC.
+
+### Daily Automation
+
+`.github/workflows/daily-load.yml` runs daily at 10:00 UTC from `main`: loads the
+current season (`scripts/load_season.py --weekly`, mart refresh included), then runs
+post-load checks (`scripts/verify_load.py`). Failures open/update a rolling GitHub
+issue. Requires repo secrets `CFBD_API_KEY` and `SUPABASE_DB_URL` (session pooler).
 
 ### dlt Table Conventions
 
@@ -80,8 +87,8 @@ cfb-database/
 │   ├── pipeline-manifest.md      # Endpoint-to-pipeline status (source of truth)
 │   ├── cfbd-api-endpoints.md     # Complete CFBD API reference
 │   ├── dlt-reference.md          # Pipeline configuration patterns
-│   ├── SPRINT_PLAN.md            # Implementation plan
-│   ├── plans/                    # Dated sprint/implementation plans (22 files)
+│   ├── plans/                    # Dated sprint/implementation plans (+ archive/)
+│   ├── handoffs/                 # Cross-repo handoff docs
 │   ├── brainstorms/              # Design exploration docs
 │   └── solutions/                # Solved problem documentation
 ├── src/
@@ -95,19 +102,23 @@ cfb-database/
 │   │   │   └── rate_limiter.py   # Monthly budget tracking
 │   │   └── run.py                # Pipeline orchestration
 │   └── schemas/
-│       ├── api/                  # 7 API view definitions (contract surface)
+│       ├── api/                  # 18 API view definitions (contract surface)
 │       ├── functions/            # SQL functions
-│       ├── marts/                # 19 materialized view definitions
-│       ├── public/               # 8 convenience views + RPCs
+│       ├── marts/                # 27 materialized view definitions (+1 plain view)
+│       ├── public/               # 12 convenience views + RPCs
 │       └── migrations/           # Schema migrations
 ├── scripts/
+│   ├── load_season.py            # Orchestrate full season load + mart refresh
+│   ├── verify_load.py            # Post-load verification checks
 │   ├── refresh_marts.py          # Mart refresh script
-│   └── run_migrations.py         # Migration runner
-├── tests/                        # 8 test files + test_sources/
+│   ├── run_marts.py              # Apply mart definitions
+│   └── run_migrations.py         # Migration runner (--file for one-off SQL)
+├── tests/                        # Test files + test_sources/
 │   └── conftest.py               # DB connection + mock fixtures
 ├── .dlt/
-│   ├── config.toml               # Runtime config (workers, year ranges, rate limits)
+│   ├── config.toml               # Runtime config (workers, rate limit budget)
 │   └── secrets.toml              # API keys (not committed)
+├── .github/workflows/            # CI + daily season load
 └── .githooks/pre-push            # Runs ruff + pytest before push
 ```
 
@@ -202,11 +213,16 @@ pip install -e ".[dev]"
 python -m src.pipelines.run --source reference           # Load reference data
 python -m src.pipelines.run --source games --year 2024   # Load games for a year
 
+# Season orchestration (what the daily workflow runs)
+python scripts/load_season.py --weekly    # Load current season + refresh marts
+python scripts/verify_load.py             # Post-load checks (exit 1 on failure)
+
 # Marts
 python scripts/refresh_marts.py     # Refresh all materialized views
 
 # Migrations
 python scripts/run_migrations.py    # Apply pending migrations
+python scripts/run_migrations.py --file <path>  # Apply one-off public/api/functions SQL
 
 # Testing & linting
 .venv/bin/ruff check .              # Lint
@@ -256,5 +272,5 @@ Historical depth varies by endpoint:
 ## Configuration
 
 - `pyproject.toml` -- project metadata, dependencies, CLI entry point (`cfb-pipeline`), ruff config (line-length 100, py311), pytest config
-- `.dlt/config.toml` -- runtime config: worker count, file chunking, year ranges per source, monthly API budget (75,000)
+- `.dlt/config.toml` -- runtime config: worker count, file chunking, monthly API budget (75,000). Year ranges live in `src/pipelines/config/years.py`
 - Supabase MCP server enabled in `.claude/settings.local.json` for interactive SQL during development

--- a/README.md
+++ b/README.md
@@ -13,16 +13,46 @@ College Football Data warehouse using dlt pipelines and Supabase Postgres.
    pip install -e ".[dev]"
    ```
 
-3. Run the schemas:
+3. Provision the database:
    ```bash
-   psql $DATABASE_URL -f src/schemas/001_reference.sql
-   # ... additional schema files
+   python scripts/run_migrations.py     # Core DDL (src/schemas/001-018)
+   python scripts/run_marts.py          # Materialized view definitions
+   python scripts/refresh_marts.py      # Populate/refresh the marts
+   ```
+   One-off SQL in `src/schemas/public/`, `api/`, or `functions/` is applied with:
+   ```bash
+   python scripts/run_migrations.py --file src/schemas/public/008_trajectory_averages_function.sql
    ```
 
 4. Load data:
    ```bash
    python -m src.pipelines.run --source reference
    ```
+
+## In-Season Operations
+
+A GitHub Actions workflow (`.github/workflows/daily-load.yml`) runs every day at
+10:00 UTC from `main`: it loads the current season, refreshes all marts, and runs
+`scripts/verify_load.py`. Failures open/update a rolling GitHub issue.
+
+Required repo secrets:
+
+| Secret | Value |
+|--------|-------|
+| `CFBD_API_KEY` | collegefootballdata.com API key (exported as `SOURCES__CFBD__API_KEY`) |
+| `SUPABASE_DB_URL` | Supabase **session pooler** connection string (IPv4-capable; the transaction pooler rejects the `statement_timeout` startup option the mart refresh needs) |
+
+The same flow can be run manually:
+
+```bash
+python scripts/load_season.py                    # Load current season + refresh marts
+python scripts/load_season.py --season 2026 --weekly   # Explicit season, week-by-week game stats
+python scripts/load_season.py --dry-run          # Show the plan and API call estimate
+python scripts/verify_load.py                    # Post-load checks (exits 1 on failure)
+```
+
+`--weekly` loads game box scores week-by-week (~35K rows per merge) to stay under
+Supabase statement timeouts; the daily workflow always uses it.
 
 ## CLI Usage
 
@@ -42,10 +72,13 @@ python -m src.pipelines.run --status
 
 ## Architecture
 
-- **Source:** CFBD API (61 endpoints)
+- **Source:** CFBD API (see `docs/pipeline-manifest.md` for endpoint-to-table coverage)
 - **ETL:** dlt pipelines with year-based iteration
-- **Destination:** Supabase Postgres (10 schemas, ~35 tables)
+- **Destination:** Supabase Postgres (10 schemas, ~35 tables + marts/api/public layers)
 
 ## Rate Limits
 
-Using Tier 3 (75,000 calls/month). Full historical backfill requires ~1,100 calls.
+Using Tier 3 (75,000 calls/month), read by the rate limiter from
+`.dlt/config.toml` (`sources.cfbd.monthly_budget`). A full single-season
+refresh is ~730 estimated calls (`scripts/load_season.py --dry-run` prints the
+current estimate), so even daily loads stay well under budget.

--- a/docs/SCHEMA_CONTRACT.md
+++ b/docs/SCHEMA_CONTRACT.md
@@ -4,7 +4,7 @@
 > only depend on objects listed here as **public**. Everything else is internal and may change
 > without notice.
 
-Last updated: 2026-02-06
+Last updated: 2026-07-19
 
 ---
 
@@ -156,7 +156,7 @@ These reference tables are stable enough for direct access.
 |----------|--------|-------------|
 | `ref.get_era` | `ref` | Returns era code/name for a given year |
 | `analytics.refresh_all_views` | `analytics` | Refreshes all analytics materialized views (admin use) |
-| `marts.refresh_all` | `marts` | Refreshes all 28 mart materialized views in dependency order (5 layers). Returns (view_name, duration_ms, status). |
+| `marts.refresh_all` | `marts` | Refreshes all 27 mart materialized views in dependency order (5 layers). Returns (view_name, duration_ms, status). |
 
 ---
 

--- a/docs/SCHEMA_CONTRACT.md
+++ b/docs/SCHEMA_CONTRACT.md
@@ -8,6 +8,15 @@ Last updated: 2026-02-06
 
 ---
 
+## Recent Contract Changes
+
+- **2026-07-19 — `get_trajectory_averages` default season end now tracks loaded data.**
+  `p_season_end` default changed from a pinned `2025` to `NULL`, which resolves to the
+  latest season present in `public.team_season_trajectory`. Callers omitting the argument
+  will start receiving 2026 rows as they materialize; explicit arguments behave unchanged.
+
+---
+
 ## Contract Rules
 
 1. **API views and RPCs are versioned.** Breaking changes require a migration and coordination
@@ -123,7 +132,7 @@ Server-side functions callable via `supabase.rpc()`.
 | `get_field_position_splits` | `public` | `(p_team, p_season)` | EPA and success rate by field position zone |
 | `get_home_away_splits` | `public` | `(p_team, p_season)` | Home vs away performance comparison |
 | `get_conference_splits` | `public` | `(p_team, p_season)` | Performance vs conference, non-conference, ranked opponents |
-| `get_trajectory_averages` | `public` | `(p_conference, p_season_start?, p_season_end?)` | Conference and FBS average benchmarks |
+| `get_trajectory_averages` | `public` | `(p_conference, p_season_start?, p_season_end?)` | Conference and FBS average benchmarks. Omitted `p_season_end` resolves to the latest loaded season (changed 2026-07-19; previously pinned to 2025). |
 | `get_player_season_stats_pivoted` | `public` | `(p_team, p_season)` | Pivoted player stats (pass/rush/rec/def/kick in columns) |
 | `get_player_search` | `public` | `(p_query text, p_position?, p_team?, p_season?, p_limit? default 25)` | Fuzzy player name search using pg_trgm. Returns player_id, name, team, position, season, height, weight, jersey, stars, recruit_rating, similarity_score. Supports typo tolerance. |
 | `get_available_seasons` | `public` | `()` | List of seasons with data |

--- a/docs/handoffs/2026-07-19-portal-surveillance-cron-to-cfb-scout.md
+++ b/docs/handoffs/2026-07-19-portal-surveillance-cron-to-cfb-scout.md
@@ -1,3 +1,39 @@
+# Handoff: Portal Surveillance Cron → cfb-scout
+
+**Date:** 2026-07-19
+**Removed from this repo:** `src/schemas/migrations/017_portal_surveillance_cron.sql` (introduced in commit `593a16c`, 2026-02-26)
+
+## Why this was removed from cfb-database
+
+The migration defines `scouting.fn_evaluate_portal_value()` and schedules it via
+pg_cron, but every table it touches — `scouting.players`, `scouting.transfer_events`,
+`scouting.pff_grades`, `scouting.alerts`, `scouting.alert_history` — belongs to the
+`scouting` schema, which `docs/SCHEMA_CONTRACT.md` assigns to **cfb-scout**. This repo
+never creates those tables, so:
+
+- Applying the file against a database without the scouting schema **fails outright**.
+- It was wired into no runner (`scripts/run_migrations.py` does not reference
+  `src/schemas/migrations/`), so it only ever ran if applied by hand.
+- Its `017` number collides with `src/schemas/017_era_reference.sql`.
+
+Per the schema-ownership contract, the function and its cron schedule should live in
+cfb-scout's migration chain instead.
+
+## Action for cfb-scout
+
+1. Adopt the SQL below into cfb-scout's migrations (renumber to fit its chain).
+2. pg_cron must be enabled on the Supabase project (Dashboard → Database → Extensions)
+   if `create extension` lacks permission.
+3. Check whether the job is already live before re-applying:
+   `SELECT jobname, schedule FROM cron.job;`
+   - Live-database state as of this handoff: see note at the bottom of this doc.
+   - If `daily-portal-surveillance` already exists, the `cron.schedule` call in the SQL
+     would create a duplicate under some pg_cron versions — prefer
+     `cron.alter_job`/`cron.unschedule` first.
+
+## Original SQL (verbatim)
+
+```sql
 -- src/schemas/migrations/017_portal_surveillance_cron.sql
 -- Goal: Automated Transfer Portal Surveillance via pg_cron
 
@@ -78,3 +114,8 @@ select cron.schedule(
 );
 
 comment on function scouting.fn_evaluate_portal_value() is 'Automated scouter that identifies high-value portal entrants and fires system alerts.';
+```
+
+## Live database state
+
+_To be recorded during verification: `SELECT jobname, schedule FROM cron.job;`_

--- a/docs/pipeline-manifest.md
+++ b/docs/pipeline-manifest.md
@@ -65,7 +65,7 @@ Only 3 actual variant columns in user data tables. dlt internal tables also have
 | 1 | `/conferences` | ref.conferences | reference.py | conferences_resource | YES | replace | id | WORKING |
 | 2 | `/teams` | ref.teams | reference.py | teams_resource | YES | replace | id | WORKING |
 | 3 | `/venues` | ref.venues | reference.py | venues_resource | YES | replace | id | WORKING |
-| 4 | `/coaches` | ref.coaches | reference.py | coaches_resource | YES | replace | first_name, last_name | WORKING (PK bug in config) |
+| 4 | `/coaches` | ref.coaches | reference.py | coaches_resource | YES | merge | first_name, last_name | WORKING |
 | 5 | `/plays/types` | ref.play_types | reference.py | play_types_resource | YES | replace | id | WORKING |
 
 ### Core Game Data (merge disposition)
@@ -89,7 +89,7 @@ Only 3 actual variant columns in user data tables. dlt internal tables also have
 |---|---|---|---|---|---|---|---|---|---|
 | 16 | `/plays` | core.plays | plays.py | plays_resource | YES | merge | id | 2004-2026 | WORKING |
 | 17 | `/plays/stats` | stats.play_stats | stats.py | play_stats_resource | YES | merge | game_id, play_id, athlete_id, stat_type | 2014-2026 | WORKING |
-| 18 | `/plays/stats/types` | — | — | — | — | — | — | — | UNMAPPED |
+| 18 | `/plays/stats/types` | ref.play_stat_types | reference.py | play_stat_types_resource | YES | merge | id | — | WORKING |
 | 19 | `/live/plays` | — | — | — | — | — | — | — | UNMAPPED |
 
 ### Stats Data (merge disposition)
@@ -97,7 +97,7 @@ Only 3 actual variant columns in user data tables. dlt internal tables also have
 | # | API Path | Table | Source File | Resource Function | Wired? | Disposition | Primary Key | Year Range | Status |
 |---|---|---|---|---|---|---|---|---|---|
 | 20 | `/stats/season` | stats.team_season_stats | stats.py | team_season_stats_resource | YES | merge | season, team, stat_name | 2004-2026 | WORKING |
-| 21 | `/stats/player/season` | stats.player_season_stats | stats.py | player_season_stats_resource | YES | merge | **player_id, season, category** (WRONG — needs stat_type too) | 2004-2026 | WORKING (PK bug) |
+| 21 | `/stats/player/season` | stats.player_season_stats | stats.py | player_season_stats_resource | YES | merge | player_id, season, team, category, stat_type | 2004-2026 | WORKING |
 | 22 | `/stats/season/advanced` | stats.advanced_team_stats | stats.py | advanced_team_stats_resource | YES | merge | season, team | 2004-2026 | WORKING |
 | 23 | `/stats/game/advanced` | — | — | — | — | — | — | — | UNMAPPED |
 | 24 | `/stats/game/havoc` | stats.game_havoc | stats.py | game_havoc_resource | YES | merge | game_id, team | 2014-2026 | WORKING |
@@ -119,7 +119,7 @@ Only 3 actual variant columns in user data tables. dlt internal tables also have
 |---|---|---|---|---|---|---|---|---|---|
 | 31 | `/recruiting/players` | recruiting.recruits | recruiting.py | recruits_resource | YES | merge | id | 2000-2026 | WORKING |
 | 32 | `/recruiting/teams` | recruiting.team_recruiting | recruiting.py | team_recruiting_resource | YES | merge | year, team | 2000-2026 | WORKING |
-| 33 | `/player/portal` | recruiting.transfer_portal | recruiting.py | transfer_portal_resource | YES | merge | **season, first_name, last_name** (PK mismatch in config) | 2000-2026 | WORKING (PK bug) |
+| 33 | `/player/portal` | recruiting.transfer_portal | recruiting.py | transfer_portal_resource | YES | merge | first_name, last_name, origin, season | 2000-2026 | WORKING |
 | 34 | `/recruiting/groups` | recruiting.recruiting_groups | recruiting.py | recruiting_groups_resource | YES | merge | year, team, position_group | 2000-2026 | WORKING |
 
 ### Player Data
@@ -134,13 +134,13 @@ Only 3 actual variant columns in user data tables. dlt internal tables also have
 
 | # | API Path | Table | Source File | Resource Function | Wired? | Disposition | Primary Key | Year Range | Status |
 |---|---|---|---|---|---|---|---|---|---|
-| 38 | `/lines` | betting.lines | betting.py | lines_resource | YES | merge | **game_id, provider** (config says id — mismatch) | 2013-2026 | WORKING (PK bug) |
+| 38 | `/lines` | betting.lines | betting.py | lines_resource | YES | merge | game_id, provider | 2013-2026 | WORKING |
 
 ### Draft Data (merge disposition)
 
 | # | API Path | Table | Source File | Resource Function | Wired? | Disposition | Primary Key | Year Range | Status |
 |---|---|---|---|---|---|---|---|---|---|
-| 39 | `/draft/picks` | draft.draft_picks | draft.py | draft_picks_resource | YES | merge | **year, overall** (config says college_athlete_id — mismatch) | 2000-2026 | WORKING (PK bug) |
+| 39 | `/draft/picks` | draft.draft_picks | draft.py | draft_picks_resource | YES | merge | year, overall | 2000-2026 | WORKING |
 | 40 | `/draft/positions` | ref.draft_positions | reference.py | draft_positions_resource | YES | replace | name | — | WORKING |
 | 41 | `/draft/teams` | ref.draft_teams | reference.py | draft_teams_resource | YES | replace | location, nickname | — | WORKING |
 
@@ -188,14 +188,21 @@ Only 3 actual variant columns in user data tables. dlt internal tables also have
 
 | Status | Count |
 |---|---|
-| WORKING | 45 |
-| WORKING (PK bug) | 5 |
+| WORKING | 51 |
 | WORKING (note) | 1 |
 | CONFIG_ONLY | 0 |
 | DEFERRED | 4 |
-| UNMAPPED | 4 |
+| UNMAPPED | 3 |
 | REMOVED | 1 |
 | **Total** | **60** |
+
+**2026-07-19 update:** The 5 "WORKING (PK bug)" entries (coaches, player_season_stats,
+transfer_portal, lines, draft_picks) were already fixed in the source modules — statuses
+and PKs above now reflect the code. `/plays/stats/types` was loaded (26 rows in
+`ref.play_stat_types`) but still marked UNMAPPED; corrected. Also as of this date,
+`/games/teams` and `/games/players` load **only** via `game_stats_source`
+(`games.py` no longer yields them), whose week-by-week path avoids Supabase merge
+timeouts — `run.py --source game_stats --weekly` or `scripts/load_season.py --weekly`.
 
 **Sprint 4 Progress:** Promoted 15 endpoints from UNMAPPED/CONFIG_ONLY to WORKING: `/game/box/advanced`, `/plays/stats`, `/stats/season/advanced`, `/stats/game/havoc`, `/ratings/sp/conferences`, `/player/usage`, `/player/returning`, `/teams/ats`, `/ppa/games`, `/ppa/players/games`, `/metrics/fg/ep`, `/wepa/players/passing`, `/wepa/players/rushing`, `/wepa/team/season`, `/wepa/players/kicking`. Removed `/player/search` (requires searchTerm; use core.rosters instead). Deleted dead code: `adjusted_metrics.py` (duplicate of `wepa.py`), `players.py` (broken source).
 

--- a/docs/plans/archive/SPRINT_PLAN.md
+++ b/docs/plans/archive/SPRINT_PLAN.md
@@ -1,5 +1,10 @@
 # CFB Database — Sprint Plan
 
+> **SUPERSEDED (2026-07-19).** Historical Sprint 0-1 planning document, kept for
+> reference. Its status claims no longer hold (e.g. "Tests: None" — the repo now
+> has a full test suite; the listed PK bugs are fixed). See `docs/plans/` for the
+> later sprint plans and `docs/pipeline-manifest.md` for current pipeline status.
+
 > Reviewed by plan-reviewer. Incorporates feedback on migration safety, testing timing, dlt disposition conflicts, partitioning complexity, and Sprint 3 decomposition.
 
 ## Project Status

--- a/scripts/load_season.py
+++ b/scripts/load_season.py
@@ -4,6 +4,7 @@
 Orchestrates pipeline sources in dependency order and refreshes materialized views.
 
 Usage:
+    python scripts/load_season.py                                   # Load current season
     python scripts/load_season.py --season 2025                     # Load everything for 2025
     python scripts/load_season.py --season 2025 --sources games,stats  # Load specific sources
     python scripts/load_season.py --season 2025 --dry-run           # Show what would run
@@ -206,7 +207,12 @@ def load_season(
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Load all data for a specific season")
-    parser.add_argument("--season", type=int, required=True, help="Season year to load")
+    parser.add_argument(
+        "--season",
+        type=int,
+        default=None,
+        help="Season year to load (default: current season)",
+    )
     parser.add_argument(
         "--sources",
         type=str,
@@ -224,10 +230,17 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    season = args.season
+    if season is None:
+        from src.pipelines.config.years import get_current_season
+
+        season = get_current_season()
+        logger.info(f"No --season given; using current season {season}")
+
     sources = args.sources.split(",") if args.sources else None
 
     summary = load_season(
-        season=args.season,
+        season=season,
         sources=sources,
         dry_run=args.dry_run,
         skip_refresh=args.skip_refresh,

--- a/scripts/load_season.py
+++ b/scripts/load_season.py
@@ -53,12 +53,24 @@ ESTIMATED_CALLS = {
 }
 
 
+def upcoming_schedule_season(season: int, month: int) -> int | None:
+    """Return the next season to schedule-refresh during the off-season.
+
+    Before August, get_current_season() still points at the previous season,
+    but the upcoming season's schedule is already published on CFBD. Auto-mode
+    loads keep it fresh via a cheap games-only pull (~15 calls) so the daily
+    automation never depends on a manual dispatch to pick up the new season.
+    """
+    return season + 1 if month < 8 else None
+
+
 def load_season(
     season: int,
     sources: list[str] | None = None,
     dry_run: bool = False,
     skip_refresh: bool = False,
     weekly: bool = False,
+    upcoming_schedule: int | None = None,
 ) -> dict:
     """Load or refresh all data for a given season.
 
@@ -68,6 +80,8 @@ def load_season(
         dry_run: If True, show plan without executing
         skip_refresh: If True, skip mart refresh after loading
         weekly: If True, load game_stats week-by-week (~35K rows per merge)
+        upcoming_schedule: If set, also refresh this season's schedule tables
+            (games source only) after the main load
 
     Returns:
         Summary dict with timing and row counts
@@ -123,6 +137,8 @@ def load_season(
             print(f"  {src:15s}  ~{est:,} API calls")
         print(f"\n  Total estimated:  ~{total_est:,} calls")
         print(f"  Budget remaining: {remaining:,} calls")
+        if upcoming_schedule:
+            print(f"  + Refresh {upcoming_schedule} schedule (games source, ~15 calls)")
         if not skip_refresh:
             print("  + Refresh all materialized views after loading")
         return {"dry_run": True, "estimated_calls": total_est}
@@ -167,6 +183,27 @@ def load_season(
             elapsed = time.time() - src_start
             results[src] = {"status": "error", "duration_s": round(elapsed, 1), "error": str(e)}
             logger.error(f"  {src} failed after {elapsed:.1f}s: {e}")
+
+    # Off-season: keep the upcoming season's published schedule fresh
+    if upcoming_schedule:
+        logger.info(f"Refreshing upcoming season {upcoming_schedule} schedule...")
+        src_start = time.time()
+        try:
+            info = run_games_pipeline(years=[upcoming_schedule])
+            elapsed = time.time() - src_start
+            results["games_upcoming"] = {
+                "status": "ok",
+                "duration_s": round(elapsed, 1),
+                "info": str(info),
+            }
+        except Exception as e:
+            elapsed = time.time() - src_start
+            results["games_upcoming"] = {
+                "status": "error",
+                "duration_s": round(elapsed, 1),
+                "error": str(e),
+            }
+            logger.error(f"  upcoming schedule failed after {elapsed:.1f}s: {e}")
 
     # Refresh marts
     if not skip_refresh:
@@ -231,11 +268,17 @@ def main() -> None:
     args = parser.parse_args()
 
     season = args.season
+    upcoming = None
     if season is None:
+        from datetime import datetime
+
         from src.pipelines.config.years import get_current_season
 
         season = get_current_season()
+        upcoming = upcoming_schedule_season(season, datetime.now().month)
         logger.info(f"No --season given; using current season {season}")
+        if upcoming:
+            logger.info(f"Off-season: will also refresh the {upcoming} schedule")
 
     sources = args.sources.split(",") if args.sources else None
 
@@ -245,6 +288,7 @@ def main() -> None:
         dry_run=args.dry_run,
         skip_refresh=args.skip_refresh,
         weekly=args.weekly,
+        upcoming_schedule=upcoming,
     )
 
     if summary.get("errors", 0) > 0:

--- a/scripts/run_migrations.py
+++ b/scripts/run_migrations.py
@@ -5,6 +5,10 @@ Usage:
     python scripts/run_migrations.py --from 002         # Run from 002 onwards
     python scripts/run_migrations.py --only 009         # Run only 009
     python scripts/run_migrations.py --dry-run          # Print SQL without executing
+    python scripts/run_migrations.py --file src/schemas/public/008_trajectory_averages_function.sql
+
+--file applies a single SQL file outside MIGRATION_ORDER -- the supported path
+for one-off changes to public/, api/, and functions/ definitions.
 """
 
 import argparse
@@ -90,7 +94,33 @@ def main() -> None:
     parser.add_argument("--from", dest="from_num", help="Start from migration number (e.g., 002)")
     parser.add_argument("--only", help="Run only this migration number (e.g., 009)")
     parser.add_argument("--dry-run", action="store_true", help="Print SQL without executing")
+    parser.add_argument(
+        "--file",
+        dest="sql_file",
+        help="Apply a single SQL file (path relative to repo root or absolute)",
+    )
     args = parser.parse_args()
+
+    if args.sql_file:
+        sql_path = Path(args.sql_file)
+        if not sql_path.is_absolute():
+            sql_path = Path(__file__).parent.parent / sql_path
+        if not sql_path.exists():
+            logger.error(f"SQL file not found: {sql_path}")
+            sys.exit(1)
+
+        if args.dry_run:
+            run_migration(sql_path, conn=None, dry_run=True)
+            return
+
+        import psycopg2
+
+        conn = psycopg2.connect(get_db_url())
+        try:
+            run_migration(sql_path, conn)
+        finally:
+            conn.close()
+        return
 
     # Filter migrations
     migrations = MIGRATION_ORDER

--- a/scripts/verify_load.py
+++ b/scripts/verify_load.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Verify a season load actually landed: partition, counts, coverage, freshness.
+
+Intended to run right after scripts/load_season.py (the daily workflow does),
+failing loudly so a silent bad load surfaces as a red job instead of a stale
+dashboard weeks later.
+
+Usage:
+    python scripts/verify_load.py                   # Verify current season
+    python scripts/verify_load.py --season 2026     # Verify a specific season
+    python scripts/verify_load.py --strict          # Treat staleness as failure year-round
+
+Checks:
+    1. plays partition for the season exists (core.plays_yNNNN)
+    2. core.games row count for the season matches the CFBD /games count (1 API call)
+    3. completed games have game_team_stats rows (tolerance for FCS games
+       without box scores)
+    4. completed games have plays rows (same tolerance)
+    5. marts.data_freshness is_stale flags -- heuristic only: the matview infers
+       freshness from pg_stat vacuum/analyze timestamps, so staleness WARNs
+       off-season and FAILs in-season (or with --strict)
+
+Pre-season semantics: with no completed games, checks 3-4 pass vacuously and
+check 2 is the meaningful one (schedules publish in July, so core.games must
+already have rows for the upcoming season).
+"""
+
+import argparse
+import logging
+import sys
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+# Completed games allowed to lack box scores / plays before failing.
+# FCS opponents and canceled-but-marked-completed games routinely have none.
+MISSING_STATS_TOLERANCE = 10
+
+PASS, WARN, FAIL = "PASS", "WARN", "FAIL"
+
+
+def is_in_season(month: int) -> bool:
+    """September through January: weekly tables must be actively refreshing."""
+    return month in {9, 10, 11, 12, 1}
+
+
+def evaluate_missing(missing: int, tolerance: int = MISSING_STATS_TOLERANCE) -> str:
+    """Grade a count of completed games missing downstream rows."""
+    if missing == 0:
+        return PASS
+    if missing <= tolerance:
+        return WARN
+    return FAIL
+
+
+def evaluate_game_counts(api_count: int, db_count: int) -> str:
+    """Grade API-vs-DB game count reconciliation for a season."""
+    if api_count > 0 and db_count == 0:
+        return FAIL
+    if db_count < api_count:
+        return FAIL
+    return PASS
+
+
+def evaluate_staleness(frequency: str, in_season: bool, strict: bool) -> str:
+    """Grade an is_stale row from marts.data_freshness."""
+    if frequency == "weekly" and (in_season or strict):
+        return FAIL
+    return WARN
+
+
+class Report:
+    def __init__(self) -> None:
+        self.failures = 0
+
+    def record(self, status: str, name: str, detail: str) -> None:
+        print(f"[{status}] {name}: {detail}")
+        if status == FAIL:
+            self.failures += 1
+
+
+def check_partition(cur, season: int, report: Report) -> None:
+    cur.execute("SELECT to_regclass(%s)", (f"core.plays_y{season}",))
+    exists = cur.fetchone()[0] is not None
+    report.record(
+        PASS if exists else FAIL,
+        "plays_partition",
+        f"core.plays_y{season} {'exists' if exists else 'MISSING'}",
+    )
+
+
+def check_game_counts(cur, season: int, report: Report) -> None:
+    from src.pipelines.sources.base import make_request
+    from src.pipelines.utils.api_client import get_client
+
+    client = get_client()
+    try:
+        api_count = len(make_request(client, "/games", params={"year": season}))
+    finally:
+        client.close()
+
+    cur.execute("SELECT COUNT(*) FROM core.games WHERE season = %s", (season,))
+    db_count = cur.fetchone()[0]
+    report.record(
+        evaluate_game_counts(api_count, db_count),
+        "game_counts",
+        f"api={api_count} db={db_count}",
+    )
+
+
+def check_completed_have_team_stats(cur, season: int, report: Report) -> None:
+    cur.execute(
+        """
+        SELECT COUNT(*)
+        FROM core.games g
+        WHERE g.season = %s AND g.completed
+          AND NOT EXISTS (SELECT 1 FROM core.game_team_stats s WHERE s.id = g.id)
+        """,
+        (season,),
+    )
+    missing = cur.fetchone()[0]
+    report.record(
+        evaluate_missing(missing),
+        "completed_have_team_stats",
+        f"{missing} completed game(s) missing box scores (tolerance {MISSING_STATS_TOLERANCE})",
+    )
+
+
+def check_completed_have_plays(cur, season: int, report: Report) -> None:
+    # p.season predicate enables partition pruning; plays has no week column
+    cur.execute(
+        """
+        SELECT COUNT(*)
+        FROM core.games g
+        WHERE g.season = %s AND g.completed
+          AND NOT EXISTS (
+              SELECT 1 FROM core.plays p WHERE p.season = %s AND p.game_id = g.id
+          )
+        """,
+        (season, season),
+    )
+    missing = cur.fetchone()[0]
+    report.record(
+        evaluate_missing(missing),
+        "completed_have_plays",
+        f"{missing} completed game(s) missing plays (tolerance {MISSING_STATS_TOLERANCE})",
+    )
+
+
+def check_freshness(cur, in_season: bool, strict: bool, report: Report) -> None:
+    cur.execute(
+        """
+        SELECT schema_name, table_name, expected_refresh_frequency, days_since_activity
+        FROM marts.data_freshness
+        WHERE is_stale
+        ORDER BY schema_name, table_name
+        """
+    )
+    rows = cur.fetchall()
+    if not rows:
+        report.record(PASS, "data_freshness", "no stale tables")
+        return
+
+    for schema_name, table_name, frequency, days in rows:
+        report.record(
+            evaluate_staleness(frequency, in_season, strict),
+            "data_freshness",
+            f"{schema_name}.{table_name} stale ({frequency}, {days} days since activity)",
+        )
+
+
+def verify(season: int, strict: bool) -> int:
+    """Run all checks. Returns the number of failures."""
+    from datetime import datetime
+
+    import psycopg2
+
+    from scripts.refresh_marts import get_db_url
+
+    in_season = is_in_season(datetime.now().month)
+    report = Report()
+
+    conn = psycopg2.connect(get_db_url())
+    try:
+        with conn.cursor() as cur:
+            check_partition(cur, season, report)
+            check_game_counts(cur, season, report)
+            check_completed_have_team_stats(cur, season, report)
+            check_completed_have_plays(cur, season, report)
+            check_freshness(cur, in_season, strict, report)
+    finally:
+        conn.close()
+
+    if report.failures:
+        logger.error(f"{report.failures} check(s) FAILED for season {season}")
+    else:
+        logger.info(f"All checks passed for season {season}")
+    return report.failures
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Verify a season load")
+    parser.add_argument(
+        "--season",
+        type=int,
+        default=None,
+        help="Season to verify (default: current season)",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Treat weekly-table staleness as failure even off-season",
+    )
+    args = parser.parse_args()
+
+    season = args.season
+    if season is None:
+        from src.pipelines.config.years import get_current_season
+
+        season = get_current_season()
+        logger.info(f"No --season given; verifying current season {season}")
+
+    sys.exit(1 if verify(season, strict=args.strict) else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pipelines/sources/games.py
+++ b/src/pipelines/sources/games.py
@@ -1,6 +1,10 @@
 """Games and drives data sources - year-iterated loading.
 
 These tables contain game event data and require year-based iteration.
+
+Game box scores (game_team_stats, game_player_stats) load exclusively via
+game_stats.py, whose week-by-week path keeps merge batches small enough for
+Supabase statement timeouts.
 """
 
 import logging
@@ -39,8 +43,6 @@ def games_source(
         game_media_resource(years),
         game_weather_resource(years),
         records_resource(years),
-        game_team_stats_resource(years),
-        game_player_stats_resource(years),
     ]
 
 
@@ -177,78 +179,6 @@ def records_resource(years: list[int]) -> Iterator[dict]:
             data = make_request(client, "/records", params={"year": year})
 
             yield from data
-
-    finally:
-        client.close()
-
-
-@dlt.resource(
-    name="game_team_stats",
-    write_disposition="merge",
-    primary_key="id",
-)
-def game_team_stats_resource(years: list[int]) -> Iterator[dict]:
-    """Load team box scores per game for specified years.
-
-    Args:
-        years: List of years to load game team stats for
-    """
-    client = get_client()
-    try:
-        for year in years:
-            logger.info(f"Loading game team stats for {year}...")
-
-            # CFBD games/teams endpoint requires week parameter
-            # Regular season: weeks 1-15, postseason: weeks 1-5
-            for season_type in ["regular", "postseason"]:
-                max_week = 15 if season_type == "regular" else 5
-                for week in range(1, max_week + 1):
-                    try:
-                        data = make_request(
-                            client,
-                            "/games/teams",
-                            params={"year": year, "seasonType": season_type, "week": week},
-                        )
-                        yield from data
-                    except Exception:
-                        # Some weeks may not have games (esp postseason)
-                        continue
-
-    finally:
-        client.close()
-
-
-@dlt.resource(
-    name="game_player_stats",
-    write_disposition="merge",
-    primary_key="id",
-)
-def game_player_stats_resource(years: list[int]) -> Iterator[dict]:
-    """Load player box scores per game for specified years.
-
-    Args:
-        years: List of years to load game player stats for
-    """
-    client = get_client()
-    try:
-        for year in years:
-            logger.info(f"Loading game player stats for {year}...")
-
-            # CFBD games/players endpoint requires week parameter
-            # Regular season: weeks 1-15, postseason: weeks 1-5
-            for season_type in ["regular", "postseason"]:
-                max_week = 15 if season_type == "regular" else 5
-                for week in range(1, max_week + 1):
-                    try:
-                        data = make_request(
-                            client,
-                            "/games/players",
-                            params={"year": year, "seasonType": season_type, "week": week},
-                        )
-                        yield from data
-                    except Exception:
-                        # Some weeks may not have games (esp postseason)
-                        continue
 
     finally:
         client.close()

--- a/src/pipelines/utils/rate_limiter.py
+++ b/src/pipelines/utils/rate_limiter.py
@@ -118,9 +118,20 @@ class RateLimiter:
 _rate_limiter: RateLimiter | None = None
 
 
+def _configured_budget(default: int = 75000) -> int:
+    """Read sources.cfbd.monthly_budget from dlt config, falling back to default."""
+    try:
+        import dlt
+
+        value = dlt.config.get("sources.cfbd.monthly_budget")
+        return int(value) if value else default
+    except Exception:
+        return default
+
+
 def get_rate_limiter() -> RateLimiter:
     """Get the global rate limiter instance."""
     global _rate_limiter
     if _rate_limiter is None:
-        _rate_limiter = RateLimiter()
+        _rate_limiter = RateLimiter(monthly_budget=_configured_budget())
     return _rate_limiter

--- a/src/schemas/public/008_trajectory_averages_function.sql
+++ b/src/schemas/public/008_trajectory_averages_function.sql
@@ -1,11 +1,13 @@
 -- Trajectory averages function
 -- Returns conference and FBS average metrics per season for comparison charts.
 -- Created ad-hoc in Supabase; now tracked in version control.
+-- p_season_end NULL (the default) resolves to the latest season present in
+-- public.team_season_trajectory, so omitted-arg callers track the current season.
 
 CREATE OR REPLACE FUNCTION public.get_trajectory_averages(
     p_conference TEXT,
     p_season_start INT DEFAULT 2020,
-    p_season_end INT DEFAULT 2025
+    p_season_end INT DEFAULT NULL
 )
 RETURNS TABLE(
     season BIGINT,
@@ -27,7 +29,14 @@ RETURNS TABLE(
 LANGUAGE plpgsql
 SET search_path = ''
 AS $function$
+DECLARE
+    v_season_end INT;
 BEGIN
+    v_season_end := COALESCE(
+        p_season_end,
+        (SELECT MAX(t.season)::INT FROM public.team_season_trajectory t)
+    );
+
     RETURN QUERY
     SELECT
         t.season,
@@ -48,7 +57,7 @@ BEGIN
     FROM public.team_season_trajectory t
     JOIN public.teams tm ON t.team = tm.school
     WHERE tm.classification = 'fbs'
-      AND t.season BETWEEN p_season_start AND p_season_end
+      AND t.season BETWEEN p_season_start AND v_season_end
     GROUP BY t.season
     ORDER BY t.season;
 END;

--- a/tests/test_load_season.py
+++ b/tests/test_load_season.py
@@ -1,0 +1,16 @@
+"""Unit tests for load_season's season-selection helpers (no DB, no API)."""
+
+from scripts.load_season import upcoming_schedule_season
+
+
+class TestUpcomingScheduleSeason:
+    def test_pre_august_months_refresh_next_schedule(self):
+        # Jan-Jul: get_current_season() points at last calendar year's season,
+        # so the upcoming season's schedule needs its own refresh (same month
+        # boundary as get_current_season)
+        for month in (1, 2, 3, 4, 5, 6, 7):
+            assert upcoming_schedule_season(2025, month) == 2026
+
+    def test_in_season_months_skip(self):
+        for month in (8, 9, 10, 11, 12):
+            assert upcoming_schedule_season(2026, month) is None

--- a/tests/test_marts.py
+++ b/tests/test_marts.py
@@ -59,6 +59,19 @@ ALL_MATERIALIZED_VIEWS = (
 )
 
 
+@pytest.fixture(scope="module")
+def scouting_schema_exists(db_conn):
+    """The scouting schema is owned and deployed by cfb-scout, not this repo."""
+    with db_conn.cursor() as cur:
+        cur.execute("SELECT 1 FROM information_schema.schemata WHERE schema_name = 'scouting'")
+        return cur.fetchone() is not None
+
+
+def _skip_if_scouting_absent(schema_name: str, scouting_schema_exists: bool) -> None:
+    if schema_name == "scouting" and not scouting_schema_exists:
+        pytest.skip("scouting schema absent (owned by cfb-scout)")
+
+
 # ---------------------------------------------------------------------------
 # Existence tests
 # ---------------------------------------------------------------------------
@@ -72,7 +85,8 @@ class TestMartViewsExist:
         ALL_MATERIALIZED_VIEWS,
         ids=[f"{s}.{v}" for s, v in ALL_MATERIALIZED_VIEWS],
     )
-    def test_view_exists(self, db_conn, schema_name, view_name):
+    def test_view_exists(self, db_conn, schema_name, view_name, scouting_schema_exists):
+        _skip_if_scouting_absent(schema_name, scouting_schema_exists)
         with db_conn.cursor() as cur:
             cur.execute(
                 """
@@ -99,7 +113,8 @@ class TestMartViewsHaveData:
         ALL_MATERIALIZED_VIEWS,
         ids=[f"{s}.{v}" for s, v in ALL_MATERIALIZED_VIEWS],
     )
-    def test_view_has_rows(self, db_conn, schema_name, view_name):
+    def test_view_has_rows(self, db_conn, schema_name, view_name, scouting_schema_exists):
+        _skip_if_scouting_absent(schema_name, scouting_schema_exists)
         with db_conn.cursor() as cur:
             # Use quoted identifiers to handle leading underscores safely
             cur.execute(f'SELECT COUNT(*) FROM "{schema_name}"."{view_name}"')

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -77,3 +77,26 @@ class TestRateLimiter:
         limiter = RateLimiter(monthly_budget=100, state_file=state_file)
         limiter.record_call(1)
         assert state_file.exists()
+
+
+class TestConfiguredBudget:
+    def test_reads_dlt_config_value(self):
+        from src.pipelines.utils.rate_limiter import _configured_budget
+
+        with patch("dlt.config") as mock_config:
+            mock_config.get.return_value = 50000
+            assert _configured_budget() == 50000
+
+    def test_falls_back_to_default_when_unset(self):
+        from src.pipelines.utils.rate_limiter import _configured_budget
+
+        with patch("dlt.config") as mock_config:
+            mock_config.get.return_value = None
+            assert _configured_budget() == 75000
+
+    def test_falls_back_to_default_on_error(self):
+        from src.pipelines.utils.rate_limiter import _configured_budget
+
+        with patch("dlt.config") as mock_config:
+            mock_config.get.side_effect = RuntimeError("no config")
+            assert _configured_budget() == 75000

--- a/tests/test_sources/test_games.py
+++ b/tests/test_sources/test_games.py
@@ -1,0 +1,28 @@
+"""Tests for games and game stats source composition."""
+
+from src.pipelines.sources.game_stats import game_stats_source
+from src.pipelines.sources.games import games_source
+
+
+def test_games_source_excludes_game_stats():
+    """Game box scores must not load via games_source.
+
+    game_team_stats/game_player_stats merges time out on Supabase at full-season
+    size; they load exclusively via game_stats_source's week-by-week path.
+    """
+    source = games_source(years=[2024])
+
+    assert set(source.resources.keys()) == {
+        "games",
+        "drives",
+        "game_media",
+        "game_weather",
+        "records",
+    }
+
+
+def test_game_stats_source_owns_game_stats():
+    """game_stats_source is the only loader for game box score tables."""
+    source = game_stats_source(years=[2024])
+
+    assert set(source.resources.keys()) == {"game_team_stats", "game_player_stats"}

--- a/tests/test_verify_load.py
+++ b/tests/test_verify_load.py
@@ -1,0 +1,64 @@
+"""Unit tests for verify_load's pure grading helpers (no DB, no API)."""
+
+from scripts.verify_load import (
+    FAIL,
+    PASS,
+    WARN,
+    evaluate_game_counts,
+    evaluate_missing,
+    evaluate_staleness,
+    is_in_season,
+)
+
+
+class TestIsInSeason:
+    def test_season_months(self):
+        assert all(is_in_season(m) for m in (9, 10, 11, 12, 1))
+
+    def test_off_season_months(self):
+        assert not any(is_in_season(m) for m in (2, 3, 4, 5, 6, 7, 8))
+
+
+class TestEvaluateMissing:
+    def test_zero_missing_passes(self):
+        assert evaluate_missing(0) == PASS
+
+    def test_within_tolerance_warns(self):
+        assert evaluate_missing(1) == WARN
+        assert evaluate_missing(10) == WARN
+
+    def test_beyond_tolerance_fails(self):
+        assert evaluate_missing(11) == FAIL
+
+
+class TestEvaluateGameCounts:
+    def test_db_matches_api(self):
+        assert evaluate_game_counts(api_count=800, db_count=800) == PASS
+
+    def test_db_exceeds_api(self):
+        # DB keeps games the API has since dropped; not a load failure
+        assert evaluate_game_counts(api_count=800, db_count=805) == PASS
+
+    def test_db_behind_api_fails(self):
+        assert evaluate_game_counts(api_count=800, db_count=750) == FAIL
+
+    def test_db_empty_with_api_data_fails(self):
+        assert evaluate_game_counts(api_count=800, db_count=0) == FAIL
+
+    def test_both_empty_passes(self):
+        assert evaluate_game_counts(api_count=0, db_count=0) == PASS
+
+
+class TestEvaluateStaleness:
+    def test_weekly_in_season_fails(self):
+        assert evaluate_staleness("weekly", in_season=True, strict=False) == FAIL
+
+    def test_weekly_off_season_warns(self):
+        assert evaluate_staleness("weekly", in_season=False, strict=False) == WARN
+
+    def test_weekly_off_season_strict_fails(self):
+        assert evaluate_staleness("weekly", in_season=False, strict=True) == FAIL
+
+    def test_seasonal_always_warns(self):
+        assert evaluate_staleness("seasonal", in_season=True, strict=False) == WARN
+        assert evaluate_staleness("seasonal", in_season=False, strict=True) == WARN


### PR DESCRIPTION
Gets the database ready to run itself for the 2026 season. A full audit found the data model and season handling already 2026-ready (year ranges include 2026, `get_current_season()` flips on Aug 1, `plays_y2026` partition exists) — but every load was manual, one contract RPC silently capped at 2025, and a timeout-prone resource was wired into the main games source.

## Critical fixes

- **Game box scores load only via `game_stats_source`.** `games_source` also yielded `game_team_stats`/`game_player_stats`, duplicating the loads and re-introducing full-season merges that time out on Supabase. Regression test pins both resource sets.
- **`get_trajectory_averages()` default now tracks loaded data.** `p_season_end` default was pinned to `2025`, silently excluding 2026 for cfb-app callers omitting the arg. Now `NULL` → resolves to `MAX(season)` in `team_season_trajectory`. Contract-change note added to `SCHEMA_CONTRACT.md` — **cfb-app should be aware**.
- **Portal-surveillance cron migration removed.** It targets the cfb-scout-owned `scouting` schema, collides with `017_era_reference.sql` numbering, was wired to no runner, and fails where scouting doesn't exist. Full SQL preserved in `docs/handoffs/2026-07-19-portal-surveillance-cron-to-cfb-scout.md`.
- **CI no longer hostage to cfb-scout:** `scouting.player_mart` tests skip when the schema is absent.

## Daily automation (new)

- `.github/workflows/daily-load.yml`: daily 10:00 UTC, year-round. Runs `load_season.py --weekly` (mart refresh included) then `verify_load.py`; concurrency-guarded; failures open/update a rolling GitHub issue.
- `scripts/verify_load.py` (new): partition existence, API-vs-DB game count reconciliation, box-score/plays coverage of completed games, mart staleness (FAIL in-season, WARN off-season). Exits nonzero so bad loads go red. Grading helpers unit-tested.
- `load_season.py --season` now optional, defaulting to the current season — no yearly edit needed.
- Rate limiter reads `monthly_budget` from `.dlt/config.toml`; dead `year_ranges`/`calls_per_second` config removed (`years.py` is the single source of truth).

## Docs

- `pipeline-manifest.md`: 5 stale "PK bug" rows and `/plays/stats/types` were already fixed/loaded in code — statuses and PKs corrected (now 51 WORKING); dated note on the box-score sourcing change.
- README: real provisioning path (`run_migrations.py` → `run_marts.py` → `refresh_marts.py`) and a new In-Season Operations section.
- CLAUDE.md counts corrected (27 marts / 18 api / 12 public); SPRINT_PLAN archived with a superseded banner; `SCHEMA_CONTRACT.md` 28→27 marts.

## Before the schedule goes live (post-merge, manual)

1. Add repo secret **`CFBD_API_KEY`**.
2. Confirm **`SUPABASE_DB_URL`** secret is the **session pooler** URL (GitHub runners are IPv4-only; the transaction pooler rejects the `statement_timeout` startup option the mart refresh needs).
3. Dispatch one manual `daily-load.yml` run (season input `2026`) and watch it go green — this doubles as the live 2026 verification (schedules are already published, so `core.games` should populate).

## Out of scope (deliberately)

2027-proofing (no DEFAULT plays partition; `years.py` ceilings and test pins stop at 2026) and the `game_player_stats` historical backfill — both documented for a future pass.

## Testing

- `ruff check` + `ruff format --check` clean; `pytest -q`: 361 passed, 232 skipped (live-DB integration tests skip without credentials; CI runs them with the repo secret).
- Live-DB steps couldn't run from the authoring sandbox (network policy blocks the Supabase host); the manual workflow dispatch above completes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aq5tEVxkthmuRX7JH9qEW

---
_Generated by [Claude Code](https://claude.ai/code/session_018aq5tEVxkthmuRX7JH9qEW)_