### PR TITLE
Fix round 3 of daily-load failures: FK catch-all, ref root-key reset, team_talent shells

### DIFF
--- a/src/schemas/migrations/037_fk_deferrable_catchall.sql
+++ b/src/schemas/migrations/037_fk_deferrable_catchall.sql
@@ -1,0 +1,69 @@
+-- Migration: 037_fk_deferrable_catchall
+-- Extends: 035_fk_deferrable.sql (applied to prod 2026-07-21 ~14:34Z)
+--
+-- 035 converted the five known core.games child FKs to DEFERRABLE INITIALLY
+-- DEFERRED so dlt's merge delete+reinsert (one transaction per load package)
+-- passes FK checks at COMMIT instead of mid-transaction. The validation run
+-- after 035 (run 29840221192 / job 88666912063, games step) surfaced a SIXTH
+-- constraint with the identical failure:
+--   psycopg2.errors.ForeignKeyViolation: update or delete on table "games"
+--   violates foreign key constraint "fk_advanced_game_stats_game" on table
+--   "advanced_game_stats"
+--   DETAIL:  Key (id)=(401752939) is still referenced from table
+--   "advanced_game_stats".
+-- Like fk_play_stats_game before it, fk_advanced_game_stats_game exists only
+-- in prod -- it is not defined in any tracked migration -- so enumerating
+-- constraints by name in the repo keeps missing one per validation round.
+--
+-- This migration ends the sequential discovery: it walks pg_constraint and
+-- makes EVERY not-yet-deferrable FK whose referenced table lives in a
+-- dlt-loaded dataset schema DEFERRABLE INITIALLY DEFERRED. Any table in
+-- those schemas is subject to merge delete+reinsert within a load
+-- transaction, so every FK pointing at one is exposed to the same
+-- mid-transaction false positive. Deferring the check to COMMIT preserves
+-- the exact same integrity guarantee (a genuinely orphaned child row still
+-- fails the load) while tolerating the transient delete+reinsert window.
+--
+-- ALTER CONSTRAINT (not drop/re-add) keeps each constraint's existing
+-- definition -- columns, ON DELETE/ON UPDATE actions, validation state --
+-- which matters precisely because the untracked ones have no repo source to
+-- recreate them from. conparentid = 0 skips partition-inherited copies
+-- (ALTER CONSTRAINT on those is rejected; the parent constraint covers
+-- them; no such FK exists today -- core.plays has none -- but the guard
+-- keeps this re-runnable if that changes).
+--
+-- Not in MIGRATION_ORDER: applied via run_migrations.py --file (deploy
+-- manifest), like 019-036. Idempotent (already-deferrable FKs are filtered
+-- out, so a re-run is a no-op).
+--
+--   python scripts/run_migrations.py --file src/schemas/migrations/037_fk_deferrable_catchall.sql
+
+DO $$
+DECLARE
+    fk record;
+    n integer := 0;
+BEGIN
+    FOR fk IN
+        SELECT con.conname,
+               con.conrelid::regclass AS child_table,
+               con.confrelid::regclass AS parent_table
+        FROM pg_constraint con
+        JOIN pg_class parent ON parent.oid = con.confrelid
+        JOIN pg_namespace pn ON pn.oid = parent.relnamespace
+        WHERE con.contype = 'f'
+          AND NOT con.condeferrable
+          AND con.conparentid = 0
+          AND pn.nspname IN ('ref', 'core', 'stats', 'ratings', 'recruiting',
+                             'betting', 'draft', 'metrics')
+        ORDER BY con.conname
+    LOOP
+        EXECUTE format(
+            'ALTER TABLE %s ALTER CONSTRAINT %I DEFERRABLE INITIALLY DEFERRED',
+            fk.child_table, fk.conname
+        );
+        RAISE NOTICE 'made deferrable: % on % (references %)',
+            fk.conname, fk.child_table, fk.parent_table;
+        n := n + 1;
+    END LOOP;
+    RAISE NOTICE '037_fk_deferrable_catchall: % constraint(s) converted', n;
+END $$;

