### PR TITLE
Tier 2 analytics: house Elo, ridge-adjusted EPA, scored edges, predictions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
-      - run: pip install -e ".[dev]"
+      - run: pip install -e ".[dev,compute]"
       - run: pytest -q --tb=short
         env:
           SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}

--- a/.github/workflows/daily-load.yml
+++ b/.github/workflows/daily-load.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
-      - run: pip install -e .
+      - run: pip install -e ".[compute]"
       - name: Set dlt destination credentials
         # dlt requires the postgres:// scheme (see .dlt/secrets.toml.example)
         run: echo "DESTINATION__POSTGRES__CREDENTIALS=$(printf '%s' "$SUPABASE_DB_URL" | sed 's/^postgresql:/postgres:/')" >> "$GITHUB_ENV"
@@ -59,6 +59,19 @@ jobs:
           else
             python scripts/load_season.py --weekly
           fi
+      - name: Update house Elo
+        run: python scripts/compute_house_elo.py --incremental
+      - name: Refit adjusted EPA
+        run: |
+          if [ -n "${{ inputs.season }}" ]; then
+            python scripts/compute_adjusted_epa.py --season "${{ inputs.season }}"
+          else
+            python scripts/compute_adjusted_epa.py --season "$(python -c "from src.pipelines.config.years import get_current_season; print(get_current_season())")"
+          fi
+      - name: Write game predictions
+        run: python scripts/compute_predictions.py
+      - name: Refresh Tier 2 marts
+        run: python scripts/refresh_marts.py --views marts.house_elo,marts.house_elo_game,marts.team_adjusted_epa,marts.scored_matchup_edges,marts.prediction_accuracy
       - name: Verify load
         run: |
           if [ -n "${{ inputs.season }}" ]; then

--- a/.github/workflows/deploy-schema.yml
+++ b/.github/workflows/deploy-schema.yml
@@ -27,6 +27,7 @@ on:
           - presence_check
           - apply
           - backfill
+          - compute
         default: presence_check
       marts_from:
         description: "run_marts.py --from value, e.g. 029 (apply only)"
@@ -57,6 +58,14 @@ on:
         description: "Backfill: comma-separated pipeline sources, e.g. stats,betting (backfill only)"
         required: false
         type: string
+      compute_script:
+        description: "Compute script name, e.g. compute_house_elo (compute only)"
+        required: false
+        type: string
+      compute_args:
+        description: "Comma-separated args passed to the compute script (compute only)"
+        required: false
+        type: string
 
 concurrency:
   group: deploy-schema
@@ -81,7 +90,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
-      - run: pip install -e .
+      - run: pip install -e ".[compute]"
       - name: Set dlt destination credentials
         # dlt requires the postgres:// scheme (see .dlt/secrets.toml.example)
         run: echo "DESTINATION__POSTGRES__CREDENTIALS=$(printf '%s' "$SUPABASE_DB_URL" | sed 's/^postgresql:/postgres:/')" >> "$GITHUB_ENV"
@@ -100,4 +109,6 @@ jobs:
           if [ -n "${{ inputs.backfill_start }}" ]; then ARGS+=(--backfill-start "${{ inputs.backfill_start }}"); fi
           if [ -n "${{ inputs.backfill_end }}" ]; then ARGS+=(--backfill-end "${{ inputs.backfill_end }}"); fi
           if [ -n "${{ inputs.sources }}" ]; then ARGS+=(--sources "${{ inputs.sources }}"); fi
+          if [ -n "${{ inputs.compute_script }}" ]; then ARGS+=(--compute-script "${{ inputs.compute_script }}"); fi
+          if [ -n "${{ inputs.compute_args }}" ]; then ARGS+=(--compute-args "${{ inputs.compute_args }}"); fi
           python scripts/deploy_schema.py "${ARGS[@]}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,13 +53,14 @@ The database uses multiple Postgres schemas organized by data domain:
 | `draft` | NFL draft data | picks, positions |
 | `metrics` | Advanced metrics | PPA, win probability |
 | `analytics` | Computed analytics | EPA, style profiles |
-| `marts` | Materialized views (27) | Denormalized, query-optimized |
-| `api` | API view layer (18) | Contract surface for cfb-app/cfb-scout |
+| `marts` | Materialized views (32) | Denormalized, query-optimized |
+| `api` | API view layer (23) | Contract surface for cfb-app/cfb-scout |
+| `predictions` | Prediction snapshots | game_predictions (append-only daily) |
 | `public` | Convenience views/RPCs (12) | Downstream consumer interface |
 
 ### Marts System
 
-27 materialized views in the `marts` schema provide denormalized, query-optimized data (plus the plain view `analytics.data_quality_dashboard`). Refresh via:
+32 materialized views in the `marts` schema provide denormalized, query-optimized data (plus the plain view `analytics.data_quality_dashboard`). Refresh via:
 ```bash
 python scripts/refresh_marts.py        # Refresh all marts
 ```
@@ -102,9 +103,9 @@ cfb-database/
 │   │   │   └── rate_limiter.py   # Monthly budget tracking
 │   │   └── run.py                # Pipeline orchestration
 │   └── schemas/
-│       ├── api/                  # 18 API view definitions (contract surface)
+│       ├── api/                  # 23 API view definitions (contract surface)
 │       ├── functions/            # SQL functions
-│       ├── marts/                # 27 materialized view definitions (+1 plain view)
+│       ├── marts/                # 32 materialized view definitions (+1 plain view)
 │       ├── public/               # 12 convenience views + RPCs
 │       └── migrations/           # Schema migrations
 ├── scripts/
@@ -112,7 +113,11 @@ cfb-database/
 │   ├── verify_load.py            # Post-load verification checks
 │   ├── refresh_marts.py          # Mart refresh script
 │   ├── run_marts.py              # Apply mart definitions
-│   └── run_migrations.py         # Migration runner (--file for one-off SQL)
+│   ├── run_migrations.py         # Migration runner (--file for one-off SQL)
+│   ├── compute_house_elo.py      # Compute house Elo ratings from game history
+│   ├── compute_adjusted_epa.py   # Compute team adjusted EPA ratings
+│   ├── compute_predictions.py    # Generate game predictions and edges
+│   └── check_backtest.py         # Backtest prediction accuracy and scoring
 ├── tests/                        # Test files + test_sources/
 │   └── conftest.py               # DB connection + mock fixtures
 ├── .dlt/

--- a/docs/SCHEMA_CONTRACT.md
+++ b/docs/SCHEMA_CONTRACT.md
@@ -4,11 +4,48 @@
 > only depend on objects listed here as **public**. Everything else is internal and may change
 > without notice.
 
-Last updated: 2026-07-20
+Last updated: 2026-07-21
 
 ---
 
 ## Recent Contract Changes
