### PR TITLE
feat: api.coach_records — coach career SU + ATS records view

### DIFF
--- a/deploys/coach-records-manifest.json
+++ b/deploys/coach-records-manifest.json
@@ -1,0 +1,6 @@
+{
+  "action": "apply",
+  "files": [
+    "src/schemas/api/038_coach_records.sql"
+  ]
+}

--- a/docs/SCHEMA_CONTRACT.md
+++ b/docs/SCHEMA_CONTRACT.md
@@ -4,7 +4,7 @@
 > only depend on objects listed here as **public**. Everything else is internal and may change
 > without notice.
 
-Last updated: 2026-07-21
+Last updated: 2026-07-22
 
 > **Note on cfb-analytics:** the retired OU-only app (rstover-fo/cfb-analytics) was never a
 > warehouse consumer -- it ran its own DuckDB ingestion. Its unique features (rivals page,
@@ -14,6 +14,33 @@ Last updated: 2026-07-21
 ---
 
 ## Recent Contract Changes
+
+- **2026-07-22 — `api.coach_records` added (view authored, pending deploy).**
+  Beta testers (sports bettors) asked for "coaches' records straight-up AND
+  against-the-spread, ranked by win percentage" -- nothing coach-related
+  existed in the frontend even though the warehouse had the pieces at
+  mismatched grains (`ref.coaches`/`ref.coaches__seasons` at coach-season
+  grain, `marts.team_ats_records` at team-season grain). New view
+  `api.coach_records` (`src/schemas/api/038_coach_records.sql`) aggregates a
+  coach-season CTE (built directly from `ref.coaches`/`ref.coaches__seasons`,
+  the same join idiom as `marts.coach_record`/`marts.coaching_tenure`)
+  LEFT JOINed per-season to `marts.team_ats_records` on team name + year (no
+  shared surrogate id), then grouped up to **coach x team (career-at-school)
+  grain** -- distinct from `api.coaching_history`, which splits a coach's
+  non-contiguous stints at one school into separate tenure rows. Columns:
+  `coach_name`, `first_name`, `last_name`, `team`, `first_season`,
+  `last_season`, `seasons_count`, `games`, `wins`, `losses`, `ties`,
+  `win_pct`, `ats_games`, `ats_wins`, `ats_losses`, `ats_pushes`,
+  `ats_win_pct`, `seasons_with_ats_data`. **Caveats:** (1) coach attribution
+  is whole-season -- `ref.coaches__seasons` attributes an entire season to
+  one head coach per school, so mid-season coaching changes (e.g. an interim
+  coach finishing a season) are not splittable at this grain; treat records
+  as season-or-larger-grain only, never per-game. (2) ATS coverage is
+  partial -- `marts.team_ats_records` doesn't extend back through every
+  coach's full career (older seasons predate consistently tracked betting
+  lines), so `ats_*` columns can be NULL or based on fewer seasons than the
+  straight-up record; use `seasons_with_ats_data` to gauge coverage per row.
+  Deploy manifest: `deploys/coach-records-manifest.json`.
 
 - **2026-07-22 — FBS rank scoping fix: `api.leaderboard_teams` and
   `public.team_epa_season` rank columns are now computed WITHIN classification
@@ -304,6 +331,7 @@ These are the primary PostgREST-accessible views. Queries go through Supabase cl
 | `api.game_line_scores` | **Deployed** | 45,897 | Game line scores pivoted into Q1-Q4 columns with OT periods summed. Columns: game_id, season, home_q1, home_q2, home_q3, home_q4, home_ot, away_q1, away_q2, away_q3, away_q4, away_ot |
 | `api.team_playcalling_profile` | **Deployed** | 4,627 | Team playcalling identity with situational tendencies and percentile rankings. One row per team-season. Columns: team, season, conference, games_played, overall_run_rate, early_down_run_rate, third_down_pass_rate, red_zone_run_rate, overall_success_rate, overall_avg_epa, third_down_success_rate, red_zone_success_rate, leading_run_rate, trailing_run_rate, run_rate_delta, pace_plays_per_game, overall_run_rate_pctl, early_down_run_rate_pctl, third_down_pass_rate_pctl, overall_epa_pctl, third_down_success_pctl, red_zone_success_pctl, run_rate_delta_pctl, pace_pctl |
 | `api.coaching_history` | **Deployed** | 2,752 | Coaching tenure analytics: career spans, W-L records, talent metrics. One row per coach-team-tenure. Columns: first_name, last_name, team, tenure_start, tenure_end, seasons_count, total_wins, total_losses, win_pct, conf_wins, conf_losses, conf_win_pct, bowl_games, bowl_wins, inherited_talent_rank, year3_talent_rank, talent_improvement, is_active |
