### PR TITLE
fix: rank within classification (FBS-scoped ranks) in leaderboard + team EPA views

### DIFF
--- a/deploys/fbs-rank-scope-manifest.json
+++ b/deploys/fbs-rank-scope-manifest.json
@@ -1,0 +1,7 @@
+{
+  "action": "apply",
+  "files": [
+    "src/schemas/public/002_marts_views.sql",
+    "src/schemas/api/005_leaderboard_teams.sql"
+  ]
+}

--- a/docs/SCHEMA_CONTRACT.md
+++ b/docs/SCHEMA_CONTRACT.md
@@ -15,6 +15,66 @@ Last updated: 2026-07-21
 
 ## Recent Contract Changes
 
+- **2026-07-22 — FBS rank scoping fix: `api.leaderboard_teams` and
+  `public.team_epa_season` rank columns are now computed WITHIN classification
+  (consumer-visible semantics change).** Beta testers found Oklahoma's EPA
+  rank showing "#176" (FBS has ~136 teams) and FCS teams (e.g. North Dakota
+  State) appearing on the EPA leaderboard. Root cause: every rank column on
+  these two views was a `RANK() OVER (PARTITION BY season ...)` computed
+  across **all** classifications (FBS + FCS + lower), because none of the
+  underlying marts carry a `classification` column -- only `ref.teams` does.
+  Fixed at the view layer only (no matview rebuilds):
+  - **`api.leaderboard_teams`** (`src/schemas/api/005_leaderboard_teams.sql`):
+    added a `classification` column (LEFT JOIN to a `ref.teams`-deduped CTE,
+    same dedup pattern as `api.team_playcalling_profile`); `wins_rank`,
+    `ppg_rank`, `defense_ppg_rank`, and `epa_rank` are now
+    `PARTITION BY tss.season, classification` instead of `PARTITION BY
+    tss.season`. **All rows are still returned** -- there is no `WHERE
+    classification = 'fbs'` filter on this view; consumers must filter
+    client-side same as before, but ranks are now scoped within whichever
+    classification each row belongs to (FBS ranked among ~136 FBS peers, FCS
+    among FCS peers, etc).
+  - **`public.team_epa_season`** (`src/schemas/public/002_marts_views.sql`):
+    added a `classification` column via the same dedup join; `off_epa_rank`
+    and `def_epa_rank` are now `PARTITION BY e.season, classification`
+    instead of `PARTITION BY e.season`. All pre-existing columns kept their
+    names and relative order -- `classification` and the two rank columns
+    are appended, so `SELECT *` consumers (cfb-app's team page) keep working
+    unchanged aside from gaining the new column.
+  - **Scope-checked but not changed:** `marts.team_wepa_season`
+    (`epa_rank`/`defense_rank`, exposed via `api.team_wepa_season`) sources
+    from `metrics.wepa_team_season`, itself a passthrough of CFBD's
+    `/wepa/team/season` endpoint. That table has no `classification` column
+    at all (dlt-created straight from the CFBD payload) and its row count
+    (1,587 rows across the `metrics` year range 2014-2026) averages ~130
+    teams/season -- consistent with FBS-only coverage (FBS has run
+    127-136 teams over that span), not the 250+ a combined FBS+FCS count
+    would produce. CFBD's WEPA endpoint appears to be FBS-only at the
+    source; left unchanged, and its ranks are not scoped by classification.
+  - **Scope-checked and confirmed affected, but not surfaced anywhere yet:**
+    `marts.team_adjusted_epa` (`off_rank`/`def_rank`/`net_rank`) is built
+    from `analytics.adjusted_epa_build`
+    (`scripts/compute_adjusted_epa.py`), whose team list comes from
+    `marts.play_epa` with no classification filter -- any FCS team that
+    plays an FBS opponent gets plays recorded and is included in the ridge
+    fit and its ranks, so this mart *is* affected by the same root cause.
+    However, `off_rank`/`def_rank`/`net_rank` are not currently exposed
+    through any `api.*` or `public.*` view -- there is no `api.team_adjusted_epa`
+    view, and the two views that reference this mart
+    (`marts.team_week_features` / `api.team_week_features`,
+    `marts.adjusted_epa_week` / `api.adjusted_epa_week`) pull `adj_epa_off`/
+    `adj_epa_def`/`adj_epa_net` coefficient values or a different,
+    already-unranked mart (`analytics.adjusted_epa_week_build`), not this
+    mart's rank columns. No view-layer change made; flagging here so a
+    future `api.team_adjusted_epa` view (if ever added) scopes ranks by
+    classification from day one.
+  - New tests: `tests/test_api_views.py::TestLeaderboardTeams::test_epa_rank_scoped_to_fbs`
+    (modeled on `TestTeamDetail::test_only_fbs_teams`) asserts
+    `MAX(epa_rank)` among `classification = 'fbs'` rows for the most recent
+    season stays `<= 140`. `public.team_epa_season` is not contract-tested
+    anywhere in `tests/` (only the underlying `marts.team_epa_season` is, in
+    `tests/test_marts.py`), so no public-view test was added for it.
+
 - **2026-07-21 — `api.game_recaps` added (Deployed).** P3.3 Lane D: nightly
   LLM-generated game recaps, one row per completed FBS game (season >= 2014), written by
   `scripts/generate_recaps.py` (model `claude-haiku-4-5`) from warehouse facts only --
@@ -233,7 +293,7 @@ These are the primary PostgREST-accessible views. Queries go through Supabase cl
 | `api.team_history` | **Deployed** | 3,667 | Multi-season team history with records, ratings, EPA trends. Columns: team, season, conference, games, wins, losses, conf_wins, conf_losses, ppg, opp_ppg, avg_margin, sp_rating, sp_rank, elo, fpi, epa_per_play, epa_tier, success_rate, explosiveness, total_plays, recruiting_rank, recruiting_points |
 | `api.game_detail` | **Deployed** | 45,897 | Single game: teams, scores, betting lines, EPA, venue. Columns: game_id, season, week, season_type, start_date, completed, home_team, away_team, home_points, away_points, winner, point_diff, home_spread, over_under, spread_result, ou_result, home_epa, away_epa, pregame_home_win_prob, venue, attendance, excitement_index |
 | `api.matchup` | **Deployed** | 11,975 | Head-to-head matchup history and current season comparison. Columns: team1, team2, total_games, team1_wins, team2_wins, ties, first_meeting, last_meeting, recent_results (JSONB array), team1/team2 current season stats |
-| `api.leaderboard_teams` | **Deployed** | 3,667 | Team leaderboard with rankings, ratings, EPA. Columns: team, conference, season, wins, losses, win_pct, ppg, opp_ppg, sp_rank, epa_per_play, epa_tier, wins_rank, ppg_rank, defense_ppg_rank, epa_rank |
+| `api.leaderboard_teams` | **Deployed** | 3,667 | Team leaderboard with rankings, ratings, EPA. Columns: team, conference, season, classification, wins, losses, win_pct, ppg, opp_ppg, sp_rank, epa_per_play, epa_tier, wins_rank, ppg_rank, defense_ppg_rank, epa_rank. Rank columns are scoped `PARTITION BY season, classification` (see 2026-07-22 changelog entry) -- all rows still returned, no `WHERE fbs` filter. |
 | `api.roster_lookup` | **Deployed** | 340,855 | Stable roster view for player matching |
 | `api.recruit_lookup` | **Deployed** | 67,179 | Stable recruiting view for recruit data |
 | `api.player_season_leaders` | **Deployed** | 152,966 | Season stat leaders by category (passing, rushing, receiving, defensive). Columns: season, category, player_id, player_name, team, yards, touchdowns, interceptions, pct, attempts, completions, carries, yards_per_carry, receptions, yards_per_reception, longest, total_tackles, solo_tackles, sacks, tackles_for_loss, passes_defended, yards_rank |
@@ -325,7 +385,7 @@ eventually migrate to `api.*`.
 | `public.teams_with_logos` | Deployed | Teams with logo URLs |
 | `public.games` | Deployed | Game schedule and results |
 | `public.roster` | Deployed | Player roster data |
-| `public.team_epa_season` | Deployed | Team EPA per season (duplicate of marts view) |
+| `public.team_epa_season` | Deployed | Team EPA per season (duplicate of marts view). Adds a `classification` column; `off_epa_rank`/`def_epa_rank` are scoped `PARTITION BY season, classification` (see 2026-07-22 changelog entry) |
 | `public.team_season_epa` | Deployed | Team season EPA (alternate shape) |
 | `public.defensive_havoc` | Deployed | Defensive havoc metrics |
 | `public.team_style_profile` | Deployed | Team style characterization |

--- a/mcp/src/cfb_mcp/server.py
+++ b/mcp/src/cfb_mcp/server.py
@@ -460,9 +460,17 @@ async def get_leaderboard(
             )
             source = "api.team_wepa_season"
         else:
+            # Rank columns are computed WITHIN classification (2026-07-22
+            # contract change), so an unfiltered order-by-rank would interleave
+            # FCS/lower rank-1 teams with FBS leaders. This is an FBS
+            # leaderboard: filter to fbs.
             rows = await client.select(
                 "leaderboard_teams",
-                {"season": eq(season), "order": _LEADERBOARD_ORDER[metric]},
+                {
+                    "season": eq(season),
+                    "classification": eq("fbs"),
+                    "order": _LEADERBOARD_ORDER[metric],
+                },
                 profile="api",
                 limit=limit,
             )

--- a/mcp/tests/test_get_leaderboard.py
+++ b/mcp/tests/test_get_leaderboard.py
@@ -23,6 +23,9 @@ async def test_get_leaderboard_epa_metric_uses_leaderboard_teams():
     request = route.calls.last.request
     assert request.url.params["season"] == "eq.2024"
     assert request.url.params["order"] == "epa_rank.asc"
+    # Ranks are within-classification (2026-07-22 contract change): without
+    # this filter, FCS/lower rank-1 teams would interleave with FBS leaders.
+    assert request.url.params["classification"] == "eq.fbs"
 
 
 @pytest.mark.asyncio

--- a/src/schemas/api/005_leaderboard_teams.sql
+++ b/src/schemas/api/005_leaderboard_teams.sql
@@ -2,14 +2,27 @@
 -- Flexible team rankings/leaderboards by season
 -- Query with filters: ?season=eq.2024&order=epa_per_play.desc
 -- Exposed via PostgREST as /api/leaderboard_teams
+--
+-- Rank columns (wins_rank, ppg_rank, defense_ppg_rank, epa_rank) are computed
+-- WITHIN classification (PARTITION BY season, classification), not across all
+-- of FBS+FCS+lower. All rows are still returned (no WHERE fbs filter) --
+-- consumers filter by classification themselves.
 
 DROP VIEW IF EXISTS api.leaderboard_teams;
 
 CREATE VIEW api.leaderboard_teams AS
+WITH teams_deduped AS (
+    -- ref.teams has ~35 duplicate school names; pick FBS classification first, else first row
+    SELECT DISTINCT ON (school)
+        school, classification
+    FROM ref.teams
+    ORDER BY school, classification NULLS LAST
+)
 SELECT
     tss.team,
     tss.conference,
     tss.season,
+    t.classification,
 
     -- Record
     tss.games,
@@ -43,14 +56,18 @@ SELECT
     tss.recruiting_rank,
     tss.recruiting_points,
 
-    -- Computed rankings within season
-    RANK() OVER (PARTITION BY tss.season ORDER BY tss.wins DESC, tss.avg_margin DESC) AS wins_rank,
-    RANK() OVER (PARTITION BY tss.season ORDER BY tss.ppg DESC) AS ppg_rank,
-    RANK() OVER (PARTITION BY tss.season ORDER BY tss.opp_ppg ASC) AS defense_ppg_rank,
-    RANK() OVER (PARTITION BY tss.season ORDER BY epa.epa_per_play DESC NULLS LAST) AS epa_rank
+    -- Computed rankings within season AND classification (fix: previously
+    -- ranked across FBS+FCS+lower, so FBS teams could show ranks like #176
+    -- when FBS has ~136 teams)
+    RANK() OVER (PARTITION BY tss.season, t.classification ORDER BY tss.wins DESC, tss.avg_margin DESC) AS wins_rank,
+    RANK() OVER (PARTITION BY tss.season, t.classification ORDER BY tss.ppg DESC) AS ppg_rank,
+    RANK() OVER (PARTITION BY tss.season, t.classification ORDER BY tss.opp_ppg ASC) AS defense_ppg_rank,
+    RANK() OVER (PARTITION BY tss.season, t.classification ORDER BY epa.epa_per_play DESC NULLS LAST) AS epa_rank
 
 FROM marts.team_season_summary tss
 LEFT JOIN marts.team_epa_season epa
-    ON epa.team = tss.team AND epa.season = tss.season;
+    ON epa.team = tss.team AND epa.season = tss.season
+LEFT JOIN teams_deduped t
+    ON t.school = tss.team;
 
-COMMENT ON VIEW api.leaderboard_teams IS 'Team leaderboard with records, ratings, EPA, and computed rankings';
+COMMENT ON VIEW api.leaderboard_teams IS 'Team leaderboard with records, ratings, EPA, and computed rankings. Rank columns (wins_rank, ppg_rank, defense_ppg_rank, epa_rank) are computed within classification (PARTITION BY season, classification) -- FBS teams rank among ~136 FBS peers, not all classifications combined. All rows returned regardless of classification; filter client-side.';

--- a/src/schemas/api/005_leaderboard_teams.sql
+++ b/src/schemas/api/005_leaderboard_teams.sql
@@ -71,3 +71,7 @@ LEFT JOIN teams_deduped t
     ON t.school = tss.team;
 
 COMMENT ON VIEW api.leaderboard_teams IS 'Team leaderboard with records, ratings, EPA, and computed rankings. Rank columns (wins_rank, ppg_rank, defense_ppg_rank, epa_rank) are computed within classification (PARTITION BY season, classification) -- FBS teams rank among ~136 FBS peers, not all classifications combined. All rows returned regardless of classification; filter client-side.';
+
+-- Re-grant on every apply: this file DROPs the view first, which discards
+-- existing grants (no ALTER DEFAULT PRIVILEGES in this database).
+GRANT SELECT ON api.leaderboard_teams TO anon, authenticated;

--- a/src/schemas/public/002_marts_views.sql
+++ b/src/schemas/public/002_marts_views.sql
@@ -27,6 +27,13 @@ FROM marts.defensive_havoc;
 CREATE OR REPLACE VIEW public.team_epa_season
 WITH (security_invoker = true)
 AS
+WITH teams_deduped AS (
+    -- ref.teams has ~35 duplicate school names; pick FBS classification first, else first row
+    SELECT DISTINCT ON (school)
+        school, classification
+    FROM ref.teams
+    ORDER BY school, classification NULLS LAST
+)
 SELECT
     e.team,
     e.season,
@@ -36,11 +43,14 @@ SELECT
     e.epa_per_play,
     e.success_rate,
     COALESCE(e.explosiveness, 0::NUMERIC) AS explosiveness,
-    (RANK() OVER (PARTITION BY e.season ORDER BY e.epa_per_play DESC))::INT AS off_epa_rank,
-    (RANK() OVER (PARTITION BY e.season ORDER BY COALESCE(d.opp_epa_per_play, 999::NUMERIC)))::INT AS def_epa_rank
+    t.classification,
+    (RANK() OVER (PARTITION BY e.season, t.classification ORDER BY e.epa_per_play DESC))::INT AS off_epa_rank,
+    (RANK() OVER (PARTITION BY e.season, t.classification ORDER BY COALESCE(d.opp_epa_per_play, 999::NUMERIC)))::INT AS def_epa_rank
 FROM marts.team_epa_season e
 LEFT JOIN marts.defensive_havoc d
-    ON e.team = d.team AND e.season = d.season;
+    ON e.team = d.team AND e.season = d.season
+LEFT JOIN teams_deduped t
+    ON t.school = e.team;
 
 CREATE OR REPLACE VIEW public.team_season_epa
 WITH (security_invoker = true)

--- a/src/schemas/public/002_marts_views.sql
+++ b/src/schemas/public/002_marts_views.sql
@@ -43,9 +43,10 @@ SELECT
     e.epa_per_play,
     e.success_rate,
     COALESCE(e.explosiveness, 0::NUMERIC) AS explosiveness,
-    t.classification,
     (RANK() OVER (PARTITION BY e.season, t.classification ORDER BY e.epa_per_play DESC))::INT AS off_epa_rank,
-    (RANK() OVER (PARTITION BY e.season, t.classification ORDER BY COALESCE(d.opp_epa_per_play, 999::NUMERIC)))::INT AS def_epa_rank
+    (RANK() OVER (PARTITION BY e.season, t.classification ORDER BY COALESCE(d.opp_epa_per_play, 999::NUMERIC)))::INT AS def_epa_rank,
+    -- appended LAST: CREATE OR REPLACE VIEW can only add columns at the end
+    t.classification
 FROM marts.team_epa_season e
 LEFT JOIN marts.defensive_havoc d
     ON e.team = d.team AND e.season = d.season

--- a/tests/test_api_views.py
+++ b/tests/test_api_views.py
@@ -148,6 +148,7 @@ LEADERBOARD_TEAMS_COLUMNS = {
     "team",
     "conference",
     "season",
+    "classification",
     "games",
     "wins",
     "losses",
@@ -865,6 +866,41 @@ class TestLeaderboardTeams:
         assert len(rows) >= 1, "No team with epa_rank = 1 for 2024"
         row = dict(zip(columns, rows[0]))
         assert row["epa_per_play"] is not None
+
+    def test_epa_rank_scoped_to_fbs(self, db_conn):
+        """epa_rank should be computed within classification, not across FBS+FCS+lower.
+
+        FBS has ~136 teams, so the max epa_rank among classification='fbs' rows
+        for the most recent season with data must stay well under the old
+        cross-classification bug (e.g. Oklahoma showing "#176"). Regression
+        test for the FBS rank-scoping fix.
+        """
+        rows, _ = _fetch_all(
+            db_conn,
+            """
+            SELECT MAX(season) FROM api.leaderboard_teams
+            WHERE classification = 'fbs' AND epa_rank IS NOT NULL
+            """,
+        )
+        season = rows[0][0]
+        assert season is not None, "No FBS rows with epa_rank found in api.leaderboard_teams"
+
+        rows, _ = _fetch_all(
+            db_conn,
+            """
+            SELECT MAX(epa_rank)
+            FROM api.leaderboard_teams
+            WHERE season = %s AND classification = 'fbs'
+            """,
+            (season,),
+        )
+        max_epa_rank = rows[0][0]
+        assert max_epa_rank is not None
+        assert max_epa_rank <= 140, (
+            f"Max epa_rank among FBS teams in season {season} is {max_epa_rank}, "
+            "expected <= 140 (FBS has ~136 teams; a higher max indicates ranks "
+            "are leaking in FCS/lower-classification teams)"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Beta testers flagged two symptoms with one root cause: Oklahoma's team page showed **EPA "Rank #176"** (FBS has ~136 teams) and **North Dakota State (FCS)** appeared on the EPA leaderboard. Every rank in the exposed views is a `RANK() OVER (PARTITION BY season)` computed across ALL classifications (FBS+FCS+II/III), because no mart carries a classification column.

## Changes

- **`public.team_epa_season`** (`src/schemas/public/002_marts_views.sql`): join a deduped `ref.teams` CTE (`DISTINCT ON (school) … ORDER BY school, classification NULLS LAST` — the established pattern from `api/014`, handles the ~35 duplicate school names), repartition `off_epa_rank`/`def_epa_rank` by `(season, classification)`, and expose `classification` (appended **last** — `CREATE OR REPLACE VIEW` only permits adding columns at the end).
- **`api.leaderboard_teams`** (`src/schemas/api/005_leaderboard_teams.sql`): same join; all four rank windows (`wins_rank`, `ppg_rank`, `defense_ppg_rank`, `epa_rank`) repartitioned by `(season, classification)`; new `classification` column. All rows still returned — consumers filter.
- **Contract tests**: `classification` added to `LEADERBOARD_TEAMS_COLUMNS`; new `TestLeaderboardTeams::test_epa_rank_scoped_to_fbs` asserting `MAX(epa_rank)` for FBS rows in the latest season ≤ 140.
- **`docs/SCHEMA_CONTRACT.md`**: dated changelog entry — rank semantics are now within-classification (consumer-visible change).
- **`deploys/fbs-rank-scope-manifest.json`**: `apply` manifest for the two view files.

## Scope-check findings (no changes needed)

- `marts.team_wepa_season` ranks are already FBS-scoped: its source (`metrics.wepa_team_season`, straight from CFBD `/wepa`) averages ~130 teams/season — FBS-only.
- `marts.team_adjusted_epa` ranks ARE cross-classification (its team list comes from unfiltered `marts.play_epa`), but no api/public view exposes those rank columns today; documented in the changelog for whenever one does.

FBS teams now rank #1–~136 among FBS peers; FCS teams get coherent FCS-scoped ranks (which also sets up cleanly for a potential FCS data tier later).

## After merging

Push a `deploy/**` branch with `deploys/fbs-rank-scope-manifest.json` (or I will) to apply the two views live; the companion cfb-app PR consumes the new column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNx7MmfrWbhFwx1du79KY3

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNx7MmfrWbhFwx1du79KY3)_