### PR TITLE
docs(mcp): mark Python stdio server superseded by cfb-app's HTTP endpoint

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,5 +1,12 @@
 # cfb-mcp
 
+> **Superseded (2026-07-21):** the primary MCP interface is now the streamable-HTTP
+> server hosted inside cfb-app at `https://v0-production-data-application.vercel.app/api/mcp`
+> (bearer-token protected; see cfb-app's `docs/MCP.md`). It ports this server's tool
+> design 1:1 and is reachable from claude.ai, Claude Code, and Claude Desktop without
+> local setup. This Python stdio server remains functional for local/offline use and
+> as the reference implementation, but new tool work should land in cfb-app.
+
 A read-only [MCP](https://modelcontextprotocol.io) server over the `cfb-database` Supabase
 warehouse. Local **stdio** transport, built with the official Python `mcp` SDK (FastMCP
 style). It exposes eight LLM-facing tools covering teams, games, matchups, rankings,


### PR DESCRIPTION
One-paragraph README banner: the primary MCP interface is now cfb-app's streamable-HTTP `/api/mcp` endpoint (cfb-app PR #20); this Python stdio server stays functional for local/offline use and as the reference implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNx7MmfrWbhFwx1du79KY3

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNx7MmfrWbhFwx1du79KY3)_