+| `api.coach_records` | **Pending deploy** | -- | Coach career record by school, straight-up and against-the-spread, for ranking coaches by win percentage. One row per coach-team (career-at-school grain, unlike `api.coaching_history`'s per-tenure grain). Columns: coach_name, first_name, last_name, team, first_season, last_season, seasons_count, games, wins, losses, ties, win_pct, ats_games, ats_wins, ats_losses, ats_pushes, ats_win_pct, seasons_with_ats_data. Coach attribution is whole-season (no mid-season splits); `ats_*` coverage is partial pre-lines-era -- see `seasons_with_ats_data` and the 2026-07-22 changelog entry. |
 | `api.recruiting_roi` | **Deployed** | 1,324 | Recruiting investment vs on-field outcomes. 4-year rolling BCR, wins over expected, draft production. One row per team-season. Columns: team, season, conference, blue_chip_ratio, avg_recruit_rating, total_wins, win_pct, epa_per_play, players_drafted, wins_over_expected, recruiting_efficiency, win_pct_pctl, epa_pctl, recruiting_efficiency_pctl |
 | `api.transfer_portal_impact` | **Deployed** | 1,374 | Transfer portal activity correlated with team performance changes. Portal era (2021+). One row per team-season. Columns: team, season, conference, transfers_in, transfers_out, net_transfers, avg_transfer_stars, portal_dependency, win_delta, net_transfers_pctl, win_delta_pctl, portal_dependency_pctl |
 | `api.conference_comparison` | **Deployed** | 347 | Conference-level season analytics with percentile rankings. One row per conference-season. Columns: conference, season, member_count, avg_wins, avg_sp_rating, avg_epa, avg_recruiting_rank, non_conf_win_pct, avg_sp_pctl, avg_epa_pctl, avg_recruiting_pctl, non_conf_win_pct_pctl |

--- a/src/schemas/api/038_coach_records.sql
+++ b/src/schemas/api/038_coach_records.sql
@@ -1,0 +1,119 @@
+-- api.coach_records
+-- Coach records at coach x team (career-at-school) grain: straight-up AND
+-- against-the-spread (ATS) win/loss record, so beta testers (sports
+-- bettors) can rank coaches by win percentage either way.
+--
+-- GRAIN: one row per (coach, team) -- a coach's whole career at a single
+-- school, aggregated across every season they were listed as that school's
+-- head coach. This differs from api.coaching_history (marts.coaching_tenure),
+-- which splits a coach's non-contiguous stints at the same school into
+-- separate tenure rows -- this view collapses all stints into one career
+-- record per coach-team pair.
+--
+-- CAVEAT -- coach attribution is whole-season: ref.coaches__seasons (CFBD's
+-- /coaches endpoint) attributes an entire season's games to a single head
+-- coach per school. Mid-season coaching changes (e.g. an interim coach
+-- finishing out a season after a firing) are NOT splittable at this grain --
+-- all of that season's games land under whichever name CFBD's season row
+-- lists. Do not use this view to attribute individual games to a specific
+-- coach; it is only valid at season-or-larger grain.
+--
+-- CAVEAT -- ATS coverage is partial: marts.team_ats_records (sourced from
+-- betting.team_ats / CFBD's historical betting lines) does not extend back
+-- through every coach's full career -- older seasons predate consistently
+-- tracked betting lines. The season-to-team ATS join is a LEFT JOIN, so
+-- ats_* columns can be NULL (no ATS data for any of the coach's seasons at
+-- that team) or based on fewer seasons than the straight-up record covers.
+-- Use seasons_with_ats_data to see how many of a coach's seasons at that
+-- team actually have ATS data backing the ats_* aggregates.
+--
+-- Join key: ref.coaches__seasons.school (team name) + year, joined to
+-- marts.team_ats_records.team + season -- there is no shared surrogate id
+-- between coaching data and betting data.
+--
+-- PostgREST usage:
+--   GET /api/coach_records?team=eq.Alabama&order=win_pct.desc
+--   GET /api/coach_records?coach_name=ilike.*saban*&order=ats_win_pct.desc
+
+DROP VIEW IF EXISTS api.coach_records;
+
+CREATE VIEW api.coach_records AS
+WITH coach_seasons AS (
+    -- One row per coach-team-season, via the dlt parent/child relationship
+    -- (same idiom as marts.coach_record / marts.coaching_tenure).
+    SELECT
+        c.first_name,
+        c.last_name,
+        COALESCE(NULLIF(TRIM(c.first_name || ' ' || c.last_name), ''), c.last_name, c.first_name)
+            AS coach_name,
+        cs.school AS team,
+        cs.year AS season,
+        cs.games,
+        cs.wins,
+        cs.losses,
+        cs.ties
+    FROM ref.coaches c
+    JOIN ref.coaches__seasons cs ON cs._dlt_parent_id = c._dlt_id
+    WHERE cs.school IS NOT NULL
+      AND cs.year IS NOT NULL
+),
+coach_seasons_ats AS (
+    -- LEFT JOIN so seasons/teams with no betting-line coverage still keep
+    -- their straight-up record; ATS columns simply stay NULL for that season.
+    SELECT
+        cse.*,
+        tar.ats_wins,
+        tar.ats_losses,
+        tar.ats_pushes,
+        (tar.team IS NOT NULL) AS has_ats_data
+    FROM coach_seasons cse
+    LEFT JOIN marts.team_ats_records tar
+        ON tar.team = cse.team
+        AND tar.season = cse.season
+)
+SELECT
+    coach_name,
+    first_name,
+    last_name,
+    team,
+
+    -- Career span at this school
+    MIN(season) AS first_season,
+    MAX(season) AS last_season,
+    COUNT(DISTINCT season) AS seasons_count,
+
+    -- Straight-up record
+    SUM(COALESCE(games, 0))::int AS games,
+    SUM(COALESCE(wins, 0))::int AS wins,
+    SUM(COALESCE(losses, 0))::int AS losses,
+    SUM(COALESCE(ties, 0))::int AS ties,
+    ROUND(
+        SUM(COALESCE(wins, 0))::numeric
+        / NULLIF(SUM(COALESCE(wins, 0)) + SUM(COALESCE(losses, 0)), 0),
+        4
+    ) AS win_pct,
+
+    -- Against-the-spread record, aggregated over whichever of the coach's
+    -- seasons at this team have betting-line coverage
+    SUM(COALESCE(ats_wins, 0))::int
+        + SUM(COALESCE(ats_losses, 0))::int
+        + SUM(COALESCE(ats_pushes, 0))::int AS ats_games,
+    SUM(COALESCE(ats_wins, 0))::int AS ats_wins,
+    SUM(COALESCE(ats_losses, 0))::int AS ats_losses,
+    SUM(COALESCE(ats_pushes, 0))::int AS ats_pushes,
+    ROUND(
+        SUM(COALESCE(ats_wins, 0))::numeric
+        / NULLIF(SUM(COALESCE(ats_wins, 0)) + SUM(COALESCE(ats_losses, 0)), 0),
+        4
+    ) AS ats_win_pct,
+
+    -- Coverage indicator: how many of this coach's seasons at this team
+    -- actually had a matching marts.team_ats_records row
+    COUNT(*) FILTER (WHERE has_ats_data) AS seasons_with_ats_data
+
+FROM coach_seasons_ats
+GROUP BY coach_name, first_name, last_name, team;
+
+COMMENT ON VIEW api.coach_records IS 'Coach career records at a school (coach x team grain), straight-up and against-the-spread. Columns: coach_name, first_name, last_name, team, first_season, last_season, seasons_count, games, wins, losses, ties, win_pct, ats_games, ats_wins, ats_losses, ats_pushes, ats_win_pct, seasons_with_ats_data. Coach attribution is whole-season (mid-season coaching changes not splittable -- see ref.coaches__seasons). ATS columns are partial pre-lines-era coverage (LEFT JOIN to marts.team_ats_records); use seasons_with_ats_data to gauge coverage. Backed by ref.coaches / ref.coaches__seasons and marts.team_ats_records.';
+
+GRANT SELECT ON api.coach_records TO anon, authenticated;

--- a/tests/test_api_views.py
+++ b/tests/test_api_views.py
@@ -476,6 +476,27 @@ GAME_RECAPS_COLUMNS = {
     "generated_at",
 }
 
+COACH_RECORDS_COLUMNS = {
+    "coach_name",
+    "first_name",
+    "last_name",
+    "team",
+    "first_season",
+    "last_season",
+    "seasons_count",
+    "games",
+    "wins",
+    "losses",
+    "ties",
+    "win_pct",
+    "ats_games",
+    "ats_wins",
+    "ats_losses",
+    "ats_pushes",
+    "ats_win_pct",
+    "seasons_with_ats_data",
+}
+
 # ---------------------------------------------------------------------------
 # Test: views exist and return rows
 # ---------------------------------------------------------------------------
@@ -513,6 +534,9 @@ class TestViewsExistAndReturnRows:
             # Tier 3 analytics: feature vectors and adjusted EPA coefficients
             ("api.team_week_features", 15000),
             ("api.adjusted_epa_week", 50000),
+            # Coach x team career grain -- coaches x schools over the loaded
+            # coaching era (ref.coaches__seasons), conservative floor.
+            ("api.coach_records", 200),
         ],
         ids=[
             "team_detail",
@@ -531,6 +555,7 @@ class TestViewsExistAndReturnRows:
             "game_predictions",
             "team_week_features",
             "adjusted_epa_week",
+            "coach_records",
         ],
     )
     def test_view_returns_rows(self, db_conn, view_name, min_rows):
