### PR TITLE
fix: scope verify_load coverage checks to FBS-involved games

### DIFF
--- a/scripts/verify_load.py
+++ b/scripts/verify_load.py
@@ -13,9 +13,10 @@ Usage:
 Checks:
     1. plays partition for the season exists (core.plays_yNNNN)
     2. core.games row count for the season matches the CFBD /games count (1 API call)
-    3. completed games have game_team_stats rows (tolerance for FCS games
-       without box scores)
-    4. completed games have plays rows (same tolerance)
+    3. completed FBS-involved games have game_team_stats rows (lower-division
+       games are excluded -- CFBD only reliably publishes box scores for games
+       with an FBS side; small tolerance for stragglers)
+    4. completed FBS-involved games have plays rows (same scope + tolerance)
     5. marts.data_freshness is_stale flags -- heuristic only: the matview infers
        freshness from pg_stat vacuum/analyze timestamps, so staleness WARNs
        off-season and FAILs in-season (or with --strict)
@@ -108,12 +109,20 @@ def check_game_counts(cur, season: int, report: Report) -> None:
     )
 
 
+# core.games mirrors CFBD /games, which spans every classification (FBS, FCS,
+# II, III -- 3800+ rows/season), but box scores and plays are only reliably
+# published for games involving an FBS team. Coverage checks therefore scope
+# to FBS-involved games; a season-wide count would "miss" ~2K lower-division
+# games by construction and could never clear MISSING_STATS_TOLERANCE.
+FBS_INVOLVED = "(g.home_classification = 'fbs' OR g.away_classification = 'fbs')"
+
+
 def check_completed_have_team_stats(cur, season: int, report: Report) -> None:
     cur.execute(
-        """
+        f"""
         SELECT COUNT(*)
         FROM core.games g
-        WHERE g.season = %s AND g.completed
+        WHERE g.season = %s AND g.completed AND {FBS_INVOLVED}
           AND NOT EXISTS (SELECT 1 FROM core.game_team_stats s WHERE s.id = g.id)
         """,
         (season,),
@@ -122,17 +131,17 @@ def check_completed_have_team_stats(cur, season: int, report: Report) -> None:
     report.record(
         evaluate_missing(missing),
         "completed_have_team_stats",
-        f"{missing} completed game(s) missing box scores (tolerance {MISSING_STATS_TOLERANCE})",
+        f"{missing} completed FBS game(s) missing box scores (tolerance {MISSING_STATS_TOLERANCE})",
     )
 
 
 def check_completed_have_plays(cur, season: int, report: Report) -> None:
     # p.season predicate enables partition pruning; plays has no week column
     cur.execute(
-        """
+        f"""
         SELECT COUNT(*)
         FROM core.games g
-        WHERE g.season = %s AND g.completed
+        WHERE g.season = %s AND g.completed AND {FBS_INVOLVED}
           AND NOT EXISTS (
               SELECT 1 FROM core.plays p WHERE p.season = %s AND p.game_id = g.id
           )
@@ -143,7 +152,7 @@ def check_completed_have_plays(cur, season: int, report: Report) -> None:
     report.record(
         evaluate_missing(missing),
         "completed_have_plays",
-        f"{missing} completed game(s) missing plays (tolerance {MISSING_STATS_TOLERANCE})",
+        f"{missing} completed FBS game(s) missing plays (tolerance {MISSING_STATS_TOLERANCE})",
     )
 
 

--- a/tests/test_verify_load.py
+++ b/tests/test_verify_load.py
@@ -62,3 +62,40 @@ class TestEvaluateStaleness:
     def test_seasonal_always_warns(self):
         assert evaluate_staleness("seasonal", in_season=True, strict=False) == WARN
         assert evaluate_staleness("seasonal", in_season=False, strict=True) == WARN
+
+
+class TestCoverageChecksScopedToFbs:
+    """Coverage checks must not count lower-division games (run 29866568883:
+    a season-wide count reported 2,178 'missing' games -- every FCS/II/III
+    game in core.games -- and can never clear the tolerance)."""
+
+    class _RecordingCursor:
+        def __init__(self):
+            self.queries = []
+
+        def execute(self, sql, params=None):
+            self.queries.append(sql)
+
+        def fetchone(self):
+            return (0,)
+
+    def _check_sql(self, check_fn):
+        from scripts.verify_load import Report
+
+        cur = self._RecordingCursor()
+        check_fn(cur, 2025, Report())
+        return cur.queries[0]
+
+    def test_team_stats_check_scoped_to_fbs_involved_games(self):
+        from scripts.verify_load import check_completed_have_team_stats
+
+        sql = self._check_sql(check_completed_have_team_stats)
+        assert "g.home_classification = 'fbs'" in sql
+        assert "g.away_classification = 'fbs'" in sql
+
+    def test_plays_check_scoped_to_fbs_involved_games(self):
+        from scripts.verify_load import check_completed_have_plays
+
+        sql = self._check_sql(check_completed_have_plays)
+        assert "g.home_classification = 'fbs'" in sql
+        assert "g.away_classification = 'fbs'" in sql


### PR DESCRIPTION
## Summary

Tonight's dispatched Daily Season Load ([run 29866568883](https://github.com/rstover-fo/cfb-database/actions/runs/29866568883)) was the first run to get past the load stages — **all five fix rounds (#25–#29) worked; every load stage and all Tier 2/3 compute steps went green.** It then failed on the *last* step, `verify_load.py`, which also skipped the dependent `recaps` job:

```
[FAIL] completed_have_team_stats: 2156 completed game(s) missing box scores (tolerance 10)
[FAIL] completed_have_plays: 2178 completed game(s) missing plays (tolerance 10)
```

## Root cause

The two coverage checks count **all** completed `core.games` rows for the season, but `core.games` mirrors CFBD `/games` across every classification — 3,831 rows for 2025 including FCS/II/III — while box scores and plays only exist for games involving an FBS side. The ~2,150 "missing" games are lower-division by construction, so the tolerance-of-10 check can never pass on a completed season. This was never exercised before: runs #1 and #2 both failed in load stages before reaching verify.

## Fix

- Scope both checks to `(g.home_classification = 'fbs' OR g.away_classification = 'fbs')`, matching the platform's actual load coverage (and the existing FBS filter in `scripts/generate_recaps.py`).
- Update messages ("completed FBS game(s)…") and the module docstring.
- Add a regression test asserting the FBS predicate is present in both check queries (recording-cursor pattern, no DB).

`pytest tests/test_verify_load.py` → 16 passed; ruff check + format clean.

## After merging

Re-dispatch **Daily Season Load** (the load is idempotent; optionally set `recap_limit=3`). With verify passing, the recaps job will run for the first time and write the first `analytics.game_recaps` rows. The off-season staleness WARNs (`core.plays` 165.8 days, etc.) are non-fatal and expected in July.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNx7MmfrWbhFwx1du79KY3

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNx7MmfrWbhFwx1du79KY3)_