### PR TITLE
docs: register cfb-app contract compliance and cfb-analytics retirement

### DIFF
--- a/docs/SCHEMA_CONTRACT.md
+++ b/docs/SCHEMA_CONTRACT.md
@@ -6,9 +6,20 @@
 
 Last updated: 2026-07-20
 
+> **Note on cfb-analytics:** the retired OU-only app (rstover-fo/cfb-analytics) was never a
+> warehouse consumer -- it ran its own DuckDB ingestion. Its unique features (rivals page,
+> compare page, CSV export, a11y patterns, query tests) were ported into cfb-app in July 2026
+> and the repo is kept for reference only. cfb-app and cfb-scout remain the two consumers.
+
 ---
 
 ## Recent Contract Changes
+
+- **2026-07-20 — cfb-app fully contract-compliant.** As of cfb-app PRs #15-#17, the app has
+  zero direct `core.*` access (a repo-side contract-guard test enforces this), consumes
+  `api.game_drives` / `api.game_plays` / `api.poll_rankings` / `api.matchup`, and ships new
+  `/rivals` and `/compare` pages on the contracted surface. Deprecated raw access from the
+  2026-07-20 views entry below can now be considered fully retired.
 
 - **2026-07-20 — Added `api.game_drives`, `api.game_plays`, `api.poll_rankings`.**
   Closes the Phase 0 Lane D gap where cfb-app queried `core.drives`, `core.plays`, and


### PR DESCRIPTION
Contract bookkeeping for the July 2026 consolidation: adds a changelog entry recording that cfb-app is fully contract-compliant as of its PRs #15–#17 (zero direct `core.*` access, enforced by a repo-side contract-guard test; consumes the new `api.game_drives`/`api.game_plays`/`api.poll_rankings` plus previously-unused `api.matchup`), and a header note clarifying that the retired cfb-analytics app was never a warehouse consumer and its features now live in cfb-app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNx7MmfrWbhFwx1du79KY3

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNx7MmfrWbhFwx1du79KY3)_