--- a/src/schemas/migrations/038_ref_root_key_reset.sql
+++ b/src/schemas/migrations/038_ref_root_key_reset.sql
@@ -1,0 +1,71 @@
+-- Migration: 038_ref_root_key_reset
+--
+-- Validation run 29840221192 / job 88666912063 (reference step, 7.2s):
+--   dlt.destinations.exceptions.DatabaseTerminalException:
+--   column "_dlt_root_id" of relation "coaches__seasons" contains null values
+-- preceded by dlt's warning:
+--   You are adding a root_key in column _dlt_root_id to an already existing
+--   table coaches__seasons ... Column(s) ['"_dlt_root_id"'] with NOT NULL
+--   are being added to existing table coaches__seasons.
+--
+-- Root cause: dlt now propagates a root-key column (_dlt_root_id, NOT NULL)
+-- into nested child tables of merge-disposition resources. ref.coaches__seasons
+-- predates that requirement, so dlt issues
+--   ALTER TABLE coaches__seasons ADD COLUMN _dlt_root_id varchar NOT NULL
+-- against a populated table, which Postgres rejects ("contains null values").
+--
+-- Fix: TRUNCATE the affected CHILD tables (only), so dlt's ADD COLUMN ...
+-- NOT NULL succeeds on an empty table and its stored schema advances
+-- cleanly. Parents keep their rows -- root tables never carry _dlt_root_id,
+-- so they need no ALTER -- and the reference source re-yields the full
+-- /coaches snapshot on every run (merge disposition, no year filter), so the
+-- child rows are fully rebuilt by the next reference load. Backfilling
+-- _dlt_root_id values by hand was rejected: dlt's stored destination schema
+-- would still lack the column, so dlt would attempt the same ADD COLUMN on
+-- the next run and fail with "column already exists" instead.
+--
+-- The predicate is generic (any ref/ref_staging table with _dlt_parent_id
+-- but no _dlt_root_id) rather than naming coaches__seasons, because every
+-- pre-root-key child table in the ref dataset -- e.g. the teams/teams_fbs
+-- logo child tables, if they were created without it -- hits the identical
+-- ALTER on its next schema sync, and dlt only reports the first failure per
+-- run. Scoped to the ref dataset only: it is small, fully re-yielded every
+-- load, and the only dataset that has shown this failure (all other sources
+-- cleared their schema sync in runs 29827205023/29840221192).
+--
+-- Not in MIGRATION_ORDER: applied via run_migrations.py --file (deploy
+-- manifest), like 019-037. Idempotent: once dlt adds _dlt_root_id, the
+-- predicate no longer matches and this is a no-op.
+--
+--   python scripts/run_migrations.py --file src/schemas/migrations/038_ref_root_key_reset.sql
+
+DO $$
+DECLARE
+    child record;
+    n integer := 0;
+BEGIN
+    FOR child IN
+        SELECT c.table_schema, c.table_name
+        FROM information_schema.columns c
+        JOIN information_schema.tables t
+          ON t.table_schema = c.table_schema
+         AND t.table_name = c.table_name
+         AND t.table_type = 'BASE TABLE'
+        WHERE c.table_schema IN ('ref', 'ref_staging')
+          AND c.column_name = '_dlt_parent_id'
+          AND NOT EXISTS (
+              SELECT 1
+              FROM information_schema.columns r
+              WHERE r.table_schema = c.table_schema
+                AND r.table_name = c.table_name
+                AND r.column_name = '_dlt_root_id'
+          )
+        ORDER BY c.table_schema, c.table_name
+    LOOP
+        EXECUTE format('TRUNCATE TABLE %I.%I', child.table_schema, child.table_name);
+        RAISE NOTICE 'truncated %.% (child table missing _dlt_root_id; next reference load rebuilds it)',
+            child.table_schema, child.table_name;
+        n := n + 1;
+    END LOOP;
+    RAISE NOTICE '038_ref_root_key_reset: % child table(s) truncated', n;
+END $$;

