### PR TITLE
fix: season-accurate classification in rank views (realignment leak)

### DIFF
--- a/deploys/season-classification-manifest.json
+++ b/deploys/season-classification-manifest.json
@@ -1,0 +1,7 @@
+{
+  "action": "apply",
+  "files": [
+    "src/schemas/public/002_marts_views.sql",
+    "src/schemas/api/005_leaderboard_teams.sql"
+  ]
+}

--- a/docs/SCHEMA_CONTRACT.md
+++ b/docs/SCHEMA_CONTRACT.md
@@ -15,6 +15,48 @@ Last updated: 2026-07-22
 
 ## Recent Contract Changes
 
+- **2026-07-22 — `classification` on `public.team_epa_season` and
+  `api.leaderboard_teams` is now SEASON-ACCURATE (consumer-visible semantics
+  change; realignment fix).** Beta testers flagged North Dakota State's
+  dominant 2025 FCS season (12-1, 0.40 EPA/play) appearing inside the 2025
+  FBS partition on FBS leaderboards. Root cause: both views derived
+  `classification` from a deduped `ref.teams` join, and `ref.teams` mirrors
+  CFBD `/teams` -- **current** membership, not historical. NDSU moved up to
+  FBS (Mountain West) for 2026, so `ref.teams` now says `fbs` for NDSU, and
+  that reclassified *every* historical NDSU season, including the FCS one it
+  actually played in 2025. Any team that changes classification (realignment,
+  reclassification) has the same bug in its historical seasons. Fixed by
+  adding a `team_season_class` CTE to both views that derives classification
+  per `(team, season)` from `core.games.home_classification` /
+  `away_classification` (dlt snake_case of CFBD `homeClassification` /
+  `awayClassification` -- the classification each team actually carried in
+  its own games that season; same source used by `scripts/verify_load.py`
+  and `scripts/generate_recaps.py`), deduped with
+  `mode() WITHIN GROUP (ORDER BY classification)` per team-season (in case
+  of disagreement across a team's games in one season), LEFT JOINed on
+  `(team, season)`, and COALESCEd with the existing `ref.teams`-deduped CTE
+  as a fallback for team-seasons with no loaded games in `core.games`. Rank
+  windows (`off_epa_rank`/`def_epa_rank` on `public.team_epa_season`;
+  `wins_rank`/`ppg_rank`/`defense_ppg_rank`/`epa_rank` on
+  `api.leaderboard_teams`) still `PARTITION BY season, classification` --
+  now season-accurate, so NDSU's 2025 season partitions correctly under FCS
+  and its future 2026 season will partition under FBS. Column name and
+  position unchanged on both views (`public.team_epa_season` still appends
+  `classification` last per the `CREATE OR REPLACE VIEW` column-order
+  constraint; `api.leaderboard_teams` DROPs and recreates, so no ordering
+  constraint applies, and it wasn't reordered). `api.leaderboard_teams`
+  keeps its in-file `GRANT SELECT ... TO anon, authenticated;` (re-granted
+  on every apply since the DROP discards existing grants). Performance:
+  `team_season_class` scans `core.games` (~90K rows) grouped by
+  `(team, season)` in both views -- acceptable at this scale. Files:
+  `src/schemas/public/002_marts_views.sql`,
+  `src/schemas/api/005_leaderboard_teams.sql`. New regression test:
+  `tests/test_api_views.py::TestLeaderboardTeams::test_classification_is_season_accurate`
+  asserts `api.leaderboard_teams` classification for North Dakota State,
+  season 2025, is `'fcs'`. The existing `test_epa_rank_scoped_to_fbs` (max
+  `epa_rank` among FBS rows `<= 140`) still holds. Deploy manifest:
+  `deploys/season-classification-manifest.json`.
+
 - **2026-07-22 — `api.coach_records` added (view authored, pending deploy).**
   Beta testers (sports bettors) asked for "coaches' records straight-up AND
   against-the-spread, ranked by win percentage" -- nothing coach-related

--- a/src/schemas/api/005_leaderboard_teams.sql
+++ b/src/schemas/api/005_leaderboard_teams.sql
@@ -7,12 +7,43 @@
 -- WITHIN classification (PARTITION BY season, classification), not across all
 -- of FBS+FCS+lower. All rows are still returned (no WHERE fbs filter) --
 -- consumers filter by classification themselves.
+--
+-- `classification` is SEASON-ACCURATE, not "current membership": ref.teams
+-- mirrors CFBD /teams (current classification only), so a realignment team
+-- (e.g. North Dakota State moving FCS -> FBS for 2026) would otherwise have
+-- ALL of its historical seasons reclassified to its new division, leaking a
+-- dominant FCS season onto FBS rank partitions/leaderboards. team_season_class
+-- derives classification per (team, season) from
+-- core.games.home_classification/away_classification (dlt snake_case of CFBD
+-- homeClassification/awayClassification -- the classification each team
+-- actually carried in its own games that season; same source used by
+-- scripts/verify_load.py and scripts/generate_recaps.py). Scans core.games
+-- (~90K rows) grouped by (team, season) -- fine for view-time cost here.
+-- Falls back to the ref.teams dedup (current-membership) only for
+-- team-seasons with no loaded games.
 
 DROP VIEW IF EXISTS api.leaderboard_teams;
 
 CREATE VIEW api.leaderboard_teams AS
-WITH teams_deduped AS (
+WITH team_season_class AS (
+    SELECT
+        team,
+        season,
+        mode() WITHIN GROUP (ORDER BY classification) AS classification
+    FROM (
+        SELECT g.home_team AS team, g.season, g.home_classification AS classification
+        FROM core.games g
+        WHERE g.home_classification IS NOT NULL
+        UNION ALL
+        SELECT g.away_team, g.season, g.away_classification
+        FROM core.games g
+        WHERE g.away_classification IS NOT NULL
+    ) x
+    GROUP BY team, season
+),
+teams_deduped AS (
     -- ref.teams has ~35 duplicate school names; pick FBS classification first, else first row
+    -- fallback only: current membership, used when core.games has no rows for a team-season
     SELECT DISTINCT ON (school)
         school, classification
     FROM ref.teams
@@ -22,7 +53,7 @@ SELECT
     tss.team,
     tss.conference,
     tss.season,
-    t.classification,
+    COALESCE(tsc.classification, t.classification) AS classification,
 
     -- Record
     tss.games,
@@ -59,18 +90,20 @@ SELECT
     -- Computed rankings within season AND classification (fix: previously
     -- ranked across FBS+FCS+lower, so FBS teams could show ranks like #176
     -- when FBS has ~136 teams)
-    RANK() OVER (PARTITION BY tss.season, t.classification ORDER BY tss.wins DESC, tss.avg_margin DESC) AS wins_rank,
-    RANK() OVER (PARTITION BY tss.season, t.classification ORDER BY tss.ppg DESC) AS ppg_rank,
-    RANK() OVER (PARTITION BY tss.season, t.classification ORDER BY tss.opp_ppg ASC) AS defense_ppg_rank,
-    RANK() OVER (PARTITION BY tss.season, t.classification ORDER BY epa.epa_per_play DESC NULLS LAST) AS epa_rank
+    RANK() OVER (PARTITION BY tss.season, COALESCE(tsc.classification, t.classification) ORDER BY tss.wins DESC, tss.avg_margin DESC) AS wins_rank,
+    RANK() OVER (PARTITION BY tss.season, COALESCE(tsc.classification, t.classification) ORDER BY tss.ppg DESC) AS ppg_rank,
+    RANK() OVER (PARTITION BY tss.season, COALESCE(tsc.classification, t.classification) ORDER BY tss.opp_ppg ASC) AS defense_ppg_rank,
+    RANK() OVER (PARTITION BY tss.season, COALESCE(tsc.classification, t.classification) ORDER BY epa.epa_per_play DESC NULLS LAST) AS epa_rank
 
 FROM marts.team_season_summary tss
 LEFT JOIN marts.team_epa_season epa
     ON epa.team = tss.team AND epa.season = tss.season
+LEFT JOIN team_season_class tsc
+    ON tsc.team = tss.team AND tsc.season = tss.season
 LEFT JOIN teams_deduped t
     ON t.school = tss.team;
 
-COMMENT ON VIEW api.leaderboard_teams IS 'Team leaderboard with records, ratings, EPA, and computed rankings. Rank columns (wins_rank, ppg_rank, defense_ppg_rank, epa_rank) are computed within classification (PARTITION BY season, classification) -- FBS teams rank among ~136 FBS peers, not all classifications combined. All rows returned regardless of classification; filter client-side.';
+COMMENT ON VIEW api.leaderboard_teams IS 'Team leaderboard with records, ratings, EPA, and computed rankings. Rank columns (wins_rank, ppg_rank, defense_ppg_rank, epa_rank) are computed within classification (PARTITION BY season, classification) -- FBS teams rank among ~136 FBS peers, not all classifications combined. All rows returned regardless of classification; filter client-side. classification is season-accurate (core.games home_classification/away_classification per (team, season), ref.teams fallback) -- realignment teams (e.g. North Dakota State moving FCS -> FBS for 2026) keep their historical seasons in the correct classification partition instead of leaking into their current one.';
 
 -- Re-grant on every apply: this file DROPs the view first, which discards
 -- existing grants (no ALTER DEFAULT PRIVILEGES in this database).

--- a/src/schemas/public/002_marts_views.sql
+++ b/src/schemas/public/002_marts_views.sql
@@ -1,6 +1,11 @@
 -- Public-facing views that expose marts materialized views
 -- These provide stable read interfaces for the frontend app.
 -- Created ad-hoc in Supabase; now tracked in version control.
+--
+-- public.team_epa_season's `classification` column is SEASON-ACCURATE (derived
+-- from core.games per (team, season), ref.teams-current-membership fallback) --
+-- see the team_season_class CTE below and the 2026-07-22 changelog entry in
+-- docs/SCHEMA_CONTRACT.md.
 
 CREATE OR REPLACE VIEW public.defensive_havoc
 WITH (security_invoker = true)
@@ -27,8 +32,38 @@ FROM marts.defensive_havoc;
 CREATE OR REPLACE VIEW public.team_epa_season
 WITH (security_invoker = true)
 AS
-WITH teams_deduped AS (
+-- classification here is SEASON-ACCURATE, not "current membership":
+-- ref.teams mirrors CFBD /teams (current classification only), so a
+-- realignment team (e.g. North Dakota State moving FCS -> FBS for 2026)
+-- would otherwise have ALL of its historical seasons reclassified to its
+-- new division, leaking a dominant FCS season onto FBS rank partitions.
+-- team_season_class derives classification per (team, season) from
+-- core.games.home_classification/away_classification (dlt snake_case of
+-- CFBD homeClassification/awayClassification -- the classification each
+-- team actually carried in its own games that season; same source used by
+-- scripts/verify_load.py and scripts/generate_recaps.py). Scans
+-- core.games (~90K rows) grouped by (team, season) -- fine for view-time
+-- cost here. Falls back to the ref.teams dedup (current-membership) only
+-- for team-seasons with no loaded games.
+WITH team_season_class AS (
+    SELECT
+        team,
+        season,
+        mode() WITHIN GROUP (ORDER BY classification) AS classification
+    FROM (
+        SELECT g.home_team AS team, g.season, g.home_classification AS classification
+        FROM core.games g
+        WHERE g.home_classification IS NOT NULL
+        UNION ALL
+        SELECT g.away_team, g.season, g.away_classification
+        FROM core.games g
+        WHERE g.away_classification IS NOT NULL
+    ) x
+    GROUP BY team, season
+),
+teams_deduped AS (
     -- ref.teams has ~35 duplicate school names; pick FBS classification first, else first row
+    -- fallback only: current membership, used when core.games has no rows for a team-season
     SELECT DISTINCT ON (school)
         school, classification
     FROM ref.teams
@@ -43,15 +78,21 @@ SELECT
     e.epa_per_play,
     e.success_rate,
     COALESCE(e.explosiveness, 0::NUMERIC) AS explosiveness,
-    (RANK() OVER (PARTITION BY e.season, t.classification ORDER BY e.epa_per_play DESC))::INT AS off_epa_rank,
-    (RANK() OVER (PARTITION BY e.season, t.classification ORDER BY COALESCE(d.opp_epa_per_play, 999::NUMERIC)))::INT AS def_epa_rank,
+    (RANK() OVER (PARTITION BY e.season, COALESCE(tsc.classification, t.classification) ORDER BY e.epa_per_play DESC))::INT AS off_epa_rank,
+    (RANK() OVER (PARTITION BY e.season, COALESCE(tsc.classification, t.classification) ORDER BY COALESCE(d.opp_epa_per_play, 999::NUMERIC)))::INT AS def_epa_rank,
     -- appended LAST: CREATE OR REPLACE VIEW can only add columns at the end
-    t.classification
+    -- season-accurate classification (core.games), falling back to ref.teams current membership
+    COALESCE(tsc.classification, t.classification) AS classification
 FROM marts.team_epa_season e
 LEFT JOIN marts.defensive_havoc d
     ON e.team = d.team AND e.season = d.season
+LEFT JOIN team_season_class tsc
+    ON tsc.team = e.team AND tsc.season = e.season
 LEFT JOIN teams_deduped t
     ON t.school = e.team;
+
+COMMENT ON VIEW public.team_epa_season IS
+    'Season-level EPA metrics per team with off_epa_rank/def_epa_rank scoped PARTITION BY season, classification. classification is season-accurate (core.games home_classification/away_classification per (team, season), ref.teams fallback) -- realignment teams (e.g. North Dakota State moving FCS -> FBS for 2026) keep their historical seasons in the correct classification partition instead of leaking into their current one.';
 
 CREATE OR REPLACE VIEW public.team_season_epa
 WITH (security_invoker = true)

--- a/tests/test_api_views.py
+++ b/tests/test_api_views.py
@@ -929,6 +929,31 @@ class TestLeaderboardTeams:
             "are leaking in FCS/lower-classification teams)"
         )
 
+    def test_classification_is_season_accurate(self, db_conn):
+        """classification reflects the team's classification IN THAT SEASON, not current membership.
+
+        North Dakota State moved up to FBS (Mountain West) for 2026, but its
+        2025 season was played (and dominated, 12-1) at the FCS level. If
+        classification were sourced from ref.teams (current CFBD /teams
+        membership) instead of core.games (season-accurate), NDSU's 2025 row
+        would incorrectly show 'fbs' and leak onto FBS leaderboards/rank
+        partitions. Regression test for the season-classification fix.
+        """
+        rows, _ = _fetch_all(
+            db_conn,
+            """
+            SELECT classification
+            FROM api.leaderboard_teams
+            WHERE team = 'North Dakota State' AND season = 2025
+            """,
+        )
+        if not rows:
+            pytest.skip("North Dakota State 2025 row not present in api.leaderboard_teams")
+        assert rows[0][0] == "fcs", (
+            f"North Dakota State 2025 classification is {rows[0][0]!r}, expected 'fcs' "
+            "(season-accurate, not current 2026 FBS membership)"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Test: roster_lookup filters


### PR DESCRIPTION
## Summary

The final piece of the "NDSU on the FBS leaderboards" investigation. The root cause was **conference realignment semantics, not a broken filter**: `ref.teams` mirrors CFBD's *current* membership, where North Dakota State is FBS (Mountain West, 2026) — so their dominant 2025 **FCS** season ranked inside the 2025 FBS partition and topped FBS boards.

## Changes

- `public.team_epa_season` and `api.leaderboard_teams` now derive `classification` **season-accurately**: a `team_season_class` CTE computes each (team, season)'s modal classification from that season's own games (`core.games.home/away_classification`), `COALESCE`d with the previous current-membership fallback for team-seasons with no loaded games. Used both for the exposed `classification` column and inside every `PARTITION BY season, classification` rank window. Column names/positions unchanged; the api view keeps its in-file `GRANT`.
- Regression test: `TestLeaderboardTeams::test_classification_is_season_accurate` — NDSU's 2025 row must read `fcs`.
- `docs/SCHEMA_CONTRACT.md` changelog entry; `deploys/season-classification-manifest.json` apply manifest.

## Deploy status

Already applied to production (after a GitHub Actions runner-queue delay) and **verified live**: the 2025 FBS EPA leaderboard is now Vanderbilt / North Texas / Notre Dame / Oregon / USC — NDSU no longer appears. The companion app change (cfb-app #27, merged) consumes the season-accurate column. This PR's CI exercises the live views, including the NDSU regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNx7MmfrWbhFwx1du79KY3

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNx7MmfrWbhFwx1du79KY3)_