### PR TITLE
Fix round 5: single shared /games fetch + games-before-drives sequencing

### DIFF
--- a/src/pipelines/run.py
+++ b/src/pipelines/run.py
@@ -173,7 +173,16 @@ def run_reference_pipeline():
 
 
 def run_games_pipeline(years: list[int] | None = None, mode: str = "incremental"):
-    """Run the games data pipeline."""
+    """Run the games data pipeline.
+
+    Two sequential loads, not one: games commits first, THEN drives (and
+    media/weather/records). Within a single load package dlt's per-table
+    merge jobs commit independently and in no guaranteed order, so a drives
+    merge can reach its deferred fk_drives_game check before the games merge
+    that carries a new parent row has committed. Sequencing removes the
+    race; the shared games_cache guarantees the drives orphan filter sees
+    exactly the /games response the first load merged (see games_source).
+    """
     years_str = f"years={years}" if years else f"mode={mode}"
     print(f"\n=== Loading Games Data ({years_str}) ===\n")
 
@@ -183,12 +192,21 @@ def run_games_pipeline(years: list[int] | None = None, mode: str = "incremental"
         dataset_name="core",
     )
 
-    source = games_source(years=years, mode=mode)
-    info = pipeline.run(source)
+    games_cache: dict[int, list[dict]] = {}
 
-    print(f"\nLoad info: {info}")
+    games_only = games_source(years=years, mode=mode, games_cache=games_cache).with_resources(
+        "games"
+    )
+    info = pipeline.run(games_only)
+    print(f"\nLoad info (games): {info}")
 
