### PR TITLE
Adopt tuned model parameters: Elo K=28, divisor=22, EPA λ=100

### DIFF
--- a/scripts/compute_adjusted_epa.py
+++ b/scripts/compute_adjusted_epa.py
@@ -31,10 +31,12 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(mess
 logger = logging.getLogger(__name__)
 
 # Ridge penalty applied to the offense/defense team columns only (mu, hfa are
-# unpenalized). ~200 "pseudo-plays" worth of shrinkage toward 0 per team
+# unpenalized). ~100 "pseudo-plays" worth of shrinkage toward 0 per team
 # coefficient. Recorded per row in analytics.adjusted_epa_build so historical
-# fits stay auditable even if this tunable changes later.
-LAMBDA = 200.0
+# fits stay auditable even if this tunable changes later. Retuned 200 -> 100
+# on 2026-07-22 per the tune_params walk-forward advisory (with Elo K=28,
+# DIVISOR=22: blend margin MAE 13.60 -> 13.20 over 2015-2025, ATS flat).
+LAMBDA = 100.0
 
 # Server-side cursor fetch batch size for the per-season play stream.
 CURSOR_ITERSIZE = 10_000

--- a/scripts/compute_house_elo.py
+++ b/scripts/compute_house_elo.py
@@ -8,8 +8,11 @@ below `# --- I/O layer ---` is a thin wrapper: fetch rows from core.games,
 feed them through the engine, write the results to
 analytics.house_elo_game / analytics.house_elo_current.
 
-Parameters (SEED, K, HFA, DIVISOR, CARRYOVER, POOL_THRESHOLD) are FINAL per
-the design doc -- do not retune here; see the plan's tunable ledger.
+Parameters (SEED, K, HFA, DIVISOR, CARRYOVER, POOL_THRESHOLD) change only by
+deliberate retune decision, never casually -- see the plan's tunable ledger.
+Retuned 2026-07-22 (user-approved tune_params walk-forward advisory): K
+20 -> 28, DIVISOR 25 -> 22, alongside compute_adjusted_epa.py's LAMBDA
+200 -> 100. Blend margin MAE 13.60 -> 13.20 over 2015-2025, ATS flat.
 
 Usage:
     python scripts/compute_house_elo.py --full
@@ -86,9 +89,9 @@ class EloEngine:
     """
 
     SEED = 1500.0
-    K = 20.0
+    K = 28.0
     HFA = 65.0
-    DIVISOR = 25.0
+    DIVISOR = 22.0
     CARRYOVER = 2.0 / 3.0
     POOL_THRESHOLD = 4
     POOLED = "__FCS__"

--- a/tests/test_house_elo.py
+++ b/tests/test_house_elo.py
@@ -99,7 +99,7 @@ class TestEngineSingleGame:
         elo_diff_home = 65.0  # 1500 - 1500 + HFA(65), non-neutral
         exp_home = expected_score(elo_diff_home)
         mult = math.log(8) * (2.2 / (0.001 * elo_diff_home + 2.2))
-        delta = 20 * mult * (1 - exp_home)
+        delta = EloEngine.K * mult * (1 - exp_home)
 
         assert row["home_postgame_elo"] == pytest.approx(1500 + delta, abs=1e-6)
         assert row["away_postgame_elo"] == pytest.approx(1500 - delta, abs=1e-6)

--- a/tests/test_predictions.py
+++ b/tests/test_predictions.py
@@ -32,15 +32,15 @@ from scripts.compute_predictions import (
 
 class TestEloMargin:
     def test_equal_ratings_non_neutral(self):
-        # (1500 - 1500) / 25 + 65 / 25 = 2.6
-        assert elo_margin(1500, 1500, neutral=False) == pytest.approx(2.6)
+        # (1500 - 1500 + 65) / DIVISOR(22)
+        assert elo_margin(1500, 1500, neutral=False) == pytest.approx(65 / 22)
 
     def test_equal_ratings_neutral(self):
         assert elo_margin(1500, 1500, neutral=True) == pytest.approx(0.0)
 
     def test_home_favorite_scales_with_diff(self):
-        # (1600 - 1500 + 65) / 25 = 6.6
-        assert elo_margin(1600, 1500, neutral=False) == pytest.approx(6.6)
+        # (1600 - 1500 + 65) / DIVISOR(22)
+        assert elo_margin(1600, 1500, neutral=False) == pytest.approx(165 / 22)
 
 
 class TestEpaMargin:

--- a/tests/test_tune_params.py
+++ b/tests/test_tune_params.py
@@ -113,10 +113,10 @@ class TestGridConstruction:
         assert BASELINE_LAMBDA in lambda_grid(quick=False)
         assert BASELINE_WEIGHT in weight_grid(quick=False)
         # And they match the live production defaults, not hardcoded copies.
-        assert BASELINE_K == EloEngine.K == 20.0
-        assert BASELINE_DIVISOR == EloEngine.DIVISOR == 25.0
+        assert BASELINE_K == EloEngine.K == 28.0
+        assert BASELINE_DIVISOR == EloEngine.DIVISOR == 22.0
         assert BASELINE_HFA == EloEngine.HFA == 65.0
-        assert BASELINE_LAMBDA == LAMBDA == 200.0
+        assert BASELINE_LAMBDA == LAMBDA == 100.0
         assert BASELINE_WEIGHT == BLEND_ELO == 0.6
 
 


### PR DESCRIPTION
User-approved adoption of the Tier 3 tuning advisory (`tune_params.py`, walk-forward over 2015–2025): house Elo K-factor 20 → **28**, Elo margin divisor 25 → **22**, adjusted-EPA ridge λ 200 → **100**. HFA (65) and the blend weight (0.6) are unchanged. Backtested effect: blend margin MAE **13.60 → 13.20**, ATS at |edge|≥6 flat.

The constants are single-sourced (`EloEngine` in `compute_house_elo.py`, `LAMBDA` in `compute_adjusted_epa.py`) and imported everywhere else (`compute_adjusted_epa_week`, `compute_predictions`, `tune_params` baselines), so this is a two-file change plus test updates. Tests that hand-computed expected values against the old constants now either derive from `EloEngine.K`/the divisor fraction or assert the new ledger values (`test_tune_params` deliberately pins literals — it exists to catch accidental drift).

After merge, the full rebuild runs via serialized deploy pushes: Elo history (`--full`), adjusted EPA (all seasons), as-of weekly EPA (full), prediction backfill (`--as-of-week`) + `check_backtest` to confirm the 13.20 reproduces in prod, feature substrate (full), `train_model` refits, `score_fitted --upcoming`, and a mart refresh.

Full no-DB suite: 721 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aq5tEVxkthmuRX7JH9qEW

---
_Generated by [Claude Code](https://claude.ai/code/session_018aq5tEVxkthmuRX7JH9qEW)_