### PR TITLE
fix: four reproducible daily-load failures (draft_teams, FK race, team_talent, career stats)

### DIFF
--- a/docs/pipeline-manifest.md
+++ b/docs/pipeline-manifest.md
@@ -175,7 +175,7 @@ Only 3 actual variant columns in user data tables. dlt internal tables also have
 | 52 | `/teams/matchup` | core.team_matchups | — | — | — | DEFERRED | team1, team2, season | — | Computed from games via matchup_history mart |
 | 53 | `/teams/ats` | betting.team_ats | betting.py | team_ats_resource | YES | merge | year, team_id | 2013-2026 | WORKING |
 | 54 | `/roster` | core.rosters | rosters.py | rosters_resource | YES | merge | id, team, year | 2004-2026 | WORKING (requires team list) |
-| 55 | `/talent` | recruiting.team_talent | recruiting.py | team_talent_resource | YES | merge | year, school | 2000-2026 | WORKING |
+| 55 | `/talent` | recruiting.team_talent | recruiting.py | team_talent_resource | YES | merge | year, team | 2000-2026 | WORKING |
 
 ### Adjusted Metrics (WEPA)
 

--- a/src/pipelines/config/endpoints.py
+++ b/src/pipelines/config/endpoints.py
@@ -305,7 +305,8 @@ RECRUITING_ENDPOINTS = {
     "team_talent": EndpointConfig(
         path="/talent",
         table_name="team_talent",
-        primary_key=["year", "school"],
+        # CFBD v2 renamed the /talent response field from "school" to "team".
+        primary_key=["year", "team"],
         schema="recruiting",
         write_disposition="merge",
     ),

--- a/src/pipelines/sources/recruiting.py
+++ b/src/pipelines/sources/recruiting.py
@@ -119,13 +119,18 @@ def transfer_portal_resource(years: list[int]) -> Iterator[dict]:
 @dlt.resource(
     name="team_talent",
     write_disposition="merge",
-    primary_key=["year", "school"],
+    primary_key=["year", "team"],
 )
 def team_talent_resource(years: list[int]) -> Iterator[dict]:
     """Load team talent composite ratings.
 
     Args:
         years: List of years to load talent data for
+
+    Note: CFBD v2 renamed the /talent response field from "school" to
+    "team" -- the merge key follows that rename. See
+    src/schemas/migrations/033_team_talent_reset.sql for the one-time
+    table reset this required.
     """
     client = get_client()
     try:

--- a/src/pipelines/sources/reference.py
+++ b/src/pipelines/sources/reference.py
@@ -162,11 +162,20 @@ def draft_positions_resource():
     primary_key=["location", "nickname"],
 )
 def draft_teams_resource():
-    """Load NFL draft teams."""
+    """Load NFL draft teams.
+
+    CFBD's DraftTeam.nickname is nullable, but it's part of the merge key
+    (location alone isn't unique -- e.g. New York Giants/Jets share
+    location "New York"). A NULL nickname makes dlt's NormalizeJobFailed
+    reject the row ("Cannot coerce NULL ... column nickname which is not
+    nullable"), so stamp any missing nickname to "" before it reaches dlt.
+    """
     client = get_client()
     try:
         data = make_request(client, "/draft/teams")
-        yield from data
+        for row in data:
+            row["nickname"] = row.get("nickname") or ""
+            yield row
     finally:
         client.close()
 

--- a/src/schemas/013_analytics_views.sql
+++ b/src/schemas/013_analytics_views.sql
@@ -148,8 +148,13 @@ WITH ranked AS (
 )
 SELECT
     r.player_id,
-    r.player,
-    r.position,
+    -- last player name / position (most recent season) -- player/position
+    -- can vary across seasons for the same player_id (name formatting,
+    -- position changes), and the unique index below is keyed on just
+    -- (player_id, category, stat_type), so these must be aggregated
+    -- the same way team/conference are, not grouped on directly.
+    MAX(CASE WHEN r.rn = 1 THEN r.player END) AS player,
+    MAX(CASE WHEN r.rn = 1 THEN r.position END) AS position,
     -- last team / conference (most recent season)
     MAX(CASE WHEN r.rn = 1 THEN r.team END) AS team,
     MAX(CASE WHEN r.rn = 1 THEN r.conference END) AS conference,
@@ -161,7 +166,7 @@ SELECT
     SUM(r.stat::numeric) AS total_stat,
     ROUND(SUM(r.stat::numeric) / NULLIF(COUNT(DISTINCT r.season), 0), 2) AS avg_stat_per_season
 FROM ranked r
-GROUP BY r.player_id, r.player, r.position, r.category, r.stat_type;
+GROUP BY r.player_id, r.category, r.stat_type;
 
 -- Unique index required for CONCURRENTLY refresh
 CREATE UNIQUE INDEX IF NOT EXISTS ux_player_career_stats