-    return info
+    rest = games_source(years=years, mode=mode, games_cache=games_cache).with_resources(
+        "drives", "game_media", "game_weather", "records"
+    )
+    info_rest = pipeline.run(rest)
+    print(f"\nLoad info (drives/media/weather/records): {info_rest}")
+
+    return info_rest
 
 
 def run_game_stats_pipeline(

--- a/src/pipelines/sources/games.py
+++ b/src/pipelines/sources/games.py
@@ -24,12 +24,21 @@ logger = logging.getLogger(__name__)
 def games_source(
     years: list[int] | None = None,
     mode: str = "incremental",
+    games_cache: dict[int, list[dict]] | None = None,
 ) -> DltSource:
     """Source for games and drives data.
 
     Args:
         years: Specific years to load. If None, uses mode to determine years.
         mode: "incremental" loads current season, "backfill" loads all historical.
+        games_cache: Optional {year: /games response} cache shared between the
+            games resource and the drives orphan filter (and across the two
+            sequential source instances run_games_pipeline creates). CFBD sits
+            behind a CDN and two /games fetches seconds apart can return
+            different game sets (observed: deploy run 29845763420, id
+            401754543 present in one response and absent from the other), so
+            the drives filter must reuse the exact response the games merge
+            loaded, never a second fetch.
     """
     if years is None:
         if mode == "incremental":
@@ -37,13 +46,23 @@ def games_source(
         else:  # backfill
             years = YEAR_RANGES["games_modern"].to_list()
 
+    if games_cache is None:
+        games_cache = {}
+
     return [
-        games_resource(years),
-        drives_resource(years),
+        games_resource(years, games_cache),
+        drives_resource(years, games_cache),
         game_media_resource(years),
         game_weather_resource(years),
         records_resource(years),
     ]
+
+
+def _fetch_year_games(client, year: int, games_cache: dict[int, list[dict]]) -> list[dict]:
+    """Fetch /games for a year once, serving repeats from the shared cache."""
+    if year not in games_cache:
+        games_cache[year] = make_request(client, "/games", params={"year": year})
+    return games_cache[year]
 
 
 @dlt.resource(
@@ -51,19 +70,24 @@ def games_source(
     write_disposition="merge",
     primary_key="id",
 )
-def games_resource(years: list[int]) -> Iterator[dict]:
+def games_resource(
+    years: list[int], games_cache: dict[int, list[dict]] | None = None
+) -> Iterator[dict]:
     """Load games for specified years.
 
     Args:
         years: List of years to load games for
+        games_cache: Shared {year: /games response} cache (see games_source)
     """
+    if games_cache is None:
+        games_cache = {}
     client = get_client()
     try:
         for year in years:
             logger.info(f"Loading games for {year}...")
 
             # Load FBS games
-            data = make_request(client, "/games", params={"year": year})
+            data = _fetch_year_games(client, year, games_cache)
 
             for game in data:
                 # Add year for partitioning if needed
@@ -79,26 +103,32 @@ def games_resource(years: list[int]) -> Iterator[dict]:
     write_disposition="merge",
     primary_key="id",
 )
-def drives_resource(years: list[int]) -> Iterator[dict]:
+def drives_resource(
+    years: list[int], games_cache: dict[int, list[dict]] | None = None
+) -> Iterator[dict]:
     """Load drives for specified years.
 
     CFBD's /drives can return drives for game ids that /games no longer
     lists for the same year (e.g. 2025's 401754543 -- cancelled/delisted
     games whose partial drive data lingers). Such rows have no parent for
     fk_drives_game, so each year's drives are filtered against that year's
-    /games id set; dropped drives are logged, never loaded.
+    /games id set; dropped drives are logged, never loaded. The id set MUST
+    come from the same /games response the games resource loaded (the shared
+    games_cache) -- a second fetch can disagree with the first (CDN cache
+    variance, see games_source) and re-admit an orphan.
 
     Args:
         years: List of years to load drives for
+        games_cache: Shared {year: /games response} cache (see games_source)
     """
+    if games_cache is None:
+        games_cache = {}
     client = get_client()
     try:
         for year in years:
             logger.info(f"Loading drives for {year}...")
 
-            game_ids = {
-                game["id"] for game in make_request(client, "/games", params={"year": year})
-            }
+            game_ids = {game["id"] for game in _fetch_year_games(client, year, games_cache)}
 
             year_drives: list[dict] = []
             orphan_ids: set[int | None] = set()

--- a/tests/test_sources/test_games.py
+++ b/tests/test_sources/test_games.py
@@ -106,3 +106,51 @@ def test_drives_resource_raises_on_mass_drop():
         # dlt wraps the resource's ValueError in ResourceExtractionError
         with pytest.raises(ResourceExtractionError, match="Orphan filter"):
             _drives_rows([2025])
+
+
+def test_drives_filter_reuses_shared_games_cache():
+    """The orphan filter must use the exact /games response the games
+    resource loaded -- never a second fetch. Two CFBD /games calls seconds
+    apart can disagree (CDN cache variance, deploy run 29845763420), which
+    re-admits orphans the games merge never saw."""
+    from unittest.mock import MagicMock, patch
+
+    from src.pipelines.sources.games import drives_resource, games_resource
+
+    first_games = [{"id": 100}]
+    diverged_games = [{"id": 100}, {"id": 999}]  # what a second fetch would say
+    drives = {
+        "regular": [
+            {"id": "100-1", "gameId": 100},
+            {"id": "100-2", "gameId": 100},
+            {"id": "100-3", "gameId": 100},
+            {"id": "999-1", "gameId": 999},  # orphan per the FIRST response
+        ],
+        "postseason": [],
+    }
+    games_responses = iter([first_games, diverged_games])
+
+    def side_effect(client, path, params=None):
+        if path == "/games":
+            return next(games_responses)
+        if path == "/drives":
+            return drives[params["seasonType"]]
+        raise AssertionError(f"unexpected path {path}")
+
+    cache: dict[int, list[dict]] = {}
+    with (
+        patch("src.pipelines.sources.games.get_client") as mock_get_client,
+        patch("src.pipelines.sources.games.make_request") as mock_make_request,
+    ):
+        mock_get_client.return_value = MagicMock()
+        mock_make_request.side_effect = side_effect
+
+        games_rows = list(games_resource([2025], cache))
+        drive_rows = list(drives_resource([2025], cache))
+
+    assert [g["id"] for g in games_rows] == [100]
+    # 999-1 dropped: the filter saw first_games via the cache, not the
+    # diverged second response (which was never fetched)
+    assert [d["id"] for d in drive_rows] == ["100-1", "100-2", "100-3"]
+    games_calls = [c for c in mock_make_request.call_args_list if c.args[1] == "/games"]
+    assert len(games_calls) == 1


### PR DESCRIPTION
Round 4 got recruiting green (validation run 29845763420: reference OK, recruiting OK) but games failed on `fk_drives_game` for the **same id 401754543** — and this time with **no orphan-drop warning in the log**, meaning the round-4 filter looked at a `/games` response that *contained* 401754543 while the games resource's own fetch (~700ms earlier) *didn't*. Two `/games?year=2025` calls seconds apart returning different game sets is CFBD CDN cache variance; a filter based on a second fetch can therefore re-admit exactly the orphan it exists to drop.

Two changes close both remaining holes:

1. **Shared `/games` cache** — `games_source` threads a `{year: /games response}` dict through `games_resource` and `drives_resource`. `/games` is fetched once per year; the drives filter set is by construction identical to the game rows the merge loaded. (This also drops round 4's extra API call.)

2. **Sequenced loads** — `run_games_pipeline` now runs two loads on the same pipeline: `games` first, then `drives`/`game_media`/`game_weather`/`records`. dlt's per-table merge jobs commit independently in no guaranteed order, so a drives merge could reach its deferred FK check before the games merge carrying a new parent row committed. With sequencing, every drive the filter admits references a game already committed.

New test proves the property directly: with a fake `/games` that returns a *diverged* set on a hypothetical second call, the filter still drops the orphan and `/games` is fetched exactly once. Full no-DB suite: 719 passed.

No migration this round — deploy is just the validation backfill re-run from the updated main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aq5tEVxkthmuRX7JH9qEW

---
_Generated by [Claude Code](https://claude.ai/code/session_018aq5tEVxkthmuRX7JH9qEW)_