@@ -572,6 +597,7 @@ class TestViewColumns:
             ("api.team_week_features", TEAM_WEEK_FEATURES_COLUMNS),
             ("api.live_scoreboard", LIVE_SCOREBOARD_COLUMNS),
             ("api.adjusted_epa_week", ADJUSTED_EPA_WEEK_COLUMNS),
+            ("api.coach_records", COACH_RECORDS_COLUMNS),
         ],
         ids=[
             "team_detail",
@@ -594,6 +620,7 @@ class TestViewColumns:
             "team_week_features",
             "live_scoreboard",
             "adjusted_epa_week",
+            "coach_records",
         ],
     )
     def test_columns_present(self, db_conn, view_name, expected_columns):
@@ -1179,3 +1206,56 @@ class TestPollRankings:
         assert postseason == 25, (
             f"AP Top 25 postseason (final) poll for 2024 has {postseason} rows, expected 25"
         )
+
+
+# ---------------------------------------------------------------------------
+# Test: coach_records filters and data quality
+# ---------------------------------------------------------------------------
+
+
+class TestCoachRecords:
+    """api.coach_records -- coach x team career record, straight-up and ATS."""
+
+    def test_saban_alabama_exists(self, db_conn):
+        """A well-known durable coach's career record at his school should exist."""
+        rows, columns = _fetch_all(
+            db_conn,
+            """
+            SELECT wins
+            FROM api.coach_records
+            WHERE coach_name ILIKE %s AND team = %s
+            """,
+            ("%Saban%", "Alabama"),
+        )
+        assert len(rows) == 1, f"Expected 1 Saban/Alabama row, got {len(rows)}"
+        row = dict(zip(columns, rows[0]))
+        assert row["wins"] > 100, f"Saban at Alabama should have 100+ wins, got {row['wins']}"
+
+    def test_win_pct_range(self, db_conn):
+        """Straight-up win_pct should be between 0 and 1 where populated."""
+        rows, _ = _fetch_all(
+            db_conn,
+            """
+            SELECT win_pct
+            FROM api.coach_records
+            WHERE win_pct IS NOT NULL
+            LIMIT 5000
+            """,
+        )
+        for (win_pct,) in rows:
+            assert 0 <= win_pct <= 1, f"win_pct {win_pct} out of [0, 1] range"
+
+    def test_ats_win_pct_null_or_in_range(self, db_conn):
+        """ats_win_pct should be NULL (no ATS coverage) or between 0 and 1."""
+        rows, _ = _fetch_all(
+            db_conn,
+            """
+            SELECT ats_win_pct
+            FROM api.coach_records
+            LIMIT 5000
+            """,
+        )
+        for (ats_win_pct,) in rows:
+            assert ats_win_pct is None or 0 <= ats_win_pct <= 1, (
+                f"ats_win_pct {ats_win_pct} is neither NULL nor in [0, 1] range"
+            )


