### PR TITLE
Fix round 4 of daily-load failures: drives orphan filter, recruiting_groups v2 shape, team_talent column

### DIFF
--- a/src/pipelines/sources/games.py
+++ b/src/pipelines/sources/games.py
@@ -82,6 +82,12 @@ def games_resource(years: list[int]) -> Iterator[dict]:
 def drives_resource(years: list[int]) -> Iterator[dict]:
     """Load drives for specified years.
 
+    CFBD's /drives can return drives for game ids that /games no longer
+    lists for the same year (e.g. 2025's 401754543 -- cancelled/delisted
+    games whose partial drive data lingers). Such rows have no parent for
+    fk_drives_game, so each year's drives are filtered against that year's
+    /games id set; dropped drives are logged, never loaded.
+
     Args:
         years: List of years to load drives for
     """
@@ -90,21 +96,41 @@ def drives_resource(years: list[int]) -> Iterator[dict]:
         for year in years:
             logger.info(f"Loading drives for {year}...")
 
+            game_ids = {
+                game["id"] for game in make_request(client, "/games", params={"year": year})
+            }
+
+            year_drives: list[dict] = []
+            orphan_ids: set[int | None] = set()
+            dropped = 0
+
             # CFBD drives endpoint requires seasonType parameter
-            data = make_request(client, "/drives", params={"year": year, "seasonType": "regular"})
+            for season_type in ("regular", "postseason"):
+                data = make_request(
+                    client, "/drives", params={"year": year, "seasonType": season_type}
+                )
+                for drive in data:
+                    gid = drive.get("gameId", drive.get("game_id"))
+                    if gid not in game_ids:
+                        orphan_ids.add(gid)
+                        dropped += 1
+                        continue
+                    drive["season"] = year
+                    year_drives.append(drive)
 
-            for drive in data:
-                drive["season"] = year
-                yield drive
+            if orphan_ids:
+                logger.warning(
+                    f"Dropping {dropped} drive(s) for {len(orphan_ids)} game(s) absent "
+                    f"from /games?year={year}: {sorted(map(str, orphan_ids))[:10]}"
+                )
+            total = dropped + len(year_drives)
+            if total and dropped / total > 0.25:
+                raise ValueError(
+                    f"Orphan filter would drop {dropped}/{total} drives for {year} -- "
+                    "that is field-rename/coverage breakage, not stray game ids"
+                )
 
-            # Also load postseason drives
-            postseason_data = make_request(
-                client, "/drives", params={"year": year, "seasonType": "postseason"}
-            )
-
-            for drive in postseason_data:
-                drive["season"] = year
-                yield drive
+            yield from year_drives
 
     finally:
         client.close()

--- a/src/pipelines/sources/recruiting.py
+++ b/src/pipelines/sources/recruiting.py
@@ -153,6 +153,14 @@ def team_talent_resource(years: list[int]) -> Iterator[dict]:
 def recruiting_groups_resource(years: list[int]) -> Iterator[dict]:
     """Load recruiting data by position group.
 
+    CFBD v2 changed /recruiting/groups to an aggregate over a
+    startYear/endYear range (the old year param is gone) and dropped the
+    year field from the response entirely. Requesting one year at a time
+    and stamping it locally preserves the (year, team, position_group)
+    grain the table has always had. positionGroup is nullable in the v2
+    schema; the merge key requires it, so a missing value gets the
+    "All Positions" label CFBD uses for the cross-position aggregate.
+
     Args:
         years: List of years to load recruiting groups for
     """
@@ -161,9 +169,15 @@ def recruiting_groups_resource(years: list[int]) -> Iterator[dict]:
         for year in years:
             logger.info(f"Loading recruiting groups for {year}...")
 
-            data = make_request(client, "/recruiting/groups", params={"year": year})
+            data = make_request(
+                client, "/recruiting/groups", params={"startYear": year, "endYear": year}
+            )
 
-            yield from data
+            for row in data:
+                row["year"] = year
+                if not row.get("positionGroup") and not row.get("position_group"):
+                    row["positionGroup"] = "All Positions"
+                yield row
 
     finally:
         client.close()