--- a/src/schemas/migrations/032_fk_drives_cascade.sql
+++ b/src/schemas/migrations/032_fk_drives_cascade.sql
@@ -1,0 +1,80 @@
+-- Migration: 032_fk_drives_cascade
+--
+-- Fixes a reproducible daily-load failure (run 29827205023):
+--   psycopg2.errors.ForeignKeyViolation: update or delete on table "games"
+--   violates foreign key constraint "fk_drives_game" on table "drives"
+--
+-- Root cause: dlt's "merge" write disposition is delete+reinsert -- for each
+-- resource, dlt deletes destination rows whose primary key appears in the
+-- current load package, then inserts the fresh rows. core.games and
+-- core.drives are sibling resources of the same cfbd_games dlt source
+-- (src/pipelines/sources/games.py) loaded in a single pipeline run, and dlt
+-- gives no ordering guarantee between resources within a run. When a game's
+-- score/status is updated (any in-progress or recently completed game),
+-- games' merge issues a DELETE on core.games for that id while core.drives
+-- still holds (or has not yet had reinserted) rows referencing that game_id
+-- -- the non-cascading FK added in add_fk_constraints.sql blocks the delete
+-- outright and fails the whole load.
+--
+-- The same hazard applies to every other child table with a non-cascading
+-- FK to core.games(id) that is itself loaded by a dlt merge resource in the
+-- same daily run (scripts/load_season.py's SOURCE_ORDER runs games, stats,
+-- betting, and metrics back to back for the same season every day). Grepping
+-- add_fk_constraints.sql and 012_foreign_keys.sql for `REFERENCES core.games`
+-- turns up four such FKs total:
+--   - core.drives.game_id               (cfbd_games source    -- games.py)
+--   - betting.lines.game_id             (cfbd_betting source  -- betting.py)
+--   - metrics.pregame_win_probability.game_id (cfbd_metrics source -- metrics.py)
+--   - stats.game_havoc.game_id          (cfbd_stats source    -- stats.py)
+-- core.plays has no FK to core.games (partitioned tables can't carry one --
+-- see 012's "SKIPPED" note) so it isn't affected here. game_team_stats and
+-- game_player_stats (game_stats.py / cfbd_game_stats source) were checked
+-- too -- no FK to core.games exists for either, so they aren't in scope.
+--
+-- Fix: recreate all four as ON DELETE CASCADE. This doesn't weaken
+-- integrity in practice: every one of these child resources is re-merged
+-- in the same daily run as games, so a cascade-deleted row is reinstated by
+-- that resource's own insert step moments later -- the cascade only ever
+-- removes a row for the instant between games' delete and the child
+-- resource's own reinsert, instead of aborting the whole load.
+--
+-- 012_foreign_keys.sql originally added these same three (drives/lines/
+-- pregame_win_probability) under `_id`-suffixed names
+-- (fk_drives_game_id, etc.); add_fk_constraints.sql later re-added them
+-- (plus game_havoc) under the shorter names that are live today (confirmed
+-- by the error text above). Both DROP forms are included so this is
+-- idempotent regardless of which names exist in a given environment.
+--
+-- Apply via:
+--   python scripts/run_migrations.py --file src/schemas/migrations/032_fk_drives_cascade.sql
+
+-- core.drives.game_id -> core.games.id
+ALTER TABLE core.drives DROP CONSTRAINT IF EXISTS fk_drives_game;
+ALTER TABLE core.drives DROP CONSTRAINT IF EXISTS fk_drives_game_id;
+ALTER TABLE core.drives
+  ADD CONSTRAINT fk_drives_game
+  FOREIGN KEY (game_id) REFERENCES core.games(id) ON DELETE CASCADE NOT VALID;
+ALTER TABLE core.drives VALIDATE CONSTRAINT fk_drives_game;
+
+-- betting.lines.game_id -> core.games.id
+ALTER TABLE betting.lines DROP CONSTRAINT IF EXISTS fk_lines_game;
+ALTER TABLE betting.lines DROP CONSTRAINT IF EXISTS fk_lines_game_id;
+ALTER TABLE betting.lines
+  ADD CONSTRAINT fk_lines_game
+  FOREIGN KEY (game_id) REFERENCES core.games(id) ON DELETE CASCADE NOT VALID;
+ALTER TABLE betting.lines VALIDATE CONSTRAINT fk_lines_game;
+
+-- metrics.pregame_win_probability.game_id -> core.games.id
+ALTER TABLE metrics.pregame_win_probability DROP CONSTRAINT IF EXISTS fk_pregame_wp_game;
+ALTER TABLE metrics.pregame_win_probability DROP CONSTRAINT IF EXISTS fk_pregame_wp_game_id;
+ALTER TABLE metrics.pregame_win_probability
+  ADD CONSTRAINT fk_pregame_wp_game
+  FOREIGN KEY (game_id) REFERENCES core.games(id) ON DELETE CASCADE NOT VALID;
+ALTER TABLE metrics.pregame_win_probability VALIDATE CONSTRAINT fk_pregame_wp_game;
+
+-- stats.game_havoc.game_id -> core.games.id
+ALTER TABLE stats.game_havoc DROP CONSTRAINT IF EXISTS fk_game_havoc_game;
+ALTER TABLE stats.game_havoc
+  ADD CONSTRAINT fk_game_havoc_game
+  FOREIGN KEY (game_id) REFERENCES core.games(id) ON DELETE CASCADE NOT VALID;
+ALTER TABLE stats.game_havoc VALIDATE CONSTRAINT fk_game_havoc_game;

--- a/src/schemas/migrations/033_team_talent_reset.sql
+++ b/src/schemas/migrations/033_team_talent_reset.sql
@@ -1,0 +1,39 @@
+-- One-off reset BEFORE reloading team_talent under the widened merge key
+-- =============================================================================
+-- src/pipelines/sources/recruiting.py and src/pipelines/config/endpoints.py
+-- now merge recruiting.team_talent on [year, team] instead of [year, school]
+-- -- CFBD's v2 /talent response renamed the "school" field to "team", so
+-- the pipeline was writing rows with no "school" value at all.
+--
+-- The reload cannot run against the old table: prod's recruiting.team_talent
+-- was built under the old [year, school] key, so its rows have "school"
+-- populated and no "team" column exists. dlt adds new merge-key columns as
+-- NOT NULL, and since none of the existing rows can supply a value, the
+-- first reload attempt fails the same way the rankings rekey did (see
+-- 023_rankings_rekey_reset.sql) --
+--   table "team_talent" did not receive any data for column "school"
+--   (non-nullable primary key) [UnboundColumnException]
+-- Dropping the table (rather than trying to rename/backfill the column)
+-- also sheds the old [year, school] unique index, which would reject the
+-- new [year, team] key. dlt recreates the table with the new schema on the
+-- next load.
+--
+-- Safe because recruiting.team_talent is small (one row per team per
+-- season) and fully reproducible from the CFBD /talent endpoint -- the next
+-- daily run (or a manual `python -m src.pipelines.run --source recruiting`)
+-- reloads it in full under the new key.
+--
+-- Dependent-view check: grepped src/schemas/ for `recruiting.team_talent`
+-- and `team_talent`'s `school` column -- nothing reads from this table.
+-- marts.team_talent_composite (017_team_talent_composite.sql) sounds like a
+-- dependent but isn't: it computes its own talent score from
+-- core.roster + recruiting.recruits + recruiting.transfer_portal and never
+-- touches recruiting.team_talent. So no view needs to be dropped or
+-- rewritten here. (If a future view does read recruiting.team_talent, it
+-- must select `team`, not `school`, and will need to be re-applied after
+-- the reload since this migration only drops the base table.)
+--
+-- Not in MIGRATION_ORDER: applied via run_migrations.py --file (deploy
+-- manifest), like 019-023. Idempotent (IF EXISTS).
+
+DROP TABLE IF EXISTS recruiting.team_talent;

--- a/src/schemas/migrations/034_player_career_stats_fix.sql
+++ b/src/schemas/migrations/034_player_career_stats_fix.sql
@@ -1,0 +1,83 @@
+-- Migration: 034_player_career_stats_fix
+--
+-- Fixes REFRESH MATERIALIZED VIEW CONCURRENTLY analytics.player_career_stats
+-- failing with:
+--   duplicate key value violates unique constraint "ux_player_career_stats"
+--   DETAIL: Key (player_id, category, stat_type)=(...) already exists.
+--
+-- Root cause: 013_analytics_views.sql's original definition grouped by
+-- r.player_id, r.player, r.position, r.category, r.stat_type, but the
+-- unique index backing CONCURRENTLY refresh is only on
+-- (player_id, category, stat_type). A player whose `player` name spelling
+-- or `position` differs across seasons in stats.player_season_stats (name
+-- formatting changes, position switches) produces more than one GROUP BY
+-- group for the same (player_id, category, stat_type) -- i.e. more than one
+-- row per unique-index key -- which is exactly what the index rejects.
+--
+-- Fix: aggregate player/position the same way team/conference already are
+-- in this view (MAX(CASE WHEN rn = 1 THEN ... END), picking the most recent
+-- season's value) instead of grouping on them directly, and drop them from
+-- GROUP BY. This is the identical fix applied to 013_analytics_views.sql --
+-- copied verbatim here so prod can be repaired without waiting on a full
+-- migration run.
+--
+-- Apply via:
+--   python scripts/run_migrations.py --file src/schemas/migrations/034_player_career_stats_fix.sql
+--
+-- Idempotent: DROP MATERIALIZED VIEW IF EXISTS + recreate.
+
+DROP MATERIALIZED VIEW IF EXISTS analytics.player_career_stats;
+
+CREATE MATERIALIZED VIEW analytics.player_career_stats AS
+WITH ranked AS (
+    SELECT
+        player_id,
+        player,
+        position,
+        team,
+        conference,
+        season,
+        category,
+        stat_type,
+        stat,
+        ROW_NUMBER() OVER (
+            PARTITION BY player_id, category, stat_type
+            ORDER BY season DESC
+        ) AS rn
+    FROM stats.player_season_stats
+)
+SELECT
+    r.player_id,
+    -- last player name / position (most recent season) -- player/position
+    -- can vary across seasons for the same player_id (name formatting,
+    -- position changes), and the unique index below is keyed on just
+    -- (player_id, category, stat_type), so these must be aggregated
+    -- the same way team/conference are, not grouped on directly.
+    MAX(CASE WHEN r.rn = 1 THEN r.player END) AS player,
+    MAX(CASE WHEN r.rn = 1 THEN r.position END) AS position,
+    -- last team / conference (most recent season)
+    MAX(CASE WHEN r.rn = 1 THEN r.team END) AS team,
+    MAX(CASE WHEN r.rn = 1 THEN r.conference END) AS conference,
+    COUNT(DISTINCT r.season)::int AS seasons_played,
+    MIN(r.season)::int AS first_season,
+    MAX(r.season)::int AS last_season,
+    r.category,
+    r.stat_type,
+    SUM(r.stat::numeric) AS total_stat,
+    ROUND(SUM(r.stat::numeric) / NULLIF(COUNT(DISTINCT r.season), 0), 2) AS avg_stat_per_season
+FROM ranked r
+GROUP BY r.player_id, r.category, r.stat_type;
+
+-- Unique index required for CONCURRENTLY refresh
+CREATE UNIQUE INDEX ux_player_career_stats
+    ON analytics.player_career_stats(player_id, category, stat_type);
+
+-- Query indexes
+CREATE INDEX ix_player_career_stats_player
+    ON analytics.player_career_stats(player);
+CREATE INDEX ix_player_career_stats_team
+    ON analytics.player_career_stats(team);
+CREATE INDEX ix_player_career_stats_position
+    ON analytics.player_career_stats(position);
+CREATE INDEX ix_player_career_stats_category
+    ON analytics.player_career_stats(category, stat_type);


### PR DESCRIPTION
Today's scheduled daily-load (run 29827205023) failed on four distinct errors. Log analysis shows none are transient — all four reproduce on every run:

1. **`reference` / `draft_teams`** — dlt NormalizeJobFailed: CFBD marks `DraftTeam.nickname` nullable, but it's half our merge key (`location` alone collides — New York Giants/Jets). Fix: stamp `nickname = ""` when null before yield.
2. **`games` / FK merge race** — `fk_drives_game` ForeignKeyViolation: dlt merge is delete+reinsert per table with no cross-table ordering, so deleting a `core.games` row can race a child that still references it. Migration 032 recreates all four `core.games` child FKs (`drives`, `betting.lines`, `metrics.pregame_win_probability`, `stats.game_havoc`) with `ON DELETE CASCADE`; the children are re-merged in the same run, so cascade-deleted rows are reinstated. (`core.plays` has no FK — partitioned; game stats tables have no FK to games.)
3. **`recruiting` / `team_talent`** — CFBD v2 renamed the `/talent` field `school` → `team`; the old merge key now binds no data. Merge key updated to `["year","team"]`; migration 033 drops the old-keyed table for a clean reload (023 rankings-reset precedent; table is small and fully reproducible). `marts.team_talent_composite` verified independent — it never reads this table.
4. **`analytics.player_career_stats`** — REFRESH CONCURRENTLY duplicate-key: the view GROUPed BY `player, position` beyond its `(player_id, category, stat_type)` unique index, so name/position drift across seasons collapses two groups onto one key. Fixed via the same `rn = 1` aggregation pattern the view already uses for team/conference; migration 034 is the standalone prod applier.

Post-merge sequence (this session drives it): deploy migrations 032/033/034 via `deploy/**`, then `workflow_dispatch` daily-load with `recap_limit=3` — one run validates these fixes, the Tier 3 daily steps, and PR #22's recap smoke together.

Local gates: ruff clean, 671 no-DB tests passed; all new SQL pglast-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aq5tEVxkthmuRX7JH9qEW

---
_Generated by [Claude Code](https://claude.ai/code/session_018aq5tEVxkthmuRX7JH9qEW)_