+
+- **2026-07-21 — Tier 2 analytics: house Elo, ridge-adjusted EPA, scored edges, predictions.**
+  Five new `marts.*` materialized views and five new `api.*` views add a house-generated
+  opinion layer on top of the warehouse's authoritative CFBD data. All of it is
+  **transparent math -- no fitted ML model**: `elo_v1` is Elo-only, `elo_epa_blend_v1` blends
+  0.6*Elo + 0.4*ridge-adjusted EPA; both are closed-form and reproducible from the SQL/Python
+  alone (`scripts/compute_house_elo.py`, `scripts/compute_adjusted_epa.py`,
+  `scripts/compute_predictions.py`; see `docs/plans/2026-07-21-tier2-analytics-plan.md`).
+  - **House Elo:** `marts.house_elo` (season-end rating per team-season, ranked, with a
+    `low_confidence` flag for thin seasons) and `marts.house_elo_game` (game-grain pregame/
+    postgame Elo, win probability, expected-vs-actual margin) -- exposed as `api.team_elo` and
+    `api.game_elo_history`. Full history from 1869; CFBD's own Elo (coverage ~2015+) is carried
+    alongside purely for side-by-side comparison, not used in the computation.
+  - **Ridge-adjusted EPA:** `marts.team_adjusted_epa` -- opponent-adjusted offensive/defensive
+    EPA per team-season from a ridge regression (lambda=200) over `marts.play_epa`, 2004+, with
+    CFBD's WEPA (`marts.team_wepa_season`) joined in as a sanity check only. Not exposed as its
+    own API view; it feeds the predictions below.
+  - **Scored edges:** `marts.scored_matchup_edges` -- house expected margin/win probability vs.
+    the market line for **upcoming** games only, with the resulting `edge` and `edge_pick`.
+    Normally empty out of season -- that is expected behavior, not a data-quality failure.
+    Exposed as `api.scored_matchup_edges`.
+  - **Predictions:** new `predictions` schema (`predictions.game_predictions`) holds
+    append-only daily snapshots -- one immutable row per `(game_id, model_version,
+    prediction_date)`, written by `scripts/compute_predictions.py`. It is readable directly,
+    but downstream consumers should prefer `api.game_predictions` (latest snapshot per
+    game/model via `DISTINCT ON`) unless the full day-by-day history is needed.
+  - **Backtest surface:** `marts.prediction_accuracy` -- retroactive scoring (margin MAE/RMSE,
+    ATS record, Brier score vs. CFBD's own pregame win probability) by season, model, and
+    edge-threshold. Exposed as `api.prediction_accuracy`.
+  - **`marts.matchup_edges` (016) is now documented as style-only.** It predates house Elo/EPA
+    and is an unvalidated style-matchup scorer; prediction use should read
+    `marts.scored_matchup_edges` instead.
+  - `marts.refresh_all()` now refreshes 37 materialized views in 6 dependency layers (was 32
+    in 5 layers); the daily workflow runs the three compute scripts and an explicit
+    `refresh_marts.py --views` pass over the 5 new Tier 2 marts after the season load step.
+  - cfb-app should regenerate `supabase gen types` to pick up the new `predictions` schema and
+    the new/changed views.
 
 - **2026-07-20 — Added `api.game_drives`, `api.game_plays`, `api.poll_rankings`.**
   Closes the Phase 0 Lane D gap where cfb-app queried `core.drives`, `core.plays`, and
@@ -117,6 +154,11 @@ These are the primary PostgREST-accessible views. Queries go through Supabase cl
 | `api.game_drives` | **Live** | 183,603 | Drive-by-drive summary for a game, one row per possession. Columns: game_id, season, drive_number, offense, defense, start_period, start_yards_to_goal, end_yards_to_goal, plays, yards, drive_result, scoring, start_offense_score, end_offense_score, start_defense_score, end_defense_score, start_time_minutes, start_time_seconds, elapsed_minutes, elapsed_seconds, is_home_offense |
 | `api.game_plays` | **Live** | 3,611,707 | Play-by-play for a game, one row per snap, unfiltered by play type (cfb-app filters client-side). Columns: game_id, season, drive_number, play_number, offense, defense, period, clock_minutes, clock_seconds, down, distance, yards_to_goal, yards_gained, play_type, play_text, ppa, scoring, offense_score, defense_score |
 | `api.poll_rankings` | **Live** | ~31,000 | Weekly poll rankings (AP Top 25, Coaches Poll, CFP, etc). Columns: season, season_type, week, poll, rank, school, conference, first_place_votes, points. Filter `season_type = 'regular'` for weekly polls; final poll is `season_type = 'postseason'` (week 1). Tied teams share a rank (next rank skipped) |
+| `api.team_elo` | **Live** | ~29,000 | Season-end house Elo rating per team-season, ranked within season. Columns: team, season, season_end_elo, elo_rank, games_played, low_confidence, cfbd_elo |
+| `api.game_elo_history` | **Live** | ~71,000 | Game-grain house Elo history: pregame/postgame Elo both sides, win probability, expected vs actual margin, CFBD Elo copies for validation. Columns: game_id, season, week, season_type, start_date, neutral_site, home_team, away_team, home_pregame_elo, away_pregame_elo, home_postgame_elo, away_postgame_elo, home_win_prob, expected_home_margin, actual_home_margin, mov_multiplier, cfbd_home_pregame_elo, cfbd_away_pregame_elo, margin_error, abs_margin_error |
+| `api.scored_matchup_edges` | **Live** | Varies (in-season) | House model expected margin/win probability vs. the market line for upcoming games, with the resulting edge. Empty out of season by design -- not a failure. Columns: game_id, season, week, season_type, start_date, home_team, away_team, neutral_site, model_version, prediction_date, home_elo_pregame, away_elo_pregame, elo_margin, epa_margin, expected_home_margin, home_win_prob, market_provider, market_spread, market_home_margin, market_captured_at, edge, edge_pick, abs_edge |
+| `api.prediction_accuracy` | **Live** | ~90 | Retroactive scoring of house predictions by season/model/edge-threshold: margin MAE/RMSE, ATS record, Brier score (house vs. CFBD). Columns: model_version, season, edge_threshold, n_games, n_with_market, margin_mae, margin_rmse, ats_wins, ats_losses, ats_pushes, ats_hit_rate, brier, cfbd_brier, n_scored_win_prob |
+| `api.game_predictions` | **Live** | ~20,000+ | Latest house prediction snapshot per (game, model), from the append-only `predictions.game_predictions` log. Columns: prediction_id, computed_at, prediction_date, model_version, game_id, season, week, season_type, home_team, away_team, neutral_site, home_elo_pregame, away_elo_pregame, elo_margin, epa_margin, expected_home_margin, home_win_prob, market_provider, market_home_margin, market_spread, market_captured_at, edge, edge_pick |
 
 ### Marts (schema: `marts`) -- Materialized Views
 
@@ -139,7 +181,7 @@ cfb-app for advanced features.
 | `marts.coach_record` | Deployed | Coach win/loss records by team and season |
 | `marts.recruiting_class` | Deployed | Recruiting class summaries per team/year |
 | `marts.conference_era_summary` | Deployed | Conference-level aggregates across eras |
-| `marts.matchup_edges` | Deployed | Matchup advantage/disadvantage analysis |
+| `marts.matchup_edges` | Deployed | Matchup advantage/disadvantage analysis from team style profiles. **Style-only** as of 2026-07-21 -- for prediction use read `marts.scored_matchup_edges` instead. |
 | `marts.play_epa` | Deployed | Per-play EPA values |
 | `marts.player_game_epa` | Deployed | Player EPA aggregated per game |
 | `marts.player_season_epa` | Deployed | Player EPA aggregated per season |
@@ -157,6 +199,11 @@ cfb-app for advanced features.
 | `marts.returning_production` | Deployed | Returning production by team-season (PPA and usage returning from prior season), passthrough of `stats.player_returning`. Grain: `(season, team)`. Unique key: `(team, season)`. |
 | `marts.player_usage` | Deployed | Player usage rates by season (overall/pass/rush/down-split shares), passthrough of `stats.player_usage`. Grain: `(season, athlete_id)`. Unique key: `(season, athlete_id)`. |
 | `marts.team_ats_records` | Deployed | Team against-the-spread records by season, passthrough of `betting.team_ats` plus computed `ats_win_pct`. Grain: `(season, team_id)`. Unique key: `(team_id, season)`. |
+| `marts.house_elo` | Deployed | Season-end house Elo rating per team-season (last game's postgame Elo), ranked within season, with CFBD Elo joined in for comparison. Grain: `(team, season)`. |
+| `marts.house_elo_game` | Deployed | Game-grain house Elo history: pregame/postgame Elo both sides, win probability, expected vs actual margin, plus derived `margin_error`. Grain: `(game_id)`. |
+| `marts.team_adjusted_epa` | Deployed | Ridge-regressed opponent-adjusted EPA (offense/defense/net, lambda=200) per team-season, 2004+, with CFBD's WEPA joined in as a sanity check. Grain: `(team, season)`. |
+| `marts.scored_matchup_edges` | Deployed | House expected margin/win probability vs. the market line for upcoming games only; legitimately empty out of season (no empty-guard by design). Grain: `(game_id, model_version)`. |
+| `marts.prediction_accuracy` | Deployed | Retroactive scoring of house predictions: margin MAE/RMSE, ATS record, Brier score (house vs. CFBD) by season/model/edge-threshold. Grain: `(model_version, season, edge_threshold)`. |
 
 ### Public Schema Views
 
@@ -216,7 +263,7 @@ These reference tables are stable enough for direct access.
 |----------|--------|-------------|
 | `ref.get_era` | `ref` | Returns era code/name for a given year |
 | `analytics.refresh_all_views` | `analytics` | Refreshes all analytics materialized views (admin use) |
-| `marts.refresh_all` | `marts` | Refreshes all 32 mart materialized views in dependency order (5 layers). Returns (view_name, duration_ms, status). |
+| `marts.refresh_all` | `marts` | Refreshes all 37 mart materialized views in dependency order (6 layers). Returns (view_name, duration_ms, status). |
 
 ---
 
@@ -300,6 +347,19 @@ columns. These are pipeline internals and must not be queried by downstream repo
 Tables: `drives`, `games`, `games__away_line_scores`, `games__home_line_scores`,
 `game_media`, `game_player_stats` (+ nested), `game_team_stats` (+ nested), `game_weather`,
 `plays`, `rankings`, `records`, `roster`, `roster__recruit_ids`, `_dlt_version`
+
+### predictions Schema
+
+Added 2026-07-21 (Tier 2 analytics). `predictions.game_predictions` is **readable**
+(`SELECT` granted to `anon`/`authenticated`; `INSERT`/`UPDATE`/`DELETE` are revoked) but it is
+pipeline output, not the contract surface -- it is an append-only log with one immutable row
+per `(game_id, model_version, prediction_date)`. Downstream consumers should prefer
+`api.game_predictions`, which resolves to the latest snapshot per game/model, unless the full
+day-by-day prediction history is actually needed.
+
+| Table | Description |
+|-------|-------------|
+| `predictions.game_predictions` | Append-only daily house prediction snapshots (house Elo + ridge-adjusted-EPA expected margin/win probability vs. the market line). Written by `scripts/compute_predictions.py`. Prefer `api.game_predictions` for the latest-snapshot contract view. |
 
 ### Analytics Materialized Views (Internal)
 

--- a/docs/plans/2026-07-21-tier2-analytics-plan.md
+++ b/docs/plans/2026-07-21-tier2-analytics-plan.md
@@ -1,0 +1,76 @@
+# cfb-database: Tier 2 Analytics — House Elo, Ridge-Adjusted EPA, Scored Edges, Predictions
+
+## Context
+
+Tier 1 (PR #13) and the Phase 0 contract views (PR #14) are merged and live; the warehouse loads itself daily and surfaces authoritative CFBD data. What it still cannot do is **generate its own opinions**: there is no house team-strength rating (CFBD's Elo starts 2015; `marts/016_matchup_edges` only styles-scores completed games with an unvalidated number), no opponent-adjusted EPA of our own (WEPA is CFBD's black box), no expected margins for upcoming games, and no place to store predictions so accuracy is auditable. Tier 2 closes that gap with **transparent math only — no fitted ML model** (user decision): house Elo from 157 years of `core.games`, ridge-regressed opponent-adjusted EPA over `marts.play_epa` (3.6M plays, 2004+), a blended expected margin compared against the market line, and an append-only `predictions` schema scored retroactively for MAE/ATS/Brier — benchmarked against CFBD's own `metrics.pregame_win_probability` and the closing line.
+
+**User decisions:** all four capabilities in scope; predictions = ratings → spread + edge vs market (no ML fit, no backtested model training); execution follows the model-delegation ladder.
+
+**Constraints:** sandbox cannot reach prod — all DB work runs via the push-triggered `deploy/**` + `deploy-manifest.json` mechanism; Supabase may be downsized from XL, so no giant single-statement SQL (per-season idempotent writes, thin marts); no new CFBD endpoints (budget untouched). Verified numbering: next mart **034**, next api **028**, next migration **024** (019+ apply via `run_migrations.py --file`).
+
+## Architecture
+
+Sequential Elo and ridge linear algebra don't belong in Postgres. Three **Python compute scripts** run on the Actions runner, write `analytics.*` staging tables idempotently (DELETE+INSERT per season / ON CONFLICT), and **thin marts** surface them (no UNION-ALL live arm needed — the staging tables ARE the materialization). One new deploy-manifest action **`compute`** (allowlisted scripts only) runs them from deploy branches; the daily workflow runs them incrementally.
+
+## Design decisions (final; tunables flagged)
+
+### House Elo — `scripts/compute_house_elo.py` (stdlib only, unit-testable without DB)
+- Seed 1500; **K=20**; HFA **+65 Elo** (0 if neutral); expected margin = elo_diff/**25**; win prob = canonical 400-scale logistic.
+- **MOV multiplier (538 form):** `ln(|margin|+1) × 2.2/(0.001·elo_diff_winner + 2.2)`.
+- **Season carryover:** `1500 + (prev − 1500)·2/3`.
+- **Pooling (era-safe, data-density):** teams with <4 games in a season collapse into a per-season `__FCS__` pooled opponent (resets to 1500 yearly). Full history from 1869, no floor; `low_confidence` flag = <4 games or season<1900.
+- Tables: `analytics.house_elo_game` (grain game_id: pregame/postgame Elo both sides, win prob, expected vs actual margin, CFBD elo copies for validation) + `analytics.house_elo_current` (grain team: live rating snapshot). Modes `--full` (deploy) / `--incremental` (daily, current season only). Prints Pearson r vs CFBD Elo 2015+ (expect ≳0.9).
+
+### Ridge-adjusted EPA — `scripts/compute_adjusted_epa.py` (numpy)
+- Per season: `epa ~ mu + off[team] + def[team] + hfa·is_home_offense`, garbage time excluded, plays streamed via server-side cursor into accumulated `XᵀX`/`Xᵀy` (never a dense X); ridge **λ=200** on team columns only (≈200 pseudo-plays prior); solve ~520² normal equations with `np.linalg.solve`.
+- Table: `analytics.adjusted_epa_build` (team, season, off_coef, def_coef, hfa_coef, mu, plays, lambda). Sign: off higher=better, def lower=better. Coverage 2004+. Daily mode refits current season only. Prints correlation vs `marts.team_wepa_season` as sanity check.
+
+### Expected margin, win prob, edge — `scripts/compute_predictions.py` (stdlib)
+- `elo_margin = elo_diff/25 + 2.6·(1−neutral)`; `epa_margin = (off_h + def_a − off_a − def_h)·68 + hfa_coef·68·(1−neutral)`; **blend 0.6·elo + 0.4·epa** (falls back to Elo-only pre-2004/thin data). Win prob = **Elo-only** logistic (calibrated, comparable to CFBD).
+- Market-implied home margin = **−spread** (verified vs `api/003_game_detail.sql` cover logic). Upcoming: latest `betting.line_snapshots` per game (consensus preferred), fallback `betting.lines`. Past: `betting.lines` ≈ closing (documented limitation pre-2026-07-21).
+- **`edge = expected_home_margin + spread`** (>0 = home undervalued); `edge_pick` home/away; report thresholds |edge| ≥ {3, 6, 10}.
+- `predictions.game_predictions`: append-only, unique `(game_id, model_version, prediction_date)` with same-day ON CONFLICT DO UPDATE → one immutable snapshot per day, auditable line-vs-model evolution. Backfill mode writes retro predictions 2015–2025 from `house_elo_game` pregame ratings for scoring.
+
+**Tunable ledger (revisit after backtest gate):** K=20, divisor=25, HFA=65, MOV 2.2/0.001, carryover 2/3, pooling ≥4, λ=200, PLAYS=68, blend 60/40, thresholds {3,6,10}.
+
+## File inventory
+
+| Kind | Files |
+|---|---|
+| Migrations (via `--file`) | `024_predictions_schema.sql` (CREATE SCHEMA predictions + game_predictions + grants), `025_tier2_analytics_staging.sql` (3 analytics tables; DDL also duplicated IF-NOT-EXISTS in consuming marts, mirroring 022↔011) |
+| Scripts (new) | `compute_house_elo.py`, `compute_adjusted_epa.py`, `compute_predictions.py`, `check_backtest.py` (read-only gate report) |
+| Scripts (edit) | `deploy_schema.py` (+`compute` action, `COMPUTE_SCRIPTS` allowlist, ComputeSpec, CLI mapping), `refresh_marts.py` (+Layer 6, +`--views` ordered-subset flag), `check_presence.py` (+Tier 2 gate rows) |
+| Marts 034–038 | `house_elo` (team/season, empty-guard), `house_elo_game` (game grain, empty-guard), `team_adjusted_epa` (team/season + WEPA compare, empty-guard), `scored_matchup_edges` (UPCOMING games vs market, no guard — empty out of season), `prediction_accuracy` (season/model/threshold: MAE, RMSE, ATS records, Brier + CFBD-Brier + beat-closing-line rate; emits elo-only and blend rows) |
+| API 028–032 | `team_elo`, `game_elo_history`, `scored_matchup_edges`, `prediction_accuracy`, `game_predictions` (DISTINCT ON latest per game) |
+| Config | `pyproject.toml`: `[project.optional-dependencies] compute = ["numpy>=1.26"]`; **CI Tests job and both workflows install `.[dev,compute]`** (ridge unit test also `pytest.importorskip("numpy")` for numpy-less local envs); `daily-load.yml` + compute steps; `deploy-schema.yml` + compute inputs |
+| Tests | new no-DB: `test_house_elo.py` (hand-computed deltas), `test_adjusted_epa.py` (synthetic-recovery, λ→∞ shrinkage), `test_predictions.py` (blend/logistic/edge signs); edits: `test_deploy_schema.py` (compute action + allowlist), `test_marts.py` + `test_api_views.py` inventories |
+| Docs | `SCHEMA_CONTRACT.md` (predictions schema, 5 marts, 5 views, 016 marked style-only for prediction use), `CLAUDE.md` (schema row, counts 34→39 marts / 27→32 api), `docs/plans/2026-07-21-tier2-analytics-plan.md` |
+
+**Untouched by design:** `marts/016_matchup_edges` (contracted; superseded for prediction use, not rewritten), `betting.lines` schema, `load_season.py` (stays ingestion-only, numpy-free).
+
+Daily-load step order: load_season --weekly → elo --incremental → adjusted_epa --season current → predictions → `refresh_marts --views <5 tier2 marts>` → verify_load.
+
+## Execution phases (each leaves prod consistent; deploy branch per phase)
+
+0. **Infra + presence gate**: compute action + tests, numpy extra, `--views` flag, presence rows → `deploy/tier2-presence` (presence_check). Confirms play_epa depth, snapshots accruing, CFBD elo/WP present. Prod unchanged.
+1. **Schema**: migrations 024+025 → `deploy/tier2-schema` (apply). Empty tables, nothing reads them.
+2. **Elo historical build**: → `deploy/tier2-elo` (compute --full). Gate: r vs CFBD Elo ≳0.9.
+3. **Ridge historical fit**: → `deploy/tier2-epa` (compute --from 2004). Gate: strong WEPA correlation.
+4. **Marts + views**: 034–038 + 028–032 + Layer-6 registration → `deploy/tier2-marts` (apply marts_from=034, files=api, refresh).
+5. **Backtest gate**: predictions --backfill 2015 2025 + `check_backtest.py` → `deploy/tier2-backtest`. **GATE:** Brier/MAE within documented band of CFBD pregame WP; ATS at |edge|≥6 > 50%. If off: tune K/λ/blend (main loop), re-run 2/3/5.
+6. **Daily wiring + tests + docs + PR**: workflows, test inventories (only after marts live — inherited sequencing rule), contract/CLAUDE docs, final clean `deploy/tier2-apply`, PR to main; **verification = PR CI green against the populated live DB**, then merge.
+
+## Delegation map (per the Tier 1 precedent)
+
+| Task class | Model |
+|---|---|
+| Registry/inventory adds (refresh layers, test lists, presence rows), index SQL, CLAUDE.md row, manifest JSON, numpy-extra edit | **haiku** |
+| Compute-script scaffolding (DB IO/CLI/idempotency), thin marts 034–036 + all api views, migrations DDL, all tests, workflow edits, `--views` flag, `check_backtest.py`, docs/contract | **sonnet** |
+| Elo parameterization, ridge design/numerics, blend + backtest methodology (leakage, gates), `prediction_accuracy` + `scored_matchup_edges` SQL, deploy-sequencing review | **opus** |
+| Orchestration, commits, deploy pushes, log reading, param tuning from backtest, final PR | **main loop (fable)** |
+
+## Verification
+
+- Unit gates locally every phase: `ruff check`, `ruff format --check`, `pytest -q` (compute math tested without DB).
+- Live gates per phase from deploy-run logs: Elo–CFBD correlation (Phase 2), WEPA correlation (Phase 3), empty-guards (Phase 4), backtest metrics via `check_backtest.py` (Phase 5: MAE/ATS/Brier vs CFBD benchmark and closing line).
+- End-to-end: PR CI (745+ tests incl. new inventories) against the live, populated database; then one daily-load run showing the compute steps + targeted refresh green.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ dev = [
     "pytest>=8.0.0",
     "ruff>=0.4.0",
 ]
+compute = [
+    "numpy>=1.26",
+]
 
 [project.scripts]
 cfb-pipeline = "src.pipelines.run:main"

--- a/scripts/check_backtest.py
+++ b/scripts/check_backtest.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Backtest gate report for Tier 2 predictions (read-only, no writes).
+
+Reads marts.prediction_accuracy (src/schemas/marts/038_prediction_accuracy.sql,
+docs/plans/2026-07-21-tier2-analytics-plan.md Phase 5) and prints:
+
+  1. Per-season rows at edge_threshold=0 for each model_version: n_games,
+     margin_mae, brier vs cfbd_brier -- the walk-forward-honest per-season
+     view (edge_threshold=0 is the only row where these are the whole-season
+     "every game" numbers; see 038's header).
+  2. Cross-season aggregates for each model_version at all four edge
+     thresholds (0/3/6/10), computed with a direct GROUP BY over the mart
+     (not by re-deriving anything from predictions.game_predictions):
+     ats_hit_rate is re-aggregated from summed ats_wins/ats_losses (not
+     averaged season-hit-rates), margin_mae is n_games-weighted, and
+     brier/cfbd_brier are n_scored_win_prob-weighted (their own valid
+     population, which can differ from n_games).
+  3. One BACKTEST_GATE line per model_version -- the Phase 5 gate artifact.
+     ats6_hit_rate/ats6_n come from the edge_threshold=6 aggregate (the
+     plan's "ATS at |edge|>=6 > 50%" criterion); brier/cfbd_brier/margin_mae
+     come from the edge_threshold=0 aggregate (the unconditional
+     whole-season baseline, not filtered to only high-edge games).
+
+This script never fails the gate itself -- reading the printed numbers
+against the plan's thresholds and deciding whether to re-tune (K, lambda,
+blend weights) is a human call in the Phase 5 loop, per the plan. The only
+failure mode here is the mart itself being missing or empty, which means
+`compute_predictions.py --backfill <start> <end>` and a mart refresh haven't
+run yet.
+
+Usage:
+    python scripts/check_backtest.py
+"""
+
+import logging
+import sys
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+EDGE_THRESHOLDS = (0, 3, 6, 10)
+BASELINE_THRESHOLD = 0
+GATE_THRESHOLD = 6
+
+AGGREGATE_QUERY = """
+    SELECT
+        model_version,
+        edge_threshold,
+        SUM(n_games) AS n_games,
+        SUM(ats_wins) AS ats_wins,
+        SUM(ats_losses) AS ats_losses,
+        SUM(ats_pushes) AS ats_pushes,
+        ROUND(
+            SUM(ats_wins)::numeric / NULLIF(SUM(ats_wins) + SUM(ats_losses), 0), 4
+        ) AS ats_hit_rate,
+        ROUND(SUM(margin_mae * n_games) / NULLIF(SUM(n_games), 0), 4) AS margin_mae,
+        SUM(n_scored_win_prob) AS n_scored_win_prob,
+        ROUND(
+            SUM(brier * n_scored_win_prob) / NULLIF(SUM(n_scored_win_prob), 0), 6
+        ) AS brier,
+        ROUND(
+            SUM(cfbd_brier * n_scored_win_prob) / NULLIF(SUM(n_scored_win_prob), 0), 6
+        ) AS cfbd_brier
+    FROM marts.prediction_accuracy
+    GROUP BY model_version, edge_threshold
+    ORDER BY model_version, edge_threshold
+"""
+
+PER_SEASON_QUERY = """
+    SELECT model_version, season, n_games, margin_mae, brier, cfbd_brier
+    FROM marts.prediction_accuracy
+    WHERE edge_threshold = %s
+    ORDER BY model_version, season
+"""
+
+
+def section(title: str) -> None:
+    print(f"\n===== {title} =====")
+
+
+def table_exists(cur, schema: str, table: str) -> bool:
+    cur.execute("SELECT to_regclass(%s)", (f"{schema}.{table}",))
+    return cur.fetchone()[0] is not None
+
+
+def print_per_season(cur) -> None:
+    section("PER-SEASON (edge_threshold=0)")
+    cur.execute(PER_SEASON_QUERY, (BASELINE_THRESHOLD,))
+    rows = cur.fetchall()
+    if not rows:
+        print("(no rows)")
+        return
+    for model_version, season, n_games, margin_mae, brier, cfbd_brier in rows:
+        print(
+            f"model={model_version} season={season} n={n_games} "
+            f"margin_mae={margin_mae} brier={brier} cfbd_brier={cfbd_brier}"
+        )
+
+
+_AGGREGATE_COLUMNS = [
+    "model_version",
+    "edge_threshold",
+    "n_games",
+    "ats_wins",
+    "ats_losses",
+    "ats_pushes",
+    "ats_hit_rate",
+    "margin_mae",
+    "n_scored_win_prob",
+    "brier",
+    "cfbd_brier",
+]
+
+
+def fetch_aggregates(cur) -> dict[tuple[str, int], dict]:
+    """Cross-season, n-weighted aggregate per (model_version, edge_threshold),
+    keyed for easy lookup by the gate-line builder below."""
+    cur.execute(AGGREGATE_QUERY)
+    aggregates: dict[tuple[str, int], dict] = {}
+    for values in cur.fetchall():
+        row = dict(zip(_AGGREGATE_COLUMNS, values))
+        aggregates[(row["model_version"], row["edge_threshold"])] = row
+    return aggregates
+
+
+def print_aggregates(aggregates: dict[tuple[str, int], dict]) -> None:
+    section("CROSS-SEASON AGGREGATE (n-weighted, all edge thresholds)")
+    if not aggregates:
+        print("(no rows)")
+        return
+    for key in sorted(aggregates):
+        row = aggregates[key]
+        print(
+            f"model={row['model_version']} edge_threshold={row['edge_threshold']} "
+            f"n_games={row['n_games']} ats_wins={row['ats_wins']} "
+            f"ats_losses={row['ats_losses']} ats_hit_rate={row['ats_hit_rate']} "
+            f"margin_mae={row['margin_mae']} brier={row['brier']} "
+            f"cfbd_brier={row['cfbd_brier']}"
+        )
+
+
+def print_gate_lines(aggregates: dict[tuple[str, int], dict]) -> None:
+    """The Phase 5 gate artifact: one BACKTEST_GATE line per model_version."""
+    section("BACKTEST GATE")
+    model_versions = sorted({model for model, _threshold in aggregates})
+    if not model_versions:
+        print("(no rows)")
+        return
+
+    for model_version in model_versions:
+        gate_row = aggregates.get((model_version, GATE_THRESHOLD))
+        baseline_row = aggregates.get((model_version, BASELINE_THRESHOLD))
+
+        ats6_hit_rate = gate_row["ats_hit_rate"] if gate_row else None
+        ats6_n = (gate_row["ats_wins"] + gate_row["ats_losses"]) if gate_row else None
+        brier = baseline_row["brier"] if baseline_row else None
+        cfbd_brier = baseline_row["cfbd_brier"] if baseline_row else None
+        margin_mae = baseline_row["margin_mae"] if baseline_row else None
+
+        print(
+            f"BACKTEST_GATE model={model_version} ats6_hit_rate={ats6_hit_rate} "
+            f"ats6_n={ats6_n} brier={brier} cfbd_brier={cfbd_brier} margin_mae={margin_mae}"
+        )
+
+
+def run() -> int:
+    import psycopg2
+
+    from scripts.refresh_marts import get_db_url
+
+    conn = psycopg2.connect(get_db_url())
+    try:
+        with conn.cursor() as cur:
+            if not table_exists(cur, "marts", "prediction_accuracy"):
+                logger.error(
+                    "marts.prediction_accuracy is MISSING -- run "
+                    "`python scripts/compute_predictions.py --backfill <start> <end>` "
+                    "then refresh marts (python scripts/refresh_marts.py) before retrying."
+                )
+                return 1
+
+            cur.execute("SELECT COUNT(*) FROM marts.prediction_accuracy")
+            (count,) = cur.fetchone()
+            if count == 0:
+                logger.error(
+                    "marts.prediction_accuracy is EMPTY -- run "
+                    "`python scripts/compute_predictions.py --backfill <start> <end>` "
+                    "then refresh marts (python scripts/refresh_marts.py) before retrying."
+                )
+                return 1
+
+            print_per_season(cur)
+            aggregates = fetch_aggregates(cur)
+            print_aggregates(aggregates)
+            print_gate_lines(aggregates)
+    finally:
+        conn.close()
+
+    return 0
+
+
+def main() -> None:
+    sys.exit(run())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_presence.py
+++ b/scripts/check_presence.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
-"""Presence/recon check for Tier 1 gate tables (Phase 0 of the analytics-unlock sprint).
+"""Presence/recon check for Tier 1 and Tier 2 gate tables (Phase 0 of the analytics-unlock sprint).
 
 Prints live row counts, column dumps, ref.play_stat_types contents, and an
 athlete_id/roster overlap sample for the tables that gate the WEPA, player-EPA,
 havoc, returning-production, player-usage, and ATS work
-(docs/plans/2026-07-19-tier1-analytics-unlock-plan.md, Phase 0). Output is
-grouped into clearly delimited sections so a GitHub Actions job log can be
-read directly without a live DB connection.
+(docs/plans/2026-07-19-tier1-analytics-unlock-plan.md, Phase 0). Also reports
+Tier 2 tables (house-Elo, EPA, predictions, line snapshots) and depth metrics
+for backtest benchmarks. Output is grouped into clearly delimited sections so a
+GitHub Actions job log can be read directly without a live DB connection.
 
 Usage:
     python scripts/check_presence.py             # recon mode: always exit 0
@@ -43,6 +44,16 @@ STRICT_GATE_TABLES: list[tuple[str, str]] = [
     ("stats", "player_usage"),
     ("stats", "player_returning"),
     ("betting", "team_ats"),
+]
+
+# Tier 2 tables (advanced analytics, predictions, lines) reported for context
+# but NOT enforced in --strict mode (legitimately absent before Phase 1/2).
+TIER_2_GATE_TABLES: list[tuple[str, str]] = [
+    ("analytics", "house_elo_current"),
+    ("analytics", "house_elo_game"),
+    ("analytics", "adjusted_epa_build"),
+    ("predictions", "game_predictions"),
+    ("betting", "line_snapshots"),
 ]
 
 # Play-by-play athlete_id linkage only goes back to ~2014; a single recent
@@ -148,6 +159,61 @@ def print_athlete_overlap(cur, counts: dict[tuple[str, str], int | None]) -> Non
     print(f"match rate: {pct:.1f}%")
 
 
+def print_tier_2_row_counts(cur) -> dict[tuple[str, str], int | None]:
+    """Print row counts for TIER_2_GATE_TABLES; return {(schema, table): count or None}.
+
+    Tier 2 tables are reported for context but are not enforced in strict mode.
+    """
+    section("ROW COUNTS - TIER 2 (advanced analytics / predictions)")
+    counts: dict[tuple[str, str], int | None] = {}
+    for schema, table in TIER_2_GATE_TABLES:
+        if not table_exists(cur, schema, table):
+            print(f"{schema}.{table}: MISSING")
+            counts[(schema, table)] = None
+            continue
+        count = row_count(cur, schema, table)
+        counts[(schema, table)] = count
+        print(f"{schema}.{table}: {count:,}")
+    return counts
+
+
+def print_depth_checks(cur) -> None:
+    """Print season depth and row counts for backtest benchmark tables."""
+    section("DEPTH CHECKS - BACKTEST BENCHMARKS")
+
+    # marts.play_epa depth
+    if table_exists(cur, "marts", "play_epa"):
+        cur.execute(
+            """
+            SELECT MIN(season), MAX(season), COUNT(*)
+            FROM marts.play_epa
+            """
+        )
+        min_season, max_season, total_rows = cur.fetchone()
+        print(
+            f"marts.play_epa depth: "
+            f"MIN(season)={min_season}, MAX(season)={max_season}, COUNT(*)={total_rows:,}"
+        )
+    else:
+        print("marts.play_epa: MISSING")
+
+    # metrics.pregame_win_probability depth
+    if table_exists(cur, "metrics", "pregame_win_probability"):
+        cur.execute(
+            """
+            SELECT MIN(season), MAX(season), COUNT(*)
+            FROM metrics.pregame_win_probability
+            """
+        )
+        min_season, max_season, total_rows = cur.fetchone()
+        print(
+            f"metrics.pregame_win_probability depth: "
+            f"MIN(season)={min_season}, MAX(season)={max_season}, COUNT(*)={total_rows:,}"
+        )
+    else:
+        print("metrics.pregame_win_probability: MISSING")
+
+
 def evaluate_strict(counts: dict[tuple[str, str], int | None]) -> bool:
     """Return True (pass) iff every strict gate table is present and non-empty."""
     return all(counts.get(t) for t in STRICT_GATE_TABLES)
@@ -165,6 +231,8 @@ def run(strict: bool) -> int:
             print_columns(cur, counts)
             print_play_stat_types(cur, counts)
             print_athlete_overlap(cur, counts)
+            print_tier_2_row_counts(cur)
+            print_depth_checks(cur)
     finally:
         conn.close()
 

--- a/scripts/compute_adjusted_epa.py
+++ b/scripts/compute_adjusted_epa.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+"""Ridge-regressed opponent-adjusted EPA (Tier 2 analytics).
+
+Fits, per season, the model
+
+    epa ~ mu + off[team] + def[team] + hfa * is_home_offense
+
+over every non-garbage-time play in ``marts.play_epa`` (2004+), with a ridge
+penalty on the team coefficients only. Writes one row per (team, season) to
+``analytics.adjusted_epa_build`` (src/schemas/migrations/025_tier2_analytics_staging.sql).
+
+Sign convention: off_coef higher = better offense; def_coef LOWER / more
+negative = better defense (EPA allowed above average).
+
+See docs/plans/2026-07-21-tier2-analytics-plan.md ("Ridge-adjusted EPA")
+for the design this implements.
+
+Usage:
+    python scripts/compute_adjusted_epa.py --season 2024
+    python scripts/compute_adjusted_epa.py --from 2004     # 2004..max season present
+"""
+
+import argparse
+import logging
+import sys
+from collections.abc import Iterable
+
+import numpy as np
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+# Ridge penalty applied to the offense/defense team columns only (mu, hfa are
+# unpenalized). ~200 "pseudo-plays" worth of shrinkage toward 0 per team
+# coefficient. Recorded per row in analytics.adjusted_epa_build so historical
+# fits stay auditable even if this tunable changes later.
+LAMBDA = 200.0
+
+# Server-side cursor fetch batch size for the per-season play stream.
+CURSOR_ITERSIZE = 10_000
+
+PLAY_QUERY = """
+    SELECT
+        pe.offense,
+        pe.defense,
+        pe.epa,
+        (pe.offense = g.home_team AND NOT COALESCE(g.neutral_site, false)) AS is_home_offense
+    FROM marts.play_epa pe
+    JOIN core.games g ON g.id = pe.game_id
+    WHERE pe.season = %s
+      AND NOT pe.is_garbage_time
+      AND pe.epa IS NOT NULL
+"""
+
+TEAM_LIST_QUERY = """
+    SELECT DISTINCT offense AS team FROM marts.play_epa WHERE season = %s
+    UNION
+    SELECT DISTINCT defense AS team FROM marts.play_epa WHERE season = %s
+"""
+
+
+class RidgeAccumulator:
+    """Streaming accumulator for the ridge-adjusted EPA normal equations.
+
+    Fixed column layout for a given season's team list (``teams``, assumed
+    already sorted by the caller so results are reproducible):
+
+        index 0        -> mu (intercept)
+        index 1        -> hfa (home-field advantage)
+        index 2..T+1   -> offense indicator per team (team order as given)
+        index T+2..2T+1 -> defense indicator per team (team order as given)
+
+    where T = len(teams). Each play is a design-matrix row with exactly four
+    nonzero entries: mu=1, hfa=is_home_offense (0/1), one offense indicator=1,
+    one defense indicator=1. ``add_play`` folds a row's contribution straight
+    into the dense XtX/Xty accumulators via that row's 4x4 outer product --
+    the full (n_plays x 2T+2) design matrix X is never built.
+
+    Why the ridge penalty is required for a unique solution: on defense and
+    offense alike, every row has exactly one offense indicator set and one
+    defense indicator set, so summing the offense-indicator columns
+    reproduces the mu column exactly (and likewise for the defense-indicator
+    columns). That is an exact linear dependency among X's columns -- without
+    penalization XtX is rank-deficient (singular) and infinitely many beta
+    solve the normal equations equivalently (any additive shift moved between
+    mu and the team coefficients cancels). Adding `lam * P` with `P` an
+    identity matrix zeroed at the mu/hfa indices only touches the team-column
+    block, which is exactly where the null-space vectors of that dependency
+    have their support, so for lam > 0 the penalized system XtX + lam*P is
+    strictly positive definite and `np.linalg.solve` returns a unique beta.
+    mu/hfa stay unpenalized (P is 0 there) because they are not part of that
+    collinearity and are quantities we want a genuine unshrunk estimate of.
+    """
+
+    MU_IDX = 0
+    HFA_IDX = 1
+
+    def __init__(self, teams: list[str]):
+        self.teams = list(teams)
+        self.n_teams = len(self.teams)
+        self._team_idx = {team: i for i, team in enumerate(self.teams)}
+
+        size = 2 * self.n_teams + 2
+        self.xtx = np.zeros((size, size), dtype=np.float64)
+        self.xty = np.zeros(size, dtype=np.float64)
+        self.off_play_counts = np.zeros(self.n_teams, dtype=np.int64)
+        self.n_plays = 0
+
+    @property
+    def off_start(self) -> int:
+        return 2
+
+    @property
+    def def_start(self) -> int:
+        return 2 + self.n_teams
+
+    def add_play(self, off_team: str, def_team: str, is_home_offense: bool, epa: float) -> None:
+        """Fold one play's row into XtX/Xty via its 4x4 outer product."""
+        off_i = self._team_idx[off_team]
+        def_i = self._team_idx[def_team]
+        idx_off = self.off_start + off_i
+        idx_def = self.def_start + def_i
+        hfa_val = 1.0 if is_home_offense else 0.0
+
+        idxs = np.array((self.MU_IDX, self.HFA_IDX, idx_off, idx_def))
+        vals = np.array((1.0, hfa_val, 1.0, 1.0), dtype=np.float64)
+
+        # Outer product of the row's 4 nonzero entries = the 16 XtX cells it
+        # touches; vals * epa = the 4 Xty cells it touches. Everywhere else
+        # in the row is 0, so this is exactly x @ x.T and x * epa restricted
+        # to the nonzero support, without ever materializing the full row.
+        self.xtx[np.ix_(idxs, idxs)] += np.outer(vals, vals)
+        self.xty[idxs] += vals * epa
+
+        self.off_play_counts[off_i] += 1
+        self.n_plays += 1
+
+    def add_plays(self, plays: Iterable[tuple[str, str, bool, float]]) -> None:
+        """Batch variant of add_play for streaming a cursor efficiently."""
+        for off_team, def_team, is_home_offense, epa in plays:
+            self.add_play(off_team, def_team, is_home_offense, epa)
+
+    def solve(self, lam: float) -> tuple[float, float, dict[str, float], dict[str, float], int]:
+        """Solve the ridge-penalized normal equations.
+
+        Returns (mu, hfa, off_coef, def_coef, n_plays) where off_coef and
+        def_coef are {team: coefficient} dicts covering every team passed to
+        __init__.
+        """
+        size = 2 * self.n_teams + 2
+        penalty = np.eye(size, dtype=np.float64)
+        penalty[self.MU_IDX, self.MU_IDX] = 0.0
+        penalty[self.HFA_IDX, self.HFA_IDX] = 0.0
+
+        beta = np.linalg.solve(self.xtx + lam * penalty, self.xty)
+
+        mu = float(beta[self.MU_IDX])
+        hfa = float(beta[self.HFA_IDX])
+        off_coef = {team: float(beta[self.off_start + i]) for i, team in enumerate(self.teams)}
+        def_coef = {team: float(beta[self.def_start + i]) for i, team in enumerate(self.teams)}
+        return mu, hfa, off_coef, def_coef, self.n_plays
+
+
+def get_db_url() -> str:
+    """Get database URL from dlt secrets or environment.
+
+    Adds statement_timeout=0 since a full-history fit streams millions of
+    plays per season through a server-side cursor.
+    """
+    import os
+
+    import dlt
+
+    url = None
+    try:
+        creds = dlt.secrets.get("destination.postgres.credentials")
+        if creds:
+            url = str(creds)
+    except Exception:
+        pass
+
+    if not url:
+        url = os.environ.get("SUPABASE_DB_URL") or os.environ.get("DATABASE_URL")
+
+    if not url:
+        raise RuntimeError(
+            "No database URL found. Set destination.postgres.credentials in "
+            ".dlt/secrets.toml or SUPABASE_DB_URL environment variable."
+        )
+
+    if "options=" not in url:
+        separator = "&" if "?" in url else "?"
+        url = f"{url}{separator}options=-c%20statement_timeout%3D0"
+
+    return url
+
+
+def get_season_teams(cur, season: int) -> list[str]:
+    """Cheap pass to fix the sorted team list for a season before streaming plays.
+
+    Teams present on either side (offense or defense) get both an offense and
+    a defense column, even if they never appear on the other side that year.
+    """
+    cur.execute(TEAM_LIST_QUERY, (season, season))
+    return sorted(row[0] for row in cur.fetchall())
+
+
+def get_max_season(cur) -> int | None:
+    cur.execute("SELECT MAX(season) FROM marts.play_epa")
+    row = cur.fetchone()
+    return int(row[0]) if row and row[0] is not None else None
+
+
+def fit_season(conn, season: int) -> tuple[RidgeAccumulator, list[str]] | None:
+    """Stream one season's plays into a RidgeAccumulator. None if no teams/plays."""
+    with conn.cursor() as cur:
+        teams = get_season_teams(cur, season)
+
+    if not teams:
+        logger.warning(f"season={season}: no teams found in marts.play_epa, skipping")
+        return None
+
+    logger.info(f"season={season}: {len(teams)} teams, streaming plays...")
+
+    accumulator = RidgeAccumulator(teams)
+    cursor_name = f"adjusted_epa_plays_{season}"
+    with conn.cursor(name=cursor_name) as cur:
+        cur.itersize = CURSOR_ITERSIZE
+        cur.execute(PLAY_QUERY, (season,))
+        for offense, defense, epa, is_home_offense in cur:
+            accumulator.add_play(offense, defense, bool(is_home_offense), float(epa))
+
+    if accumulator.n_plays == 0:
+        logger.warning(f"season={season}: 0 qualifying plays, skipping")
+        return None
+
+    logger.info(f"season={season}: accumulated {accumulator.n_plays} plays")
+    return accumulator, teams
+
+
+def write_season(conn, season: int, accumulator: RidgeAccumulator, lam: float) -> None:
+    from psycopg2.extras import execute_values
+
+    mu, hfa, off_coef, def_coef, _n_plays = accumulator.solve(lam)
+    n_teams = accumulator.n_teams
+
+    rows = [
+        (
+            team,
+            season,
+            off_coef[team],
+            def_coef[team],
+            hfa,
+            mu,
+            int(accumulator.off_play_counts[i]),
+            lam,
+            n_teams,
+        )
+        for i, team in enumerate(accumulator.teams)
+    ]
+
+    with conn.cursor() as cur:
+        cur.execute("DELETE FROM analytics.adjusted_epa_build WHERE season = %s", (season,))
+        execute_values(
+            cur,
+            """
+            INSERT INTO analytics.adjusted_epa_build
+                (team, season, off_coef, def_coef, hfa_coef, mu, plays, lambda, n_teams)
+            VALUES %s
+            """,
+            rows,
+        )
+    conn.commit()
+    logger.info(f"season={season}: wrote {len(rows)} rows to analytics.adjusted_epa_build")
+
+
+def validate_season(conn, season: int, accumulator: RidgeAccumulator) -> None:
+    """Print a Pearson-r sanity check against marts.team_wepa_season, if present."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT team, epa_total, epa_allowed_total
+            FROM marts.team_wepa_season
+            WHERE season = %s
+            """,
+            (season,),
+        )
+        wepa_rows = cur.fetchall()
+
+    if not wepa_rows:
+        logger.info(f"season={season}: no marts.team_wepa_season rows, skipping validation")
+        return
+
+    _mu, _hfa, off_coef, def_coef, _n_plays = accumulator.solve(LAMBDA)
+
+    wepa_off, wepa_def, adj_off, adj_def = [], [], [], []
+    for team, epa_total, epa_allowed_total in wepa_rows:
+        if team not in off_coef or epa_total is None or epa_allowed_total is None:
+            continue
+        wepa_off.append(float(epa_total))
+        wepa_def.append(float(epa_allowed_total))
+        adj_off.append(off_coef[team])
+        adj_def.append(def_coef[team])
+
+    n = len(wepa_off)
+    if n < 2:
+        logger.info(
+            f"season={season}: only {n} overlapping team(s) with marts.team_wepa_season, "
+            "skipping validation"
+        )
+        return
+
+    r_off = float(np.corrcoef(adj_off, wepa_off)[0, 1])
+    r_def = float(np.corrcoef(adj_def, wepa_def)[0, 1])
+    print(f"ADJEPA_VALIDATION season={season} n={n} r_off={r_off:.4f} r_def={r_def:.4f}")
+
+
+def compute_seasons(seasons: list[int]) -> int:
+    """Fit and write each season. Returns count of failed/skipped seasons."""
+    import psycopg2
+
+    db_url = get_db_url()
+    conn = psycopg2.connect(db_url)
+
+    failures = 0
+    try:
+        for season in seasons:
+            try:
+                result = fit_season(conn, season)
+                if result is None:
+                    failures += 1
+                    continue
+                accumulator, _teams = result
+                write_season(conn, season, accumulator, LAMBDA)
+                validate_season(conn, season, accumulator)
+            except Exception as e:
+                conn.rollback()
+                logger.error(f"season={season}: FAILED: {e}")
+                failures += 1
+    finally:
+        conn.close()
+
+    return failures
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Fit ridge-adjusted EPA per season")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--from",
+        dest="from_season",
+        type=int,
+        help="Fit every season from YYYY through the max season in marts.play_epa",
+    )
+    group.add_argument(
+        "--season",
+        dest="season",
+        type=int,
+        help="Fit a single season",
+    )
+    args = parser.parse_args()
+
+    if args.season is not None:
+        seasons = [args.season]
+    else:
+        import psycopg2
+
+        conn = psycopg2.connect(get_db_url())
+        try:
+            with conn.cursor() as cur:
+                max_season = get_max_season(cur)
+        finally:
+            conn.close()
+
+        if max_season is None:
+            logger.error("marts.play_epa has no rows; cannot determine max season")
+            sys.exit(1)
+        if args.from_season > max_season:
+            logger.error(f"--from {args.from_season} is after max season present ({max_season})")
+            sys.exit(1)
+        seasons = list(range(args.from_season, max_season + 1))
+
+    logger.info(f"Fitting ridge-adjusted EPA for {len(seasons)} season(s): {seasons}")
+    failures = compute_seasons(seasons)
+
+    if failures:
+        logger.warning(f"{failures} season(s) failed or had no data")
+    else:
+        logger.info("All seasons fit successfully")
+
+    sys.exit(1 if failures else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compute_adjusted_epa.py
+++ b/scripts/compute_adjusted_epa.py
@@ -328,7 +328,13 @@ def compute_seasons(seasons: list[int]) -> int:
             try:
                 result = fit_season(conn, season)
                 if result is None:
-                    failures += 1
+                    # A season with no plays yet is a legitimate pre-season
+                    # state, not a failure: get_current_season() flips to the
+                    # new season on Aug 1 weeks before play_epa has rows, and
+                    # the daily workflow must not die in that window (Codex
+                    # P2, PR #18). Predictions fall back to the previous
+                    # season's coefficients until data exists.
+                    logger.info(f"season={season}: no play data yet, clean no-op")
                     continue
                 accumulator, _teams = result
                 write_season(conn, season, accumulator, LAMBDA)

--- a/scripts/compute_house_elo.py
+++ b/scripts/compute_house_elo.py
@@ -1,0 +1,649 @@
+#!/usr/bin/env python3
+"""Compute house Elo ratings from core.games (docs/plans/2026-07-21-tier2-analytics-plan.md).
+
+Architecture: the Elo math (`expected_score`, `mov_multiplier`, `EloEngine`) is
+pure -- it operates on plain dicts/floats and touches no I/O, so it is fully
+unit-testable without a database (see tests/test_house_elo.py). Everything
+below `# --- I/O layer ---` is a thin wrapper: fetch rows from core.games,
+feed them through the engine, write the results to
+analytics.house_elo_game / analytics.house_elo_current.
+
+Parameters (SEED, K, HFA, DIVISOR, CARRYOVER, POOL_THRESHOLD) are FINAL per
+the design doc -- do not retune here; see the plan's tunable ledger.
+
+Usage:
+    python scripts/compute_house_elo.py --full
+        Recompute all of history: seasons 1869..max(core.games.season),
+        rewriting analytics.house_elo_game season by season and the
+        analytics.house_elo_current snapshot at the end. Idempotent.
+
+    python scripts/compute_house_elo.py --season 2024
+        Recompute a single season. Engine state is rebuilt from each team's
+        latest analytics.house_elo_game row with season < 2024 (no replay of
+        prior history needed), then that season's games are (re)computed and
+        the season + snapshot are rewritten.
+
+    python scripts/compute_house_elo.py --incremental
+        Shorthand for `--season <max season in core.games with completed
+        games>`. What the daily workflow runs.
+
+Both modes print a validation line after writing:
+    ELO_VALIDATION n=<rows> pearson_r=<r to 4 decimals>
+comparing our home_pregame_elo to CFBD's own home_pregame_elo for
+season >= 2015 rows where CFBD's value is present (expect r >~ 0.9).
+"""
+
+import argparse
+import logging
+import math
+import sys
+from collections import Counter, defaultdict
+
+import dlt
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+DEFAULT_START_SEASON = 1869
+VALIDATION_MIN_SEASON = 2015
+
+
+# =============================================================================
+# Pure Elo engine -- no I/O, no DB, unit-tested directly.
+# =============================================================================
+
+
+def expected_score(elo_diff: float) -> float:
+    """Canonical 400-scale logistic win probability for `elo_diff` = own - opponent
+    (already including home-field advantage, if any)."""
+    return 1.0 / (1.0 + 10 ** (-elo_diff / 400.0))
+
+
+def mov_multiplier(margin: int, elo_diff_winner: float) -> float:
+    """FiveThirtyEight-style margin-of-victory multiplier.
+
+    `margin` may be signed or unsigned -- only its magnitude is used.
+    `elo_diff_winner` is the pregame Elo differential (including HFA) from the
+    winning side's perspective; callers pass 0 for a tie.
+
+    A tie (margin == 0) gives ln(1) == 0, so the multiplier -- and therefore
+    process_game's rating delta -- is exactly 0 for ties. That is intentional
+    per the design: the actual-minus-expected term would otherwise still
+    carry a direction signal, but zeroing it out via the multiplier is the
+    accepted simplification (ties are rare in the modern game, where
+    sudden-death overtime has applied since 1996).
+    """
+    return math.log(abs(margin) + 1) * (2.2 / (0.001 * elo_diff_winner + 2.2))
+
+
+class EloEngine:
+    """Stateful, pure (no I/O) house-Elo rating engine.
+
+    Call sequence per season: `start_season(season, team_game_counts)` once,
+    then `process_game(game)` once per completed game in that season in
+    chronological order, then (optionally, once per snapshot needed)
+    `current_snapshot(season)`.
+    """
+
+    SEED = 1500.0
+    K = 20.0
+    HFA = 65.0
+    DIVISOR = 25.0
+    CARRYOVER = 2.0 / 3.0
+    POOL_THRESHOLD = 4
+    POOLED = "__FCS__"
+
+    def __init__(self) -> None:
+        # Rating store, keyed by "alias identity": a real team name for teams
+        # tracked individually, or POOLED for the shared low-sample bucket.
+        self.ratings: dict[str, float] = {}
+        # Real team name -> season of that team's most recent processed game.
+        # This is both the carryover clock (elapsed = target - last_season)
+        # and the "last played" field surfaced in current_snapshot().
+        self.last_season: dict[str, int] = {}
+        # Real team name -> this season's alias (POOLED or itself), rebuilt
+        # by every start_season() call.
+        self.alias: dict[str, str] = {}
+        # Real team name -> games played in the *current* season only, reset
+        # by every start_season() call.
+        self.games_played: dict[str, int] = {}
+        self.last_game_id: dict[str, int] = {}
+        self.last_game_date: dict[str, object] = {}
+
+    def resolve(self, team: str) -> str:
+        """Return the alias identity a real team's games are recorded under
+        for the season most recently started (itself, or POOLED)."""
+        return self.alias.get(team, team)
+
+    def start_season(self, season: int, team_game_counts: dict[str, int]) -> None:
+        """Begin a new season: rebuild the pooling alias map and apply
+        season-carryover regression to teams about to play.
+
+        team_game_counts: {team: games this team plays in `season`}. Teams
+        with fewer than POOL_THRESHOLD games alias to the shared POOLED
+        bucket for the season (their individual rating is left untouched,
+        frozen, until they return to individual tracking).
+
+        Carryover only applies to teams already known (i.e. with a prior
+        last_season entry) that are about to play this season -- a brand
+        new team has nothing to carry over from and simply starts at SEED
+        on its first process_game() call. Because last_season is only ever
+        updated by process_game (never by start_season itself), a team that
+        sits out N seasons and then returns has elapsed = N computed in one
+        shot from its true last-played rating -- no compounding across
+        empty seasons.
+        """
+        self.alias = {}
+        self.games_played = {}
+        for team, count in team_game_counts.items():
+            self.alias[team] = self.POOLED if count < self.POOL_THRESHOLD else team
+
+        # The pooled bucket has no persistent identity of its own -- it
+        # resets to the seed rating at the start of every season.
+        self.ratings[self.POOLED] = self.SEED
+
+        for team in team_game_counts:
+            if team not in self.last_season:
+                continue
+            elapsed = season - self.last_season[team]
+            if elapsed <= 0:
+                continue
+            current = self.ratings.get(team, self.SEED)
+            offset = current - self.SEED
+            self.ratings[team] = self.SEED + offset * (self.CARRYOVER**elapsed)
+
+    def process_game(self, game: dict) -> dict:
+        """Process one completed game, updating engine state in place and
+        returning the full analytics.house_elo_game row (dict) for it.
+
+        `game` keys: game_id, season, week, season_type, start_date,
+        neutral_site, home_team, away_team, home_points, away_points,
+        cfbd_home_pregame_elo, cfbd_away_pregame_elo.
+        """
+        season = game["season"]
+        home_team = game["home_team"]
+        away_team = game["away_team"]
+        neutral_site = bool(game.get("neutral_site"))
+
+        home_alias = self.resolve(home_team)
+        away_alias = self.resolve(away_team)
+        same_bucket = home_alias == away_alias
+
+        home_pregame = self.ratings.get(home_alias, self.SEED)
+        away_pregame = home_pregame if same_bucket else self.ratings.get(away_alias, self.SEED)
+
+        hfa_elo = 0.0 if neutral_site else self.HFA
+        elo_diff_home = home_pregame - away_pregame + hfa_elo
+        exp_home = expected_score(elo_diff_home)
+        expected_home_margin = elo_diff_home / self.DIVISOR
+
+        home_points = game["home_points"]
+        away_points = game["away_points"]
+        actual_margin = home_points - away_points
+
+        if actual_margin > 0:
+            actual_home = 1.0
+            elo_diff_w = elo_diff_home
+        elif actual_margin < 0:
+            actual_home = 0.0
+            elo_diff_w = -elo_diff_home
+        else:
+            actual_home = 0.5
+            elo_diff_w = 0.0
+
+        mult = mov_multiplier(actual_margin, elo_diff_w)
+        delta = self.K * mult * (actual_home - exp_home)
+
+        if same_bucket:
+            # Both sides are low-sample teams sharing the pooled bucket (an
+            # FCS-vs-FCS-caliber matchup). The two deltas would otherwise
+            # collide into a single dict slot; net movement of a bucket
+            # playing itself isn't well-defined, so we leave it unchanged.
+            # Documented limitation -- not expected to occur in FBS-centric
+            # core.games data.
+            home_postgame = home_pregame
+            away_postgame = away_pregame
+            self.ratings[home_alias] = home_pregame
+        else:
+            home_postgame = home_pregame + delta
+            away_postgame = away_pregame - delta
+            self.ratings[home_alias] = home_postgame
+            self.ratings[away_alias] = away_postgame
+
+        # Bookkeeping keyed by REAL team names (never aliases) for the
+        # current-season snapshot.
+        game_id = game.get("game_id")
+        start_date = game.get("start_date")
+        for team in (home_team, away_team):
+            self.games_played[team] = self.games_played.get(team, 0) + 1
+            self.last_game_id[team] = game_id
+            self.last_game_date[team] = start_date
+            self.last_season[team] = season
+
+        return {
+            "game_id": game_id,
+            "season": season,
+            "week": game.get("week"),
+            "season_type": game.get("season_type"),
+            "start_date": start_date,
+            "neutral_site": neutral_site,
+            "home_team": home_team,
+            "away_team": away_team,
+            "home_pregame_elo": home_pregame,
+            "away_pregame_elo": away_pregame,
+            "home_postgame_elo": home_postgame,
+            "away_postgame_elo": away_postgame,
+            "home_win_prob": exp_home,
+            "expected_home_margin": expected_home_margin,
+            "actual_home_margin": actual_margin,
+            "mov_multiplier": mult,
+            "cfbd_home_pregame_elo": game.get("cfbd_home_pregame_elo"),
+            "cfbd_away_pregame_elo": game.get("cfbd_away_pregame_elo"),
+        }
+
+    def current_snapshot(self, season: int) -> list[dict]:
+        """Return one row per real team ever seen, for
+        analytics.house_elo_current (updated_at is left to the caller/SQL
+        `now()`).
+
+        `rating` is read through the team's alias for the most recently
+        started season, so a currently-pooled team reports the shared
+        pooled rating (matching what its games actually used).
+        """
+        rows = []
+        for team, last_season in self.last_season.items():
+            if last_season > season:
+                continue  # defensive: shouldn't happen, we never look ahead
+            alias = self.resolve(team)
+            rating = self.ratings.get(alias, self.SEED)
+            games_played = self.games_played.get(team, 0)
+            low_confidence = games_played < self.POOL_THRESHOLD or last_season < 1900
+            rows.append(
+                {
+                    "team": team,
+                    "season": last_season,
+                    "rating": rating,
+                    "games_played": games_played,
+                    "last_game_id": self.last_game_id.get(team),
+                    "last_game_date": self.last_game_date.get(team),
+                    "low_confidence": low_confidence,
+                }
+            )
+        return rows
+
+
+def pearson_r(xs: list[float], ys: list[float]) -> float:
+    """Pure-Python Pearson correlation coefficient (stdlib only, no numpy)."""
+    n = len(xs)
+    if n == 0 or n != len(ys):
+        return float("nan")
+    mean_x = sum(xs) / n
+    mean_y = sum(ys) / n
+    cov = sum((x - mean_x) * (y - mean_y) for x, y in zip(xs, ys))
+    var_x = sum((x - mean_x) ** 2 for x in xs)
+    var_y = sum((y - mean_y) ** 2 for y in ys)
+    denom = math.sqrt(var_x * var_y)
+    if denom == 0:
+        return float("nan")
+    return cov / denom
+
+
+# =============================================================================
+# --- I/O layer --- (thin: fetch core.games, drive the engine, write results)
+# =============================================================================
+
+
+def get_db_url() -> str:
+    """Get database URL from dlt secrets or environment.
+
+    Copied from scripts/refresh_marts.py's get_db_url pattern.
+    """
+    import os
+
+    url = None
+    try:
+        creds = dlt.secrets.get("destination.postgres.credentials")
+        if creds:
+            url = str(creds)
+    except Exception:
+        pass
+
+    if not url:
+        url = os.environ.get("SUPABASE_DB_URL") or os.environ.get("DATABASE_URL")
+
+    if not url:
+        raise RuntimeError(
+            "No database URL found. Set destination.postgres.credentials in "
+            ".dlt/secrets.toml or SUPABASE_DB_URL environment variable."
+        )
+
+    if "options=" not in url:
+        separator = "&" if "?" in url else "?"
+        url = f"{url}{separator}options=-c%20statement_timeout%3D0"
+
+    return url
+
+
+GAMES_QUERY = """
+    SELECT id, season, week, season_type, start_date, neutral_site,
+           home_team, away_team, home_points, away_points,
+           home_pregame_elo, away_pregame_elo
+    FROM core.games
+    WHERE completed = true
+      AND home_points IS NOT NULL
+      AND away_points IS NOT NULL
+      AND season BETWEEN %s AND %s
+    ORDER BY start_date NULLS LAST, id
+"""
+
+# Seeds engine state for --season/--incremental: each team's most recent
+# postgame rating and season, read back from what we've already written.
+# Ordered by season DESC first (not start_date) so a team's true last-played
+# *season* always wins the tiebreak, even for old rows with NULL start_date.
+SEED_STATE_QUERY = """
+    SELECT DISTINCT ON (team) team, season, postgame
+    FROM (
+        SELECT home_team AS team, season, start_date, game_id,
+               home_postgame_elo AS postgame
+        FROM analytics.house_elo_game
+        WHERE season < %s
+        UNION ALL
+        SELECT away_team AS team, season, start_date, game_id,
+               away_postgame_elo AS postgame
+        FROM analytics.house_elo_game
+        WHERE season < %s
+    ) t
+    ORDER BY team, season DESC, start_date DESC NULLS LAST, game_id DESC
+"""
+
+
+def to_engine_game(row: dict) -> dict:
+    """Map a core.games DB row to the dict shape EloEngine.process_game
+    expects, renaming CFBD's own pregame Elo columns so they never collide
+    with the keys the engine computes itself."""
+    cfbd_home = row["home_pregame_elo"]
+    cfbd_away = row["away_pregame_elo"]
+    return {
+        "game_id": row["id"],
+        "season": row["season"],
+        "week": row["week"],
+        "season_type": row["season_type"],
+        "start_date": row["start_date"],
+        "neutral_site": row["neutral_site"],
+        "home_team": row["home_team"],
+        "away_team": row["away_team"],
+        "home_points": row["home_points"],
+        "away_points": row["away_points"],
+        "cfbd_home_pregame_elo": float(cfbd_home) if cfbd_home is not None else None,
+        "cfbd_away_pregame_elo": float(cfbd_away) if cfbd_away is not None else None,
+    }
+
+
+def compute_team_game_counts(season_games: list[dict]) -> dict[str, int]:
+    """Count games per team within a single season's already-buffered rows."""
+    counts: Counter[str] = Counter()
+    for g in season_games:
+        counts[g["home_team"]] += 1
+        counts[g["away_team"]] += 1
+    return dict(counts)
+
+
+def load_games_by_season(conn, start_season: int, end_season: int) -> dict[int, list[dict]]:
+    """Stream core.games via a named server-side cursor, bucketed by season.
+
+    We fetch everything with one query (ORDER BY start_date NULLS LAST, id,
+    per the plan) and bucket rows into a dict keyed by season in Python,
+    rather than relying on the SQL ordering to keep seasons contiguous --
+    games with a NULL start_date (common pre-modern-era) sort to the very
+    end of the *entire* result set under NULLS LAST, which would otherwise
+    interleave seasons. Bucketing by season is correct regardless of stream
+    order; within a season's bucket, rows keep the relative order they
+    arrived in (dated games first in chronological order, undated ones
+    trailing in id order) -- a reasonable placement when true chronological
+    order isn't known.
+
+    A season is at most a few thousand rows, and full history is well under
+    a million, so buffering everything in memory is simple and cheap
+    (one query total, per the plan).
+    """
+    import psycopg2.extras
+
+    buckets: dict[int, list[dict]] = defaultdict(list)
+    with conn.cursor(
+        name="house_elo_games_cursor", cursor_factory=psycopg2.extras.RealDictCursor
+    ) as cur:
+        cur.itersize = 5000
+        cur.execute(GAMES_QUERY, (start_season, end_season))
+        for row in cur:
+            buckets[row["season"]].append(dict(row))
+    return buckets
+
+
+def seed_state(engine: EloEngine, conn, target_season: int) -> None:
+    """Rebuild engine.ratings/last_season from the latest persisted
+    analytics.house_elo_game rows before `target_season`, so --season and
+    --incremental never need to replay full history."""
+    with conn.cursor() as cur:
+        cur.execute(SEED_STATE_QUERY, (target_season, target_season))
+        for team, season, postgame in cur.fetchall():
+            if postgame is not None:
+                engine.ratings[team] = float(postgame)
+            engine.last_season[team] = season
+
+
+def fetch_max_season(conn) -> int | None:
+    with conn.cursor() as cur:
+        cur.execute("SELECT MAX(season) FROM core.games")
+        row = cur.fetchone()
+    return row[0] if row else None
+
+
+def fetch_max_completed_season(conn) -> int | None:
+    with conn.cursor() as cur:
+        cur.execute("SELECT MAX(season) FROM core.games WHERE completed = true")
+        row = cur.fetchone()
+    return row[0] if row else None
+
+
+def write_season(conn, season: int, rows: list[dict]) -> None:
+    """Idempotent per-season write: DELETE then bulk INSERT, one commit."""
+    from psycopg2.extras import execute_values
+
+    cur = conn.cursor()
+    try:
+        cur.execute("DELETE FROM analytics.house_elo_game WHERE season = %s", (season,))
+        if rows:
+            values = [
+                (
+                    r["game_id"],
+                    r["season"],
+                    r["week"],
+                    r["season_type"],
+                    r["start_date"],
+                    r["neutral_site"],
+                    r["home_team"],
+                    r["away_team"],
+                    r["home_pregame_elo"],
+                    r["away_pregame_elo"],
+                    r["home_postgame_elo"],
+                    r["away_postgame_elo"],
+                    r["home_win_prob"],
+                    r["expected_home_margin"],
+                    r["actual_home_margin"],
+                    r["mov_multiplier"],
+                    r["cfbd_home_pregame_elo"],
+                    r["cfbd_away_pregame_elo"],
+                )
+                for r in rows
+            ]
+            execute_values(
+                cur,
+                """
+                INSERT INTO analytics.house_elo_game (
+                    game_id, season, week, season_type, start_date, neutral_site,
+                    home_team, away_team, home_pregame_elo, away_pregame_elo,
+                    home_postgame_elo, away_postgame_elo, home_win_prob,
+                    expected_home_margin, actual_home_margin, mov_multiplier,
+                    cfbd_home_pregame_elo, cfbd_away_pregame_elo
+                ) VALUES %s
+                """,
+                values,
+            )
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        cur.close()
+
+
+def write_snapshot(conn, rows: list[dict]) -> None:
+    """Full replace of analytics.house_elo_current (updated_at = now() in SQL)."""
+    from psycopg2.extras import execute_values
+
+    cur = conn.cursor()
+    try:
+        cur.execute("DELETE FROM analytics.house_elo_current")
+        if rows:
+            values = [
+                (
+                    r["team"],
+                    r["season"],
+                    r["rating"],
+                    r["games_played"],
+                    r["last_game_id"],
+                    r["last_game_date"],
+                    r["low_confidence"],
+                )
+                for r in rows
+            ]
+            execute_values(
+                cur,
+                """
+                INSERT INTO analytics.house_elo_current (
+                    team, season, rating, games_played, last_game_id,
+                    last_game_date, low_confidence, updated_at
+                ) VALUES %s
+                """,
+                values,
+                template="(%s, %s, %s, %s, %s, %s, %s, now())",
+            )
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        cur.close()
+
+
+def run_full(conn, start_season: int, end_season: int) -> list[dict]:
+    logger.info(f"Loading core.games {start_season}-{end_season}")
+    buckets = load_games_by_season(conn, start_season, end_season)
+    engine = EloEngine()
+    all_rows: list[dict] = []
+    last_season_processed = None
+    for season in sorted(buckets):
+        season_games = buckets[season]
+        team_game_counts = compute_team_game_counts(season_games)
+        engine.start_season(season, team_game_counts)
+        rows = [engine.process_game(to_engine_game(g)) for g in season_games]
+        write_season(conn, season, rows)
+        all_rows.extend(rows)
+        last_season_processed = season
+        logger.info(f"  season {season}: {len(rows)} games written")
+
+    if last_season_processed is not None:
+        snapshot = engine.current_snapshot(last_season_processed)
+        write_snapshot(conn, snapshot)
+        logger.info(
+            f"Snapshot written: {len(snapshot)} teams (as of season {last_season_processed})"
+        )
+    else:
+        logger.warning("No completed games found in the requested season range")
+
+    return all_rows
+
+
+def run_season(conn, season: int) -> list[dict]:
+    engine = EloEngine()
+    logger.info(f"Seeding engine state from analytics.house_elo_game (season < {season})")
+    seed_state(engine, conn, season)
+    logger.info(f"Loading core.games for season {season}")
+    buckets = load_games_by_season(conn, season, season)
+    season_games = buckets.get(season, [])
+    team_game_counts = compute_team_game_counts(season_games)
+    engine.start_season(season, team_game_counts)
+    rows = [engine.process_game(to_engine_game(g)) for g in season_games]
+    logger.info(f"Season {season}: {len(rows)} games computed")
+    write_season(conn, season, rows)
+
+    snapshot = engine.current_snapshot(season)
+    write_snapshot(conn, snapshot)
+    logger.info(f"Snapshot written: {len(snapshot)} teams (as of season {season})")
+
+    return rows
+
+
+def print_validation(rows: list[dict]) -> None:
+    pairs = [
+        (r["home_pregame_elo"], r["cfbd_home_pregame_elo"])
+        for r in rows
+        if r["season"] >= VALIDATION_MIN_SEASON and r["cfbd_home_pregame_elo"] is not None
+    ]
+    n = len(pairs)
+    r = pearson_r([p[0] for p in pairs], [p[1] for p in pairs]) if n else float("nan")
+    print(f"ELO_VALIDATION n={n} pearson_r={r:.4f}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Compute house Elo ratings from core.games into analytics.house_elo_*"
+    )
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
+        "--full",
+        action="store_true",
+        help=f"Recompute all history: seasons {DEFAULT_START_SEASON}..max(core.games.season)",
+    )
+    mode.add_argument(
+        "--season",
+        type=int,
+        help="Recompute a single season (engine state rebuilt from prior house_elo_game rows)",
+    )
+    mode.add_argument(
+        "--incremental",
+        action="store_true",
+        help="Recompute the current season (max season in core.games with completed games)",
+    )
+    args = parser.parse_args()
+
+    import psycopg2
+
+    conn = psycopg2.connect(get_db_url())
+    try:
+        if args.full:
+            max_season = fetch_max_season(conn)
+            if max_season is None:
+                logger.error("core.games is empty -- nothing to compute")
+                sys.exit(1)
+            rows = run_full(conn, DEFAULT_START_SEASON, max_season)
+        elif args.season is not None:
+            rows = run_season(conn, args.season)
+        else:
+            max_completed = fetch_max_completed_season(conn)
+            if max_completed is None:
+                logger.error("No completed games found in core.games")
+                sys.exit(1)
+            rows = run_season(conn, max_completed)
+
+        print_validation(rows)
+    except Exception:
+        conn.rollback()
+        logger.exception("House Elo compute failed")
+        sys.exit(1)
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compute_house_elo.py
+++ b/scripts/compute_house_elo.py
@@ -388,6 +388,38 @@ def compute_team_game_counts(season_games: list[dict]) -> dict[str, int]:
     return dict(counts)
 
 
+# Pooling counts come from the FULL season schedule (completed or not), NOT
+# from completed-to-date rows. A mid-season --incremental run sees only a few
+# completed games per team in weeks 1-3; counting those would alias every
+# normal team into the pooled __FCS__ bucket and overwrite their carried
+# ratings with the 1500 pooled rating (Codex P1, PR #18). For fully played-out
+# historical seasons the two counts are identical, so --full is unaffected.
+SCHEDULED_COUNTS_QUERY = """
+    SELECT season, team, COUNT(*) AS n
+    FROM (
+        SELECT season, home_team AS team
+        FROM core.games WHERE season BETWEEN %s AND %s
+        UNION ALL
+        SELECT season, away_team AS team
+        FROM core.games WHERE season BETWEEN %s AND %s
+    ) sides
+    GROUP BY season, team
+"""
+
+
+def fetch_scheduled_counts(conn, start_season: int, end_season: int) -> dict[int, dict[str, int]]:
+    """Per-season {team: scheduled games} over ALL games (see note above)."""
+    counts: dict[int, dict[str, int]] = {}
+    with conn.cursor() as cur:
+        cur.execute(
+            SCHEDULED_COUNTS_QUERY,
+            (start_season, end_season, start_season, end_season),
+        )
+        for season, team, n in cur.fetchall():
+            counts.setdefault(int(season), {})[team] = int(n)
+    return counts
+
+
 def load_games_by_season(conn, start_season: int, end_season: int) -> dict[int, list[dict]]:
     """Stream core.games via a named server-side cursor, bucketed by season.
 
@@ -539,12 +571,13 @@ def write_snapshot(conn, rows: list[dict]) -> None:
 def run_full(conn, start_season: int, end_season: int) -> list[dict]:
     logger.info(f"Loading core.games {start_season}-{end_season}")
     buckets = load_games_by_season(conn, start_season, end_season)
+    scheduled_counts = fetch_scheduled_counts(conn, start_season, end_season)
     engine = EloEngine()
     all_rows: list[dict] = []
     last_season_processed = None
     for season in sorted(buckets):
         season_games = buckets[season]
-        team_game_counts = compute_team_game_counts(season_games)
+        team_game_counts = scheduled_counts.get(season) or compute_team_game_counts(season_games)
         engine.start_season(season, team_game_counts)
         rows = [engine.process_game(to_engine_game(g)) for g in season_games]
         write_season(conn, season, rows)
@@ -571,7 +604,8 @@ def run_season(conn, season: int) -> list[dict]:
     logger.info(f"Loading core.games for season {season}")
     buckets = load_games_by_season(conn, season, season)
     season_games = buckets.get(season, [])
-    team_game_counts = compute_team_game_counts(season_games)
+    scheduled_counts = fetch_scheduled_counts(conn, season, season)
+    team_game_counts = scheduled_counts.get(season) or compute_team_game_counts(season_games)
     engine.start_season(season, team_game_counts)
     rows = [engine.process_game(to_engine_game(g)) for g in season_games]
     logger.info(f"Season {season}: {len(rows)} games computed")

--- a/scripts/compute_predictions.py
+++ b/scripts/compute_predictions.py
@@ -1,0 +1,642 @@
+#!/usr/bin/env python3
+"""Compute house predictions (Elo + ridge-EPA blend) vs the market line.
+
+Architecture mirrors scripts/compute_house_elo.py: the prediction math
+(`elo_margin`, `epa_margin`, `blend_margin`, `elo_win_prob`, `compute_edge`,
+plus the small lookup helpers below them) is pure -- plain floats/dicts, no
+I/O -- so it is fully unit-testable without a database (see
+tests/test_predictions.py). Everything below `# --- I/O layer ---` is a thin
+wrapper: fetch games + ratings + market lines, feed them through the pure
+functions, upsert the results into predictions.game_predictions
+(src/schemas/migrations/024_predictions_schema.sql).
+
+House Elo's `expected_score` (the 400-scale logistic) and the season-carryover
+constants (`EloEngine.SEED`, `EloEngine.CARRYOVER`) are imported from
+compute_house_elo rather than re-derived, per
+docs/plans/2026-07-21-tier2-analytics-plan.md.
+
+Every game gets TWO rows, one per model_version:
+  - MODEL_ELO ("elo_v1"): expected_home_margin = elo_margin, epa_margin
+    column is always NULL (this model never looks at EPA).
+  - MODEL_BLEND ("elo_epa_blend_v1"): expected_home_margin =
+    blend_margin(elo_margin, epa_margin); epa_margin column holds the
+    computed value, or NULL if either team lacks a usable ridge-EPA fit
+    (blend then falls back to Elo-only for expected_home_margin too).
+home_win_prob is Elo-only in BOTH rows.
+
+Usage:
+    python scripts/compute_predictions.py
+        Score upcoming/pending games: NOT completed games in the current
+        season or any already-published next-season schedule. Ratings come
+        from the live analytics.house_elo_current snapshot (with carryover
+        applied for teams whose snapshot predates the game's season) and the
+        current analytics.adjusted_epa_build fit (current-or-previous season
+        only, per team). Market line: latest betting.line_snapshots per game
+        if that table exists, else betting.lines. prediction_date is written
+        as `(now() AT TIME ZONE 'utc')::date` -- a SQL-side expression, not a
+        Python-computed value -- so every row in the batch gets the exact
+        same date the DB itself would use, one single commit.
+
+    python scripts/compute_predictions.py --backfill 2015 2025
+        Retroactively score completed games for seasons 2015-2025 (inclusive)
+        using each game's true walk-forward pregame Elo from
+        analytics.house_elo_game and SAME-SEASON-ONLY ridge-adjusted EPA
+        (documented leaky-for-blend -- see marts/038_prediction_accuracy.sql's
+        header). Market line: betting.lines only (closing-line proxy).
+        prediction_date = the game's start_date::date, falling back to
+        make_date(season, 1, 1) when start_date is NULL, so re-running a
+        backfill is idempotent under the (game_id, model_version,
+        prediction_date) unique key. Commits once per season.
+"""
+
+import argparse
+import logging
+import sys
+from datetime import date
+
+from scripts.compute_house_elo import EloEngine, expected_score
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+# =============================================================================
+# Pure prediction math -- no I/O, no DB, unit-tested directly.
+# Parameters are FINAL per the design doc; see the plan's tunable ledger.
+# =============================================================================
+
+PLAYS = 68
+BLEND_ELO = 0.6
+BLEND_EPA = 0.4
+MODEL_ELO = "elo_v1"
+MODEL_BLEND = "elo_epa_blend_v1"
+
+
+def elo_margin(home_elo: float, away_elo: float, neutral: bool) -> float:
+    """Elo-implied expected home margin: elo_diff/DIVISOR, plus a home-field
+    bump of HFA/DIVISOR unless the game is at a neutral site."""
+    hfa = 0.0 if neutral else EloEngine.HFA
+    return (home_elo - away_elo + hfa) / EloEngine.DIVISOR
+
+
+def elo_win_prob(home_elo: float, away_elo: float, neutral: bool) -> float:
+    """Elo-only home win probability (canonical 400-scale logistic), used as
+    home_win_prob for BOTH model_versions -- the blend only changes the
+    expected margin, never the win probability."""
+    hfa = 0.0 if neutral else EloEngine.HFA
+    return expected_score(home_elo - away_elo + hfa)
+
+
+def epa_margin(
+    off_h: float, def_h: float, off_a: float, def_a: float, hfa_coef: float, neutral: bool
+) -> float:
+    """Ridge-adjusted-EPA implied expected home margin.
+
+    Sign convention (analytics.adjusted_epa_build): off_coef higher = better
+    offense; def_coef LOWER/more negative = better defense (EPA allowed
+    above average), so `def_a` is ADDED (a stingy away defense pulls the
+    home margin down) and `def_h` is SUBTRACTED (a stingy home defense pulls
+    the home margin up). hfa_coef is the home team's row's fitted
+    home-field-advantage coefficient for that team's season; zeroed at a
+    neutral site.
+    """
+    per_play_edge = (off_h + def_a) - (off_a + def_h)
+    hfa_term = hfa_coef * PLAYS * (0 if neutral else 1)
+    return per_play_edge * PLAYS + hfa_term
+
+
+def blend_margin(elo_m: float, epa_m: float | None) -> float:
+    """0.6*Elo + 0.4*EPA blend; falls back to Elo-only when EPA is
+    unavailable (thin/pre-2004 data, or either team missing a ridge fit)."""
+    if epa_m is None:
+        return elo_m
+    return BLEND_ELO * elo_m + BLEND_EPA * epa_m
+
+
+def compute_edge(
+    expected_home_margin: float, market_spread: float | None
+) -> tuple[float | None, str | None]:
+    """Compare the model's expected home margin against the market.
+
+    market_home_margin = -market_spread (negative spread = home favored,
+    matching api/003_game_detail.sql's cover logic). edge =
+    expected_home_margin - market_home_margin = expected_home_margin +
+    market_spread; edge > 0 means the model likes home more than the market
+    does (home undervalued) -> pick home. edge == 0 also picks home (no
+    "push" pick). Returns (None, None) when there is no market line to
+    compare against.
+    """
+    if market_spread is None:
+        return None, None
+    edge = expected_home_margin + market_spread
+    edge_pick = "home" if edge >= 0 else "away"
+    return edge, edge_pick
+
+
+def carryover_rating(rating: float, elapsed: int) -> float:
+    """Regress `rating` toward EloEngine.SEED for `elapsed` seasons with no
+    persisted house_elo_game activity, replicating EloEngine.start_season's
+    per-team carryover exactly (SEED/CARRYOVER imported, not re-derived).
+    A no-op when elapsed <= 0 (rating is already current)."""
+    if elapsed <= 0:
+        return rating
+    offset = rating - EloEngine.SEED
+    return EloEngine.SEED + offset * (EloEngine.CARRYOVER**elapsed)
+
+
+def resolve_elo(team: str, season: int, elo_current: dict[str, tuple[float, int]]) -> float:
+    """Rating to use for `team` in a game played in `season`, from the
+    analytics.house_elo_current snapshot ({team: (rating, snapshot_season)}).
+    Missing team -> EloEngine.SEED (1500). A snapshot older than `season`
+    gets carryover_rating applied for the elapsed seasons."""
+    entry = elo_current.get(team)
+    if entry is None:
+        return EloEngine.SEED
+    rating, snapshot_season = entry
+    return carryover_rating(rating, season - snapshot_season)
+
+
+def lookup_epa_coefs(
+    epa_by_team_season: dict[tuple[str, int], dict], team: str, season: int, lookback: int
+) -> dict | None:
+    """Return `team`'s analytics.adjusted_epa_build row for the greatest
+    season in [season - lookback, season], or None if none qualifies.
+
+    lookback=1 (upcoming mode): current-or-immediately-previous season only.
+    lookback=0 (backfill mode): same-season only (documented leaky-for-blend
+    -- see marts/038_prediction_accuracy.sql's header).
+    """
+    for candidate in range(season, season - lookback - 1, -1):
+        row = epa_by_team_season.get((team, candidate))
+        if row is not None:
+            return row
+    return None
+
+
+def build_predictions_for_game(
+    game: dict,
+    home_elo: float,
+    away_elo: float,
+    epa_by_team_season: dict[tuple[str, int], dict],
+    epa_lookback: int,
+    market: dict | None,
+) -> list[dict]:
+    """Build the two model_version rows (elo_v1, elo_epa_blend_v1) for one
+    game. `game` needs: game_id, season, week, season_type, home_team,
+    away_team, neutral_site. `market` is {"provider", "spread",
+    "captured_at"} or None. Returns dicts with every predictions.game_predictions
+    value column except computed_at/prediction_date (added by the caller)."""
+    neutral = bool(game.get("neutral_site"))
+    elo_m = elo_margin(home_elo, away_elo, neutral)
+    win_prob = elo_win_prob(home_elo, away_elo, neutral)
+
+    home_epa_row = lookup_epa_coefs(
+        epa_by_team_season, game["home_team"], game["season"], epa_lookback
+    )
+    away_epa_row = lookup_epa_coefs(
+        epa_by_team_season, game["away_team"], game["season"], epa_lookback
+    )
+    epa_m = None
+    if home_epa_row is not None and away_epa_row is not None:
+        epa_m = epa_margin(
+            home_epa_row["off_coef"],
+            home_epa_row["def_coef"],
+            away_epa_row["off_coef"],
+            away_epa_row["def_coef"],
+            home_epa_row["hfa_coef"],
+            neutral,
+        )
+
+    if market:
+        market_provider = market.get("provider")
+        market_spread = market.get("spread")
+        market_home_margin = -market_spread if market_spread is not None else None
+        market_captured_at = market.get("captured_at")
+    else:
+        market_provider = None
+        market_spread = None
+        market_home_margin = None
+        market_captured_at = None
+
+    base = {
+        "game_id": game["game_id"],
+        "season": game["season"],
+        "week": game["week"],
+        "season_type": game["season_type"],
+        "home_team": game["home_team"],
+        "away_team": game["away_team"],
+        "neutral_site": neutral,
+        "home_elo_pregame": home_elo,
+        "away_elo_pregame": away_elo,
+        "elo_margin": elo_m,
+        "home_win_prob": win_prob,
+        "market_provider": market_provider,
+        "market_home_margin": market_home_margin,
+        "market_spread": market_spread,
+        "market_captured_at": market_captured_at,
+    }
+
+    rows = []
+    for model_version, expected, epa_col in (
+        (MODEL_ELO, elo_m, None),
+        (MODEL_BLEND, blend_margin(elo_m, epa_m), epa_m),
+    ):
+        edge, edge_pick = compute_edge(expected, market_spread)
+        rows.append(
+            {
+                **base,
+                "model_version": model_version,
+                "epa_margin": epa_col,
+                "expected_home_margin": expected,
+                "edge": edge,
+                "edge_pick": edge_pick,
+            }
+        )
+    return rows
+
+
+# =============================================================================
+# --- I/O layer --- (thin: fetch games/ratings/market, drive the math, write)
+# =============================================================================
+
+
+def get_db_url() -> str:
+    """Get database URL from dlt secrets or environment.
+
+    Copied from scripts/compute_house_elo.py's get_db_url pattern (each
+    compute_*.py script keeps its own copy rather than importing across
+    scripts for this one utility).
+    """
+    import os
+
+    import dlt
+
+    url = None
+    try:
+        creds = dlt.secrets.get("destination.postgres.credentials")
+        if creds:
+            url = str(creds)
+    except Exception:
+        pass
+
+    if not url:
+        url = os.environ.get("SUPABASE_DB_URL") or os.environ.get("DATABASE_URL")
+
+    if not url:
+        raise RuntimeError(
+            "No database URL found. Set destination.postgres.credentials in "
+            ".dlt/secrets.toml or SUPABASE_DB_URL environment variable."
+        )
+
+    if "options=" not in url:
+        separator = "&" if "?" in url else "?"
+        url = f"{url}{separator}options=-c%20statement_timeout%3D0"
+
+    return url
+
+
+TARGET_GAMES_QUERY = """
+    SELECT id AS game_id, season, week, season_type, start_date, neutral_site,
+           home_team, away_team
+    FROM core.games
+    WHERE NOT COALESCE(completed, false)
+      AND season >= (SELECT COALESCE(MAX(season), 0) FROM core.games WHERE completed)
+    ORDER BY season, start_date NULLS LAST, id
+"""
+
+BACKFILL_GAMES_QUERY = """
+    SELECT game_id, season, week, season_type, start_date, neutral_site,
+           home_team, away_team, home_pregame_elo, away_pregame_elo
+    FROM analytics.house_elo_game
+    WHERE season = %s
+    ORDER BY start_date NULLS LAST, game_id
+"""
+
+MARKET_SNAPSHOTS_QUERY = """
+    SELECT DISTINCT ON (game_id) game_id, provider, spread, captured_at
+    FROM betting.line_snapshots
+    WHERE game_id = ANY(%s)
+    ORDER BY game_id, CASE WHEN provider = 'consensus' THEN 0 ELSE 1 END, captured_at DESC
+"""
+
+MARKET_LINES_QUERY = """
+    SELECT DISTINCT ON (game_id) game_id, provider, spread
+    FROM betting.lines
+    WHERE game_id = ANY(%s)
+    ORDER BY game_id, CASE WHEN provider = 'consensus' THEN 0 ELSE 1 END, provider
+"""
+
+# Column order matches predictions.game_predictions exactly (see
+# src/schemas/migrations/024_predictions_schema.sql), minus computed_at and
+# prediction_date, which the two write_* functions handle separately.
+_ROW_COLUMNS = [
+    "model_version",
+    "game_id",
+    "season",
+    "week",
+    "season_type",
+    "home_team",
+    "away_team",
+    "neutral_site",
+    "home_elo_pregame",
+    "away_elo_pregame",
+    "elo_margin",
+    "epa_margin",
+    "expected_home_margin",
+    "home_win_prob",
+    "market_provider",
+    "market_home_margin",
+    "market_spread",
+    "market_captured_at",
+    "edge",
+    "edge_pick",
+]
+
+_UPDATE_SET_COLUMNS = [
+    "computed_at",
+    "season",
+    "week",
+    "season_type",
+    "home_team",
+    "away_team",
+    "neutral_site",
+    "home_elo_pregame",
+    "away_elo_pregame",
+    "elo_margin",
+    "epa_margin",
+    "expected_home_margin",
+    "home_win_prob",
+    "market_provider",
+    "market_home_margin",
+    "market_spread",
+    "market_captured_at",
+    "edge",
+    "edge_pick",
+]
+
+_UPSERT_SQL = """
+    INSERT INTO predictions.game_predictions (
+        computed_at, prediction_date, model_version, game_id, season, week,
+        season_type, home_team, away_team, neutral_site,
+        home_elo_pregame, away_elo_pregame, elo_margin, epa_margin,
+        expected_home_margin, home_win_prob,
+        market_provider, market_home_margin, market_spread, market_captured_at,
+        edge, edge_pick
+    ) VALUES %s
+    ON CONFLICT (game_id, model_version, prediction_date) DO UPDATE SET
+        {update_set}
+""".format(update_set=",\n        ".join(f"{c} = EXCLUDED.{c}" for c in _UPDATE_SET_COLUMNS))
+
+_ROW_PLACEHOLDERS = ", ".join(["%s"] * len(_ROW_COLUMNS))
+# Upcoming mode: prediction_date is a fixed SQL-side expression (same value
+# for every row in the batch -- one INSERT statement, one transaction-local
+# `now()`), never a Python-computed date.
+_UPCOMING_TEMPLATE = f"(now(), (now() AT TIME ZONE 'utc')::date, {_ROW_PLACEHOLDERS})"
+# Backfill mode: prediction_date varies per game (each game's start_date),
+# so it is a bound parameter, prepended ahead of the shared row values.
+_BACKFILL_TEMPLATE = f"(now(), %s, {_ROW_PLACEHOLDERS})"
+
+
+def _row_values(row: dict) -> tuple:
+    return tuple(row[c] for c in _ROW_COLUMNS)
+
+
+def table_exists(conn, schema: str, table: str) -> bool:
+    with conn.cursor() as cur:
+        cur.execute("SELECT to_regclass(%s)", (f"{schema}.{table}",))
+        return cur.fetchone()[0] is not None
+
+
+def fetch_target_games(conn) -> list[dict]:
+    import psycopg2.extras
+
+    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(TARGET_GAMES_QUERY)
+        return [dict(row) for row in cur.fetchall()]
+
+
+def fetch_backfill_games(conn, season: int) -> list[dict]:
+    import psycopg2.extras
+
+    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(BACKFILL_GAMES_QUERY, (season,))
+        return [dict(row) for row in cur.fetchall()]
+
+
+def fetch_elo_current(conn) -> dict[str, tuple[float, int]]:
+    result: dict[str, tuple[float, int]] = {}
+    with conn.cursor() as cur:
+        cur.execute("SELECT team, rating, season FROM analytics.house_elo_current")
+        for team, rating, season in cur.fetchall():
+            if rating is None or season is None:
+                continue
+            result[team] = (float(rating), int(season))
+    return result
+
+
+def fetch_epa_coefs(conn, season: int | None = None) -> dict[tuple[str, int], dict]:
+    query = "SELECT team, season, off_coef, def_coef, hfa_coef FROM analytics.adjusted_epa_build"
+    params: tuple = ()
+    if season is not None:
+        query += " WHERE season = %s"
+        params = (season,)
+
+    result: dict[tuple[str, int], dict] = {}
+    with conn.cursor() as cur:
+        cur.execute(query, params)
+        for team, row_season, off_coef, def_coef, hfa_coef in cur.fetchall():
+            if off_coef is None or def_coef is None or hfa_coef is None:
+                continue
+            result[(team, row_season)] = {
+                "off_coef": float(off_coef),
+                "def_coef": float(def_coef),
+                "hfa_coef": float(hfa_coef),
+            }
+    return result
+
+
+def fetch_market_from_snapshots(conn, game_ids: list[int]) -> dict[int, dict]:
+    if not game_ids:
+        return {}
+    result: dict[int, dict] = {}
+    with conn.cursor() as cur:
+        cur.execute(MARKET_SNAPSHOTS_QUERY, (game_ids,))
+        for game_id, provider, spread, captured_at in cur.fetchall():
+            result[game_id] = {
+                "provider": provider,
+                "spread": float(spread) if spread is not None else None,
+                "captured_at": captured_at,
+            }
+    return result
+
+
+def fetch_market_from_lines(conn, game_ids: list[int]) -> dict[int, dict]:
+    if not game_ids:
+        return {}
+    result: dict[int, dict] = {}
+    with conn.cursor() as cur:
+        cur.execute(MARKET_LINES_QUERY, (game_ids,))
+        for game_id, provider, spread in cur.fetchall():
+            result[game_id] = {
+                "provider": provider,
+                "spread": float(spread) if spread is not None else None,
+                "captured_at": None,
+            }
+    return result
+
+
+def write_upcoming(conn, rows: list[dict]) -> None:
+    from psycopg2.extras import execute_values
+
+    if not rows:
+        return
+    values = [_row_values(r) for r in rows]
+    with conn.cursor() as cur:
+        execute_values(cur, _UPSERT_SQL, values, template=_UPCOMING_TEMPLATE)
+    conn.commit()
+
+
+def write_backfill_season(conn, rows: list[dict]) -> None:
+    from psycopg2.extras import execute_values
+
+    if not rows:
+        return
+    values = [(r["prediction_date"], *_row_values(r)) for r in rows]
+    with conn.cursor() as cur:
+        execute_values(cur, _UPSERT_SQL, values, template=_BACKFILL_TEMPLATE)
+    conn.commit()
+
+
+def run_upcoming(conn) -> None:
+    games = fetch_target_games(conn)
+    logger.info(f"Targeted {len(games)} upcoming/pending game(s)")
+    if not games:
+        logger.info("No target games; nothing to write")
+        return
+
+    elo_current = fetch_elo_current(conn)
+    epa_by_team_season = fetch_epa_coefs(conn)
+
+    game_ids = [g["game_id"] for g in games]
+    if table_exists(conn, "betting", "line_snapshots"):
+        market_by_game = fetch_market_from_snapshots(conn, game_ids)
+        logger.info("Market source: betting.line_snapshots (latest per game, consensus preferred)")
+    else:
+        market_by_game = fetch_market_from_lines(conn, game_ids)
+        logger.info("Market source: betting.lines (betting.line_snapshots not present)")
+
+    rows: list[dict] = []
+    n_with_market = 0
+    for game in games:
+        home_elo = resolve_elo(game["home_team"], game["season"], elo_current)
+        away_elo = resolve_elo(game["away_team"], game["season"], elo_current)
+        market = market_by_game.get(game["game_id"])
+        if market and market.get("spread") is not None:
+            n_with_market += 1
+        rows.extend(
+            build_predictions_for_game(
+                game, home_elo, away_elo, epa_by_team_season, epa_lookback=1, market=market
+            )
+        )
+
+    write_upcoming(conn, rows)
+    logger.info(
+        f"Wrote {len(rows)} prediction row(s) for {len(games)} game(s) "
+        f"({n_with_market} with a market line)"
+    )
+
+
+def run_backfill(conn, start: int, end: int) -> None:
+    total_games = total_rows = total_with_market = 0
+    for season in range(start, end + 1):
+        games = fetch_backfill_games(conn, season)
+        if not games:
+            logger.info(
+                f"season={season}: no completed games in analytics.house_elo_game, skipping"
+            )
+            continue
+
+        epa_by_team_season = fetch_epa_coefs(conn, season=season)
+        game_ids = [g["game_id"] for g in games]
+        market_by_game = fetch_market_from_lines(conn, game_ids)
+
+        rows: list[dict] = []
+        n_with_market = 0
+        for game in games:
+            home_elo = (
+                float(game["home_pregame_elo"])
+                if game["home_pregame_elo"] is not None
+                else EloEngine.SEED
+            )
+            away_elo = (
+                float(game["away_pregame_elo"])
+                if game["away_pregame_elo"] is not None
+                else EloEngine.SEED
+            )
+            market = market_by_game.get(game["game_id"])
+            if market and market.get("spread") is not None:
+                n_with_market += 1
+
+            start_date = game["start_date"]
+            prediction_date = start_date.date() if start_date is not None else date(season, 1, 1)
+
+            game_rows = build_predictions_for_game(
+                game, home_elo, away_elo, epa_by_team_season, epa_lookback=0, market=market
+            )
+            for row in game_rows:
+                row["prediction_date"] = prediction_date
+            rows.extend(game_rows)
+
+        write_backfill_season(conn, rows)
+        logger.info(
+            f"season={season}: {len(games)} game(s), wrote {len(rows)} row(s) "
+            f"({n_with_market} with a market line)"
+        )
+        total_games += len(games)
+        total_rows += len(rows)
+        total_with_market += n_with_market
+
+    logger.info(
+        f"Backfill {start}-{end}: {total_games} game(s) total, {total_rows} row(s) written, "
+        f"{total_with_market} with a market line"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Compute house predictions (Elo + ridge-EPA blend) into "
+        "predictions.game_predictions"
+    )
+    parser.add_argument(
+        "--backfill",
+        nargs=2,
+        type=int,
+        metavar=("START", "END"),
+        help="Backfill completed games for seasons START..END (inclusive) using "
+        "walk-forward pregame Elo + same-season EPA; prediction_date = each "
+        "game's start_date (fallback: Jan 1 of its season). Default (no flag): "
+        "score upcoming/pending games using current ratings.",
+    )
+    args = parser.parse_args()
+
+    import psycopg2
+
+    conn = psycopg2.connect(get_db_url())
+    try:
+        if args.backfill:
+            start, end = args.backfill
+            if start > end:
+                logger.error(f"--backfill start {start} is after end {end}")
+                sys.exit(1)
+            run_backfill(conn, start, end)
+        else:
+            run_upcoming(conn)
+    except Exception:
+        conn.rollback()
+        logger.exception("Predictions compute failed")
+        sys.exit(1)
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/deploy_schema.py
+++ b/scripts/deploy_schema.py
@@ -60,7 +60,12 @@ VALID_ACTIONS = {"presence_check", "apply", "backfill", "compute"}
 # Allowlist of compute scripts the "compute" action may run (scripts/<name>.py).
 # These land in later Tier 2 phases -- membership is checked, not file existence,
 # so this action can be wired up before the scripts themselves exist.
-COMPUTE_SCRIPTS = {"compute_house_elo", "compute_adjusted_epa", "compute_predictions"}
+COMPUTE_SCRIPTS = {
+    "compute_house_elo",
+    "compute_adjusted_epa",
+    "compute_predictions",
+    "check_backtest",
+}
 
 # Marts refreshed after a compute run when plan.refresh is set. One home for
 # this list so deploy_schema.py and any caller agree on the Tier 2 mart names.

--- a/scripts/deploy_schema.py
+++ b/scripts/deploy_schema.py
@@ -9,12 +9,13 @@ run_migrations.py, refresh_marts.py, load_season.py, and check_presence.py.
 
 Manifest schema:
     {
-      "action": "presence_check" | "apply" | "backfill",
+      "action": "presence_check" | "apply" | "backfill" | "compute",
       "marts_from": "029",
       "marts_only": "011",
       "files": ["src/schemas/api/019_x.sql", ...],
       "refresh": true,
-      "backfill": {"start": 2014, "end": 2025, "sources": "stats,betting"}
+      "backfill": {"start": 2014, "end": 2025, "sources": "stats,betting"},
+      "compute": {"script": "compute_house_elo", "args": ["--full"]}
     }
 
 All fields besides "action" are optional and only consulted by the action
@@ -54,7 +55,22 @@ REFRESH_MARTS = SCRIPTS_DIR / "refresh_marts.py"
 LOAD_SEASON = SCRIPTS_DIR / "load_season.py"
 CHECK_PRESENCE = SCRIPTS_DIR / "check_presence.py"
 
-VALID_ACTIONS = {"presence_check", "apply", "backfill"}
+VALID_ACTIONS = {"presence_check", "apply", "backfill", "compute"}
+
+# Allowlist of compute scripts the "compute" action may run (scripts/<name>.py).
+# These land in later Tier 2 phases -- membership is checked, not file existence,
+# so this action can be wired up before the scripts themselves exist.
+COMPUTE_SCRIPTS = {"compute_house_elo", "compute_adjusted_epa", "compute_predictions"}
+
+# Marts refreshed after a compute run when plan.refresh is set. One home for
+# this list so deploy_schema.py and any caller agree on the Tier 2 mart names.
+TIER2_MART_VIEWS = [
+    "marts.house_elo",
+    "marts.house_elo_game",
+    "marts.team_adjusted_epa",
+    "marts.scored_matchup_edges",
+    "marts.prediction_accuracy",
+]
 
 
 @dataclass
@@ -62,6 +78,12 @@ class BackfillSpec:
     start: int | None
     end: int | None
     sources: str = ""
+
+
+@dataclass
+class ComputeSpec:
+    script: str
+    args: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -73,6 +95,7 @@ class Plan:
     refresh: bool = False
     backfill: BackfillSpec | None = None
     strict: bool = False
+    compute: ComputeSpec | None = None
 
 
 # --------------------------------------------------------------------------
@@ -96,6 +119,15 @@ def validate_plan(plan: Plan) -> None:
                 f"end season ({plan.backfill.end})"
             )
 
+    if plan.action == "compute":
+        if plan.compute is None:
+            raise ValueError("compute action requires a compute block")
+        if plan.compute.script not in COMPUTE_SCRIPTS:
+            raise ValueError(
+                f"invalid compute script {plan.compute.script!r}; "
+                f"must be one of {sorted(COMPUTE_SCRIPTS)}"
+            )
+
 
 def load_manifest(path: str) -> dict:
     with open(path) as f:
@@ -113,6 +145,14 @@ def plan_from_manifest(manifest: dict) -> Plan:
             sources=str(bf.get("sources", "")),
         )
 
+    compute = None
+    cp = manifest.get("compute")
+    if cp:
+        compute = ComputeSpec(
+            script=cp.get("script"),
+            args=list(cp.get("args") or []),
+        )
+
     plan = Plan(
         action=manifest.get("action"),
         marts_from=manifest.get("marts_from"),
@@ -121,6 +161,7 @@ def plan_from_manifest(manifest: dict) -> Plan:
         refresh=bool(manifest.get("refresh", False)),
         backfill=backfill,
         strict=bool(manifest.get("strict", False)),
+        compute=compute,
     )
     validate_plan(plan)
     return plan
@@ -137,11 +178,14 @@ def plan_from_cli(
     backfill_end: int | None = None,
     sources: str | None = None,
     strict: bool = False,
+    compute_script: str | None = None,
+    compute_args: str | None = None,
 ) -> Plan:
     """Build and validate a Plan from workflow_dispatch-style CLI flags.
 
-    `files` and `sources` are comma-separated strings (workflow_dispatch inputs
-    are plain text), matching the manifest's list/string fields once parsed.
+    `files`, `sources`, and `compute_args` are comma-separated strings
+    (workflow_dispatch inputs are plain text), matching the manifest's
+    list/string fields once parsed.
     """
     file_list = [f.strip() for f in files.split(",") if f.strip()] if files else []
 
@@ -153,6 +197,11 @@ def plan_from_cli(
             sources=sources or "",
         )
 
+    compute = None
+    if compute_script is not None:
+        arg_list = [a.strip() for a in compute_args.split(",") if a.strip()] if compute_args else []
+        compute = ComputeSpec(script=compute_script, args=arg_list)
+
     plan = Plan(
         action=action,
         marts_from=marts_from,
@@ -161,6 +210,7 @@ def plan_from_cli(
         refresh=refresh,
         backfill=backfill,
         strict=strict,
+        compute=compute,
     )
     validate_plan(plan)
     return plan
@@ -256,6 +306,29 @@ def run_backfill(plan: Plan) -> int:
     return run_cmd([sys.executable, str(CHECK_PRESENCE)], "check_presence")
 
 
+def run_compute(plan: Plan) -> int:
+    c = plan.compute
+    # validate_plan guarantees a compute block with an allowlisted script.
+    assert c is not None
+    rc = run_cmd(
+        [sys.executable, str(SCRIPTS_DIR / f"{c.script}.py"), *c.args],
+        f"compute {c.script}",
+    )
+    if rc:
+        return rc
+
+    if plan.refresh:
+        rc = run_cmd(
+            [sys.executable, str(REFRESH_MARTS), "--views", ",".join(TIER2_MART_VIEWS)],
+            "refresh_marts --views (tier2)",
+        )
+        if rc:
+            return rc
+
+    logger.info("compute plan completed successfully")
+    return 0
+
+
 def execute_plan(plan: Plan) -> int:
     logger.info(f"executing plan: {plan}")
     if plan.action == "presence_check":
@@ -264,6 +337,8 @@ def execute_plan(plan: Plan) -> int:
         return run_apply(plan)
     if plan.action == "backfill":
         return run_backfill(plan)
+    if plan.action == "compute":
+        return run_compute(plan)
     raise ValueError(f"unknown action: {plan.action}")  # unreachable after validate_plan
 
 
@@ -290,6 +365,16 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--strict", action="store_true", help="Pass --strict through to check_presence.py"
     )
+    parser.add_argument(
+        "--compute-script",
+        dest="compute_script",
+        help="Compute script to run, e.g. compute_house_elo (see COMPUTE_SCRIPTS)",
+    )
+    parser.add_argument(
+        "--compute-args",
+        dest="compute_args",
+        help="Comma-separated args passed through to the compute script",
+    )
     return parser
 
 
@@ -313,6 +398,8 @@ def main(argv: list[str] | None = None) -> None:
             backfill_end=args.backfill_end,
             sources=args.sources,
             strict=args.strict,
+            compute_script=args.compute_script,
+            compute_args=args.compute_args,
         )
 
     sys.exit(execute_plan(plan))

--- a/scripts/refresh_marts.py
+++ b/scripts/refresh_marts.py
@@ -7,6 +7,9 @@ Usage:
     python scripts/refresh_marts.py --schema marts     # Only marts schema
     python scripts/refresh_marts.py --schema analytics # Only analytics schema
     python scripts/refresh_marts.py --dry-run          # Print SQL without executing
+    python scripts/refresh_marts.py --views marts.house_elo,marts.house_elo_game
+                                                         # Refresh exactly these views, in order,
+                                                         # instead of the full layered list.
 """
 
 import argparse
@@ -140,14 +143,31 @@ def refresh_marts(
     schema: str | None = None,
     concurrently: bool = True,
     dry_run: bool = False,
+    views: list[str] | None = None,
 ) -> int:
-    """Refresh materialized views. Returns count of failures."""
-    # Build view list based on schema filter
-    views = []
-    if schema is None or schema == "marts":
-        views.extend(MARTS_VIEWS)
-    if schema is None or schema == "analytics":
-        views.extend(ANALYTICS_VIEWS)
+    """Refresh materialized views. Returns count of failures.
+
+    If `views` is given, refresh exactly those views, in the given order,
+    instead of the full layered list (schema is ignored in that case). Each
+    name must be schema-qualified as marts.* or analytics.*; a name that
+    doesn't exist yet is not validated here -- Postgres will error on the
+    REFRESH and that failure surfaces per-view like any other.
+    """
+    if views is not None:
+        invalid = [v for v in views if not (v.startswith("marts.") or v.startswith("analytics."))]
+        if invalid:
+            logger.error(
+                f"Invalid --views entries (must be schema-qualified marts.* or "
+                f"analytics.*): {invalid}"
+            )
+            return 1
+    else:
+        # Build view list based on schema filter
+        views = []
+        if schema is None or schema == "marts":
+            views.extend(MARTS_VIEWS)
+        if schema is None or schema == "analytics":
+            views.extend(ANALYTICS_VIEWS)
 
     if not views:
         logger.error(f"No views found for schema: {schema}")
@@ -202,12 +222,22 @@ def main() -> None:
         action="store_true",
         help="Print SQL without executing",
     )
+    parser.add_argument(
+        "--views",
+        help=(
+            "Comma-separated fully-qualified matview names to refresh, in order "
+            "(overrides --schema and the full layered list)"
+        ),
+    )
     args = parser.parse_args()
+
+    view_list = [v.strip() for v in args.views.split(",") if v.strip()] if args.views else None
 
     failures = refresh_marts(
         schema=args.schema,
         concurrently=not args.no_concurrent,
         dry_run=args.dry_run,
+        views=view_list,
     )
     sys.exit(failures)
 

--- a/scripts/refresh_marts.py
+++ b/scripts/refresh_marts.py
@@ -68,6 +68,12 @@ MARTS_VIEWS = [
     # Layer 5: Depends on Layer 4 + standalone
     "marts.matchup_edges",
     "marts.data_freshness",
+    # Layer 6: Tier 2 analytics (read from analytics.* staging + predictions)
+    "marts.house_elo",
+    "marts.house_elo_game",
+    "marts.team_adjusted_epa",
+    "marts.scored_matchup_edges",
+    "marts.prediction_accuracy",
 ]
 
 ANALYTICS_VIEWS = [

--- a/src/schemas/api/028_team_elo.sql
+++ b/src/schemas/api/028_team_elo.sql
@@ -1,0 +1,22 @@
+-- api.team_elo
+-- Season-end house Elo rating per team per season.
+-- Thin passthrough of marts.house_elo (Tier 2 analytics,
+-- docs/plans/2026-07-21-tier2-analytics-plan.md).
+--
+-- PostgREST usage:
+--   GET /api/team_elo?season=eq.2024&order=elo_rank.asc
+
+CREATE OR REPLACE VIEW api.team_elo AS
+SELECT
+    team,
+    season,
+    season_end_elo,
+    elo_rank,
+    games_played,
+    low_confidence,
+    cfbd_elo
+FROM marts.house_elo;
+
+GRANT SELECT ON api.team_elo TO anon, authenticated;
+
+COMMENT ON VIEW api.team_elo IS 'Season-end house Elo rating per team per season. Columns: team, season, season_end_elo, elo_rank, games_played, low_confidence, cfbd_elo. low_confidence flags teams with <4 games in the season or seasons before 1900; cfbd_elo is CFBD''s own Elo (coverage ~2015+) for side-by-side comparison only. Backed by marts.house_elo.';

--- a/src/schemas/api/029_game_elo_history.sql
+++ b/src/schemas/api/029_game_elo_history.sql
@@ -1,0 +1,37 @@
+-- api.game_elo_history
+-- Game-grain house Elo history: pregame/postgame Elo both sides, win prob,
+-- expected vs actual margin, CFBD Elo copies for validation.
+-- Thin passthrough of marts.house_elo_game (Tier 2 analytics,
+-- docs/plans/2026-07-21-tier2-analytics-plan.md).
+--
+-- PostgREST usage:
+--   GET /api/game_elo_history?game_id=eq.401628455
+--   GET /api/game_elo_history?season=eq.2024&home_team=eq.Ohio State
+
+CREATE OR REPLACE VIEW api.game_elo_history AS
+SELECT
+    game_id,
+    season,
+    week,
+    season_type,
+    start_date,
+    neutral_site,
+    home_team,
+    away_team,
+    home_pregame_elo,
+    away_pregame_elo,
+    home_postgame_elo,
+    away_postgame_elo,
+    home_win_prob,
+    expected_home_margin,
+    actual_home_margin,
+    mov_multiplier,
+    cfbd_home_pregame_elo,
+    cfbd_away_pregame_elo,
+    margin_error,
+    abs_margin_error
+FROM marts.house_elo_game;
+
+GRANT SELECT ON api.game_elo_history TO anon, authenticated;
+
+COMMENT ON VIEW api.game_elo_history IS 'Game-grain house Elo history. Columns: game_id, season, week, season_type, start_date, neutral_site, home_team, away_team, home_pregame_elo, away_pregame_elo, home_postgame_elo, away_postgame_elo, home_win_prob, expected_home_margin, actual_home_margin, mov_multiplier, cfbd_home_pregame_elo, cfbd_away_pregame_elo, margin_error, abs_margin_error. margin_error = expected_home_margin - actual_home_margin (positive = model overrated the home side). Backed by marts.house_elo_game.';

--- a/src/schemas/api/030_scored_matchup_edges.sql
+++ b/src/schemas/api/030_scored_matchup_edges.sql
@@ -1,0 +1,44 @@
+-- api.scored_matchup_edges
+-- House model vs market: expected margin/win-prob compared against the
+-- market line for upcoming games, with the resulting edge.
+-- Thin passthrough of marts.scored_matchup_edges (Tier 2 analytics,
+-- docs/plans/2026-07-21-tier2-analytics-plan.md).
+--
+-- NOTE: marts.scored_matchup_edges surfaces UPCOMING games vs the market
+-- line and is expected to be empty out of season -- that is normal, not a
+-- data-quality failure.
+--
+-- PostgREST usage:
+--   GET /api/scored_matchup_edges?season=eq.2026&order=abs_edge.desc
+--   GET /api/scored_matchup_edges?week=eq.5&edge_pick=eq.home
+
+CREATE OR REPLACE VIEW api.scored_matchup_edges AS
+SELECT
+    game_id,
+    season,
+    week,
+    season_type,
+    start_date,
+    home_team,
+    away_team,
+    neutral_site,
+    model_version,
+    prediction_date,
+    home_elo_pregame,
+    away_elo_pregame,
+    elo_margin,
+    epa_margin,
+    expected_home_margin,
+    home_win_prob,
+    market_provider,
+    market_spread,
+    market_home_margin,
+    market_captured_at,
+    edge,
+    edge_pick,
+    abs_edge
+FROM marts.scored_matchup_edges;
+
+GRANT SELECT ON api.scored_matchup_edges TO anon, authenticated;
+
+COMMENT ON VIEW api.scored_matchup_edges IS 'House model expected margin/win-prob vs the market line for upcoming games. Columns: game_id, season, week, season_type, start_date, home_team, away_team, neutral_site, model_version, prediction_date, home_elo_pregame, away_elo_pregame, elo_margin, epa_margin, expected_home_margin, home_win_prob, market_provider, market_spread, market_home_margin, market_captured_at, edge, edge_pick, abs_edge. edge = expected_home_margin + spread (positive = home undervalued by the market). Backed by marts.scored_matchup_edges; normally empty out of season.';

--- a/src/schemas/api/031_prediction_accuracy.sql
+++ b/src/schemas/api/031_prediction_accuracy.sql
@@ -1,0 +1,32 @@
+-- api.prediction_accuracy
+-- Retroactive scoring of house predictions by season/model/edge-threshold:
+-- margin MAE/RMSE, ATS record, Brier score (house and CFBD), vs the market
+-- and CFBD's own pregame win probability.
+-- Thin passthrough of marts.prediction_accuracy (Tier 2 analytics,
+-- docs/plans/2026-07-21-tier2-analytics-plan.md).
+--
+-- PostgREST usage:
+--   GET /api/prediction_accuracy?season=eq.2024&model_version=eq.house_v1
+--   GET /api/prediction_accuracy?edge_threshold=eq.6&order=ats_hit_rate.desc
+
+CREATE OR REPLACE VIEW api.prediction_accuracy AS
+SELECT
+    model_version,
+    season,
+    edge_threshold,
+    n_games,
+    n_with_market,
+    margin_mae,
+    margin_rmse,
+    ats_wins,
+    ats_losses,
+    ats_pushes,
+    ats_hit_rate,
+    brier,
+    cfbd_brier,
+    n_scored_win_prob
+FROM marts.prediction_accuracy;
+
+GRANT SELECT ON api.prediction_accuracy TO anon, authenticated;
+
+COMMENT ON VIEW api.prediction_accuracy IS 'Retroactive scoring of house predictions by season/model/edge-threshold. Columns: model_version, season, edge_threshold, n_games, n_with_market, margin_mae, margin_rmse, ats_wins, ats_losses, ats_pushes, ats_hit_rate, brier, cfbd_brier, n_scored_win_prob. brier/cfbd_brier let the house win-prob model be benchmarked directly against CFBD''s pregame win probability. Backed by marts.prediction_accuracy.';

--- a/src/schemas/api/032_game_predictions.sql
+++ b/src/schemas/api/032_game_predictions.sql
@@ -1,0 +1,48 @@
+-- api.game_predictions
+-- Latest snapshot per (game, model) from the append-only prediction log:
+-- house Elo + ridge-adjusted-EPA expected margin/win-prob vs the market
+-- line, as of each game's most recent prediction_date.
+-- Thin latest-snapshot view over predictions.game_predictions (Tier 2
+-- analytics, docs/plans/2026-07-21-tier2-analytics-plan.md).
+--
+-- predictions.game_predictions is append-only across days (one immutable row
+-- per game_id/model_version/UTC prediction_date -- see
+-- migrations/024_predictions_schema.sql), so this view picks the most recent
+-- prediction_date per (game_id, model_version) via DISTINCT ON. Query the
+-- base table directly if the full day-by-day history is needed instead.
+--
+-- PostgREST usage:
+--   GET /api/game_predictions?game_id=eq.401628455
+--   GET /api/game_predictions?season=eq.2026&week=eq.5&model_version=eq.house_v1
+
+CREATE OR REPLACE VIEW api.game_predictions AS
+SELECT DISTINCT ON (game_id, model_version)
+    prediction_id,
+    computed_at,
+    prediction_date,
+    model_version,
+    game_id,
+    season,
+    week,
+    season_type,
+    home_team,
+    away_team,
+    neutral_site,
+    home_elo_pregame,
+    away_elo_pregame,
+    elo_margin,
+    epa_margin,
+    expected_home_margin,
+    home_win_prob,
+    market_provider,
+    market_home_margin,
+    market_spread,
+    market_captured_at,
+    edge,
+    edge_pick
+FROM predictions.game_predictions
+ORDER BY game_id, model_version, prediction_date DESC;
+
+GRANT SELECT ON api.game_predictions TO anon, authenticated;
+
+COMMENT ON VIEW api.game_predictions IS 'Latest house prediction snapshot per (game_id, model_version), from the append-only predictions.game_predictions log. Columns: prediction_id, computed_at, prediction_date, model_version, game_id, season, week, season_type, home_team, away_team, neutral_site, home_elo_pregame, away_elo_pregame, elo_margin, epa_margin, expected_home_margin, home_win_prob, market_provider, market_home_margin, market_spread, market_captured_at, edge, edge_pick. DISTINCT ON (game_id, model_version) ORDER BY prediction_date DESC selects the most recent snapshot; query predictions.game_predictions directly for full day-by-day history.';

--- a/src/schemas/functions/refresh_all_marts.sql
+++ b/src/schemas/functions/refresh_all_marts.sql
@@ -9,7 +9,8 @@
 --      team_talent_composite, team_tempo_metrics, transfer_portal_impact
 --   4: team_season_trajectory, conference_era_summary, team_style_profile,
 --      coaching_tenure, recruiting_roi, conference_comparison
---   5: matchup_edges
+--   5: matchup_edges, data_freshness
+--   6: house_elo, house_elo_game, team_adjusted_epa, scored_matchup_edges, prediction_accuracy
 --
 -- Usage:
 --   SELECT * FROM marts.refresh_all();
@@ -173,9 +174,37 @@ BEGIN
             RETURN NEXT;
         END;
     END LOOP;
+
+    -- Layer 6: Tier 2 analytics (read from analytics.* staging + predictions)
+    v_views := ARRAY[
+        'house_elo',
+        'house_elo_game',
+        'team_adjusted_epa',
+        'scored_matchup_edges',
+        'prediction_accuracy'
+    ];
+    v_layer := 6;
+
+    FOREACH v_name IN ARRAY v_views LOOP
+        v_start := clock_timestamp();
+        BEGIN
+            EXECUTE format('REFRESH MATERIALIZED VIEW marts.%I', v_name);
+            v_elapsed := EXTRACT(MILLISECONDS FROM clock_timestamp() - v_start)::bigint;
+            view_name := v_name;
+            duration_ms := v_elapsed;
+            status := format('OK (layer %s)', v_layer);
+            RETURN NEXT;
+        EXCEPTION WHEN OTHERS THEN
+            v_elapsed := EXTRACT(MILLISECONDS FROM clock_timestamp() - v_start)::bigint;
+            view_name := v_name;
+            duration_ms := v_elapsed;
+            status := format('ERROR (layer %s): %s', v_layer, SQLERRM);
+            RETURN NEXT;
+        END;
+    END LOOP;
 END;
 $$;
 
 COMMENT ON FUNCTION marts.refresh_all IS
-'Refreshes all 32 materialized views in the marts schema in dependency order (5 layers). '
+'Refreshes all 37 materialized views in the marts schema in dependency order (6 layers). '
 'Returns timing and status for each view. Errors are caught per-view so one failure does not abort the rest.';

--- a/src/schemas/marts/034_house_elo.sql
+++ b/src/schemas/marts/034_house_elo.sql
@@ -1,0 +1,117 @@
+-- marts.house_elo
+-- Season-end house Elo rating per team per season (Tier 2 analytics,
+-- docs/plans/2026-07-21-tier2-analytics-plan.md).
+-- Grain: (team, season) -- one row per team per season
+-- Source: analytics.house_elo_game, written by scripts/compute_house_elo.py
+--
+-- For each team, takes that team's LAST game of the season (home or away,
+-- ordered by start_date then game_id) and uses that side's POSTGAME Elo as
+-- the season-end rating. games_played counts every game (home + away) the
+-- team appears in that season within analytics.house_elo_game. cfbd_elo is
+-- CFBD's own Elo (ratings.elo_ratings, coverage ~2015+) joined in purely for
+-- side-by-side validation -- it is not used in any computation here.
+
+-- Prerequisite: the staging table this matview reads. DDL is intentionally
+-- duplicated from migrations/025_tier2_analytics_staging.sql (which is
+-- POPULATED by scripts/compute_house_elo.py, not this file) so this mart
+-- stands alone in any provisioning order -- mirrors the 022<->marts/011
+-- precedent. Keep the two definitions in sync.
+CREATE TABLE IF NOT EXISTS analytics.house_elo_game (
+    game_id BIGINT NOT NULL,
+    season BIGINT NOT NULL,
+    week BIGINT,
+    season_type VARCHAR,
+    start_date TIMESTAMPTZ,
+    neutral_site BOOLEAN,
+    home_team VARCHAR NOT NULL,
+    away_team VARCHAR NOT NULL,
+
+    home_pregame_elo NUMERIC(8, 2),
+    away_pregame_elo NUMERIC(8, 2),
+    home_postgame_elo NUMERIC(8, 2),
+    away_postgame_elo NUMERIC(8, 2),
+    home_win_prob NUMERIC(5, 4),
+    expected_home_margin NUMERIC(6, 2),
+    actual_home_margin BIGINT,
+    mov_multiplier NUMERIC(6, 3),
+
+    cfbd_home_pregame_elo NUMERIC(8, 2),
+    cfbd_away_pregame_elo NUMERIC(8, 2)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS house_elo_game_key
+    ON analytics.house_elo_game (game_id);
+
+DROP MATERIALIZED VIEW IF EXISTS marts.house_elo CASCADE;
+
+CREATE MATERIALIZED VIEW marts.house_elo AS
+WITH team_games AS (
+    -- Home-side appearances
+    SELECT
+        home_team AS team,
+        season,
+        home_postgame_elo AS postgame_elo,
+        start_date,
+        game_id
+    FROM analytics.house_elo_game
+
+    UNION ALL
+
+    -- Away-side appearances
+    SELECT
+        away_team AS team,
+        season,
+        away_postgame_elo AS postgame_elo,
+        start_date,
+        game_id
+    FROM analytics.house_elo_game
+),
+season_end AS (
+    -- Each team's most recent game of the season -> that side's postgame Elo
+    -- becomes the season-end rating.
+    SELECT DISTINCT ON (team, season)
+        team,
+        season,
+        postgame_elo AS season_end_elo
+    FROM team_games
+    ORDER BY team, season, start_date DESC NULLS LAST, game_id DESC
+),
+games_count AS (
+    SELECT
+        team,
+        season,
+        COUNT(*) AS games_played
+    FROM team_games
+    GROUP BY team, season
+)
+SELECT
+    se.team,
+    se.season,
+    se.season_end_elo,
+    RANK() OVER (PARTITION BY se.season ORDER BY se.season_end_elo DESC) AS elo_rank,
+    gc.games_played,
+    (gc.games_played < 4 OR se.season < 1900) AS low_confidence,
+    er.elo AS cfbd_elo
+FROM season_end se
+JOIN games_count gc
+    ON gc.team = se.team AND gc.season = se.season
+LEFT JOIN ratings.elo_ratings er
+    ON er.year = se.season AND er.team = se.team;
+
+-- Required for REFRESH CONCURRENTLY
+CREATE UNIQUE INDEX ON marts.house_elo (team, season);
+
+-- Query indexes
+CREATE INDEX ON marts.house_elo (season, elo_rank);
+CREATE INDEX ON marts.house_elo (season);
+
+-- Empty-guard: analytics.house_elo_game backs this mart via
+-- scripts/compute_house_elo.py. If the historical build has not run yet (or
+-- the staging table ever refreshes to zero rows), fail loudly at deploy time
+-- instead of silently serving an empty mart downstream.
+DO $$
+BEGIN
+    IF (SELECT count(*) FROM marts.house_elo) = 0 THEN
+        RAISE EXCEPTION 'marts.house_elo is empty: analytics.house_elo_game has no rows. Run scripts/compute_house_elo.py --full to build the historical house Elo ratings, then refresh this mart before use.';
+    END IF;
+END $$;

--- a/src/schemas/marts/035_house_elo_game.sql
+++ b/src/schemas/marts/035_house_elo_game.sql
@@ -1,0 +1,94 @@
+-- marts.house_elo_game
+-- Game-grain house Elo history (Tier 2 analytics,
+-- docs/plans/2026-07-21-tier2-analytics-plan.md).
+-- Grain: (game_id) -- one row per game
+-- Source: analytics.house_elo_game, written by scripts/compute_house_elo.py
+--
+-- Thin passthrough of every column in analytics.house_elo_game (pregame /
+-- postgame Elo both sides, win prob, expected vs actual margin, CFBD Elo
+-- copies retained for validation), plus two derived columns comparing the
+-- model's pregame expectation to what actually happened:
+--   margin_error     = expected_home_margin - actual_home_margin
+--   abs_margin_error = ABS(margin_error)
+-- Positive margin_error means the model expected the home team to win by
+-- more than it actually did (i.e. it overrated the home side for this game).
+
+-- Prerequisite: the staging table this matview reads. DDL is intentionally
+-- duplicated from migrations/025_tier2_analytics_staging.sql (which is
+-- POPULATED by scripts/compute_house_elo.py, not this file) so this mart
+-- stands alone in any provisioning order -- mirrors the 022<->marts/011
+-- precedent. Keep the two definitions in sync.
+CREATE TABLE IF NOT EXISTS analytics.house_elo_game (
+    game_id BIGINT NOT NULL,
+    season BIGINT NOT NULL,
+    week BIGINT,
+    season_type VARCHAR,
+    start_date TIMESTAMPTZ,
+    neutral_site BOOLEAN,
+    home_team VARCHAR NOT NULL,
+    away_team VARCHAR NOT NULL,
+
+    home_pregame_elo NUMERIC(8, 2),
+    away_pregame_elo NUMERIC(8, 2),
+    home_postgame_elo NUMERIC(8, 2),
+    away_postgame_elo NUMERIC(8, 2),
+    home_win_prob NUMERIC(5, 4),
+    expected_home_margin NUMERIC(6, 2),
+    actual_home_margin BIGINT,
+    mov_multiplier NUMERIC(6, 3),
+
+    cfbd_home_pregame_elo NUMERIC(8, 2),
+    cfbd_away_pregame_elo NUMERIC(8, 2)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS house_elo_game_key
+    ON analytics.house_elo_game (game_id);
+
+DROP MATERIALIZED VIEW IF EXISTS marts.house_elo_game CASCADE;
+
+CREATE MATERIALIZED VIEW marts.house_elo_game AS
+SELECT
+    game_id,
+    season,
+    week,
+    season_type,
+    start_date,
+    neutral_site,
+    home_team,
+    away_team,
+
+    home_pregame_elo,
+    away_pregame_elo,
+    home_postgame_elo,
+    away_postgame_elo,
+    home_win_prob,
+    expected_home_margin,
+    actual_home_margin,
+    mov_multiplier,
+
+    cfbd_home_pregame_elo,
+    cfbd_away_pregame_elo,
+
+    -- Derived: how far off the pregame expectation was from what happened.
+    (expected_home_margin - actual_home_margin) AS margin_error,
+    ABS(expected_home_margin - actual_home_margin) AS abs_margin_error
+FROM analytics.house_elo_game;
+
+-- Required for REFRESH CONCURRENTLY
+CREATE UNIQUE INDEX ON marts.house_elo_game (game_id);
+
+-- Query indexes
+CREATE INDEX ON marts.house_elo_game (season);
+CREATE INDEX ON marts.house_elo_game (home_team, season);
+CREATE INDEX ON marts.house_elo_game (away_team, season);
+
+-- Empty-guard: analytics.house_elo_game backs this mart via
+-- scripts/compute_house_elo.py. If the historical build has not run yet (or
+-- the staging table ever refreshes to zero rows), fail loudly at deploy time
+-- instead of silently serving an empty mart downstream.
+DO $$
+BEGIN
+    IF (SELECT count(*) FROM marts.house_elo_game) = 0 THEN
+        RAISE EXCEPTION 'marts.house_elo_game is empty: analytics.house_elo_game has no rows. Run scripts/compute_house_elo.py --full to build the historical house Elo ratings, then refresh this mart before use.';
+    END IF;
+END $$;

--- a/src/schemas/marts/036_team_adjusted_epa.sql
+++ b/src/schemas/marts/036_team_adjusted_epa.sql
@@ -1,0 +1,82 @@
+-- marts.team_adjusted_epa
+-- Ridge-regressed opponent-adjusted EPA per team-season (Tier 2 analytics,
+-- docs/plans/2026-07-21-tier2-analytics-plan.md).
+-- Grain: (team, season) -- one row per team per season
+-- Source: analytics.adjusted_epa_build, written by scripts/compute_adjusted_epa.py
+--
+-- SIGN CONVENTION (carried over from the staging table -- see
+-- migrations/025_tier2_analytics_staging.sql): off_adj_epa (off_coef) HIGHER
+-- = better offense (more EPA/play above average). def_adj_epa (def_coef)
+-- LOWER / more negative = better defense (EPA *allowed* above average -- a
+-- stingier defense pulls this further negative). net_adj_epa is therefore
+-- computed as (off_coef - def_coef), NOT (off_coef + def_coef): subtracting
+-- a lower (better) def_coef makes net_adj_epa larger, so net_adj_epa HIGHER
+-- = better team overall, matching off_adj_epa's own "higher is better"
+-- direction. def_rank is ordered ASC (most negative def_coef = best defense
+-- = rank 1) to match that same convention.
+--
+-- wepa_total / wepa_allowed_total are CFBD's own opponent-adjusted EPA
+-- (marts.team_wepa_season, itself a passthrough of metrics.wepa_team_season)
+-- joined in purely as a side-by-side sanity comparison against this house
+-- ridge fit -- they are not used in any computation here.
+
+-- Prerequisite: the staging table this matview reads. DDL is intentionally
+-- duplicated from migrations/025_tier2_analytics_staging.sql (which is
+-- POPULATED by scripts/compute_adjusted_epa.py, not this file) so this mart
+-- stands alone in any provisioning order -- mirrors the 022<->marts/011
+-- precedent. Keep the two definitions in sync.
+CREATE TABLE IF NOT EXISTS analytics.adjusted_epa_build (
+    team VARCHAR NOT NULL,
+    season BIGINT NOT NULL,
+    off_coef NUMERIC(8, 5),
+    def_coef NUMERIC(8, 5),
+    hfa_coef NUMERIC(8, 5),
+    mu NUMERIC(8, 5),
+    plays BIGINT,
+    lambda NUMERIC(8, 1),
+    n_teams BIGINT
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS adjusted_epa_build_key
+    ON analytics.adjusted_epa_build (team, season);
+
+DROP MATERIALIZED VIEW IF EXISTS marts.team_adjusted_epa CASCADE;
+
+CREATE MATERIALIZED VIEW marts.team_adjusted_epa AS
+SELECT
+    a.team,
+    a.season,
+    a.off_coef AS off_adj_epa,
+    a.def_coef AS def_adj_epa,
+    (a.off_coef - a.def_coef) AS net_adj_epa,
+    a.hfa_coef,
+    a.plays,
+    a.lambda,
+
+    RANK() OVER (PARTITION BY a.season ORDER BY a.off_coef DESC) AS off_rank,
+    RANK() OVER (PARTITION BY a.season ORDER BY a.def_coef ASC) AS def_rank,
+    RANK() OVER (PARTITION BY a.season ORDER BY (a.off_coef - a.def_coef) DESC) AS net_rank,
+
+    -- CFBD WEPA sanity comparison (see header)
+    w.epa_total AS wepa_total,
+    w.epa_allowed_total AS wepa_allowed_total
+FROM analytics.adjusted_epa_build a
+LEFT JOIN marts.team_wepa_season w
+    ON w.team = a.team AND w.season = a.season;
+
+-- Required for REFRESH CONCURRENTLY
+CREATE UNIQUE INDEX ON marts.team_adjusted_epa (team, season);
+
+-- Query indexes
+CREATE INDEX ON marts.team_adjusted_epa (season, net_rank);
+
+-- Empty-guard: analytics.adjusted_epa_build backs this mart via
+-- scripts/compute_adjusted_epa.py. If the historical fit has not run yet (or
+-- the staging table ever refreshes to zero rows), fail loudly at deploy time
+-- instead of silently serving an empty mart downstream.
+DO $$
+BEGIN
+    IF (SELECT count(*) FROM marts.team_adjusted_epa) = 0 THEN
+        RAISE EXCEPTION 'marts.team_adjusted_epa is empty: analytics.adjusted_epa_build has no rows. Run scripts/compute_adjusted_epa.py --from 2004 to build the historical ridge fit, then refresh this mart before use.';
+    END IF;
+END $$;

--- a/src/schemas/marts/037_scored_matchup_edges.sql
+++ b/src/schemas/marts/037_scored_matchup_edges.sql
@@ -1,0 +1,90 @@
+-- marts.scored_matchup_edges
+-- =============================================================================
+-- Tier 2 analytics (docs/plans/2026-07-21-tier2-analytics-plan.md), Phase 4.
+--
+-- The FORWARD-LOOKING surface: house expected margin vs the market line for
+-- UPCOMING (not-yet-completed) games only. One row per (game_id, model_version):
+-- the LATEST prediction snapshot for that game+model, chosen by
+-- DISTINCT ON (game_id, model_version) ORDER BY prediction_date DESC. As new
+-- daily snapshots land in predictions.game_predictions the mart re-materializes
+-- to the freshest read on each game.
+--
+-- Grain: (game_id, model_version). scripts/compute_predictions.py writes TWO
+-- model_versions for every game -- 'elo_v1' (Elo-only expected margin) and
+-- 'elo_epa_blend_v1' (0.6*Elo + 0.4*ridge-EPA blend) -- so each upcoming game
+-- appears twice, once per model. home_win_prob is Elo-only in BOTH rows
+-- (the blend only changes the expected margin, not the win probability).
+--
+-- EDGE CONVENTION (matches api/003_game_detail.sql cover logic and migration
+-- 024's column semantics):
+--   market_home_margin = -market_spread   (negative spread => home favored)
+--   edge = expected_home_margin + market_spread
+--   edge > 0  => model's expected home margin beats the market => home is
+--               undervalued => edge_pick = 'home'; edge <= 0 => edge_pick = 'away'.
+--   abs_edge = ABS(edge) is the conviction magnitude consumers rank by.
+--
+-- NULL-MARKET ROWS: a game with no line yet (market_spread IS NULL) has a NULL
+-- edge (and NULL abs_edge) written upstream -- it is still LISTED here (the
+-- house expected margin is meaningful on its own) but is UNSCOREABLE against a
+-- market until a line posts. Consumers should sort by abs_edge DESC and treat
+-- NULLs as "no ranked edge" -- the abs_edge index is DESC NULLS LAST for exactly
+-- this ordering.
+--
+-- NO EMPTY-GUARD (by design): this mart is legitimately EMPTY out of season and
+-- until the Phase 5 predictions backfill / in-season daily runs populate
+-- predictions.game_predictions. An empty result is a valid state, not a failure,
+-- so it must not RAISE at deploy time (unlike the Tier 1 marts).
+--
+-- Source: predictions.game_predictions p JOIN core.games g ON g.id = p.game_id,
+-- filtered to NOT COALESCE(g.completed, false).
+
+DROP MATERIALIZED VIEW IF EXISTS marts.scored_matchup_edges CASCADE;
+
+CREATE MATERIALIZED VIEW marts.scored_matchup_edges AS
+SELECT DISTINCT ON (p.game_id, p.model_version)
+    p.game_id,
+    p.season,
+    p.week,
+    p.season_type,
+    g.start_date,
+    p.home_team,
+    p.away_team,
+    p.neutral_site,
+
+    p.model_version,
+    p.prediction_date,
+
+    -- House ratings / expected margins
+    p.home_elo_pregame,
+    p.away_elo_pregame,
+    p.elo_margin,
+    p.epa_margin,
+    p.expected_home_margin,
+    p.home_win_prob,
+
+    -- Market line (as captured in the snapshot)
+    p.market_provider,
+    p.market_spread,
+    p.market_home_margin,
+    p.market_captured_at,
+
+    -- Edge = expected_home_margin + market_spread (>0 => home undervalued).
+    -- NULL when no market line has posted yet: listed but unscoreable.
+    p.edge,
+    p.edge_pick,
+    ABS(p.edge) AS abs_edge
+
+FROM predictions.game_predictions p
+JOIN core.games g ON g.id = p.game_id
+WHERE NOT COALESCE(g.completed, false)
+ORDER BY p.game_id, p.model_version, p.prediction_date DESC;
+
+-- Required for REFRESH CONCURRENTLY; also the natural grain key. DISTINCT ON
+-- (game_id, model_version) guarantees one row per pair, so this is unique.
+CREATE UNIQUE INDEX ON marts.scored_matchup_edges (game_id, model_version);
+
+-- Query indexes
+CREATE INDEX ON marts.scored_matchup_edges (season, week);
+
+-- Consumers rank the slate by conviction; NULLs (no line yet) sort last.
+CREATE INDEX ON marts.scored_matchup_edges (abs_edge DESC NULLS LAST);

--- a/src/schemas/marts/038_prediction_accuracy.sql
+++ b/src/schemas/marts/038_prediction_accuracy.sql
@@ -223,14 +223,14 @@ SELECT
     edge_threshold,
     n_games,
     n_with_market,
-    ROUND(margin_mae, 4) AS margin_mae,
-    ROUND(margin_rmse, 4) AS margin_rmse,
+    ROUND(margin_mae::numeric, 4) AS margin_mae,
+    ROUND(margin_rmse::numeric, 4) AS margin_rmse,
     ats_wins,
     ats_losses,
     ats_pushes,
     ROUND(ats_wins::numeric / NULLIF(ats_wins + ats_losses, 0), 4) AS ats_hit_rate,
-    ROUND(brier, 6) AS brier,
-    ROUND(cfbd_brier, 6) AS cfbd_brier,
+    ROUND(brier::numeric, 6) AS brier,
+    ROUND(cfbd_brier::numeric, 6) AS cfbd_brier,
     n_scored_win_prob
 FROM agg;
 

--- a/src/schemas/marts/038_prediction_accuracy.sql
+++ b/src/schemas/marts/038_prediction_accuracy.sql
@@ -1,0 +1,241 @@
+-- marts.prediction_accuracy
+-- =============================================================================
+-- Tier 2 analytics (docs/plans/2026-07-21-tier2-analytics-plan.md), Phase 4/5.
+--
+-- THE BACKTEST / AUDIT SURFACE. This file IS the prediction-scoring methodology
+-- for the house model -- every rule below is authoritative and intentionally
+-- documented in full so the numbers are reproducible from the SQL alone.
+--
+-- Grain: (model_version, season, edge_threshold). scripts/compute_predictions.py
+-- writes TWO model_versions per historical game -- 'elo_v1' (Elo-only expected
+-- margin) and 'elo_epa_blend_v1' (0.6*Elo + 0.4*ridge-EPA blend); home_win_prob
+-- is Elo-only in BOTH. Each (model_version, season) is scored at FOUR edge
+-- thresholds via CROSS JOIN (VALUES (0),(3),(6),(10)) t(edge_threshold), so a
+-- consumer can read "how did this model do when it only bet games it liked by
+-- >= t points."
+--
+-- ---------------------------------------------------------------------------
+-- SCORING BASE
+-- ---------------------------------------------------------------------------
+-- One row per (game_id, model_version): the LATEST prediction snapshot,
+-- DISTINCT ON (game_id, model_version) ORDER BY prediction_date DESC, joined to
+-- core.games and restricted to COMPLETED games that actually have both scores
+-- (home_points/away_points NOT NULL). Derived per game:
+--   actual_home_margin  = home_points - away_points
+--   actual_home_result  = 1.0 if home won, 0.5 if tied, 0.0 if home lost
+--                         (ties are rare/effectively nonexistent in the modern
+--                          era; scored as 0.5 for Brier, and treated as PUSHES
+--                          -- i.e. excluded -- in ATS below).
+-- CFBD's own pregame number is pulled via a 1:1 LEFT JOIN to
+-- metrics.pregame_win_probability (home_win_probability) AFTER the DISTINCT ON,
+-- so the win-prob join can never fan out the "latest snapshot" selection.
+--
+-- ---------------------------------------------------------------------------
+-- THRESHOLD SEMANTICS (each row is self-consistent -- a deliberate choice)
+-- ---------------------------------------------------------------------------
+-- A game "qualifies" for a threshold row when:
+--   edge_threshold = 0  -> ALL scored games qualify, INCLUDING NULL-market ones
+--                          (edge may be NULL). The t=0 row is the unconditional
+--                          "every game the model predicted" baseline.
+--   edge_threshold > 0  -> edge IS NOT NULL AND ABS(edge) >= edge_threshold.
+--                          (edge is NULL exactly when no market line existed, so
+--                           t>0 rows are automatically market-only.)
+-- Every metric in a row is computed over THAT row's qualifying population, so a
+-- row is internally consistent: margin error, ATS record, and Brier all describe
+-- the same slice of games the model flagged at that threshold. The t=0 row is
+-- therefore the only one where margin_mae/margin_rmse are the whole-season "all
+-- games" numbers; higher-threshold rows recompute the same formulas over the
+-- |edge| >= t subset rather than reusing the t=0 value.
+--
+-- ---------------------------------------------------------------------------
+-- METRIC DEFINITIONS
+-- ---------------------------------------------------------------------------
+-- n_games      : count of qualifying games (t=0 includes NULL-market games).
+-- n_with_market: qualifying games that carry a market_spread (for t>0 this
+--                equals n_games; it only differs at t=0).
+-- margin_mae   : AVG(ABS(expected_home_margin - actual_home_margin)) over the
+--                qualifying games.
+-- margin_rmse  : SQRT(AVG(POWER(expected_home_margin - actual_home_margin, 2)))
+--                over the qualifying games.
+--
+-- ATS (against-the-spread) -- ONLY games with market_spread NOT NULL AND
+-- |edge| >= t (so ties/pushes and NULL-market games never inflate the record):
+--   cover math uses the same convention as api/003_game_detail.sql and the edge
+--   sign: home covers when (actual_home_margin + market_spread) > 0.
+--   The model's pick WINS  when:
+--       (edge_pick = 'home' AND actual_home_margin + market_spread > 0) OR
+--       (edge_pick = 'away' AND actual_home_margin + market_spread < 0)
+--   PUSH when actual_home_margin + market_spread = 0 (excluded from hit rate).
+--   LOSS otherwise.
+--   ats_wins / ats_losses / ats_pushes are counts; ats_hit_rate =
+--   ats_wins::numeric / NULLIF(ats_wins + ats_losses, 0) -- pushes excluded from
+--   the denominator, NULL when there are no decided ATS games.
+--
+-- BRIER (probability calibration) -- computed over the SAME subset for the house
+-- model and CFBD so the comparison is meaningful: games in the qualifying
+-- population where BOTH home_win_prob AND CFBD's home_win_probability are present
+-- (inner-present intersection). n_scored_win_prob is exactly that subset's size.
+--   brier      = AVG(POWER(home_win_prob      - actual_home_result, 2))
+--   cfbd_brier = AVG(POWER(cfbd_home_win_prob - actual_home_result, 2))
+--   Both over the identical n_scored_win_prob games -- a same-subset comparison,
+--   otherwise the numbers are not comparable. Lower is better.
+--
+-- ---------------------------------------------------------------------------
+-- CAVEATS (read before trusting a row)
+-- ---------------------------------------------------------------------------
+-- * LEAKAGE: 'elo_epa_blend_v1' folds in ridge-adjusted EPA that is fit on the
+--   FULL season, so retro rows for early-season games are MILDLY LEAKY (the fit
+--   "saw" games that hadn't happened yet at kickoff). Treat 'elo_v1' as the
+--   LEAK-FREE reference -- its Elo pregame ratings are strictly sequential, so
+--   its backtest metrics are honest walk-forward numbers. Compare the blend
+--   against elo_v1, not against its own optimism.
+-- * CLOSING-LINE PROXY: past-game market_spread comes from betting.lines, which
+--   is approximately the CLOSING line. True line-movement history only begins
+--   accruing 2026-07-21, so pre-2026 ATS/edge figures are scored against
+--   closing, not against the number the model would have seen earlier in the week.
+--
+-- NO EMPTY-GUARD (by design): legitimately EMPTY until the Phase 5 predictions
+-- backfill populates predictions.game_predictions with completed-game snapshots.
+
+DROP MATERIALIZED VIEW IF EXISTS marts.prediction_accuracy CASCADE;
+
+CREATE MATERIALIZED VIEW marts.prediction_accuracy AS
+WITH latest_pred AS (
+    -- Latest snapshot per (game_id, model_version) for completed, scored games.
+    SELECT DISTINCT ON (p.game_id, p.model_version)
+        p.game_id,
+        p.model_version,
+        p.season,
+        p.expected_home_margin,
+        p.home_win_prob,
+        p.market_spread,
+        p.edge,
+        p.edge_pick,
+        g.home_points,
+        g.away_points
+    FROM predictions.game_predictions p
+    JOIN core.games g ON g.id = p.game_id
+    WHERE g.completed
+      AND g.home_points IS NOT NULL
+      AND g.away_points IS NOT NULL
+    ORDER BY p.game_id, p.model_version, p.prediction_date DESC
+),
+scored AS (
+    -- Attach actuals + CFBD's pregame win prob (1:1 join, post-DISTINCT ON).
+    SELECT
+        lp.model_version,
+        lp.season,
+        lp.game_id,
+        lp.expected_home_margin,
+        lp.home_win_prob,
+        lp.market_spread,
+        lp.edge,
+        lp.edge_pick,
+        (lp.home_points - lp.away_points)::numeric AS actual_home_margin,
+        (CASE
+            WHEN lp.home_points > lp.away_points THEN 1.0
+            WHEN lp.home_points = lp.away_points THEN 0.5
+            ELSE 0.0
+        END)::numeric AS actual_home_result,
+        wp.home_win_probability AS cfbd_home_win_prob
+    FROM latest_pred lp
+    LEFT JOIN metrics.pregame_win_probability wp ON wp.game_id = lp.game_id
+),
+expanded AS (
+    -- Fan each scored game out across the four edge thresholds and mark
+    -- whether it qualifies for that threshold's population.
+    SELECT
+        s.*,
+        th.edge_threshold,
+        (
+            th.edge_threshold = 0
+            OR (s.edge IS NOT NULL AND ABS(s.edge) >= th.edge_threshold)
+        ) AS qualifies
+    FROM scored s
+    CROSS JOIN (VALUES (0), (3), (6), (10)) AS th(edge_threshold)
+),
+agg AS (
+    SELECT
+        model_version,
+        season,
+        edge_threshold,
+
+        COUNT(*) FILTER (WHERE qualifies) AS n_games,
+        COUNT(*) FILTER (WHERE qualifies AND market_spread IS NOT NULL) AS n_with_market,
+
+        -- Margin error over the qualifying population (self-consistent per row).
+        AVG(ABS(expected_home_margin - actual_home_margin))
+            FILTER (WHERE qualifies) AS margin_mae,
+        SQRT(
+            AVG(POWER(expected_home_margin - actual_home_margin, 2))
+                FILTER (WHERE qualifies)
+        ) AS margin_rmse,
+
+        -- ATS record: market required and |edge| >= t; pushes (margin+spread=0)
+        -- excluded from wins/losses.
+        COUNT(*) FILTER (
+            WHERE qualifies
+              AND market_spread IS NOT NULL
+              AND (actual_home_margin + market_spread) <> 0
+              AND (
+                  (edge_pick = 'home' AND actual_home_margin + market_spread > 0)
+               OR (edge_pick = 'away' AND actual_home_margin + market_spread < 0)
+              )
+        ) AS ats_wins,
+        COUNT(*) FILTER (
+            WHERE qualifies
+              AND market_spread IS NOT NULL
+              AND (actual_home_margin + market_spread) <> 0
+              AND NOT (
+                  (edge_pick = 'home' AND actual_home_margin + market_spread > 0)
+               OR (edge_pick = 'away' AND actual_home_margin + market_spread < 0)
+              )
+        ) AS ats_losses,
+        COUNT(*) FILTER (
+            WHERE qualifies
+              AND market_spread IS NOT NULL
+              AND (actual_home_margin + market_spread) = 0
+        ) AS ats_pushes,
+
+        -- Brier over the same-subset intersection (both win probs present).
+        AVG(POWER(home_win_prob - actual_home_result, 2)) FILTER (
+            WHERE qualifies
+              AND home_win_prob IS NOT NULL
+              AND cfbd_home_win_prob IS NOT NULL
+        ) AS brier,
+        AVG(POWER(cfbd_home_win_prob - actual_home_result, 2)) FILTER (
+            WHERE qualifies
+              AND home_win_prob IS NOT NULL
+              AND cfbd_home_win_prob IS NOT NULL
+        ) AS cfbd_brier,
+        COUNT(*) FILTER (
+            WHERE qualifies
+              AND home_win_prob IS NOT NULL
+              AND cfbd_home_win_prob IS NOT NULL
+        ) AS n_scored_win_prob
+
+    FROM expanded
+    GROUP BY model_version, season, edge_threshold
+)
+SELECT
+    model_version,
+    season,
+    edge_threshold,
+    n_games,
+    n_with_market,
+    ROUND(margin_mae, 4) AS margin_mae,
+    ROUND(margin_rmse, 4) AS margin_rmse,
+    ats_wins,
+    ats_losses,
+    ats_pushes,
+    ROUND(ats_wins::numeric / NULLIF(ats_wins + ats_losses, 0), 4) AS ats_hit_rate,
+    ROUND(brier, 6) AS brier,
+    ROUND(cfbd_brier, 6) AS cfbd_brier,
+    n_scored_win_prob
+FROM agg;
+
+-- Required for REFRESH CONCURRENTLY; also the natural grain key.
+CREATE UNIQUE INDEX ON marts.prediction_accuracy (model_version, season, edge_threshold);
+
+-- Query index: pull one model's threshold curve across seasons.
+CREATE INDEX ON marts.prediction_accuracy (model_version, edge_threshold);

--- a/src/schemas/migrations/024_predictions_schema.sql
+++ b/src/schemas/migrations/024_predictions_schema.sql
@@ -1,0 +1,73 @@
+-- Predictions schema: append-only house prediction snapshots
+-- =============================================================================
+-- Tier 2 analytics (docs/plans/2026-07-21-tier2-analytics-plan.md), Phase 1.
+--
+-- predictions.game_predictions holds one immutable snapshot row per
+-- (game, model_version, UTC prediction_date): house Elo + ridge-adjusted-EPA
+-- expected margin/win-prob, compared against the market line, with the
+-- resulting edge. Rows are append-only across days -- the same-day
+-- ON CONFLICT DO UPDATE only lets a re-run *converge* today's snapshot
+-- (e.g. a market line refresh later the same UTC day), it never overwrites
+-- a prior day's row. That gives an auditable history of how the model's
+-- read on a game evolved as kickoff approached, which marts.prediction_accuracy
+-- (Phase 4) scores retroactively for MAE/ATS/Brier.
+--
+-- Writer: scripts/compute_predictions.py (Phase 5 of the plan). Nothing reads
+-- this table yet -- it is created empty here so schema and grants are in
+-- place before the compute script and marts land.
+--
+-- Not in MIGRATION_ORDER: applied via run_migrations.py --file (deploy
+-- manifest), like 019-023. Idempotent (IF NOT EXISTS throughout).
+
+CREATE SCHEMA IF NOT EXISTS predictions;
+
+CREATE TABLE IF NOT EXISTS predictions.game_predictions (
+    prediction_id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    computed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    prediction_date DATE NOT NULL DEFAULT ((now() AT TIME ZONE 'utc')::date),
+    model_version TEXT NOT NULL,
+
+    game_id BIGINT NOT NULL,
+    season BIGINT,
+    week BIGINT,
+    season_type VARCHAR,
+    home_team VARCHAR NOT NULL,
+    away_team VARCHAR NOT NULL,
+    neutral_site BOOLEAN,
+
+    home_elo_pregame NUMERIC(8, 2),
+    away_elo_pregame NUMERIC(8, 2),
+    elo_margin NUMERIC(6, 2),
+    epa_margin NUMERIC(6, 2),
+    expected_home_margin NUMERIC(6, 2),
+    home_win_prob NUMERIC(5, 4),
+
+    market_provider VARCHAR,
+    market_home_margin NUMERIC(6, 2),
+    market_spread NUMERIC(6, 2),
+    market_captured_at TIMESTAMPTZ,
+
+    edge NUMERIC(6, 2),
+    edge_pick VARCHAR
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS game_predictions_daily_key
+    ON predictions.game_predictions (game_id, model_version, prediction_date);
+
+CREATE INDEX IF NOT EXISTS game_predictions_game_id_idx
+    ON predictions.game_predictions (game_id);
+
+CREATE INDEX IF NOT EXISTS game_predictions_season_week_idx
+    ON predictions.game_predictions (season, week);
+
+CREATE INDEX IF NOT EXISTS game_predictions_computed_at_idx
+    ON predictions.game_predictions (computed_at);
+
+COMMENT ON TABLE predictions.game_predictions IS
+    'Append-only house prediction snapshots: one immutable row per (game_id, model_version, UTC prediction_date), same-day ON CONFLICT DO UPDATE for intra-day convergence only. Written by scripts/compute_predictions.py; scored by marts.prediction_accuracy.';
+
+-- Grant USAGE + read-only SELECT per the repo's read-access pattern
+-- (see grant_read_access_for_security_invoker.sql).
+GRANT USAGE ON SCHEMA predictions TO anon, authenticated;
+GRANT SELECT ON ALL TABLES IN SCHEMA predictions TO anon, authenticated;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON ALL TABLES IN SCHEMA predictions FROM anon, authenticated;

--- a/src/schemas/migrations/025_tier2_analytics_staging.sql
+++ b/src/schemas/migrations/025_tier2_analytics_staging.sql
@@ -1,0 +1,110 @@
+-- Tier 2 analytics staging tables: house Elo + ridge-adjusted EPA
+-- =============================================================================
+-- Tier 2 analytics (docs/plans/2026-07-21-tier2-analytics-plan.md), Phase 1.
+--
+-- Three analytics.* staging tables populated by the Python compute scripts:
+--   - analytics.house_elo_game / analytics.house_elo_current, written by
+--     scripts/compute_house_elo.py (Phase 2)
+--   - analytics.adjusted_epa_build, written by scripts/compute_adjusted_epa.py
+--     (Phase 3)
+-- Both scripts write idempotently, per season, via DELETE+INSERT (never a
+-- single giant statement -- see 022's header for why that matters on this
+-- compute tier). These tables are created empty here; nothing reads them
+-- until the compute scripts and marts 034-036 land in later phases.
+--
+-- analytics.* is contract-internal (docs/SCHEMA_CONTRACT.md) -- downstream
+-- consumers must read the marts, never these tables directly.
+--
+-- NOTE: these CREATE TABLEs are intentionally duplicated IF-NOT-EXISTS in the
+-- consuming marts (034-036), mirroring the 022<->marts/011 precedent so each
+-- mart file stands alone in any provisioning order; keep the definitions
+-- in sync.
+--
+-- Not in MIGRATION_ORDER: applied via run_migrations.py --file (deploy
+-- manifest), like 019-024. Idempotent (IF NOT EXISTS throughout).
+
+-- -----------------------------------------------------------------------------
+-- House Elo: game-grain history (pregame/postgame Elo both sides, win prob,
+-- expected vs actual margin, CFBD Elo copies retained for validation).
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS analytics.house_elo_game (
+    game_id BIGINT NOT NULL,
+    season BIGINT NOT NULL,
+    week BIGINT,
+    season_type VARCHAR,
+    start_date TIMESTAMPTZ,
+    neutral_site BOOLEAN,
+    home_team VARCHAR NOT NULL,
+    away_team VARCHAR NOT NULL,
+
+    home_pregame_elo NUMERIC(8, 2),
+    away_pregame_elo NUMERIC(8, 2),
+    home_postgame_elo NUMERIC(8, 2),
+    away_postgame_elo NUMERIC(8, 2),
+    home_win_prob NUMERIC(5, 4),
+    expected_home_margin NUMERIC(6, 2),
+    actual_home_margin BIGINT,
+    mov_multiplier NUMERIC(6, 3),
+
+    cfbd_home_pregame_elo NUMERIC(8, 2),
+    cfbd_away_pregame_elo NUMERIC(8, 2)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS house_elo_game_key
+    ON analytics.house_elo_game (game_id);
+
+CREATE INDEX IF NOT EXISTS house_elo_game_season_idx
+    ON analytics.house_elo_game (season);
+
+CREATE INDEX IF NOT EXISTS house_elo_game_home_team_season_idx
+    ON analytics.house_elo_game (home_team, season);
+
+CREATE INDEX IF NOT EXISTS house_elo_game_away_team_season_idx
+    ON analytics.house_elo_game (away_team, season);
+
+-- -----------------------------------------------------------------------------
+-- House Elo: live per-team rating snapshot (one row per team, most recent
+-- rating carried forward across seasons per the plan's carryover rule).
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS analytics.house_elo_current (
+    team VARCHAR NOT NULL,
+    season BIGINT,
+    rating NUMERIC(8, 2) NOT NULL,
+    games_played BIGINT,
+    last_game_id BIGINT,
+    last_game_date TIMESTAMPTZ,
+    low_confidence BOOLEAN,
+    updated_at TIMESTAMPTZ
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS house_elo_current_key
+    ON analytics.house_elo_current (team);
+
+-- -----------------------------------------------------------------------------
+-- Ridge-adjusted EPA: one row per (team, season) with the fitted
+-- offense/defense coefficients from scripts/compute_adjusted_epa.py.
+--
+-- Sign convention: off_coef higher = better offense (more EPA/play above
+-- average); def_coef LOWER / more negative = better defense (EPA *allowed*
+-- above average -- a stingier defense pulls this further negative). lambda
+-- is the ridge penalty used for that row's fit, recorded per row (not just
+-- documented in code) so historical fits stay auditable even if the tunable
+-- ledger value changes later.
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS analytics.adjusted_epa_build (
+    team VARCHAR NOT NULL,
+    season BIGINT NOT NULL,
+    off_coef NUMERIC(8, 5),
+    def_coef NUMERIC(8, 5),
+    hfa_coef NUMERIC(8, 5),
+    mu NUMERIC(8, 5),
+    plays BIGINT,
+    lambda NUMERIC(8, 1),
+    n_teams BIGINT
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS adjusted_epa_build_key
+    ON analytics.adjusted_epa_build (team, season);
+
+COMMENT ON TABLE analytics.adjusted_epa_build IS
+    'Ridge-regressed opponent-adjusted EPA per (team, season). Sign convention: off_coef higher = better offense; def_coef LOWER/more negative = better defense (EPA allowed above average). lambda is the ridge penalty recorded per row for auditability across tunable-ledger changes.';

--- a/tests/test_adjusted_epa.py
+++ b/tests/test_adjusted_epa.py
@@ -1,0 +1,206 @@
+"""Unit tests for the ridge-adjusted EPA solver core (no DB).
+
+Covers scripts/compute_adjusted_epa.py's RidgeAccumulator: synthetic-league
+coefficient recovery, lambda -> infinity shrinkage, home-field-advantage
+recovery, and exact XtX/Xty accumulation against an independently built
+dense design matrix.
+"""
+
+import pytest
+
+pytest.importorskip("numpy")
+
+import numpy as np  # noqa: E402
+
+from scripts.compute_adjusted_epa import RidgeAccumulator  # noqa: E402
+
+TEAMS = ["Alpha", "Bravo", "Charlie", "Delta"]
+
+
+def _generate_synthetic_league(
+    n_plays: int,
+    seed: int,
+    mu_true: float,
+    hfa_true: float,
+    off_true: dict[str, float],
+    def_true: dict[str, float],
+    noise_sd: float,
+    teams: list[str] = TEAMS,
+) -> list[tuple[str, str, bool, float]]:
+    """Deterministically generate plays for a small synthetic league.
+
+    epa = mu + off_true[off] + def_true[def] + hfa * is_home_offense + noise
+    """
+    rng = np.random.default_rng(seed)
+    plays = []
+    for _ in range(n_plays):
+        off_team, def_team = rng.choice(teams, size=2, replace=False)
+        is_home_offense = bool(rng.integers(0, 2))
+        noise = rng.normal(0.0, noise_sd)
+        epa = mu_true + off_true[off_team] + def_true[def_team] + hfa_true * is_home_offense + noise
+        plays.append((str(off_team), str(def_team), is_home_offense, float(epa)))
+    return plays
+
+
+MU_TRUE = 0.05
+HFA_TRUE = 0.05
+OFF_TRUE = {"Alpha": 0.12, "Bravo": -0.05, "Charlie": 0.20, "Delta": -0.15}
+DEF_TRUE = {"Alpha": -0.08, "Bravo": 0.03, "Charlie": -0.02, "Delta": 0.10}
+NOISE_SD = 0.02
+N_PLAYS = 2000
+
+
+def _fit_synthetic_league(lam: float):
+    plays = _generate_synthetic_league(
+        n_plays=N_PLAYS,
+        seed=42,
+        mu_true=MU_TRUE,
+        hfa_true=HFA_TRUE,
+        off_true=OFF_TRUE,
+        def_true=DEF_TRUE,
+        noise_sd=NOISE_SD,
+    )
+    accumulator = RidgeAccumulator(TEAMS)
+    accumulator.add_plays(plays)
+    mu, hfa, off_coef, def_coef, n_plays = accumulator.solve(lam)
+    return plays, mu, hfa, off_coef, def_coef, n_plays
+
+
+class TestSyntheticRecovery:
+    """A small ridge fit (lam=1.0) should recover team effects closely."""
+
+    def test_recovers_centered_offense_effects(self):
+        _, _mu, _hfa, off_coef, _def_coef, _n = _fit_synthetic_league(lam=1.0)
+
+        off_mean = np.mean(list(off_coef.values()))
+        true_mean = np.mean(list(OFF_TRUE.values()))
+        for team in TEAMS:
+            fitted_centered = off_coef[team] - off_mean
+            true_centered = OFF_TRUE[team] - true_mean
+            assert abs(fitted_centered - true_centered) < 0.02, (
+                f"{team}: fitted_centered={fitted_centered:.4f} true_centered={true_centered:.4f}"
+            )
+
+    def test_recovers_centered_defense_effects(self):
+        _, _mu, _hfa, _off_coef, def_coef, _n = _fit_synthetic_league(lam=1.0)
+
+        def_mean = np.mean(list(def_coef.values()))
+        true_mean = np.mean(list(DEF_TRUE.values()))
+        for team in TEAMS:
+            fitted_centered = def_coef[team] - def_mean
+            true_centered = DEF_TRUE[team] - true_mean
+            assert abs(fitted_centered - true_centered) < 0.02, (
+                f"{team}: fitted_centered={fitted_centered:.4f} true_centered={true_centered:.4f}"
+            )
+
+    def test_n_plays_matches_generated_count(self):
+        _, _mu, _hfa, _off_coef, _def_coef, n_plays = _fit_synthetic_league(lam=1.0)
+        assert n_plays == N_PLAYS
+
+
+class TestHomeFieldAdvantageRecovery:
+    """hfa is unpenalized and should recover close to its true value."""
+
+    def test_hfa_recovered_within_tolerance(self):
+        _, _mu, hfa, _off_coef, _def_coef, _n = _fit_synthetic_league(lam=1.0)
+        assert abs(hfa - HFA_TRUE) < 0.02
+
+
+class TestShrinkage:
+    """As lam -> infinity, team coefficients vanish and mu -> overall mean EPA."""
+
+    def test_team_coefficients_shrink_to_zero(self):
+        _, _mu, _hfa, off_coef, def_coef, _n = _fit_synthetic_league(lam=1e9)
+        for team in TEAMS:
+            assert abs(off_coef[team]) < 1e-3, f"off[{team}]={off_coef[team]}"
+            assert abs(def_coef[team]) < 1e-3, f"def[{team}]={def_coef[team]}"
+
+    def test_mu_approaches_overall_mean_epa(self):
+        # With team coefficients pinned to ~0, mu/hfa reduce to the OLS fit of
+        # epa ~ mu + hfa * is_home_offense alone (a 2-level ANOVA): mu is the
+        # away-offense (is_home_offense=False) group mean and mu + hfa is the
+        # home-offense group mean. hfa_true is nonzero here, so mu converges
+        # to that away-group mean rather than the raw all-plays average.
+        plays, mu, _hfa, _off_coef, _def_coef, _n = _fit_synthetic_league(lam=1e9)
+        away_epa = [epa for _off, _def, is_home, epa in plays if not is_home]
+        mean_away_epa = float(np.mean(away_epa))
+        assert abs(mu - mean_away_epa) < 0.01
+
+
+class TestAccumulatorCorrectness:
+    """A tiny 5-play fixture: accumulator XtX/Xty must exactly match a
+    dense design matrix built independently in the test."""
+
+    def test_xtx_xty_match_dense_construction(self):
+        teams = ["Alpha", "Bravo", "Charlie"]
+        # (off_team, def_team, is_home_offense, epa)
+        plays = [
+            ("Alpha", "Bravo", True, 0.5),
+            ("Bravo", "Alpha", False, -0.2),
+            ("Charlie", "Alpha", True, 0.1),
+            ("Alpha", "Charlie", False, 0.3),
+            ("Bravo", "Charlie", True, -0.4),
+        ]
+
+        # Columns: [mu, hfa, off_Alpha, off_Bravo, off_Charlie,
+        #           def_Alpha, def_Bravo, def_Charlie]
+        off_col = {"Alpha": 2, "Bravo": 3, "Charlie": 4}
+        def_col = {"Alpha": 5, "Bravo": 6, "Charlie": 7}
+
+        rows = []
+        y = []
+        for off_team, def_team, is_home_offense, epa in plays:
+            row = [0.0] * 8
+            row[0] = 1.0
+            row[1] = 1.0 if is_home_offense else 0.0
+            row[off_col[off_team]] = 1.0
+            row[def_col[def_team]] = 1.0
+            rows.append(row)
+            y.append(epa)
+
+        x_dense = np.array(rows, dtype=np.float64)
+        y_dense = np.array(y, dtype=np.float64)
+        xtx_expected = x_dense.T @ x_dense
+        xty_expected = x_dense.T @ y_dense
+
+        accumulator = RidgeAccumulator(teams)
+        accumulator.add_plays(plays)
+
+        assert accumulator.xtx.shape == (8, 8)
+        assert accumulator.xty.shape == (8,)
+        np.testing.assert_allclose(accumulator.xtx, xtx_expected, atol=1e-10)
+        np.testing.assert_allclose(accumulator.xty, xty_expected, atol=1e-10)
+
+    def test_off_play_counts_track_offensive_plays_per_team(self):
+        teams = ["Alpha", "Bravo", "Charlie"]
+        plays = [
+            ("Alpha", "Bravo", True, 0.5),
+            ("Bravo", "Alpha", False, -0.2),
+            ("Charlie", "Alpha", True, 0.1),
+            ("Alpha", "Charlie", False, 0.3),
+            ("Bravo", "Charlie", True, -0.4),
+        ]
+        accumulator = RidgeAccumulator(teams)
+        accumulator.add_plays(plays)
+
+        counts = dict(zip(teams, accumulator.off_play_counts.tolist(), strict=True))
+        assert counts == {"Alpha": 2, "Bravo": 2, "Charlie": 1}
+        assert accumulator.n_plays == 5
+
+    def test_add_play_matches_add_plays(self):
+        teams = ["Alpha", "Bravo", "Charlie"]
+        plays = [
+            ("Alpha", "Bravo", True, 0.5),
+            ("Bravo", "Alpha", False, -0.2),
+            ("Charlie", "Alpha", True, 0.1),
+        ]
+
+        via_add_play = RidgeAccumulator(teams)
+        for off_team, def_team, is_home_offense, epa in plays:
+            via_add_play.add_play(off_team, def_team, is_home_offense, epa)
+
+        via_add_plays = RidgeAccumulator(teams)
+        via_add_plays.add_plays(plays)
+
+        np.testing.assert_allclose(via_add_play.xtx, via_add_plays.xtx)
+        np.testing.assert_allclose(via_add_play.xty, via_add_plays.xty)

--- a/tests/test_api_views.py
+++ b/tests/test_api_views.py
@@ -268,6 +268,108 @@ POLL_RANKINGS_COLUMNS = {
     "points",
 }
 
+TEAM_ELO_COLUMNS = {
+    "team",
+    "season",
+    "season_end_elo",
+    "elo_rank",
+    "games_played",
+    "low_confidence",
+    "cfbd_elo",
+}
+
+GAME_ELO_HISTORY_COLUMNS = {
+    "game_id",
+    "season",
+    "week",
+    "season_type",
+    "start_date",
+    "neutral_site",
+    "home_team",
+    "away_team",
+    "home_pregame_elo",
+    "away_pregame_elo",
+    "home_postgame_elo",
+    "away_postgame_elo",
+    "home_win_prob",
+    "expected_home_margin",
+    "actual_home_margin",
+    "mov_multiplier",
+    "cfbd_home_pregame_elo",
+    "cfbd_away_pregame_elo",
+    "margin_error",
+    "abs_margin_error",
+}
+
+SCORED_MATCHUP_EDGES_COLUMNS = {
+    "game_id",
+    "season",
+    "week",
+    "season_type",
+    "start_date",
+    "home_team",
+    "away_team",
+    "neutral_site",
+    "model_version",
+    "prediction_date",
+    "home_elo_pregame",
+    "away_elo_pregame",
+    "elo_margin",
+    "epa_margin",
+    "expected_home_margin",
+    "home_win_prob",
+    "market_provider",
+    "market_spread",
+    "market_home_margin",
+    "market_captured_at",
+    "edge",
+    "edge_pick",
+    "abs_edge",
+}
+
+PREDICTION_ACCURACY_COLUMNS = {
+    "model_version",
+    "season",
+    "edge_threshold",
+    "n_games",
+    "n_with_market",
+    "margin_mae",
+    "margin_rmse",
+    "ats_wins",
+    "ats_losses",
+    "ats_pushes",
+    "ats_hit_rate",
+    "brier",
+    "cfbd_brier",
+    "n_scored_win_prob",
+}
+
+GAME_PREDICTIONS_COLUMNS = {
+    "prediction_id",
+    "computed_at",
+    "prediction_date",
+    "model_version",
+    "game_id",
+    "season",
+    "week",
+    "season_type",
+    "home_team",
+    "away_team",
+    "neutral_site",
+    "home_elo_pregame",
+    "away_elo_pregame",
+    "elo_margin",
+    "epa_margin",
+    "expected_home_margin",
+    "home_win_prob",
+    "market_provider",
+    "market_home_margin",
+    "market_spread",
+    "market_captured_at",
+    "edge",
+    "edge_pick",
+}
+
 
 # ---------------------------------------------------------------------------
 # Test: views exist and return rows
@@ -297,6 +399,13 @@ class TestViewsExistAndReturnRows:
             ("api.game_drives", 150000),
             ("api.game_plays", 3000000),
             ("api.poll_rankings", 20000),
+            # Sized from 2026-07-21 Tier 2 backfill: house Elo 1869+, predictions
+            # retro 2015-2025 x 2 models
+            ("api.team_elo", 10000),
+            ("api.game_elo_history", 60000),
+            ("api.scored_matchup_edges", 1),
+            ("api.prediction_accuracy", 80),
+            ("api.game_predictions", 15000),
         ],
         ids=[
             "team_detail",
@@ -309,6 +418,11 @@ class TestViewsExistAndReturnRows:
             "game_drives",
             "game_plays",
             "poll_rankings",
+            "team_elo",
+            "game_elo_history",
+            "scored_matchup_edges",
+            "prediction_accuracy",
+            "game_predictions",
         ],
     )
     def test_view_returns_rows(self, db_conn, view_name, min_rows):
@@ -338,6 +452,11 @@ class TestViewColumns:
             ("api.game_drives", GAME_DRIVES_COLUMNS),
             ("api.game_plays", GAME_PLAYS_COLUMNS),
             ("api.poll_rankings", POLL_RANKINGS_COLUMNS),
+            ("api.team_elo", TEAM_ELO_COLUMNS),
+            ("api.game_elo_history", GAME_ELO_HISTORY_COLUMNS),
+            ("api.scored_matchup_edges", SCORED_MATCHUP_EDGES_COLUMNS),
+            ("api.prediction_accuracy", PREDICTION_ACCURACY_COLUMNS),
+            ("api.game_predictions", GAME_PREDICTIONS_COLUMNS),
         ],
         ids=[
             "team_detail",
@@ -350,6 +469,11 @@ class TestViewColumns:
             "game_drives",
             "game_plays",
             "poll_rankings",
+            "team_elo",
+            "game_elo_history",
+            "scored_matchup_edges",
+            "prediction_accuracy",
+            "game_predictions",
         ],
     )
     def test_columns_present(self, db_conn, view_name, expected_columns):

--- a/tests/test_api_views.py
+++ b/tests/test_api_views.py
@@ -401,9 +401,8 @@ class TestViewsExistAndReturnRows:
             ("api.poll_rankings", 20000),
             # Sized from 2026-07-21 Tier 2 backfill: house Elo 1869+, predictions
             # retro 2015-2025 x 2 models
-            ("api.team_elo", 10000),
-            ("api.game_elo_history", 60000),
-            ("api.scored_matchup_edges", 1),
+            ("api.team_elo", 5000),
+            ("api.game_elo_history", 40000),
             ("api.prediction_accuracy", 80),
             ("api.game_predictions", 15000),
         ],
@@ -420,7 +419,6 @@ class TestViewsExistAndReturnRows:
             "poll_rankings",
             "team_elo",
             "game_elo_history",
-            "scored_matchup_edges",
             "prediction_accuracy",
             "game_predictions",
         ],

--- a/tests/test_deploy_schema.py
+++ b/tests/test_deploy_schema.py
@@ -25,6 +25,7 @@ class TestValidActions:
 class TestComputeScripts:
     def test_expected_allowlist(self):
         assert COMPUTE_SCRIPTS == {
+            "check_backtest",
             "compute_house_elo",
             "compute_adjusted_epa",
             "compute_predictions",

--- a/tests/test_deploy_schema.py
+++ b/tests/test_deploy_schema.py
@@ -5,8 +5,10 @@ import json
 import pytest
 
 from scripts.deploy_schema import (
+    COMPUTE_SCRIPTS,
     VALID_ACTIONS,
     BackfillSpec,
+    ComputeSpec,
     Plan,
     load_manifest,
     plan_from_cli,
@@ -17,7 +19,16 @@ from scripts.deploy_schema import (
 
 class TestValidActions:
     def test_expected_actions(self):
-        assert VALID_ACTIONS == {"presence_check", "apply", "backfill"}
+        assert VALID_ACTIONS == {"presence_check", "apply", "backfill", "compute"}
+
+
+class TestComputeScripts:
+    def test_expected_allowlist(self):
+        assert COMPUTE_SCRIPTS == {
+            "compute_house_elo",
+            "compute_adjusted_epa",
+            "compute_predictions",
+        }
 
 
 class TestPlanFromManifestPresenceCheck:
@@ -27,6 +38,7 @@ class TestPlanFromManifestPresenceCheck:
         assert plan.strict is False
         assert plan.files == []
         assert plan.backfill is None
+        assert plan.compute is None
 
     def test_strict_flag_passthrough(self):
         plan = plan_from_manifest({"action": "presence_check", "strict": True})
@@ -93,6 +105,40 @@ class TestPlanFromManifestBackfill:
         assert plan.backfill.start == plan.backfill.end == 2020
 
 
+class TestPlanFromManifestCompute:
+    def test_compute_fields(self):
+        manifest = {
+            "action": "compute",
+            "compute": {"script": "compute_house_elo", "args": ["--full"]},
+        }
+        plan = plan_from_manifest(manifest)
+        assert plan.action == "compute"
+        assert plan.compute == ComputeSpec(script="compute_house_elo", args=["--full"])
+
+    def test_compute_args_optional(self):
+        manifest = {"action": "compute", "compute": {"script": "compute_adjusted_epa"}}
+        plan = plan_from_manifest(manifest)
+        assert plan.compute == ComputeSpec(script="compute_adjusted_epa", args=[])
+
+    def test_compute_refresh_passthrough(self):
+        manifest = {
+            "action": "compute",
+            "compute": {"script": "compute_predictions"},
+            "refresh": True,
+        }
+        plan = plan_from_manifest(manifest)
+        assert plan.refresh is True
+
+    def test_compute_missing_block_rejected(self):
+        with pytest.raises(ValueError, match="compute block"):
+            plan_from_manifest({"action": "compute"})
+
+    def test_compute_unknown_script_rejected(self):
+        manifest = {"action": "compute", "compute": {"script": "compute_something_else"}}
+        with pytest.raises(ValueError, match="compute_house_elo"):
+            plan_from_manifest(manifest)
+
+
 class TestBadAction:
     def test_unknown_action_rejected(self):
         with pytest.raises(ValueError, match="invalid action"):
@@ -107,12 +153,30 @@ class TestBadAction:
         with pytest.raises(ValueError, match="invalid action"):
             validate_plan(plan)
 
+    def test_compute_missing_block_rejected_directly(self):
+        plan = Plan(action="compute")
+        with pytest.raises(ValueError, match="compute block"):
+            validate_plan(plan)
+
+    def test_compute_unknown_script_rejected_directly(self):
+        plan = Plan(action="compute", compute=ComputeSpec(script="not_allowlisted"))
+        with pytest.raises(ValueError, match="invalid compute script") as exc_info:
+            validate_plan(plan)
+        # Message lists the allowlist so a bad script name is self-explanatory in CI logs.
+        for script in COMPUTE_SCRIPTS:
+            assert script in str(exc_info.value)
+
+    def test_compute_allowlisted_script_accepted_directly(self):
+        plan = Plan(action="compute", compute=ComputeSpec(script="compute_house_elo"))
+        validate_plan(plan)  # does not raise
+
 
 class TestPlanFromCli:
     def test_presence_check_minimal(self):
         plan = plan_from_cli(action="presence_check")
         assert plan.action == "presence_check"
         assert plan.strict is False
+        assert plan.compute is None
 
     def test_presence_check_strict(self):
         plan = plan_from_cli(action="presence_check", strict=True)
@@ -163,6 +227,40 @@ class TestPlanFromCli:
     def test_bad_action_rejected(self):
         with pytest.raises(ValueError, match="invalid action"):
             plan_from_cli(action="not_a_real_action")
+
+    def test_compute_flags_mapped(self):
+        plan = plan_from_cli(
+            action="compute",
+            compute_script="compute_house_elo",
+            compute_args="--full, --season 2024",
+        )
+        assert plan.action == "compute"
+        # Comma-separated CLI string is split and whitespace-stripped, like files/sources.
+        assert plan.compute == ComputeSpec(
+            script="compute_house_elo", args=["--full", "--season 2024"]
+        )
+
+    def test_compute_no_args_gives_empty_list(self):
+        plan = plan_from_cli(action="compute", compute_script="compute_predictions")
+        assert plan.compute == ComputeSpec(script="compute_predictions", args=[])
+
+    def test_compute_args_blank_entries_dropped(self):
+        plan = plan_from_cli(
+            action="compute", compute_script="compute_adjusted_epa", compute_args="a,,b,"
+        )
+        assert plan.compute.args == ["a", "b"]
+
+    def test_compute_unknown_script_rejected(self):
+        with pytest.raises(ValueError, match="invalid compute script"):
+            plan_from_cli(action="compute", compute_script="not_allowlisted")
+
+    def test_compute_missing_script_rejected(self):
+        with pytest.raises(ValueError, match="compute block"):
+            plan_from_cli(action="compute")
+
+    def test_compute_refresh_flag_mapped(self):
+        plan = plan_from_cli(action="compute", compute_script="compute_house_elo", refresh=True)
+        assert plan.refresh is True
 
 
 class TestLoadManifest:

--- a/tests/test_house_elo.py
+++ b/tests/test_house_elo.py
@@ -1,0 +1,235 @@
+"""Unit tests for compute_house_elo's pure Elo engine (no DB, no I/O).
+
+Covers the pure math (expected_score, mov_multiplier, pearson_r) and the
+EloEngine's stateful behavior (single-game deltas, season carryover,
+low-sample pooling, and multi-game bookkeeping) directly against plain
+dicts, per docs/plans/2026-07-21-tier2-analytics-plan.md's House Elo design.
+"""
+
+import math
+
+import pytest
+
+from scripts.compute_house_elo import (
+    EloEngine,
+    expected_score,
+    mov_multiplier,
+    pearson_r,
+)
+
+
+def make_game(
+    game_id,
+    season,
+    home_team,
+    away_team,
+    home_points,
+    away_points,
+    week=1,
+    season_type="regular",
+    start_date=None,
+    neutral_site=False,
+):
+    return {
+        "game_id": game_id,
+        "season": season,
+        "week": week,
+        "season_type": season_type,
+        "start_date": start_date,
+        "neutral_site": neutral_site,
+        "home_team": home_team,
+        "away_team": away_team,
+        "home_points": home_points,
+        "away_points": away_points,
+        "cfbd_home_pregame_elo": None,
+        "cfbd_away_pregame_elo": None,
+    }
+
+
+class TestExpectedScore:
+    def test_zero_diff_is_half(self):
+        assert expected_score(0) == pytest.approx(0.5)
+
+    def test_plus_400_favorite(self):
+        assert expected_score(400) == pytest.approx(1 / 1.1, abs=1e-9)
+
+    def test_symmetry(self):
+        for diff in (65, 133.33, 400, 1000):
+            assert expected_score(diff) + expected_score(-diff) == pytest.approx(1.0)
+
+
+class TestMovMultiplier:
+    def test_margin_7_zero_diff(self):
+        assert mov_multiplier(7, 0) == pytest.approx(math.log(8), abs=1e-4)
+        assert mov_multiplier(7, 0) == pytest.approx(2.0794, abs=1e-4)
+
+    def test_damping_reduces_multiplier_for_bigger_favorite(self):
+        neutral = mov_multiplier(7, 0)
+        favorite = mov_multiplier(7, 400)
+        assert favorite < neutral
+
+    def test_tie_margin_is_zero(self):
+        assert mov_multiplier(0, 0) == 0.0
+
+    def test_sign_of_margin_does_not_matter(self):
+        assert mov_multiplier(-7, 0) == pytest.approx(mov_multiplier(7, 0))
+
+
+class TestPearsonR:
+    def test_perfect_positive_correlation(self):
+        xs = [1.0, 2.0, 3.0, 4.0]
+        ys = [10.0, 20.0, 30.0, 40.0]
+        assert pearson_r(xs, ys) == pytest.approx(1.0)
+
+    def test_empty_input_is_nan(self):
+        assert math.isnan(pearson_r([], []))
+
+
+class TestEngineSingleGame:
+    """Two teams, equal (seed) ratings, single non-pooled game."""
+
+    def test_hand_computed_delta_and_zero_sum(self):
+        engine = EloEngine()
+        # Keep both teams out of the pooled bucket (>= POOL_THRESHOLD games).
+        engine.start_season(2020, {"Home": 4, "Away": 4})
+        game = make_game(1, 2020, "Home", "Away", home_points=30, away_points=23)
+
+        row = engine.process_game(game)
+
+        elo_diff_home = 65.0  # 1500 - 1500 + HFA(65), non-neutral
+        exp_home = expected_score(elo_diff_home)
+        mult = math.log(8) * (2.2 / (0.001 * elo_diff_home + 2.2))
+        delta = 20 * mult * (1 - exp_home)
+
+        assert row["home_postgame_elo"] == pytest.approx(1500 + delta, abs=1e-6)
+        assert row["away_postgame_elo"] == pytest.approx(1500 - delta, abs=1e-6)
+        # Zero-sum: the two deltas are exact opposites.
+        home_delta = row["home_postgame_elo"] - row["home_pregame_elo"]
+        away_delta = row["away_postgame_elo"] - row["away_pregame_elo"]
+        assert home_delta == pytest.approx(-away_delta, abs=1e-9)
+        assert row["mov_multiplier"] == pytest.approx(mult, abs=1e-9)
+
+    def test_neutral_site_removes_hfa(self):
+        engine = EloEngine()
+        engine.start_season(2020, {"Home": 4, "Away": 4})
+        game = make_game(2, 2020, "Home", "Away", home_points=21, away_points=20, neutral_site=True)
+
+        row = engine.process_game(game)
+
+        assert row["home_win_prob"] == pytest.approx(0.5)
+        assert row["expected_home_margin"] == pytest.approx(0.0)
+
+
+class TestCarryover:
+    def test_one_season_gap(self):
+        engine = EloEngine()
+        engine.ratings["Team A"] = 1700.0
+        engine.last_season["Team A"] = 2019
+        engine.start_season(2020, {"Team A": 10})
+        assert engine.ratings["Team A"] == pytest.approx(1500 + 200 * (2 / 3))
+
+    def test_two_season_gap(self):
+        engine = EloEngine()
+        engine.ratings["Team A"] = 1700.0
+        engine.last_season["Team A"] = 2018
+        engine.start_season(2020, {"Team A": 10})
+        assert engine.ratings["Team A"] == pytest.approx(1500 + 200 * (2 / 3) ** 2)
+
+    def test_pooled_resets_to_seed_every_season(self):
+        engine = EloEngine()
+        engine.ratings[EloEngine.POOLED] = 1650.0
+        engine.start_season(2020, {"Team A": 10})
+        assert engine.ratings[EloEngine.POOLED] == pytest.approx(1500.0)
+
+    def test_brand_new_team_gets_no_carryover(self):
+        engine = EloEngine()
+        # "New Team" has never been seen before -- no last_season entry.
+        engine.start_season(2020, {"New Team": 10})
+        assert "New Team" not in engine.ratings
+
+
+class TestPooling:
+    def test_low_sample_team_aliases_to_pooled(self):
+        engine = EloEngine()
+        engine.start_season(2020, {"Big State": 10, "Tiny College": 2})
+        assert engine.resolve("Tiny College") == EloEngine.POOLED
+        assert engine.resolve("Big State") == "Big State"
+
+    def test_row_records_real_team_name_not_alias(self):
+        engine = EloEngine()
+        engine.start_season(2020, {"Big State": 4, "Tiny College": 2})
+        game = make_game(3, 2020, "Big State", "Tiny College", home_points=45, away_points=3)
+
+        row = engine.process_game(game)
+
+        assert row["home_team"] == "Big State"
+        assert row["away_team"] == "Tiny College"
+
+    def test_snapshot_low_confidence_rules(self):
+        engine = EloEngine()
+        # Team A: modern era, thin sample -> low confidence via games_played.
+        engine.last_season["Team A"] = 2020
+        engine.games_played["Team A"] = 2
+        engine.ratings["Team A"] = 1550.0
+        # Team B: modern era, plenty of games -> confident.
+        engine.last_season["Team B"] = 2020
+        engine.games_played["Team B"] = 10
+        engine.ratings["Team B"] = 1600.0
+        # Team C: pre-1900 era, plenty of games -> low confidence via era.
+        engine.last_season["Team C"] = 1899
+        engine.games_played["Team C"] = 10
+        engine.ratings["Team C"] = 1500.0
+
+        snapshot = {row["team"]: row for row in engine.current_snapshot(2020)}
+
+        assert snapshot["Team A"]["low_confidence"] is True
+        assert snapshot["Team B"]["low_confidence"] is False
+        assert snapshot["Team C"]["low_confidence"] is True
+
+    def test_snapshot_reports_pooled_rating_for_pooled_team(self):
+        engine = EloEngine()
+        engine.last_season["Tiny"] = 2021
+        engine.games_played["Tiny"] = 2
+        engine.ratings[EloEngine.POOLED] = 1523.4
+        engine.alias = {"Tiny": EloEngine.POOLED}
+
+        rows = engine.current_snapshot(2021)
+
+        assert len(rows) == 1
+        assert rows[0]["team"] == "Tiny"
+        assert rows[0]["rating"] == pytest.approx(1523.4)
+        assert rows[0]["low_confidence"] is True
+
+
+class TestMiniSeasonEndToEnd:
+    def test_three_game_mini_season_bookkeeping(self):
+        engine = EloEngine()
+        # Inflate team_game_counts above POOL_THRESHOLD so this test exercises
+        # plain (non-pooled) bookkeeping, independent of how many games this
+        # scenario actually simulates.
+        engine.start_season(2021, {"A": 4, "B": 4, "C": 4})
+
+        g1 = make_game(101, 2021, "A", "B", home_points=20, away_points=10, week=1)
+        g2 = make_game(102, 2021, "A", "C", home_points=14, away_points=21, week=2)
+        g3 = make_game(103, 2021, "B", "C", home_points=17, away_points=17, week=3)
+
+        engine.process_game(g1)
+        assert engine.games_played == {"A": 1, "B": 1}
+        assert engine.last_game_id == {"A": 101, "B": 101}
+
+        engine.process_game(g2)
+        assert engine.games_played == {"A": 2, "B": 1, "C": 1}
+        assert engine.last_game_id == {"A": 102, "B": 101, "C": 102}
+
+        engine.process_game(g3)
+        assert engine.games_played == {"A": 2, "B": 2, "C": 2}
+        # A didn't play g3, so its last_game_id stays at g2.
+        assert engine.last_game_id == {"A": 102, "B": 103, "C": 103}
+
+        snapshot = {row["team"]: row for row in engine.current_snapshot(2021)}
+        assert snapshot["A"]["games_played"] == 2
+        assert snapshot["B"]["games_played"] == 2
+        assert snapshot["C"]["games_played"] == 2
+        assert snapshot["A"]["last_game_id"] == 102
+        assert snapshot["B"]["last_game_id"] == 103
+        assert snapshot["C"]["last_game_id"] == 103

--- a/tests/test_marts.py
+++ b/tests/test_marts.py
@@ -118,6 +118,10 @@ class TestMartViewsExist:
 class TestMartViewsHaveData:
     """Every materialized view should contain at least one row."""
 
+    # Legitimately empty out of season / before the schedule loads (documented
+    # in the mart headers) -- existence and columns are still asserted above.
+    EMPTY_OK = {("marts", "scored_matchup_edges")}
+
     @pytest.mark.parametrize(
         "schema_name,view_name",
         ALL_MATERIALIZED_VIEWS,
@@ -129,6 +133,8 @@ class TestMartViewsHaveData:
             # Use quoted identifiers to handle leading underscores safely
             cur.execute(f'SELECT COUNT(*) FROM "{schema_name}"."{view_name}"')
             count = cur.fetchone()[0]
+        if (schema_name, view_name) in self.EMPTY_OK and count == 0:
+            pytest.skip(f"{schema_name}.{view_name} legitimately empty out of season")
         assert count > 0, f"{schema_name}.{view_name} is empty (0 rows)"
 
 

--- a/tests/test_marts.py
+++ b/tests/test_marts.py
@@ -43,6 +43,11 @@ MARTS_VIEWS = [
     "player_usage",
     "team_ats_records",
     "transfer_portal_impact",
+    "house_elo",
+    "house_elo_game",
+    "team_adjusted_epa",
+    "scored_matchup_edges",
+    "prediction_accuracy",
 ]
 
 ANALYTICS_VIEWS = [

--- a/tests/test_predictions.py
+++ b/tests/test_predictions.py
@@ -1,0 +1,243 @@
+"""Unit tests for compute_predictions's pure prediction math (no DB, no I/O).
+
+Covers elo_margin/epa_margin/blend_margin/elo_win_prob/compute_edge against
+hand-computed values, plus the small lookup helpers (carryover_rating,
+resolve_elo, lookup_epa_coefs) and the build_predictions_for_game contract
+(two model_version rows per game, elo_v1's epa_margin always NULL), per
+docs/plans/2026-07-21-tier2-analytics-plan.md's "Expected margin, win prob,
+edge" design.
+"""
+
+import pytest
+
+from scripts.compute_house_elo import EloEngine, expected_score
+from scripts.compute_predictions import (
+    BLEND_ELO,
+    BLEND_EPA,
+    MODEL_BLEND,
+    MODEL_ELO,
+    blend_margin,
+    build_predictions_for_game,
+    carryover_rating,
+    compute_edge,
+    elo_margin,
+    elo_win_prob,
+    epa_margin,
+    lookup_epa_coefs,
+    resolve_elo,
+)
+
+
+class TestEloMargin:
+    def test_equal_ratings_non_neutral(self):
+        # (1500 - 1500) / 25 + 65 / 25 = 2.6
+        assert elo_margin(1500, 1500, neutral=False) == pytest.approx(2.6)
+
+    def test_equal_ratings_neutral(self):
+        assert elo_margin(1500, 1500, neutral=True) == pytest.approx(0.0)
+
+    def test_home_favorite_scales_with_diff(self):
+        # (1600 - 1500 + 65) / 25 = 6.6
+        assert elo_margin(1600, 1500, neutral=False) == pytest.approx(6.6)
+
+
+class TestEpaMargin:
+    """off_h=0.10, def_h=-0.05, off_a=0.08, def_a=-0.02, hfa_coef=0.03.
+
+    margin = ((off_h + def_a) - (off_a + def_h)) * 68 + hfa_coef * 68 * (not neutral)
+           = ((0.10 + -0.02) - (0.08 + -0.05)) * 68 + 0.03 * 68
+           = (0.08 - 0.03) * 68 + 2.04
+           = 0.05 * 68 + 2.04 = 3.4 + 2.04 = 5.44
+    """
+
+    def test_hand_computed_non_neutral(self):
+        result = epa_margin(
+            off_h=0.10, def_h=-0.05, off_a=0.08, def_a=-0.02, hfa_coef=0.03, neutral=False
+        )
+        assert result == pytest.approx(5.44)
+
+    def test_neutral_zeroes_hfa_term(self):
+        result = epa_margin(
+            off_h=0.10, def_h=-0.05, off_a=0.08, def_a=-0.02, hfa_coef=0.03, neutral=True
+        )
+        assert result == pytest.approx(3.4)
+
+    def test_defense_sign_handling(self):
+        # A stingier (more negative) home defense should RAISE the home
+        # margin (def_h is subtracted); a stingier away defense should
+        # LOWER it (def_a is added).
+        base = epa_margin(off_h=0.0, def_h=0.0, off_a=0.0, def_a=0.0, hfa_coef=0.0, neutral=True)
+        better_home_def = epa_margin(
+            off_h=0.0, def_h=-0.05, off_a=0.0, def_a=0.0, hfa_coef=0.0, neutral=True
+        )
+        better_away_def = epa_margin(
+            off_h=0.0, def_h=0.0, off_a=0.0, def_a=-0.05, hfa_coef=0.0, neutral=True
+        )
+        assert better_home_def > base
+        assert better_away_def < base
+
+
+class TestBlendMargin:
+    def test_exact_weights(self):
+        assert BLEND_ELO == pytest.approx(0.6)
+        assert BLEND_EPA == pytest.approx(0.4)
+        assert blend_margin(10.0, 5.0) == pytest.approx(0.6 * 10.0 + 0.4 * 5.0)
+        assert blend_margin(10.0, 5.0) == pytest.approx(8.0)
+
+    def test_none_epa_passes_through_elo(self):
+        assert blend_margin(10.0, None) == pytest.approx(10.0)
+        assert blend_margin(-3.5, None) == pytest.approx(-3.5)
+
+
+class TestEloWinProb:
+    def test_equal_ratings_neutral_is_half(self):
+        assert elo_win_prob(1500, 1500, neutral=True) == pytest.approx(0.5)
+
+    def test_equal_ratings_non_neutral_favors_home(self):
+        assert elo_win_prob(1500, 1500, neutral=False) > 0.5
+
+    def test_matches_expected_score_with_hfa(self):
+        assert elo_win_prob(1500, 1500, neutral=False) == pytest.approx(expected_score(65))
+        assert elo_win_prob(1600, 1500, neutral=True) == pytest.approx(expected_score(100))
+
+
+class TestComputeEdge:
+    def test_home_favored_market_underestimates_home(self):
+        # expected +7 (house: home by 7), spread -3 (market: home favored by
+        # 3, market_home_margin = +3) -> edge = 7 + (-3) = 4 -> pick home.
+        edge, pick = compute_edge(7, -3)
+        assert edge == pytest.approx(4)
+        assert pick == "home"
+
+    def test_home_underdog_but_house_more_bullish_than_market(self):
+        # expected +1 (house: home by 1), spread +3 (market: home a 3-point
+        # underdog, market_home_margin = -3) -> edge = 1 + 3 = 4 -> pick home.
+        edge, pick = compute_edge(1, 3)
+        assert edge == pytest.approx(4)
+        assert pick == "home"
+
+    def test_away_side_edge(self):
+        # expected -10 (house: away by 10), spread -3 (market: home favored
+        # by 3) -> edge = -10 + (-3) = -13 -> pick away.
+        edge, pick = compute_edge(-10, -3)
+        assert edge == pytest.approx(-13)
+        assert pick == "away"
+
+    def test_zero_edge_picks_home(self):
+        edge, pick = compute_edge(3, -3)
+        assert edge == pytest.approx(0)
+        assert pick == "home"
+
+    def test_no_market_returns_none_none(self):
+        assert compute_edge(7, None) == (None, None)
+
+
+class TestCarryoverRating:
+    def test_no_gap_is_passthrough(self):
+        assert carryover_rating(1700.0, elapsed=0) == pytest.approx(1700.0)
+        assert carryover_rating(1700.0, elapsed=-1) == pytest.approx(1700.0)
+
+    def test_one_season_gap_matches_engine_formula(self):
+        assert carryover_rating(1700.0, elapsed=1) == pytest.approx(1500 + 200 * (2 / 3))
+
+    def test_two_season_gap_matches_engine_formula(self):
+        assert carryover_rating(1700.0, elapsed=2) == pytest.approx(1500 + 200 * (2 / 3) ** 2)
+
+
+class TestResolveElo:
+    def test_missing_team_defaults_to_seed(self):
+        assert resolve_elo("Nobody", 2024, {}) == pytest.approx(EloEngine.SEED)
+
+    def test_current_season_snapshot_used_as_is(self):
+        elo_current = {"Big State": (1650.0, 2024)}
+        assert resolve_elo("Big State", 2024, elo_current) == pytest.approx(1650.0)
+
+    def test_stale_snapshot_gets_carryover(self):
+        elo_current = {"Big State": (1700.0, 2019)}
+        assert resolve_elo("Big State", 2020, elo_current) == pytest.approx(1500 + 200 * (2 / 3))
+
+
+class TestLookupEpaCoefs:
+    ROW_2023 = {"off_coef": 0.1, "def_coef": -0.05, "hfa_coef": 0.02}
+    ROW_2024 = {"off_coef": 0.2, "def_coef": -0.03, "hfa_coef": 0.02}
+
+    def build_epa(self):
+        return {("Big State", 2023): self.ROW_2023, ("Big State", 2024): self.ROW_2024}
+
+    def test_prefers_current_season(self):
+        epa = self.build_epa()
+        assert lookup_epa_coefs(epa, "Big State", 2024, lookback=1) == self.ROW_2024
+
+    def test_falls_back_to_previous_season_within_lookback(self):
+        epa = {("Big State", 2023): self.ROW_2023}
+        assert lookup_epa_coefs(epa, "Big State", 2024, lookback=1) == self.ROW_2023
+
+    def test_backfill_lookback_zero_is_same_season_only(self):
+        epa = {("Big State", 2023): self.ROW_2023}
+        assert lookup_epa_coefs(epa, "Big State", 2024, lookback=0) is None
+
+    def test_missing_team_returns_none(self):
+        epa = self.build_epa()
+        assert lookup_epa_coefs(epa, "Tiny College", 2024, lookback=1) is None
+
+
+class TestBuildPredictionsForGame:
+    GAME = {
+        "game_id": 1,
+        "season": 2024,
+        "week": 5,
+        "season_type": "regular",
+        "home_team": "Home U",
+        "away_team": "Away Tech",
+        "neutral_site": False,
+    }
+
+    def test_two_rows_one_per_model(self):
+        rows = build_predictions_for_game(self.GAME, 1600, 1500, {}, epa_lookback=1, market=None)
+        assert {r["model_version"] for r in rows} == {MODEL_ELO, MODEL_BLEND}
+
+    def test_elo_row_epa_margin_always_none(self):
+        epa = {
+            ("Home U", 2024): {"off_coef": 0.1, "def_coef": -0.05, "hfa_coef": 0.02},
+            ("Away Tech", 2024): {"off_coef": 0.05, "def_coef": -0.02, "hfa_coef": 0.02},
+        }
+        game_rows = build_predictions_for_game(
+            self.GAME, 1600, 1500, epa, epa_lookback=1, market=None
+        )
+        rows = {r["model_version"]: r for r in game_rows}
+        assert rows[MODEL_ELO]["epa_margin"] is None
+        assert rows[MODEL_ELO]["expected_home_margin"] == pytest.approx(
+            elo_margin(1600, 1500, neutral=False)
+        )
+        assert rows[MODEL_BLEND]["epa_margin"] is not None
+        assert rows[MODEL_BLEND]["expected_home_margin"] != rows[MODEL_ELO]["expected_home_margin"]
+
+    def test_missing_epa_falls_back_blend_to_elo_only(self):
+        game_rows = build_predictions_for_game(
+            self.GAME, 1600, 1500, {}, epa_lookback=1, market=None
+        )
+        rows = {r["model_version"]: r for r in game_rows}
+        assert rows[MODEL_BLEND]["epa_margin"] is None
+        assert rows[MODEL_BLEND]["expected_home_margin"] == pytest.approx(
+            rows[MODEL_ELO]["expected_home_margin"]
+        )
+
+    def test_win_prob_identical_across_models(self):
+        rows = build_predictions_for_game(self.GAME, 1600, 1500, {}, epa_lookback=1, market=None)
+        probs = {r["home_win_prob"] for r in rows}
+        assert len(probs) == 1
+
+    def test_no_market_yields_none_edge_for_both_rows(self):
+        rows = build_predictions_for_game(self.GAME, 1600, 1500, {}, epa_lookback=1, market=None)
+        for r in rows:
+            assert r["edge"] is None
+            assert r["edge_pick"] is None
+            assert r["market_spread"] is None
+            assert r["market_home_margin"] is None
+
+    def test_market_home_margin_is_negated_spread(self):
+        market = {"provider": "consensus", "spread": -7.0, "captured_at": None}
+        rows = build_predictions_for_game(self.GAME, 1600, 1500, {}, epa_lookback=1, market=market)
+        for r in rows:
+            assert r["market_home_margin"] == pytest.approx(7.0)
+            assert r["market_spread"] == pytest.approx(-7.0)


### PR DESCRIPTION
Executes the Tier 2 analytics sprint (`docs/plans/2026-07-21-tier2-analytics-plan.md`): the warehouse now generates its own opinions — house team-strength ratings, opponent-adjusted EPA, expected margins vs the market, and an auditable prediction ledger. **Transparent math only, no fitted ML model** (design decision): every number is reproducible from the SQL and the three compute scripts.

**Everything in this PR is already deployed, populated, and refreshed on the live database** via the deploy-branch mechanism. PR CI is the final verification gate against that populated database.

## What's new

- **House Elo** (`scripts/compute_house_elo.py`, stdlib-only): sequential Elo over **all 157 seasons of `core.games` (1869–2025)** — K=20, +65 HFA, FiveThirtyEight-form MOV damping, 2/3 season carryover, per-season pooling of sub-4-game teams. Full historical build runs in ~30s; daily mode recomputes only the current season. Surfaced as `marts.house_elo` (season-end rating per team-season, ranked) and `marts.house_elo_game` (game-grain pregame/postgame Elo + win prob), via `api.team_elo` / `api.game_elo_history`.
- **Ridge-adjusted team EPA** (`scripts/compute_adjusted_epa.py`, numpy via the new `[compute]` extra): per-season fixed-effects fit `epa ~ mu + off[team] + def[team] + hfa` over `marts.play_epa` (garbage time excluded, λ=200 on team columns, XᵀX accumulated over a server-side cursor — never a dense matrix). Surfaced as `marts.team_adjusted_epa` via ranks + WEPA compare columns.
- **Predictions** (`scripts/compute_predictions.py`): new `predictions` schema; `predictions.game_predictions` holds append-only daily snapshots — one immutable row per (game, model, UTC day). Two transparent model versions per game: `elo_v1` (Elo-only) and `elo_epa_blend_v1` (0.6·Elo + 0.4·adjusted-EPA margins); win prob is Elo-logistic. Market comparison uses `betting.line_snapshots` (current) falling back to `betting.lines` (≈closing); `edge = expected_home_margin + spread`.
- **Scored matchup edges**: `marts.scored_matchup_edges` — latest prediction vs market line for **upcoming** games (the 2026 slate is already populated), ranked by `abs_edge`. `marts/016_matchup_edges` is now documented as style-only.
- **Backtest/audit surface**: `marts.prediction_accuracy` — margin MAE/RMSE, ATS records at |edge| ≥ {0,3,6,10}, and Brier vs CFBD's own pregame win probability (same-subset), by season and model.
- **Deploy infra**: new allowlisted `compute` manifest action runs the compute scripts from `deploy/**` branches; `refresh_marts.py --views` does targeted refreshes; the daily workflow runs Elo/EPA/predictions + a Tier 2 mart refresh after each season load.

## Live validation (production numbers)

- **House Elo vs CFBD's Elo: Pearson r = 0.948 over 8,830 games (2015+)** — computed independently from raw game results.
- **Ridge-adjusted EPA vs CFBD's WEPA: r = 0.97–0.99 on both offense and defense in every season 2014–2025.**
- **Backtest over 26,453 games (2015–2025)**: blend model ATS **56.1% at |edge| ≥ 6 (n=3,285)**, rising monotonically with edge size (54.4% → 55.4% → 56.1%); Elo-only lands at 50.3% — the textbook honest result for a public-information rating, validating the scoring machinery. Margin MAE 15.9; house Brier 0.187 vs CFBD 0.159 (their WP model is better calibrated; documented).
- **Leakage caveat (documented in `marts/038`)**: the blend's retro ATS edge is partly inflated because in-season EPA coefficients are full-season fits scoring early-season games. `elo_v1` is the leak-free walk-forward reference; the 2026 season measures the blend prospectively via the append-only snapshots.

## Tunables (post-backtest ledger)

K=20 · Elo divisor=25 · HFA=65 · MOV 2.2/0.001 · carryover 2/3 · pooling ≥4 games · λ=200 · PLAYS=68 · blend 60/40 · thresholds {3,6,10}. All recorded in the sprint plan; the accuracy mart is the scoreboard for future tuning.

## Testing

`ruff` clean; `pytest -q` 511 passed locally (61 new unit tests cover the Elo engine, ridge solver on synthetic data, and prediction formulas — all runnable without a DB). DB-gated inventories for the 5 new marts + 5 new api views run in CI against the live, populated database.

## Follow-ups

- cfb-app: regenerate `supabase gen types` (new `predictions` schema + 5 views); consumers of `api.poll_rankings`-style surfaces unchanged.
- 2027-proofing pass (existing list) gains: fold 2026 into the Elo/EPA history horizon notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aq5tEVxkthmuRX7JH9qEW

---
_Generated by [Claude Code](https://claude.ai/code/session_018aq5tEVxkthmuRX7JH9qEW)_