--- a/src/schemas/migrations/039_team_talent_staging_shell.sql
+++ b/src/schemas/migrations/039_team_talent_staging_shell.sql
@@ -1,0 +1,55 @@
+-- Migration: 039_team_talent_staging_shell
+-- Corrects: 036_recruiting_staging_repair.sql's deliberate team_talent skip
+--
+-- Validation run 29840221192 / job 88666912063 (recruiting step, 5.6s):
+--   dlt.destinations.exceptions.DatabaseUndefinedRelation:
+--   relation "recruiting_staging.team_talent" does not exist
+--
+-- 033_team_talent_reset.sql dropped recruiting.team_talent outright for the
+-- CFBD v2 merge-key change (school -> team), and 036 deliberately did not
+-- recreate a staging shell for it, reasoning that dlt would see the table as
+-- brand-new and CREATE both the destination and staging tables itself. That
+-- assumption is now disproven: dlt's stored destination schema (in
+-- recruiting._dlt_version) still lists team_talent, so dlt skips table
+-- creation entirely and goes straight to the merge path, which fails on the
+-- missing staging relation (and would next fail on the missing destination
+-- table).
+--
+-- Fix: recreate BOTH tables as empty shells laid out exactly like the
+-- stored schema dlt still remembers -- columns year/school/talent plus the
+-- dlt bookkeeping pair -- with two deliberate deviations:
+--
+--   * school is NULLABLE here (it was NOT NULL as part of the old merge
+--     key). CFBD v2 responses carry `team` instead of `school`, so every
+--     row loaded from now on has school NULL; a NOT NULL school would fail
+--     the first insert. dlt never re-asserts nullability on existing
+--     columns, so the relaxation sticks.
+--   * `team` is deliberately ABSENT. dlt's stored schema predates the
+--     rename, so its next schema sync generates
+--       ALTER TABLE ... ADD COLUMN team varchar NOT NULL
+--     which succeeds because both shells are empty -- and would fail with
+--     "column already exists" if we pre-created it (same reasoning as 038's
+--     rejected hand-backfill).
+--
+-- The table is empty after this migration; the next recruiting load (which
+-- yields the full /talent snapshot per year) repopulates the loaded years,
+-- and the historical backfill re-covers the rest. That data loss already
+-- happened at 033 (the drop); this migration adds none.
+--
+-- Not in MIGRATION_ORDER: applied via run_migrations.py --file (deploy
+-- manifest), like 019-038. Idempotent (IF NOT EXISTS throughout).
+--
+--   python scripts/run_migrations.py --file src/schemas/migrations/039_team_talent_staging_shell.sql
+
+CREATE SCHEMA IF NOT EXISTS recruiting_staging;
+
+CREATE TABLE IF NOT EXISTS recruiting.team_talent (
+    year bigint,
+    school varchar,
+    talent double precision,
+    _dlt_load_id varchar NOT NULL,
+    _dlt_id varchar NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS recruiting_staging.team_talent
+  (LIKE recruiting.team_talent INCLUDING ALL);


### PR DESCRIPTION
Third round of daily-load repairs, from validation run 29840221192 (job 88666912063, sources `reference,games,recruiting`, season 2025). All three are new next-in-line errors — the round-2 fixes (draft_teams nickname stamp, stat_categories string wrap, migrations 035/036) are confirmed working in that run's log.

## games — `fk_advanced_game_stats_game` (migration 037)

`ForeignKeyViolation: update or delete on table "games" violates foreign key constraint "fk_advanced_game_stats_game" on table "advanced_game_stats"` — a **sixth** core.games child FK, untracked in repo SQL just like `fk_play_stats_game` was. Instead of adding one name per validation round, 037 walks `pg_constraint` and makes **every** not-yet-deferrable FK referencing a dlt-loaded schema (`ref, core, stats, ratings, recruiting, betting, draft, metrics`) `DEFERRABLE INITIALLY DEFERRED`. `ALTER CONSTRAINT` preserves each constraint's existing definition (needed, since the untracked ones have no repo source), and integrity is still enforced — just at COMMIT, after dlt's delete+reinsert has completed inside its single load transaction.

## reference — `coaches__seasons` `_dlt_root_id` (migration 038)

dlt now propagates a NOT NULL `_dlt_root_id` root key into merge-disposition child tables; `ref.coaches__seasons` predates it, so dlt's `ADD COLUMN ... NOT NULL` fails on the populated table. 038 truncates ref/ref_staging **child** tables missing the column (generic predicate — dlt reports only the first failure per run, so any sibling in the same state is handled in one pass). Parents keep their rows; the reference source re-yields the full `/coaches` snapshot every run, so children rebuild on the next load. Hand-backfilling the column was rejected: dlt's stored schema would still lack it and the next run would fail with "column already exists".

## recruiting — `recruiting_staging.team_talent` missing (migration 039)

036 deliberately skipped team_talent on the assumption dlt would treat the dropped table (033) as brand-new and create it. Disproven: dlt's stored destination schema still lists team_talent, so it skips creation and fails on the missing staging relation. 039 recreates both destination and staging tables as empty shells matching the stored schema, with `school` made nullable (v2 data carries `team` instead) and `team` deliberately absent so dlt's own `ADD COLUMN team varchar NOT NULL` succeeds on the empty tables.

## Deploy plan

After merge: apply 037–039 via the `deploy/daily-load-fixes` branch, then re-run the `reference,games,recruiting` 2025 validation backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aq5tEVxkthmuRX7JH9qEW

---
_Generated by [Claude Code](https://claude.ai/code/session_018aq5tEVxkthmuRX7JH9qEW)_