### PR TITLE
fix(rpc): cast bigint args in is_garbage_time calls — repairs 3 broken split RPCs

### DIFF
--- a/src/schemas/public/005_team_split_functions.sql
+++ b/src/schemas/public/005_team_split_functions.sql
@@ -45,7 +45,7 @@ BEGIN
         JOIN core.games g ON p.game_id = g.id
         WHERE g.season = p_season
           AND p.offense = p_team
-          AND NOT public.is_garbage_time(p.period, p.score_diff)
+          AND NOT public.is_garbage_time(p.period::integer, p.score_diff::integer)
     )
     SELECT
         gr.location::TEXT,
@@ -119,7 +119,7 @@ BEGIN
         JOIN public.teams opp ON opp.school = CASE WHEN g.home_team = p_team THEN g.away_team ELSE g.home_team END
         WHERE g.season = p_season
           AND p.offense = p_team
-          AND NOT public.is_garbage_time(p.period, p.score_diff)
+          AND NOT public.is_garbage_time(p.period::integer, p.score_diff::integer)
     )
     SELECT
         gr.opponent_type::TEXT,

--- a/src/schemas/public/006_play_analysis_functions.sql
+++ b/src/schemas/public/006_play_analysis_functions.sql
@@ -191,7 +191,7 @@ BEGIN
         WHERE g.season = p_season
           AND (p.offense = p_team OR p.defense = p_team)
           AND p.yardline >= 80
-          AND NOT public.is_garbage_time(p.period, p.score_diff)
+          AND NOT public.is_garbage_time(p.period::integer, p.score_diff::integer)
     )
     SELECT
         rzd.side::TEXT,


### PR DESCRIPTION
## Summary

`get_home_away_splits`, `get_conference_splits`, and `get_red_zone_splits` call `public.is_garbage_time(p.period, p.score_diff)` directly against `core.plays`, where `period`/`score_diff` are **bigint**. Postgres doesn't implicitly downcast for function resolution, so all three RPCs have errored with `function public.is_garbage_time(bigint, integer) does not exist` since the Tier 1 garbage-time filter deployed. `get_down_distance_splits`/`get_field_position_splits` were unaffected — they read the precomputed `marts.play_epa.is_garbage_time` boolean instead of calling the function.

**Blast radius:** cfb-app's team-page Home/Away, Conference, and Red Zone tabs (erroring→empty in production), and the MCP `situational_splits` tool — which is how this was caught: the owner's very first natural-language query through the new claude.ai connector surfaced the error text.

**Fix:** explicit `::integer` casts at the three call sites (minimal; keeps `is_garbage_time`'s canonical signature and its mart-column counterpart untouched).

**Deploy:** already applied to production via `deploy/fix-garbage-time` (apply-action manifest for the two files) — verified working through the live MCP endpoint post-apply.

Suggested follow-up (not in this PR): a smoke test that EXECUTEs each public RPC once against live data in CI, so signature drift between callers and helpers can't ship silently again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNx7MmfrWbhFwx1du79KY3

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNx7MmfrWbhFwx1du79KY3)_