--- a/src/schemas/migrations/040_team_talent_team_column.sql
+++ b/src/schemas/migrations/040_team_talent_team_column.sql
@@ -1,0 +1,29 @@
+-- Migration: 040_team_talent_team_column
+-- Corrects: 039_team_talent_staging_shell.sql's "team deliberately absent"
+--
+-- Validation run 29843551259 / job 88678224085 (recruiting step, 8.7s):
+--   dlt.destinations.exceptions.DatabaseTerminalException:
+--   column "team" of relation "team_talent" does not exist
+--   LINE 1: ...rt into "recruiting_staging"."team_talent"("year","team","ta...
+--
+-- 039 left `team` out of the shells expecting dlt's next schema sync to
+-- generate the ADD COLUMN itself (stored schema predating the v2 rename).
+-- The run disproved that: dlt's stored schema for the recruiting dataset
+-- ALREADY contains team_talent.team -- a schema sync in one of the earlier
+-- failed runs advanced recruiting._dlt_version past the rename even though
+-- the physical ALTER never landed (033 had dropped the table). With the
+-- stored schema showing no diff, dlt goes straight to the staging INSERT,
+-- which names the column that only exists in its bookkeeping.
+--
+-- Fix: add the column physically to both (still empty) shells, matching
+-- what the stored schema believes is already there. Nullable is fine --
+-- dlt never re-asserts nullability on existing columns, and every v2 row
+-- carries a team value.
+--
+-- Not in MIGRATION_ORDER: applied via run_migrations.py --file (deploy
+-- manifest), like 019-039. Idempotent (IF NOT EXISTS).
+--
+--   python scripts/run_migrations.py --file src/schemas/migrations/040_team_talent_team_column.sql
+
+ALTER TABLE recruiting.team_talent ADD COLUMN IF NOT EXISTS team varchar;
+ALTER TABLE recruiting_staging.team_talent ADD COLUMN IF NOT EXISTS team varchar;

--- a/tests/test_sources/test_games.py
+++ b/tests/test_sources/test_games.py
@@ -26,3 +26,83 @@ def test_game_stats_source_owns_game_stats():
     source = game_stats_source(years=[2024])
 
     assert set(source.resources.keys()) == {"game_team_stats", "game_player_stats"}
+
+
+def _drives_rows(years):
+    """Materialize drives_resource rows with the dlt wrapper unwrapped."""
+    from src.pipelines.sources.games import drives_resource
+
+    return list(drives_resource(years))
+
+
+def _fake_games_and_drives(games_by_year, drives_by_type):
+    """Return a make_request side effect serving /games and /drives."""
+
+    def side_effect(client, path, params=None):
+        if path == "/games":
+            return games_by_year[params["year"]]
+        if path == "/drives":
+            return drives_by_type[params["seasonType"]]
+        raise AssertionError(f"unexpected path {path}")
+
+    return side_effect
+
+
+def test_drives_resource_drops_orphan_game_ids():
+    """Drives whose gameId is absent from /games must not be yielded.
+
+    CFBD's /drives can keep drives for cancelled/delisted games (e.g.
+    2025's 401754543) that /games no longer lists; loading them violates
+    fk_drives_game.
+    """
+    from unittest.mock import MagicMock, patch
+
+    games = {2025: [{"id": 100}, {"id": 200}]}
+    drives = {
+        "regular": [
+            {"id": "100-1", "gameId": 100},
+            {"id": "100-2", "gameId": 100},
+            {"id": "100-3", "gameId": 100},
+            {"id": "999-1", "gameId": 999},  # orphan, under the 25% tripwire
+        ],
+        "postseason": [{"id": "200-1", "gameId": 200}],
+    }
+
+    with (
+        patch("src.pipelines.sources.games.get_client") as mock_get_client,
+        patch("src.pipelines.sources.games.make_request") as mock_make_request,
+    ):
+        mock_get_client.return_value = MagicMock()
+        mock_make_request.side_effect = _fake_games_and_drives(games, drives)
+        rows = _drives_rows([2025])
+
+    assert [r["id"] for r in rows] == ["100-1", "100-2", "100-3", "200-1"]
+    assert all(r["season"] == 2025 for r in rows)
+
+
+def test_drives_resource_raises_on_mass_drop():
+    """Dropping >25% of a year's drives means breakage, not stray ids."""
+    from unittest.mock import MagicMock, patch
+
+    import pytest
+    from dlt.extract.exceptions import ResourceExtractionError
+
+    games = {2025: [{"id": 100}]}
+    drives = {
+        "regular": [
+            {"id": "a", "gameId": 100},
+            {"id": "b", "gameId": 901},
+            {"id": "c", "gameId": 902},
+        ],
+        "postseason": [],
+    }
+
+    with (
+        patch("src.pipelines.sources.games.get_client") as mock_get_client,
+        patch("src.pipelines.sources.games.make_request") as mock_make_request,
+    ):
+        mock_get_client.return_value = MagicMock()
+        mock_make_request.side_effect = _fake_games_and_drives(games, drives)
+        # dlt wraps the resource's ValueError in ResourceExtractionError
+        with pytest.raises(ResourceExtractionError, match="Orphan filter"):
+            _drives_rows([2025])

--- a/tests/test_sources/test_recruiting.py
+++ b/tests/test_sources/test_recruiting.py
@@ -1,0 +1,48 @@
+"""Tests for recruiting source v2 response-shape adaptations."""
+
+from unittest.mock import MagicMock, patch
+
+from src.pipelines.sources.recruiting import recruiting_groups_resource
+
+
+def test_recruiting_groups_stamps_year_and_requests_year_range():
+    """v2 /recruiting/groups has no year in the response; the resource must
+    request startYear=endYear=year and stamp year onto every row."""
+    mock_response = [
+        {
+            "team": "Baylor",
+            "conference": "Big 12",
+            "positionGroup": "All Positions",
+            "averageRating": 0.83,
+            "totalRating": 42.7,
+            "commits": 51,
+            "averageStars": 2.96,
+        },
+        {
+            "team": "Baylor",
+            "conference": "Big 12",
+            "positionGroup": None,  # nullable in the v2 schema
+            "averageRating": 0.80,
+            "totalRating": 12.0,
+            "commits": 15,
+            "averageStars": 2.8,
+        },
+    ]
+
+    with (
+        patch("src.pipelines.sources.recruiting.get_client") as mock_get_client,
+        patch("src.pipelines.sources.recruiting.make_request") as mock_make_request,
+    ):
+        mock_get_client.return_value = MagicMock()
+        mock_make_request.return_value = mock_response
+
+        rows = list(recruiting_groups_resource(years=[2025]))
+
+        (_, path), kwargs = mock_make_request.call_args
+        params = kwargs["params"]
+
+    assert path == "/recruiting/groups"
+    assert params == {"startYear": 2025, "endYear": 2025}
+    assert all(r["year"] == 2025 for r in rows)
+    # NULL positionGroup would violate the (year, team, position_group) merge key
+    assert rows[1]["positionGroup"] == "All Positions"


### PR DESCRIPTION
Fourth round, from validation run 29843551259 (job 88678224085). Round 3 partially landed: **reference now loads green** — migration 038's truncate let dlt add `_dlt_root_id` to `coaches__seasons`, `teams__logos`, `teams__alternate_names`, `teams_fbs__*` cleanly — and 037's FK catch-all converted the delete-side violations away. What's left:

## games — orphan drives (code fix)

The failure moved from delete-side to **insert-side**: `fk_drives_game` DETAIL `Key (game_id)=(401754543) is not present in table "games"`, *after* the games merge had already committed. CFBD's `/drives` still returns drives for game ids `/games` no longer lists for that year (cancelled/delisted games). The deferred FK is doing exactly its job — those drives are genuine orphans. `drives_resource` now fetches the year's `/games` id set (one extra API call per year) and filters drives against it, logging what it drops. A tripwire raises if the filter would drop >25% of a year's drives, so a future CFBD field rename can't silently discard the table.

## recruiting — `recruiting_groups` v2 shape (code fix)

`NotNullViolation: null value in column "year"`. CFBD v2 rebuilt `/recruiting/groups` as an aggregate over `startYear`/`endYear` (the `year` param is gone) and its response object (`AggregatedTeamRecruiting`) carries **no year field** — confirmed against the OpenAPI spec. The resource now requests `startYear=endYear=year` and stamps `year` locally, preserving the `(year, team, position_group)` grain; a NULL `positionGroup` coalesces to `'All Positions'` since the merge key can't take NULLs.

## recruiting — `team_talent` missing `team` column (migration 040)

039 deliberately omitted `team` from the shells, expecting dlt to generate the `ADD COLUMN` from its stored-schema diff. Disproven: dlt's stored schema **already contains** `team_talent.team` (a schema sync in an earlier failed run advanced `recruiting._dlt_version` past the rename while the physical table was dropped), so dlt inserts directly into the never-created column. 040 adds it physically to both shells.

Tests: 2 new drives-filter tests, 1 new recruiting_groups test; full no-DB suite 718 passed.

## Deploy plan

After merge: apply 040 via `deploy/daily-load-fixes`, then re-run the `reference,games,recruiting` 2025 validation backfill (which also exercises the two code fixes from the deploy branch's checkout of main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aq5tEVxkthmuRX7JH9qEW

---
_Generated by [Claude Code](https://claude.ai/code/session_018aq5tEVxkthmuRX7JH9qEW)_