### PR DESCRIPTION
## Summary

Round 2 of beta-tester feedback (the sports-bettor persona): a new `api.coach_records` view powering "coaches ranked by win% straight-up and against-the-spread."

> **Note:** branched from `claude/fbs-rank-scope` (PR #32) — merge #32 first and this diff shrinks to just the coach-records commits.

## Changes

- **`src/schemas/api/038_coach_records.sql`** — new view at coach × team (career-at-school) grain: straight-up record aggregated from `ref.coaches__seasons` (first/last season, games, W-L-T, `win_pct`), ATS record joined per season from `marts.team_ats_records` and aggregated (`ats_wins/losses/pushes`, `ats_win_pct` with pushes excluded from the denominator), plus `seasons_with_ats_data` so partial betting-line coverage is visible. In-file `GRANT SELECT` (grants are dropped by DROP+CREATE — lesson applied from #32). Documented caveats: coach attribution is whole-season (mid-season changes can't split ATS), ATS coverage is partial in older seasons.
- **Contract tests** — `COACH_RECORDS_COLUMNS`, rows/columns entries, and a `TestCoachRecords` class (Saban-at-Alabama sanity row, win_pct ∈ [0,1], ats_win_pct NULL-or-in-range).
- **`docs/SCHEMA_CONTRACT.md`** — new surface row + changelog entry.
- **`deploys/coach-records-manifest.json`** — apply manifest.

## Deploy status

Already applied to production via `deploy/coach-records` (Deploy Schema run green) — this PR's CI exercises the live view. The companion cfb-app PR adds the `/coaches` page over it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNx7MmfrWbhFwx1du79KY3

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNx7MmfrWbhFwx1du79KY3)_