### PR TITLE
feat(mcp): read-only MCP server over the contracted warehouse surface (P3.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,16 @@ jobs:
       - run: pytest -q --tb=short
         env:
           SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+
+  mcp:
+    name: MCP Server
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+      - run: pip install -e "mcp[dev]"
+      - run: ruff check mcp
+      - run: pytest mcp/tests -q --tb=short

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+.pytest_cache/
+.ruff_cache/
 
 # Virtual environments
 .venv/

--- a/mcp/.env.example
+++ b/mcp/.env.example
@@ -1,0 +1,9 @@
+# cfb-mcp configuration
+#
+# Get these from: Supabase Dashboard > Project Settings > API
+# The anon key is safe to use here -- this server only reads through
+# PostgREST as the anon role, which is REVOKEd from all write operations.
+# Do NOT put the service_role key here.
+
+SUPABASE_URL=https://[PROJECT-REF].supabase.co
+SUPABASE_ANON_KEY=[YOUR-ANON-KEY]

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -20,8 +20,9 @@ leaderboards, situational splits, player search, and data freshness.
   one of those objects, the corresponding tool will start returning a `404` error from
   PostgREST -- see [RLS / permissions posture](#rls--permissions-posture) for why that fails
   safe rather than falling back to a broader query.
-- **Hard row cap.** Every read is capped at 100 rows server-side (`postgrest.DEFAULT_ROW_CAP`).
-  Tools that accept a `limit` argument can request fewer rows, never more.
+- **Hard row cap.** Every view read is capped at 100 rows server-side (`postgrest.DEFAULT_ROW_CAP`).
+  Tools that accept a `limit` argument can request fewer rows, never more. RPC-backed tools
+  are bounded by their own `p_limit` arguments or inherently small result sets.
 
 ## Install
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,155 @@
+# cfb-mcp
+
+A read-only [MCP](https://modelcontextprotocol.io) server over the `cfb-database` Supabase
+warehouse. Local **stdio** transport, built with the official Python `mcp` SDK (FastMCP
+style). It exposes eight LLM-facing tools covering teams, games, matchups, rankings,
+leaderboards, situational splits, player search, and data freshness.
+
+## What this is (and isn't)
+
+- **Data path: PostgREST over HTTPS only.** Every tool call is either a
+  `GET {SUPABASE_URL}/rest/v1/<view>` (for `api.*` views, `Accept-Profile: api`) or a
+  `POST {SUPABASE_URL}/rest/v1/rpc/<fn>` (for `public.*` RPCs, `Content-Profile: public`).
+  There is **no direct Postgres connection** anywhere in this server.
+- **No dynamic-SQL tool.** See [SQL tool deferral](#sql-tool-deferral-p35) below.
+- **Contract Rule 4.** Per `docs/SCHEMA_CONTRACT.md`, downstream consumers must never touch
+  raw tables directly -- only `api.*` views and the documented `public` RPCs. This server
+  enforces that by construction: `postgrest.py` only ever builds URLs under
+  `/rest/v1/<view>` or `/rest/v1/rpc/<fn>`, and every view/RPC name used by a tool is one
+  from the Schema Contract's public surface. If a future contract change renames or removes
+  one of those objects, the corresponding tool will start returning a `404` error from
+  PostgREST -- see [RLS / permissions posture](#rls--permissions-posture) for why that fails
+  safe rather than falling back to a broader query.
+- **Hard row cap.** Every read is capped at 100 rows server-side (`postgrest.DEFAULT_ROW_CAP`).
+  Tools that accept a `limit` argument can request fewer rows, never more.
+
+## Install
+
+```bash
+cd mcp
+pip install -e ".[dev]"
+```
+
+This installs the `cfb_mcp` package and its dev dependencies (`pytest`, `pytest-asyncio`,
+`respx`, `ruff`) from `mcp/pyproject.toml`. Verify with:
+
+```bash
+python -c "import cfb_mcp"
+```
+
+## Environment variables
+
+Copy `mcp/.env.example` to `.env` (or otherwise export the variables) and fill in:
+
+| Variable | Description |
+|----------|-------------|
+| `SUPABASE_URL` | Your Supabase project URL, e.g. `https://xxxx.supabase.co` |
+| `SUPABASE_ANON_KEY` | The **anon** (public) API key, from Supabase Dashboard > Project Settings > API. **Not** the `service_role` key. |
+
+The server reads these from the process environment at request time (no `.env` autoloading
+in-process) -- for local testing you can `export` them, and for MCP-client integrations
+(below) you supply them via the client's server config `env` block.
+
+## RLS / permissions posture
+
+`cfb-database` does **not** use Row Level Security policies for read access. Instead, read-only
+is enforced at the grant level (see
+[`docs/solutions/database-issues/security-invoker-schema-grants.md`](../docs/solutions/database-issues/security-invoker-schema-grants.md)):
+the `anon` role has `USAGE` + `SELECT` granted on every schema the `api.*` views read from,
+and `INSERT`/`UPDATE`/`DELETE`/`TRUNCATE` are `REVOKE`d from `anon`/`authenticated` everywhere.
+`api.*` views are `SECURITY INVOKER`, so they execute as `anon` and are bound by those grants.
+
+This means: **the anon key is the intended trust model for this server.** It cannot write
+regardless of which query it sends (writes fail at the database grant level, not just
+because this server declines to expose write tools), and it can read exactly the public
+surface documented in `SCHEMA_CONTRACT.md`. There's no separate secrets tier to protect here
+-- treat `SUPABASE_ANON_KEY` as a low-sensitivity, read-only credential, but still don't
+commit it (`.env` is gitignored; only `.env.example` is checked in).
+
+## SQL tool deferral (P3.5)
+
+An earlier design considered a general "run arbitrary read-only SQL" tool for maximum
+flexibility. It was **rejected for v1**: the `anon` role (see above) has `SELECT` on every
+schema in the warehouse, including internal ones (`core`, `stats`, `ratings`, `betting`,
+`recruiting`, `metrics`, dlt pipeline metadata, etc. -- see the "Internal" section of
+`SCHEMA_CONTRACT.md`). A raw-SQL tool using the anon key cannot be confined to the `api.*` /
+public-RPC surface the way PostgREST's REST endpoints naturally are, so it would silently
+violate Contract Rule 4 and expose internal, unstable objects to the model. Building that
+safely needs either a dedicated read-only Postgres role scoped to `api`/allowed `public`
+objects only, or a query-rewriting/allowlisting layer -- both out of scope here. Deferred to
+a future phase (tracked as P3.5); this server instead ships eight purpose-built tools that
+each hit one known-safe view or RPC.
+
+## Tool catalog
+
+| Tool | Arguments | Backing object(s) |
+|------|-----------|--------------------|
+| `query_team` | `team` | `api.team_detail`, `api.team_history` |
+| `query_games` | `season?`, `week?`, `team?`, `min_excitement?`, `limit?` | `api.game_detail` |
+| `query_matchup` | `team_a`, `team_b` | `api.matchup` |
+| `get_rankings` | `season`, `week?`, `poll?`, `season_type?` (`regular`\|`postseason`), `limit?` | `api.poll_rankings` |
+| `get_leaderboard` | `season`, `metric` (`wins`\|`ppg`\|`scoring_defense`\|`epa`\|`sp_rating`\|`wepa`), `limit?` | `api.leaderboard_teams`, `api.team_wepa_season` (for `wepa`) |
+| `situational_splits` | `team`, `season`, `split_type` (`home_away`\|`conference`\|`red_zone`\|`down_distance`\|`field_position`) | `get_home_away_splits`, `get_conference_splits`, `get_red_zone_splits`, `get_down_distance_splits`, `get_field_position_splits` (all `public` RPCs) |
+| `search_players` | `query`, `team?`, `season?`, `limit?` | `get_player_search` then `get_player_detail` for the top hit (`public` RPCs) |
+| `get_data_freshness` | *(none)* | `get_data_freshness` (`public` RPC) |
+
+Every tool response is JSON with a `_source` field (or one per sub-object) naming the exact
+view/RPC used, so downstream consumers of the tool output can qualify claims with their
+provenance.
+
+## Claude Desktop configuration
+
+Add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "cfb": {
+      "command": "python",
+      "args": ["-m", "cfb_mcp"],
+      "env": {
+        "SUPABASE_URL": "https://[PROJECT-REF].supabase.co",
+        "SUPABASE_ANON_KEY": "[YOUR-ANON-KEY]"
+      }
+    }
+  }
+}
+```
+
+Equivalent with the `claude` CLI:
+
+```bash
+claude mcp add cfb \
+  --env SUPABASE_URL=https://[PROJECT-REF].supabase.co \
+  --env SUPABASE_ANON_KEY=[YOUR-ANON-KEY] \
+  -- python -m cfb_mcp
+```
+
+(If you installed with `pip install -e ".[dev]"` inside a virtualenv, point `command` at
+that venv's `python`, or use the `cfb-mcp` console script installed alongside it.)
+
+## Smoke-test prompts
+
+Once connected, try these against your Claude client to sanity-check the server end-to-end:
+
+1. **"How is Oklahoma doing this season, and how have they trended over the last five
+   years?"** -- exercises `query_team`.
+2. **"Who was ranked in the AP Top 25 in week 10 of the 2024 season, and how does that
+   compare to the final CFP rankings that year?"** -- exercises `get_rankings` with both
+   `season_type='regular'` and `season_type='postseason'`.
+3. **"Find the player Caleb Williams, and tell me about Oklahoma's red zone efficiency in
+   2022."** -- exercises `search_players` and `situational_splits` in the same conversation.
+
+## Development
+
+```bash
+cd mcp
+pip install -e ".[dev]"
+ruff check .
+ruff format --check .
+pytest tests -q
+```
+
+Tests use [`respx`](https://lundberg.pro/respx/) to mock every PostgREST call -- there is no
+live network access in the test suite (and the sandbox's outbound proxy blocks
+`*.supabase.co` regardless).

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,0 +1,40 @@
+[project]
+name = "cfb-mcp"
+version = "0.1.0"
+description = "Read-only MCP server (stdio) for the cfb-database Supabase warehouse, backed exclusively by PostgREST"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "mcp>=1.6.0",
+    "httpx>=0.27.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.24.0",
+    "respx>=0.21.0",
+    "ruff>=0.4.0",
+]
+
+[project.scripts]
+cfb-mcp = "cfb_mcp.__main__:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]
+asyncio_mode = "auto"
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/cfb_mcp"]

--- a/mcp/src/cfb_mcp/__init__.py
+++ b/mcp/src/cfb_mcp/__init__.py
@@ -1,0 +1,9 @@
+"""cfb_mcp: read-only MCP server for the cfb-database Supabase warehouse.
+
+This package talks to the warehouse exclusively over PostgREST (HTTPS) --
+never direct Postgres -- and only touches objects listed as public in
+docs/SCHEMA_CONTRACT.md of the cfb-database repo (api.* views and a fixed
+set of public RPCs). See mcp/README.md for setup and the tool catalog.
+"""
+
+__version__ = "0.1.0"

--- a/mcp/src/cfb_mcp/__main__.py
+++ b/mcp/src/cfb_mcp/__main__.py
@@ -1,0 +1,16 @@
+"""Entry point for the cfb-mcp stdio server.
+
+Run with `python -m cfb_mcp` or the `cfb-mcp` console script installed by
+`pip install -e mcp[dev]`. Requires SUPABASE_URL and SUPABASE_ANON_KEY to be
+set in the environment (see mcp/.env.example).
+"""
+
+from cfb_mcp.server import mcp
+
+
+def main() -> None:
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp/src/cfb_mcp/postgrest.py
+++ b/mcp/src/cfb_mcp/postgrest.py
@@ -1,0 +1,197 @@
+"""Thin async PostgREST client for the cfb-database Supabase warehouse.
+
+Design constraints (see mcp/README.md and docs/SCHEMA_CONTRACT.md):
+
+- PostgREST over HTTPS ONLY. No direct Postgres connection, ever.
+- Reads go to ``GET {SUPABASE_URL}/rest/v1/<view>`` with an
+  ``Accept-Profile: api`` header, since every readable view lives in the
+  ``api`` schema (Contract Rule 4: raw tables and other schemas are not
+  part of the public surface this server may touch).
+- RPC calls go to ``POST {SUPABASE_URL}/rest/v1/rpc/<fn>`` with a
+  ``Content-Profile: public`` header, since every callable function is a
+  ``public`` schema RPC.
+- Every read is capped at ``DEFAULT_ROW_CAP`` rows. Callers may request a
+  smaller limit; they can never request more than the cap.
+
+This module has no knowledge of MCP tool semantics -- it only knows how to
+build PostgREST requests and turn PostgREST/network errors into short,
+actionable messages that a tool can hand straight back to the calling LLM.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+DEFAULT_ROW_CAP = 100
+REQUEST_TIMEOUT = 30.0
+
+
+class PostgrestError(Exception):
+    """Raised for any PostgREST/network failure.
+
+    ``.message`` is pre-formatted, tool-friendly text (always starts with
+    "Error: ") safe to return directly as a tool's string output.
+    """
+
+    def __init__(self, message: str):
+        super().__init__(message)
+        self.message = message
+
+
+@dataclass(frozen=True)
+class PostgrestConfig:
+    """Connection settings, read from the environment at call time.
+
+    Reading lazily (rather than at import time) keeps the module importable
+    without env vars set, and lets tests set env vars per-test.
+    """
+
+    base_url: str
+    anon_key: str
+
+    @classmethod
+    def from_env(cls) -> PostgrestConfig:
+        base_url = os.environ.get("SUPABASE_URL", "").strip().rstrip("/")
+        anon_key = os.environ.get("SUPABASE_ANON_KEY", "").strip()
+        if not base_url:
+            raise PostgrestError(
+                "Error: SUPABASE_URL is not set. Copy mcp/.env.example to .env (or set it in "
+                "your MCP client's server config) and provide your Supabase project URL."
+            )
+        if not anon_key:
+            raise PostgrestError(
+                "Error: SUPABASE_ANON_KEY is not set. Copy mcp/.env.example to .env (or set it "
+                "in your MCP client's server config) and provide your Supabase anon key."
+            )
+        return cls(base_url=base_url, anon_key=anon_key)
+
+
+# --- PostgREST operator param builders ---------------------------------
+#
+# These build the right-hand side of a PostgREST filter, e.g.
+# params={"season": eq(2024)} -> "?season=eq.2024"
+
+
+def eq(value: Any) -> str:
+    return f"eq.{value}"
+
+
+def gte(value: Any) -> str:
+    return f"gte.{value}"
+
+
+def lte(value: Any) -> str:
+    return f"lte.{value}"
+
+
+def in_(values: Iterable[Any]) -> str:
+    return "in.(" + ",".join(str(v) for v in values) + ")"
+
+
+class PostgrestClient:
+    """Async client for reading api.* views and calling public RPCs."""
+
+    def __init__(self, config: PostgrestConfig | None = None):
+        self._config = config or PostgrestConfig.from_env()
+
+    def _headers(self, profile: str, *, write: bool) -> dict[str, str]:
+        profile_header = "Content-Profile" if write else "Accept-Profile"
+        return {
+            "apikey": self._config.anon_key,
+            "Authorization": f"Bearer {self._config.anon_key}",
+            profile_header: profile,
+            "Accept": "application/json",
+        }
+
+    async def select(
+        self,
+        view: str,
+        params: dict[str, Any] | None = None,
+        *,
+        profile: str = "api",
+        limit: int = DEFAULT_ROW_CAP,
+    ) -> list[dict[str, Any]]:
+        """GET rows from a PostgREST view (Accept-Profile: <profile>).
+
+        The row cap is enforced here, not left to the caller: ``limit`` is
+        clamped to ``DEFAULT_ROW_CAP`` even if a larger value is passed in.
+        """
+        capped_limit = min(limit, DEFAULT_ROW_CAP) if limit else DEFAULT_ROW_CAP
+        query: dict[str, Any] = dict(params or {})
+        query["limit"] = str(capped_limit)
+
+        url = f"{self._config.base_url}/rest/v1/{view}"
+        async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+            try:
+                response = await client.get(
+                    url, params=query, headers=self._headers(profile, write=False)
+                )
+            except httpx.TimeoutException as e:
+                raise PostgrestError(f"Error: request to '{view}' timed out.") from e
+            except httpx.RequestError as e:
+                raise PostgrestError(f"Error: network failure calling '{view}': {e}") from e
+
+        result = _parse_response(response, view)
+        return result if isinstance(result, list) else [result]
+
+    async def rpc(
+        self,
+        function: str,
+        args: dict[str, Any] | None = None,
+        *,
+        profile: str = "public",
+    ) -> list[dict[str, Any]]:
+        """POST to a PostgREST RPC endpoint (Content-Profile: <profile>)."""
+        url = f"{self._config.base_url}/rest/v1/rpc/{function}"
+        async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+            try:
+                response = await client.post(
+                    url, json=args or {}, headers=self._headers(profile, write=True)
+                )
+            except httpx.TimeoutException as e:
+                raise PostgrestError(f"Error: request to rpc/{function} timed out.") from e
+            except httpx.RequestError as e:
+                raise PostgrestError(f"Error: network failure calling rpc/{function}: {e}") from e
+
+        result = _parse_response(response, f"rpc/{function}")
+        if result is None:
+            return []
+        return result if isinstance(result, list) else [result]
+
+
+def _parse_response(response: httpx.Response, source: str) -> Any:
+    if response.status_code >= 400:
+        raise PostgrestError(_format_error(response, source))
+    if not response.content:
+        return []
+    return response.json()
+
+
+def _format_error(response: httpx.Response, source: str) -> str:
+    status = response.status_code
+    try:
+        body = response.json()
+    except ValueError:
+        body = {}
+    detail = body.get("message") or body.get("hint") or response.text[:200] or "no details"
+
+    if status == 404:
+        return (
+            f"Error: '{source}' not found (404). Check the view/function name against "
+            "docs/SCHEMA_CONTRACT.md -- it may not be exposed via PostgREST."
+        )
+    if status in (401, 403):
+        return (
+            f"Error: permission denied calling '{source}' ({status}). The anon key may be "
+            "missing/invalid, or the object isn't granted to the anon role."
+        )
+    if status == 429:
+        return f"Error: rate limited calling '{source}' (429). Wait a moment and retry."
+    if status >= 500:
+        return f"Error: '{source}' failed with a server error ({status}): {detail}"
+    return f"Error: '{source}' request failed ({status}): {detail}"

--- a/mcp/src/cfb_mcp/server.py
+++ b/mcp/src/cfb_mcp/server.py
@@ -1,0 +1,663 @@
+"""cfb_mcp FastMCP server: 8 read-only tools over the cfb-database warehouse.
+
+Every tool is a thin, LLM-facing wrapper around one or more PostgREST calls
+(see cfb_mcp.postgrest). Tools only touch objects in the public surface
+defined by docs/SCHEMA_CONTRACT.md in cfb-database: ``api.*`` views and a
+fixed allowlist of ``public`` RPCs (Contract Rule 4). There is deliberately
+no dynamic-SQL / arbitrary-query tool -- see mcp/README.md's "SQL tool
+deferral" section for why.
+
+Every successful JSON response includes a ``_source`` field (or one per
+sub-object) naming the exact view/RPC the data came from, so the calling
+model can qualify its answer ("per api.leaderboard_teams...").
+"""
+
+from __future__ import annotations
+
+import json
+from enum import StrEnum
+from typing import Annotated, Any
+
+from mcp.server.fastmcp import FastMCP
+from pydantic import Field
+
+from cfb_mcp.postgrest import DEFAULT_ROW_CAP, PostgrestClient, PostgrestError, eq, gte
+
+mcp = FastMCP("cfb_mcp")
+
+# All eight tools are read-only, non-destructive, idempotent, and talk to an
+# external service -- same annotation set for every one of them.
+READ_ONLY_ANNOTATIONS = {
+    "readOnlyHint": True,
+    "destructiveHint": False,
+    "idempotentHint": True,
+    "openWorldHint": True,
+}
+
+
+def _dump(payload: Any) -> str:
+    return json.dumps(payload, indent=2, default=str)
+
+
+def _wrap(source: str, rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Attach a _source tag and row count to a result set."""
+    return {"_source": source, "count": len(rows), "rows": rows}
+
+
+class SplitType(StrEnum):
+    """Which situational-splits RPC to call for `situational_splits`."""
+
+    HOME_AWAY = "home_away"
+    CONFERENCE = "conference"
+    RED_ZONE = "red_zone"
+    DOWN_DISTANCE = "down_distance"
+    FIELD_POSITION = "field_position"
+
+
+_SPLIT_RPCS: dict[SplitType, str] = {
+    SplitType.HOME_AWAY: "get_home_away_splits",
+    SplitType.CONFERENCE: "get_conference_splits",
+    SplitType.RED_ZONE: "get_red_zone_splits",
+    SplitType.DOWN_DISTANCE: "get_down_distance_splits",
+    SplitType.FIELD_POSITION: "get_field_position_splits",
+}
+
+
+class LeaderboardMetric(StrEnum):
+    """Ranking metric for `get_leaderboard`."""
+
+    WINS = "wins"
+    PPG = "ppg"
+    SCORING_DEFENSE = "scoring_defense"
+    EPA = "epa"
+    SP_RATING = "sp_rating"
+    WEPA = "wepa"
+
+
+# Column to order by within api.leaderboard_teams for each non-wepa metric.
+# leaderboard_teams pre-computes these *_rank columns; wepa is handled
+# separately against api.team_wepa_season (see get_leaderboard).
+_LEADERBOARD_ORDER: dict[LeaderboardMetric, str] = {
+    LeaderboardMetric.WINS: "wins_rank.asc",
+    LeaderboardMetric.PPG: "ppg_rank.asc",
+    LeaderboardMetric.SCORING_DEFENSE: "defense_ppg_rank.asc",
+    LeaderboardMetric.EPA: "epa_rank.asc",
+    LeaderboardMetric.SP_RATING: "sp_rank.asc",
+}
+
+
+class PollSeasonType(StrEnum):
+    """season_type filter for `get_rankings` -- see api.poll_rankings.
+
+    CFBD reports the final postseason poll as week=1, which collides with
+    the regular-season week-1 poll's week number. season_type is the only
+    thing that disambiguates them.
+    """
+
+    REGULAR = "regular"
+    POSTSEASON = "postseason"
+
+
+# ---------------------------------------------------------------------
+# 1. query_team
+# ---------------------------------------------------------------------
+
+
+@mcp.tool(name="query_team", annotations={"title": "Query Team", **READ_ONLY_ANNOTATIONS})
+async def query_team(
+    team: Annotated[
+        str,
+        Field(
+            description=(
+                "Exact school name as used by CFBD, e.g. 'Oklahoma', 'Ohio State', "
+                "'Texas A&M'. This is an exact, case-sensitive match, not a fuzzy search -- "
+                "if unsure of the exact spelling, try get_leaderboard or query_games first "
+                "to confirm it."
+            )
+        ),
+    ],
+) -> str:
+    """Get a team's current-season snapshot plus its full multi-season history.
+
+    When to use: any question about a single team -- "how good is Oklahoma this
+    year", "show Oklahoma's history since 2014", ratings/EPA trends over time.
+
+    Combines two sources in one call:
+      - api.team_detail: current-season snapshot (record, SP+/Elo/FPI ratings,
+        EPA/success rate/explosiveness, recruiting rank). At most one row.
+      - api.team_history: one row per season the team has data for (record,
+        ratings, EPA), ordered season DESC. Up to 100 rows.
+
+    Caveats:
+      - Team names must match CFBD's convention exactly (case-sensitive).
+        "oklahoma" or "OU" will not match "Oklahoma".
+      - api.team_detail only includes FBS-classification teams; an FCS/other
+        team will return an empty team_detail but may still have team_history
+        rows from a season it was FBS (rare) or no rows at all.
+
+    Returns: JSON with "team_detail" and "team_history" keys, each shaped as
+    {"_source": "<view>", "count": int, "rows": [...]}. If nothing at all is
+    found, returns a plain "No team found..." string instead.
+    """
+    client = PostgrestClient()
+    try:
+        detail_rows = await client.select(
+            "team_detail", {"school": eq(team)}, profile="api", limit=1
+        )
+        history_rows = await client.select(
+            "team_history",
+            {"team": eq(team), "order": "season.desc"},
+            profile="api",
+            limit=DEFAULT_ROW_CAP,
+        )
+    except PostgrestError as e:
+        return e.message
+
+    if not detail_rows and not history_rows:
+        return (
+            f"No team found matching '{team}'. Team names are case-sensitive exact matches "
+            "(e.g. 'Oklahoma', not 'oklahoma' or 'OU')."
+        )
+
+    return _dump(
+        {
+            "team_detail": _wrap("api.team_detail", detail_rows),
+            "team_history": _wrap("api.team_history", history_rows),
+        }
+    )
+
+
+# ---------------------------------------------------------------------
+# 2. query_games
+# ---------------------------------------------------------------------
+
+
+@mcp.tool(name="query_games", annotations={"title": "Query Games", **READ_ONLY_ANNOTATIONS})
+async def query_games(
+    season: Annotated[
+        int | None,
+        Field(default=None, description="Season year, e.g. 2024. Strongly recommended."),
+    ] = None,
+    week: Annotated[
+        int | None,
+        Field(
+            default=None,
+            description="Week number within the season (regular season "
+            "roughly 1-15; bowls/playoff weeks follow CFBD's season_type/week scheme).",
+        ),
+    ] = None,
+    team: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description="Exact school name. Matches games where this team "
+            "played either home or away.",
+        ),
+    ] = None,
+    min_excitement: Annotated[
+        float | None,
+        Field(
+            default=None,
+            description="Minimum excitement_index (CFBD's game-excitement "
+            "score, roughly 0-10; >6 is generally a thrilling finish). Use to find close "
+            "or dramatic games.",
+        ),
+    ] = None,
+    limit: Annotated[
+        int,
+        Field(
+            default=DEFAULT_ROW_CAP,
+            ge=1,
+            le=DEFAULT_ROW_CAP,
+            description="Max rows to "
+            "return. Hard-capped at 100 server-side regardless of this value.",
+        ),
+    ] = DEFAULT_ROW_CAP,
+) -> str:
+    """Search games by season, week, team, and/or minimum excitement.
+
+    When to use: "what happened in Oklahoma's week 5 game", "show close games
+    in the 2023 season", "list Oklahoma's 2024 schedule".
+
+    Backed by api.game_detail: teams, scores, winner, betting lines
+    (spread/over-under and whether they hit), EPA, pregame win probability,
+    venue, attendance, excitement_index. Results are ordered by start_date
+    descending (most recent first).
+
+    Caveats:
+      - All filters are optional but combine with AND (min_excitement is a
+        floor, not a range). Calling with no filters at all returns the 100
+        most recent games across all of CFBD history -- always pass at least
+        `season` or `team` for a useful result.
+      - `team` matches home OR away, so pass one team, not both (use
+        query_matchup for head-to-head).
+      - Results are capped at 100 rows; a full season across all FBS teams
+        is ~800 games, so pair `season` with `team` or `week` to stay under
+        the cap.
+      - Uncompleted/future games have NULL scores, winner, and EPA.
+
+    Returns: JSON {"_source": "api.game_detail", "count": int, "rows": [...]},
+    or a plain "No games found..." string if the filters match nothing.
+    """
+    params: dict[str, Any] = {}
+    if season is not None:
+        params["season"] = eq(season)
+    if week is not None:
+        params["week"] = eq(week)
+    if team is not None:
+        params["or"] = f"(home_team.eq.{team},away_team.eq.{team})"
+    if min_excitement is not None:
+        params["excitement_index"] = gte(min_excitement)
+    params["order"] = "start_date.desc"
+
+    client = PostgrestClient()
+    try:
+        rows = await client.select("game_detail", params, profile="api", limit=limit)
+    except PostgrestError as e:
+        return e.message
+
+    if not rows:
+        return "No games found matching the given filters."
+    return _dump(_wrap("api.game_detail", rows))
+
+
+# ---------------------------------------------------------------------
+# 3. query_matchup
+# ---------------------------------------------------------------------
+
+
+@mcp.tool(
+    name="query_matchup",
+    annotations={"title": "Query Head-to-Head Matchup", **READ_ONLY_ANNOTATIONS},
+)
+async def query_matchup(
+    team_a: Annotated[str, Field(description="First team's exact school name.")],
+    team_b: Annotated[
+        str,
+        Field(
+            description="Second team's exact school name. Order relative to team_a doesn't "
+            "matter -- results are identical either way."
+        ),
+    ],
+) -> str:
+    """Get head-to-head history and current-season comparison between two teams.
+
+    When to use: "Oklahoma vs Texas all-time record", "how do these two teams
+    compare this season" (rivalry games, bowl previews, etc).
+
+    Backed by api.matchup, which stores one row per unordered team pair
+    (internally keyed alphabetically: team1 < team2). This tool normalizes
+    team_a/team_b alphabetically before querying, so callers never need to
+    know or care about that internal ordering.
+
+    Returns all-time record (total games, wins for each side, ties, first/
+    last meeting), a JSON array of recent results (2014+), and each team's
+    current-season record/SP+ rank/EPA for context.
+
+    Returns: JSON {"_source": "api.matchup", "count": int, "rows": [...]}
+    (rows has 0 or 1 entries), or a plain "No matchup history found..."
+    string if the teams have never played or a name is misspelled.
+    """
+    lo, hi = sorted((team_a, team_b))
+    client = PostgrestClient()
+    try:
+        rows = await client.select(
+            "matchup", {"team1": eq(lo), "team2": eq(hi)}, profile="api", limit=1
+        )
+    except PostgrestError as e:
+        return e.message
+
+    if not rows:
+        return (
+            f"No matchup history found between '{team_a}' and '{team_b}'. These teams may "
+            "have never played each other (FBS-era games only), or a team name may be "
+            "misspelled."
+        )
+    return _dump(_wrap("api.matchup", rows))
+
+
+# ---------------------------------------------------------------------
+# 4. get_rankings
+# ---------------------------------------------------------------------
+
+
+@mcp.tool(name="get_rankings", annotations={"title": "Get Poll Rankings", **READ_ONLY_ANNOTATIONS})
+async def get_rankings(
+    season: Annotated[int, Field(description="Season year, e.g. 2024.")],
+    week: Annotated[
+        int | None,
+        Field(
+            default=None,
+            description="Week number. Omit to get every week of the season "
+            "(subject to the 100-row cap, so prefer pairing with `poll`).",
+        ),
+    ] = None,
+    poll: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description="Exact poll name, e.g. 'AP Top 25', 'Coaches Poll', "
+            "'Playoff Committee Rankings'. Omit to get all polls for the given week(s).",
+        ),
+    ] = None,
+    season_type: Annotated[
+        PollSeasonType,
+        Field(
+            default=PollSeasonType.REGULAR,
+            description="'regular' (default) for weekly "
+            "in-season polls, or 'postseason' for the final poll of the season. CFBD "
+            "reports the final poll as week=1, the same week number as the regular-season "
+            "week-1 poll -- season_type is what tells them apart.",
+        ),
+    ] = PollSeasonType.REGULAR,
+    limit: Annotated[
+        int, Field(default=DEFAULT_ROW_CAP, ge=1, le=DEFAULT_ROW_CAP)
+    ] = DEFAULT_ROW_CAP,
+) -> str:
+    """Get weekly or final poll rankings (AP Top 25, Coaches Poll, CFP committee, etc).
+
+    When to use: "who was #1 in the AP poll in week 8 of 2024", "show the
+    final CFP rankings for 2023", "was Oklahoma ranked in week 3".
+
+    Backed by api.poll_rankings. Rows are ordered week, poll, rank ascending.
+
+    Caveats (important for correct interpretation):
+      - Tied teams share the same rank value, and the next rank is skipped
+        (e.g. two teams at #11 means no #12 that week) -- do not assume rank
+        values are contiguous or that one row per rank exists.
+      - To get the END-OF-SEASON final poll, set season_type='postseason'
+        (week is reported as 1, identical to the regular-season week-1 poll's
+        week number -- season_type is the only disambiguator).
+      - Omitting both `week` and `poll` for a full season can return a lot of
+        rows (many weeks x several polls x ~25 teams); the 100-row cap may
+        truncate results, so prefer narrowing with `poll` and/or `week`.
+
+    Returns: JSON {"_source": "api.poll_rankings", "count": int, "rows": [...]},
+    or a plain "No rankings found..." string if nothing matches.
+    """
+    params: dict[str, Any] = {"season": eq(season), "season_type": eq(season_type.value)}
+    if week is not None:
+        params["week"] = eq(week)
+    if poll is not None:
+        params["poll"] = eq(poll)
+    params["order"] = "week.asc,poll.asc,rank.asc"
+
+    client = PostgrestClient()
+    try:
+        rows = await client.select("poll_rankings", params, profile="api", limit=limit)
+    except PostgrestError as e:
+        return e.message
+
+    if not rows:
+        return (
+            f"No rankings found for season={season}, season_type={season_type.value} with "
+            "the given filters."
+        )
+    return _dump(_wrap("api.poll_rankings", rows))
+
+
+# ---------------------------------------------------------------------
+# 5. get_leaderboard
+# ---------------------------------------------------------------------
+
+
+@mcp.tool(
+    name="get_leaderboard", annotations={"title": "Get Team Leaderboard", **READ_ONLY_ANNOTATIONS}
+)
+async def get_leaderboard(
+    season: Annotated[int, Field(description="Season year, e.g. 2024.")],
+    metric: Annotated[
+        LeaderboardMetric,
+        Field(
+            description=(
+                "Ranking metric: 'wins' (most wins), 'ppg' (points per game), "
+                "'scoring_defense' (fewest points allowed per game), 'epa' (EPA/play), "
+                "'sp_rating' (best SP+ rank), or 'wepa' (opponent-adjusted EPA -- pulled "
+                "from a different, more advanced view, api.team_wepa_season)."
+            )
+        ),
+    ],
+    limit: Annotated[
+        int,
+        Field(
+            default=DEFAULT_ROW_CAP,
+            ge=1,
+            le=DEFAULT_ROW_CAP,
+            description="Max rows. "
+            "Capped at 100; there are ~130 FBS teams so a full-season list may be "
+            "truncated -- lower this or treat results as top-N, not exhaustive.",
+        ),
+    ] = DEFAULT_ROW_CAP,
+) -> str:
+    """Get a ranked leaderboard of teams for a season by a chosen metric.
+
+    When to use: "top 10 teams by EPA in 2024", "best scoring defense last
+    season", "who led the country in wins".
+
+    All metrics except 'wepa' are served from api.leaderboard_teams, which
+    pre-computes rank columns (wins_rank, ppg_rank, defense_ppg_rank,
+    epa_rank) via SQL window functions -- ties are possible. 'wepa' (opponent-
+    adjusted EPA) is served from the separate api.team_wepa_season view,
+    which has its own epa_rank column.
+
+    Returns: JSON {"_source": "<view>", "count": int, "rows": [...]}, ordered
+    best-to-worst for the chosen metric, or a plain "No leaderboard data
+    found..." string if the season has no data.
+    """
+    client = PostgrestClient()
+    try:
+        if metric == LeaderboardMetric.WEPA:
+            rows = await client.select(
+                "team_wepa_season",
+                {"season": eq(season), "order": "epa_rank.asc"},
+                profile="api",
+                limit=limit,
+            )
+            source = "api.team_wepa_season"
+        else:
+            rows = await client.select(
+                "leaderboard_teams",
+                {"season": eq(season), "order": _LEADERBOARD_ORDER[metric]},
+                profile="api",
+                limit=limit,
+            )
+            source = "api.leaderboard_teams"
+    except PostgrestError as e:
+        return e.message
+
+    if not rows:
+        return f"No leaderboard data found for season={season}."
+    return _dump(_wrap(source, rows))
+
+
+# ---------------------------------------------------------------------
+# 6. situational_splits
+# ---------------------------------------------------------------------
+
+
+@mcp.tool(
+    name="situational_splits",
+    annotations={"title": "Get Situational Splits", **READ_ONLY_ANNOTATIONS},
+)
+async def situational_splits(
+    team: Annotated[str, Field(description="Exact school name.")],
+    season: Annotated[int, Field(description="Season year, e.g. 2024.")],
+    split_type: Annotated[
+        SplitType,
+        Field(
+            description=(
+                "Which breakdown to compute: 'home_away' (home vs away performance), "
+                "'conference' (conference vs non-conference opponents), 'red_zone' "
+                "(trips inside the opponent 20: TD/FG/turnover rates), 'down_distance' "
+                "(success rate/EPA by down and distance bucket), or 'field_position' "
+                "(EPA/success rate by field-position zone)."
+            )
+        ),
+    ],
+) -> str:
+    """Get a team's situational performance splits for a season.
+
+    When to use: "how does Oklahoma perform on 3rd down", "home vs away splits
+    for Oklahoma in 2023", "red zone efficiency", "conference vs non-conference
+    performance".
+
+    Fans out to one of five public RPCs based on split_type:
+    get_home_away_splits, get_conference_splits, get_red_zone_splits,
+    get_down_distance_splits, get_field_position_splits -- each called as
+    (p_team=team, p_season=season). All five exclude garbage-time plays.
+
+    Caveats:
+      - Play-by-play data (needed for down_distance/field_position/red_zone/
+        home_away/conference splits) is available from the 2014 season on;
+        earlier seasons will return empty or partial results.
+      - Each RPC returns a small breakdown table (rows keyed by side
+        offense/defense, or by zone/bucket) -- this is not row-capped since
+        results are inherently small.
+
+    Returns: JSON {"_source": "public.<rpc_name>", "count": int, "rows": [...]},
+    or a plain "No <split_type> splits found..." string if the team/season
+    has no matching plays.
+    """
+    fn = _SPLIT_RPCS[split_type]
+    client = PostgrestClient()
+    try:
+        rows = await client.rpc(fn, {"p_team": team, "p_season": season}, profile="public")
+    except PostgrestError as e:
+        return e.message
+
+    if not rows:
+        return (
+            f"No {split_type.value} splits found for '{team}' in {season}. Check the team "
+            "name and that the season has play-by-play data (2014+)."
+        )
+    return _dump(_wrap(f"public.{fn}", rows))
+
+
+# ---------------------------------------------------------------------
+# 7. search_players
+# ---------------------------------------------------------------------
+
+
+@mcp.tool(name="search_players", annotations={"title": "Search Players", **READ_ONLY_ANNOTATIONS})
+async def search_players(
+    query: Annotated[
+        str,
+        Field(
+            description=(
+                "Player name to search, full or partial, typo-tolerant (trigram similarity "
+                "match). E.g. 'Caleb Williams', 'Bijan', or a misspelling like 'Calib "
+                "Williams'."
+            )
+        ),
+    ],
+    team: Annotated[
+        str | None, Field(default=None, description="Restrict search to an exact school name.")
+    ] = None,
+    season: Annotated[
+        int | None, Field(default=None, description="Restrict search to a season year.")
+    ] = None,
+    limit: Annotated[
+        int,
+        Field(
+            default=25,
+            ge=1,
+            le=DEFAULT_ROW_CAP,
+            description="Max search results (default 25, hard-capped at 100).",
+        ),
+    ] = 25,
+) -> str:
+    """Search for a player by name, then fetch full detail for the best match.
+
+    When to use: "find Caleb Williams' stats", "search for a player named
+    Bijan on Texas" -- anytime the caller has a name but not an exact
+    player_id.
+
+    Two-step workflow, both via public RPCs:
+      1. get_player_search(p_query, p_team, p_season, p_limit) -- fuzzy name
+         match via pg_trgm, ranked by similarity_score descending.
+      2. get_player_detail(p_player_id, p_season) is then called automatically
+         for the single top-ranked hit, returning full bio/recruiting/season
+         stats/PPA/WEPA/PAAR for that player.
+
+    Caveats:
+      - If multiple players share a similar name, only the top hit gets full
+        detail -- inspect the "search" rows to see other candidates and call
+        search_players again with a more specific query/team/season if the
+        top hit isn't the right one.
+      - If `season` is omitted, get_player_detail returns that player's most
+        recent season on record, which may not be the season implied by the
+        query.
+
+    Returns: JSON with "search" ({"_source": "public.get_player_search", ...})
+    and "top_hit_detail" ({"_source": "public.get_player_detail", ...}) keys.
+    If the detail lookup itself fails, returns "search" plus a
+    "top_hit_detail_error" string instead of discarding the search results.
+    Returns a plain "No players found..." string if the search itself is empty.
+    """
+    client = PostgrestClient()
+    args: dict[str, Any] = {"p_query": query, "p_limit": limit}
+    if team is not None:
+        args["p_team"] = team
+    if season is not None:
+        args["p_season"] = season
+
+    try:
+        results = await client.rpc("get_player_search", args, profile="public")
+    except PostgrestError as e:
+        return e.message
+
+    if not results:
+        return f"No players found matching '{query}'."
+
+    top = results[0]
+    detail_args: dict[str, Any] = {"p_player_id": top["player_id"]}
+    if season is not None:
+        detail_args["p_season"] = season
+
+    try:
+        detail_rows = await client.rpc("get_player_detail", detail_args, profile="public")
+    except PostgrestError as e:
+        return _dump(
+            {
+                "search": _wrap("public.get_player_search", results),
+                "top_hit_detail_error": e.message,
+            }
+        )
+
+    return _dump(
+        {
+            "search": _wrap("public.get_player_search", results),
+            "top_hit_detail": _wrap("public.get_player_detail", detail_rows),
+        }
+    )
+
+
+# ---------------------------------------------------------------------
+# 8. get_data_freshness
+# ---------------------------------------------------------------------
+
+
+@mcp.tool(
+    name="get_data_freshness", annotations={"title": "Get Data Freshness", **READ_ONLY_ANNOTATIONS}
+)
+async def get_data_freshness() -> str:
+    """Get freshness/staleness status for all tracked warehouse tables.
+
+    When to use: before answering questions about very recent games/stats,
+    to qualify how current the data is -- e.g. "as of the last refresh (X
+    days ago), ...". Also useful if a query returns unexpectedly few/no rows
+    for the current week, to check whether the pipeline has run yet.
+
+    Takes no arguments. Backed by the public.get_data_freshness() RPC, which
+    reports row_count, expected_refresh_frequency, days_since_activity, and
+    is_stale for each of ~23 tracked tables, ordered stale-first.
+
+    Returns: JSON {"_source": "public.get_data_freshness", "count": int,
+    "rows": [...]}.
+    """
+    client = PostgrestClient()
+    try:
+        rows = await client.rpc("get_data_freshness", {}, profile="public")
+    except PostgrestError as e:
+        return e.message
+    return _dump(_wrap("public.get_data_freshness", rows))

--- a/mcp/src/cfb_mcp/server.py
+++ b/mcp/src/cfb_mcp/server.py
@@ -245,7 +245,10 @@ async def query_games(
     if week is not None:
         params["week"] = eq(week)
     if team is not None:
-        params["or"] = f"(home_team.eq.{team},away_team.eq.{team})"
+        # Double-quote the value: ( ) , are structural in PostgREST logic-tree
+        # syntax, so names like "Miami (OH)" would otherwise corrupt the filter.
+        quoted = team.replace('"', '""')
+        params["or"] = f'(home_team.eq."{quoted}",away_team.eq."{quoted}")'
     if min_excitement is not None:
         params["excitement_index"] = gte(min_excitement)
     params["order"] = "start_date.desc"
@@ -298,6 +301,8 @@ async def query_matchup(
     (rows has 0 or 1 entries), or a plain "No matchup history found..."
     string if the teams have never played or a name is misspelled.
     """
+    # NOTE: Python code-point sort assumed to match the DB collation used by the
+    # view's LEAST/GREATEST pair ordering; holds for current CFBD ASCII names.
     lo, hi = sorted((team_a, team_b))
     client = PostgrestClient()
     try:

--- a/mcp/src/cfb_mcp/server.py
+++ b/mcp/src/cfb_mcp/server.py
@@ -139,8 +139,8 @@ async def query_team(
     {"_source": "<view>", "count": int, "rows": [...]}. If nothing at all is
     found, returns a plain "No team found..." string instead.
     """
-    client = PostgrestClient()
     try:
+        client = PostgrestClient()
         detail_rows = await client.select(
             "team_detail", {"school": eq(team)}, profile="api", limit=1
         )
@@ -253,8 +253,8 @@ async def query_games(
         params["excitement_index"] = gte(min_excitement)
     params["order"] = "start_date.desc"
 
-    client = PostgrestClient()
     try:
+        client = PostgrestClient()
         rows = await client.select("game_detail", params, profile="api", limit=limit)
     except PostgrestError as e:
         return e.message
@@ -304,8 +304,8 @@ async def query_matchup(
     # NOTE: Python code-point sort assumed to match the DB collation used by the
     # view's LEAST/GREATEST pair ordering; holds for current CFBD ASCII names.
     lo, hi = sorted((team_a, team_b))
-    client = PostgrestClient()
     try:
+        client = PostgrestClient()
         rows = await client.select(
             "matchup", {"team1": eq(lo), "team2": eq(hi)}, profile="api", limit=1
         )
@@ -387,8 +387,8 @@ async def get_rankings(
         params["poll"] = eq(poll)
     params["order"] = "week.asc,poll.asc,rank.asc"
 
-    client = PostgrestClient()
     try:
+        client = PostgrestClient()
         rows = await client.select("poll_rankings", params, profile="api", limit=limit)
     except PostgrestError as e:
         return e.message
@@ -449,8 +449,8 @@ async def get_leaderboard(
     best-to-worst for the chosen metric, or a plain "No leaderboard data
     found..." string if the season has no data.
     """
-    client = PostgrestClient()
     try:
+        client = PostgrestClient()
         if metric == LeaderboardMetric.WEPA:
             rows = await client.select(
                 "team_wepa_season",
@@ -524,8 +524,8 @@ async def situational_splits(
     has no matching plays.
     """
     fn = _SPLIT_RPCS[split_type]
-    client = PostgrestClient()
     try:
+        client = PostgrestClient()
         rows = await client.rpc(fn, {"p_team": team, "p_season": season}, profile="public")
     except PostgrestError as e:
         return e.message
@@ -599,7 +599,6 @@ async def search_players(
     "top_hit_detail_error" string instead of discarding the search results.
     Returns a plain "No players found..." string if the search itself is empty.
     """
-    client = PostgrestClient()
     args: dict[str, Any] = {"p_query": query, "p_limit": limit}
     if team is not None:
         args["p_team"] = team
@@ -607,6 +606,7 @@ async def search_players(
         args["p_season"] = season
 
     try:
+        client = PostgrestClient()
         results = await client.rpc("get_player_search", args, profile="public")
     except PostgrestError as e:
         return e.message
@@ -660,8 +660,8 @@ async def get_data_freshness() -> str:
     Returns: JSON {"_source": "public.get_data_freshness", "count": int,
     "rows": [...]}.
     """
-    client = PostgrestClient()
     try:
+        client = PostgrestClient()
         rows = await client.rpc("get_data_freshness", {}, profile="public")
     except PostgrestError as e:
         return e.message

--- a/mcp/tests/conftest.py
+++ b/mcp/tests/conftest.py
@@ -1,0 +1,18 @@
+"""Shared pytest fixtures for cfb_mcp tests.
+
+No live network is used anywhere in this test suite -- every PostgREST call
+is intercepted by respx. (The sandbox's outbound proxy blocks *.supabase.co
+anyway, but the tests are hermetic regardless of where they run.)
+"""
+
+import pytest
+
+TEST_BASE_URL = "https://test-project.supabase.co"
+TEST_ANON_KEY = "test-anon-key"
+
+
+@pytest.fixture(autouse=True)
+def supabase_env(monkeypatch):
+    """Every test gets a valid, fake Supabase config unless it overrides env itself."""
+    monkeypatch.setenv("SUPABASE_URL", TEST_BASE_URL)
+    monkeypatch.setenv("SUPABASE_ANON_KEY", TEST_ANON_KEY)

--- a/mcp/tests/test_get_data_freshness.py
+++ b/mcp/tests/test_get_data_freshness.py
@@ -1,0 +1,46 @@
+"""Tests for the get_data_freshness tool: public.get_data_freshness RPC."""
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from cfb_mcp.server import get_data_freshness
+from tests.conftest import TEST_BASE_URL
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_data_freshness_calls_rpc_with_no_args():
+    route = respx.post(f"{TEST_BASE_URL}/rest/v1/rpc/get_data_freshness").mock(
+        return_value=httpx.Response(200, json=[{"table_name": "games", "is_stale": False}])
+    )
+
+    result = json.loads(await get_data_freshness())
+
+    assert result["_source"] == "public.get_data_freshness"
+    assert result["count"] == 1
+    request = route.calls.last.request
+    assert request.headers["Content-Profile"] == "public"
+    assert json.loads(request.content) == {}
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_data_freshness_empty_result():
+    respx.post(f"{TEST_BASE_URL}/rest/v1/rpc/get_data_freshness").mock(
+        return_value=httpx.Response(200, json=[])
+    )
+    result = json.loads(await get_data_freshness())
+    assert result["count"] == 0
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_data_freshness_error_path():
+    respx.post(f"{TEST_BASE_URL}/rest/v1/rpc/get_data_freshness").mock(
+        return_value=httpx.Response(403, json={"message": "denied"})
+    )
+    result = await get_data_freshness()
+    assert result.startswith("Error:")

--- a/mcp/tests/test_get_leaderboard.py
+++ b/mcp/tests/test_get_leaderboard.py
@@ -1,0 +1,79 @@
+"""Tests for the get_leaderboard tool: api.leaderboard_teams / api.team_wepa_season."""
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from cfb_mcp.server import LeaderboardMetric, get_leaderboard
+from tests.conftest import TEST_BASE_URL
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_leaderboard_epa_metric_uses_leaderboard_teams():
+    route = respx.get(f"{TEST_BASE_URL}/rest/v1/leaderboard_teams").mock(
+        return_value=httpx.Response(200, json=[{"team": "Oklahoma", "epa_rank": 1}])
+    )
+
+    result = json.loads(await get_leaderboard(season=2024, metric=LeaderboardMetric.EPA))
+
+    assert result["_source"] == "api.leaderboard_teams"
+    request = route.calls.last.request
+    assert request.url.params["season"] == "eq.2024"
+    assert request.url.params["order"] == "epa_rank.asc"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_leaderboard_wepa_metric_uses_team_wepa_season():
+    route = respx.get(f"{TEST_BASE_URL}/rest/v1/team_wepa_season").mock(
+        return_value=httpx.Response(200, json=[{"team": "Oklahoma", "epa_rank": 1}])
+    )
+
+    result = json.loads(await get_leaderboard(season=2024, metric=LeaderboardMetric.WEPA))
+
+    assert result["_source"] == "api.team_wepa_season"
+    request = route.calls.last.request
+    assert request.url.params["season"] == "eq.2024"
+    assert request.url.params["order"] == "epa_rank.asc"
+
+
+@pytest.mark.parametrize(
+    "metric,expected_order",
+    [
+        (LeaderboardMetric.WINS, "wins_rank.asc"),
+        (LeaderboardMetric.PPG, "ppg_rank.asc"),
+        (LeaderboardMetric.SCORING_DEFENSE, "defense_ppg_rank.asc"),
+        (LeaderboardMetric.SP_RATING, "sp_rank.asc"),
+    ],
+)
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_leaderboard_metric_order_mapping(metric, expected_order):
+    route = respx.get(f"{TEST_BASE_URL}/rest/v1/leaderboard_teams").mock(
+        return_value=httpx.Response(200, json=[])
+    )
+    await get_leaderboard(season=2024, metric=metric)
+    assert route.calls.last.request.url.params["order"] == expected_order
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_leaderboard_row_cap_enforced():
+    route = respx.get(f"{TEST_BASE_URL}/rest/v1/leaderboard_teams").mock(
+        return_value=httpx.Response(200, json=[])
+    )
+    await get_leaderboard(season=2024, metric=LeaderboardMetric.WINS, limit=100)
+    assert route.calls.last.request.url.params["limit"] == "100"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_leaderboard_empty_result():
+    respx.get(f"{TEST_BASE_URL}/rest/v1/leaderboard_teams").mock(
+        return_value=httpx.Response(200, json=[])
+    )
+    result = await get_leaderboard(season=1800, metric=LeaderboardMetric.WINS)
+    assert "No leaderboard data found" in result

--- a/mcp/tests/test_get_rankings.py
+++ b/mcp/tests/test_get_rankings.py
@@ -1,0 +1,53 @@
+"""Tests for the get_rankings tool: api.poll_rankings."""
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from cfb_mcp.server import get_rankings
+from tests.conftest import TEST_BASE_URL
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_rankings_defaults_to_regular_season_type():
+    route = respx.get(f"{TEST_BASE_URL}/rest/v1/poll_rankings").mock(
+        return_value=httpx.Response(200, json=[{"school": "Oklahoma", "rank": 5}])
+    )
+
+    result = json.loads(await get_rankings(season=2024, week=8, poll="AP Top 25"))
+
+    assert result["_source"] == "api.poll_rankings"
+    request = route.calls.last.request
+    assert request.url.params["season"] == "eq.2024"
+    assert request.url.params["season_type"] == "eq.regular"
+    assert request.url.params["week"] == "eq.8"
+    assert request.url.params["poll"] == "eq.AP Top 25"
+    assert request.url.params["order"] == "week.asc,poll.asc,rank.asc"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_rankings_postseason_override():
+    route = respx.get(f"{TEST_BASE_URL}/rest/v1/poll_rankings").mock(
+        return_value=httpx.Response(200, json=[{"school": "Michigan", "rank": 1}])
+    )
+
+    from cfb_mcp.server import PollSeasonType
+
+    await get_rankings(season=2023, season_type=PollSeasonType.POSTSEASON)
+
+    request = route.calls.last.request
+    assert request.url.params["season_type"] == "eq.postseason"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_rankings_empty_result():
+    respx.get(f"{TEST_BASE_URL}/rest/v1/poll_rankings").mock(
+        return_value=httpx.Response(200, json=[])
+    )
+    result = await get_rankings(season=1800)
+    assert "No rankings found" in result

--- a/mcp/tests/test_postgrest.py
+++ b/mcp/tests/test_postgrest.py
@@ -1,0 +1,182 @@
+"""Unit tests for cfb_mcp.postgrest: config, operator builders, row cap, error mapping."""
+
+import httpx
+import pytest
+import respx
+
+from cfb_mcp.postgrest import (
+    DEFAULT_ROW_CAP,
+    PostgrestClient,
+    PostgrestConfig,
+    PostgrestError,
+    eq,
+    gte,
+    in_,
+    lte,
+)
+from tests.conftest import TEST_BASE_URL
+
+
+def test_operator_builders():
+    assert eq(2024) == "eq.2024"
+    assert eq("Oklahoma") == "eq.Oklahoma"
+    assert gte(6.5) == "gte.6.5"
+    assert lte(10) == "lte.10"
+    assert in_(["a", "b", "c"]) == "in.(a,b,c)"
+    assert in_([1, 2]) == "in.(1,2)"
+
+
+def test_config_missing_url_raises(monkeypatch):
+    monkeypatch.delenv("SUPABASE_URL", raising=False)
+    monkeypatch.setenv("SUPABASE_ANON_KEY", "key")
+    with pytest.raises(PostgrestError, match="SUPABASE_URL is not set"):
+        PostgrestConfig.from_env()
+
+
+def test_config_missing_key_raises(monkeypatch):
+    monkeypatch.setenv("SUPABASE_URL", TEST_BASE_URL)
+    monkeypatch.delenv("SUPABASE_ANON_KEY", raising=False)
+    with pytest.raises(PostgrestError, match="SUPABASE_ANON_KEY is not set"):
+        PostgrestConfig.from_env()
+
+
+def test_config_strips_trailing_slash(monkeypatch):
+    monkeypatch.setenv("SUPABASE_URL", TEST_BASE_URL + "/")
+    monkeypatch.setenv("SUPABASE_ANON_KEY", "key")
+    config = PostgrestConfig.from_env()
+    assert config.base_url == TEST_BASE_URL
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_select_sends_headers_and_params():
+    route = respx.get(f"{TEST_BASE_URL}/rest/v1/team_detail").mock(
+        return_value=httpx.Response(200, json=[{"school": "Oklahoma"}])
+    )
+    client = PostgrestClient()
+    rows = await client.select("team_detail", {"school": eq("Oklahoma")}, profile="api", limit=1)
+
+    assert rows == [{"school": "Oklahoma"}]
+    request = route.calls.last.request
+    assert request.headers["apikey"] == "test-anon-key"
+    assert request.headers["Authorization"] == "Bearer test-anon-key"
+    assert request.headers["Accept-Profile"] == "api"
+    assert request.url.params["school"] == "eq.Oklahoma"
+    assert request.url.params["limit"] == "1"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_select_row_cap_never_exceeded():
+    route = respx.get(f"{TEST_BASE_URL}/rest/v1/game_detail").mock(
+        return_value=httpx.Response(200, json=[])
+    )
+    client = PostgrestClient()
+    await client.select("game_detail", {}, profile="api", limit=99999)
+
+    request = route.calls.last.request
+    assert request.url.params["limit"] == str(DEFAULT_ROW_CAP)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_select_row_cap_honors_lower_requested_limit():
+    route = respx.get(f"{TEST_BASE_URL}/rest/v1/game_detail").mock(
+        return_value=httpx.Response(200, json=[])
+    )
+    client = PostgrestClient()
+    await client.select("game_detail", {}, profile="api", limit=5)
+
+    request = route.calls.last.request
+    assert request.url.params["limit"] == "5"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_rpc_sends_content_profile_and_json_body():
+    route = respx.post(f"{TEST_BASE_URL}/rest/v1/rpc/get_home_away_splits").mock(
+        return_value=httpx.Response(200, json=[{"location": "home"}])
+    )
+    client = PostgrestClient()
+    rows = await client.rpc(
+        "get_home_away_splits", {"p_team": "Oklahoma", "p_season": 2024}, profile="public"
+    )
+
+    assert rows == [{"location": "home"}]
+    request = route.calls.last.request
+    assert request.headers["Content-Profile"] == "public"
+    assert "Accept-Profile" not in request.headers
+    import json as _json
+
+    assert _json.loads(request.content) == {"p_team": "Oklahoma", "p_season": 2024}
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_select_empty_result():
+    respx.get(f"{TEST_BASE_URL}/rest/v1/matchup").mock(return_value=httpx.Response(200, json=[]))
+    client = PostgrestClient()
+    rows = await client.select("matchup", {}, profile="api")
+    assert rows == []
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_select_404_maps_to_actionable_error():
+    respx.get(f"{TEST_BASE_URL}/rest/v1/nonexistent_view").mock(
+        return_value=httpx.Response(404, json={"message": "relation not found", "code": "42P01"})
+    )
+    client = PostgrestClient()
+    with pytest.raises(PostgrestError, match="not found \\(404\\)"):
+        await client.select("nonexistent_view", {}, profile="api")
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_select_403_maps_to_permission_error():
+    respx.get(f"{TEST_BASE_URL}/rest/v1/team_detail").mock(
+        return_value=httpx.Response(403, json={"message": "permission denied"})
+    )
+    client = PostgrestClient()
+    with pytest.raises(PostgrestError, match="permission denied"):
+        await client.select("team_detail", {}, profile="api")
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_select_429_maps_to_rate_limit_error():
+    respx.get(f"{TEST_BASE_URL}/rest/v1/team_detail").mock(return_value=httpx.Response(429))
+    client = PostgrestClient()
+    with pytest.raises(PostgrestError, match="rate limited"):
+        await client.select("team_detail", {}, profile="api")
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_select_500_maps_to_server_error():
+    respx.get(f"{TEST_BASE_URL}/rest/v1/team_detail").mock(
+        return_value=httpx.Response(500, json={"message": "internal error"})
+    )
+    client = PostgrestClient()
+    with pytest.raises(PostgrestError, match="server error \\(500\\)"):
+        await client.select("team_detail", {}, profile="api")
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_select_network_error_is_wrapped():
+    respx.get(f"{TEST_BASE_URL}/rest/v1/team_detail").mock(side_effect=httpx.ConnectError("boom"))
+    client = PostgrestClient()
+    with pytest.raises(PostgrestError, match="network failure"):
+        await client.select("team_detail", {}, profile="api")
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_select_timeout_is_wrapped():
+    respx.get(f"{TEST_BASE_URL}/rest/v1/team_detail").mock(
+        side_effect=httpx.TimeoutException("timed out")
+    )
+    client = PostgrestClient()
+    with pytest.raises(PostgrestError, match="timed out"):
+        await client.select("team_detail", {}, profile="api")

--- a/mcp/tests/test_query_games.py
+++ b/mcp/tests/test_query_games.py
@@ -1,0 +1,73 @@
+"""Tests for the query_games tool: api.game_detail."""
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from cfb_mcp.server import query_games
+from tests.conftest import TEST_BASE_URL
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_query_games_filters_and_or_clause():
+    route = respx.get(f"{TEST_BASE_URL}/rest/v1/game_detail").mock(
+        return_value=httpx.Response(200, json=[{"game_id": 1}])
+    )
+
+    result = json.loads(await query_games(season=2024, week=5, team="Oklahoma", min_excitement=6.5))
+
+    assert result["_source"] == "api.game_detail"
+    assert result["count"] == 1
+
+    request = route.calls.last.request
+    assert request.url.params["season"] == "eq.2024"
+    assert request.url.params["week"] == "eq.5"
+    assert request.url.params["or"] == "(home_team.eq.Oklahoma,away_team.eq.Oklahoma)"
+    assert request.url.params["excitement_index"] == "gte.6.5"
+    assert request.url.params["order"] == "start_date.desc"
+    assert request.url.params["limit"] == "100"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_query_games_limit_is_capped_at_100():
+    route = respx.get(f"{TEST_BASE_URL}/rest/v1/game_detail").mock(
+        return_value=httpx.Response(200, json=[])
+    )
+    await query_games(season=2024, limit=100)
+    assert route.calls.last.request.url.params["limit"] == "100"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_query_games_no_filters_still_works():
+    route = respx.get(f"{TEST_BASE_URL}/rest/v1/game_detail").mock(
+        return_value=httpx.Response(200, json=[{"game_id": 1}])
+    )
+    await query_games()
+    request = route.calls.last.request
+    assert "season" not in request.url.params
+    assert "or" not in request.url.params
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_query_games_empty_result():
+    respx.get(f"{TEST_BASE_URL}/rest/v1/game_detail").mock(
+        return_value=httpx.Response(200, json=[])
+    )
+    result = await query_games(season=1899)
+    assert result == "No games found matching the given filters."
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_query_games_error_path():
+    respx.get(f"{TEST_BASE_URL}/rest/v1/game_detail").mock(
+        return_value=httpx.Response(404, json={"message": "not found"})
+    )
+    result = await query_games(season=2024)
+    assert result.startswith("Error:")

--- a/mcp/tests/test_query_games.py
+++ b/mcp/tests/test_query_games.py
@@ -25,10 +25,27 @@ async def test_query_games_filters_and_or_clause():
     request = route.calls.last.request
     assert request.url.params["season"] == "eq.2024"
     assert request.url.params["week"] == "eq.5"
-    assert request.url.params["or"] == "(home_team.eq.Oklahoma,away_team.eq.Oklahoma)"
+    assert request.url.params["or"] == '(home_team.eq."Oklahoma",away_team.eq."Oklahoma")'
     assert request.url.params["excitement_index"] == "gte.6.5"
     assert request.url.params["order"] == "start_date.desc"
     assert request.url.params["limit"] == "100"
+    # Tool-level guard: reads must stay confined to the contracted api schema
+    assert request.headers["Accept-Profile"] == "api"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_query_games_quotes_reserved_chars_in_team_name():
+    """Parens/commas are structural in PostgREST logic trees; quoting keeps
+    names like "Miami (OH)" from corrupting the or= filter."""
+    route = respx.get(f"{TEST_BASE_URL}/rest/v1/game_detail").mock(
+        return_value=httpx.Response(200, json=[{"game_id": 1}])
+    )
+
+    await query_games(season=2024, team="Miami (OH)")
+
+    or_param = route.calls.last.request.url.params["or"]
+    assert or_param == '(home_team.eq."Miami (OH)",away_team.eq."Miami (OH)")'
 
 
 @pytest.mark.asyncio

--- a/mcp/tests/test_query_games.py
+++ b/mcp/tests/test_query_games.py
@@ -88,3 +88,16 @@ async def test_query_games_error_path():
     )
     result = await query_games(season=2024)
     assert result.startswith("Error:")
+
+
+@pytest.mark.asyncio
+async def test_missing_env_returns_error_string_not_exception(monkeypatch):
+    """Config errors must surface as the tool's friendly Error: string, not an
+    MCP exception — client construction happens inside each tool's try block."""
+    monkeypatch.delenv("SUPABASE_URL", raising=False)
+    monkeypatch.delenv("SUPABASE_ANON_KEY", raising=False)
+
+    result = await query_games(season=2024)
+
+    assert isinstance(result, str)
+    assert result.startswith("Error: SUPABASE_URL is not set")

--- a/mcp/tests/test_query_matchup.py
+++ b/mcp/tests/test_query_matchup.py
@@ -1,0 +1,51 @@
+"""Tests for the query_matchup tool: api.matchup, alphabetically-normalized pair."""
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from cfb_mcp.server import query_matchup
+from tests.conftest import TEST_BASE_URL
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_query_matchup_normalizes_team_order():
+    route = respx.get(f"{TEST_BASE_URL}/rest/v1/matchup").mock(
+        return_value=httpx.Response(200, json=[{"team1": "Oklahoma", "team2": "Texas"}])
+    )
+
+    # Texas < Oklahoma alphabetically is false ("O" < "T"), so team1 should be
+    # Oklahoma regardless of argument order.
+    result = json.loads(await query_matchup(team_a="Texas", team_b="Oklahoma"))
+
+    assert result["_source"] == "api.matchup"
+    request = route.calls.last.request
+    assert request.url.params["team1"] == "eq.Oklahoma"
+    assert request.url.params["team2"] == "eq.Texas"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_query_matchup_same_params_either_argument_order():
+    route = respx.get(f"{TEST_BASE_URL}/rest/v1/matchup").mock(
+        return_value=httpx.Response(200, json=[{"team1": "Oklahoma", "team2": "Texas"}])
+    )
+
+    await query_matchup(team_a="Oklahoma", team_b="Texas")
+    first_call_params = dict(route.calls.last.request.url.params)
+
+    await query_matchup(team_a="Texas", team_b="Oklahoma")
+    second_call_params = dict(route.calls.last.request.url.params)
+
+    assert first_call_params == second_call_params
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_query_matchup_not_found():
+    respx.get(f"{TEST_BASE_URL}/rest/v1/matchup").mock(return_value=httpx.Response(200, json=[]))
+    result = await query_matchup(team_a="Oklahoma", team_b="Rice")
+    assert "No matchup history found" in result

--- a/mcp/tests/test_query_team.py
+++ b/mcp/tests/test_query_team.py
@@ -1,0 +1,66 @@
+"""Tests for the query_team tool: api.team_detail + api.team_history."""
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from cfb_mcp.server import query_team
+from tests.conftest import TEST_BASE_URL
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_query_team_success_shapes_both_sources():
+    detail_route = respx.get(f"{TEST_BASE_URL}/rest/v1/team_detail").mock(
+        return_value=httpx.Response(200, json=[{"school": "Oklahoma", "wins": 10}])
+    )
+    history_route = respx.get(f"{TEST_BASE_URL}/rest/v1/team_history").mock(
+        return_value=httpx.Response(
+            200, json=[{"team": "Oklahoma", "season": 2024}, {"team": "Oklahoma", "season": 2023}]
+        )
+    )
+
+    result = json.loads(await query_team(team="Oklahoma"))
+
+    assert result["team_detail"]["_source"] == "api.team_detail"
+    assert result["team_detail"]["count"] == 1
+    assert result["team_history"]["_source"] == "api.team_history"
+    assert result["team_history"]["count"] == 2
+
+    detail_request = detail_route.calls.last.request
+    assert detail_request.url.params["school"] == "eq.Oklahoma"
+    assert detail_request.headers["Accept-Profile"] == "api"
+
+    history_request = history_route.calls.last.request
+    assert history_request.url.params["team"] == "eq.Oklahoma"
+    assert history_request.url.params["order"] == "season.desc"
+    assert history_request.url.params["limit"] == "100"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_query_team_not_found_returns_plain_message():
+    respx.get(f"{TEST_BASE_URL}/rest/v1/team_detail").mock(
+        return_value=httpx.Response(200, json=[])
+    )
+    respx.get(f"{TEST_BASE_URL}/rest/v1/team_history").mock(
+        return_value=httpx.Response(200, json=[])
+    )
+
+    result = await query_team(team="Nonexistent State")
+
+    assert result.startswith("No team found matching 'Nonexistent State'")
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_query_team_error_path_returns_error_string():
+    respx.get(f"{TEST_BASE_URL}/rest/v1/team_detail").mock(
+        return_value=httpx.Response(500, json={"message": "boom"})
+    )
+
+    result = await query_team(team="Oklahoma")
+
+    assert result.startswith("Error:")

--- a/mcp/tests/test_search_players.py
+++ b/mcp/tests/test_search_players.py
@@ -1,0 +1,83 @@
+"""Tests for the search_players tool: get_player_search then get_player_detail."""
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from cfb_mcp.server import search_players
+from tests.conftest import TEST_BASE_URL
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_search_players_fetches_detail_for_top_hit():
+    search_route = respx.post(f"{TEST_BASE_URL}/rest/v1/rpc/get_player_search").mock(
+        return_value=httpx.Response(
+            200,
+            json=[
+                {"player_id": "123", "name": "Caleb Williams", "similarity_score": 0.9},
+                {"player_id": "456", "name": "Caleb Williamson", "similarity_score": 0.5},
+            ],
+        )
+    )
+    detail_route = respx.post(f"{TEST_BASE_URL}/rest/v1/rpc/get_player_detail").mock(
+        return_value=httpx.Response(200, json=[{"player_id": "123", "pass_yds": 4000}])
+    )
+
+    result = json.loads(await search_players(query="Caleb Williams", team="Oklahoma", season=2022))
+
+    assert result["search"]["_source"] == "public.get_player_search"
+    assert result["search"]["count"] == 2
+    assert result["top_hit_detail"]["_source"] == "public.get_player_detail"
+    assert result["top_hit_detail"]["rows"][0]["player_id"] == "123"
+
+    search_body = json.loads(search_route.calls.last.request.content)
+    assert search_body == {
+        "p_query": "Caleb Williams",
+        "p_limit": 25,
+        "p_team": "Oklahoma",
+        "p_season": 2022,
+    }
+
+    detail_body = json.loads(detail_route.calls.last.request.content)
+    assert detail_body == {"p_player_id": "123", "p_season": 2022}
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_search_players_no_results():
+    respx.post(f"{TEST_BASE_URL}/rest/v1/rpc/get_player_search").mock(
+        return_value=httpx.Response(200, json=[])
+    )
+    result = await search_players(query="Nobody Realname")
+    assert "No players found" in result
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_search_players_detail_failure_preserves_search_results():
+    respx.post(f"{TEST_BASE_URL}/rest/v1/rpc/get_player_search").mock(
+        return_value=httpx.Response(200, json=[{"player_id": "123", "name": "X"}])
+    )
+    respx.post(f"{TEST_BASE_URL}/rest/v1/rpc/get_player_detail").mock(
+        return_value=httpx.Response(500, json={"message": "boom"})
+    )
+
+    result = json.loads(await search_players(query="X"))
+
+    assert result["search"]["count"] == 1
+    assert "top_hit_detail_error" in result
+    assert result["top_hit_detail_error"].startswith("Error:")
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_search_players_row_cap_passed_through():
+    route = respx.post(f"{TEST_BASE_URL}/rest/v1/rpc/get_player_search").mock(
+        return_value=httpx.Response(200, json=[])
+    )
+    await search_players(query="X", limit=100)
+    body = json.loads(route.calls.last.request.content)
+    assert body["p_limit"] == 100

--- a/mcp/tests/test_situational_splits.py
+++ b/mcp/tests/test_situational_splits.py
@@ -1,0 +1,57 @@
+"""Tests for the situational_splits tool: fan-out to the five split RPCs."""
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from cfb_mcp.server import SplitType, situational_splits
+from tests.conftest import TEST_BASE_URL
+
+
+@pytest.mark.parametrize(
+    "split_type,rpc_name",
+    [
+        (SplitType.HOME_AWAY, "get_home_away_splits"),
+        (SplitType.CONFERENCE, "get_conference_splits"),
+        (SplitType.RED_ZONE, "get_red_zone_splits"),
+        (SplitType.DOWN_DISTANCE, "get_down_distance_splits"),
+        (SplitType.FIELD_POSITION, "get_field_position_splits"),
+    ],
+)
+@pytest.mark.asyncio
+@respx.mock
+async def test_situational_splits_fans_out_to_correct_rpc(split_type, rpc_name):
+    route = respx.post(f"{TEST_BASE_URL}/rest/v1/rpc/{rpc_name}").mock(
+        return_value=httpx.Response(200, json=[{"side": "offense"}])
+    )
+
+    result = json.loads(
+        await situational_splits(team="Oklahoma", season=2024, split_type=split_type)
+    )
+
+    assert result["_source"] == f"public.{rpc_name}"
+    request = route.calls.last.request
+    assert request.headers["Content-Profile"] == "public"
+    assert json.loads(request.content) == {"p_team": "Oklahoma", "p_season": 2024}
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_situational_splits_empty_result():
+    respx.post(f"{TEST_BASE_URL}/rest/v1/rpc/get_red_zone_splits").mock(
+        return_value=httpx.Response(200, json=[])
+    )
+    result = await situational_splits(team="Rice", season=2005, split_type=SplitType.RED_ZONE)
+    assert "No red_zone splits found" in result
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_situational_splits_error_path():
+    respx.post(f"{TEST_BASE_URL}/rest/v1/rpc/get_home_away_splits").mock(
+        return_value=httpx.Response(500, json={"message": "boom"})
+    )
+    result = await situational_splits(team="Oklahoma", season=2024, split_type=SplitType.HOME_AWAY)
+    assert result.startswith("Error:")


### PR DESCRIPTION
## Summary

P3.1: a local (stdio) MCP server at `mcp/` exposing the warehouse to Claude Desktop / Claude Code for natural-language queries — **strictly over the contracted surface** (`api.*` views + `public` RPCs via PostgREST with the anon key; Contract Rule 4 applies to this server exactly as to cfb-app).

**Eight tools:** `query_team`, `query_games`, `query_matchup`, `get_rankings` (season_type='regular' default + tied-rank caveats encoded in the docstring), `get_leaderboard` (incl. WEPA), `situational_splits` (one tool fanning to the five split RPCs), `search_players` (search → detail), `get_data_freshness`.

**Design notes:**
- Own sub-project (`mcp/pyproject.toml`) — the pipeline install is untouched.
- Hard 100-row cap enforced in the client for all view reads; enums pydantic-validated; PostgREST profiles hardcoded (no user-controllable schema access).
- A raw-SQL tool was **deliberately excluded**: the anon role can read all schemas (known grants posture), so dynamic SQL can't be confined to the contract. Deferred with a dedicated-role design sketch (see README).
- New `mcp` CI job (ruff + 52 fully-mocked tests, no secrets).

**Adversarial review (Opus) — PASS with one must-fix, applied:** unquoted values in the `query_games` `or=` filter broke on "Miami (OH)"-style names (parens are structural in PostgREST logic trees) — fixed with double-quoting + regression test. Review confirmed: no schema escape via Accept-Profile, no param smuggling (httpx percent-encoding confines injections), enum enforcement, sound error handling.

## Smoke test (requested before merge)

The authoring environment can't reach Supabase, so the live check is yours. Per `mcp/README.md`: add the server to Claude Desktop or `claude mcp add` with your `SUPABASE_URL`/`SUPABASE_ANON_KEY`, then try the three scripted prompts (team lookup, OU–Texas matchup, situational splits). If those answer with real data, this is good to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNx7MmfrWbhFwx1du79KY3

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNx7MmfrWbhFwx1du79KY3)_