### PR TITLE
Analyst RPC v3: SECURITY INVOKER + membership-based role drop

### DIFF
--- a/src/schemas/public/012_run_analyst_query.sql
+++ b/src/schemas/public/012_run_analyst_query.sql
@@ -2,54 +2,62 @@
 -- `run_sql` tool (cfb-app src/lib/mcp/tools.ts §20 calls this RPC via
 -- PostgREST; until this file is applied the tool degrades gracefully).
 --
--- Security model (per the cfb-app handoff, adjusted in review -- see notes):
+-- Security model (v3 -- reshaped twice by prod findings, see below):
 --   * the boundary is the ROLE, not the textual checks: a dedicated
 --     analyst_ro NOLOGIN role holds USAGE+SELECT on the `api` schema ONLY.
 --     api views are owner-rights (NOT security_invoker -- confirmed against
 --     src/schemas/api/*), so analyst_ro needs no grants on marts/core for
 --     them to work, and direct reads of any other schema fail with
 --     insufficient_privilege. No DML grants anywhere.
---   * the function is SECURITY DEFINER and OWNED BY analyst_ro, so the
---     caller's SQL executes with analyst_ro's privileges directly. (The
---     handoff draft used SET LOCAL ROLE inside the function instead;
---     Postgres forbids that -- "cannot set parameter \"role\" within
---     security-definer function", caught by this file's self-validation
---     on first deploy. Owner-as-boundary needs no role switch at all.)
---     The transaction is marked read-only so even SECURITY DEFINER
---     functions reachable via SELECT (e.g. public.refresh_all_marts)
---     cannot write through it; the GUC is rolled back at function exit
---     (SET clause + SECURITY DEFINER establish a GUC nest level) and
---     never leaks into the caller's transaction.
+--   * the function is SECURITY INVOKER; anon/authenticated (the PostgREST
+--     roles) are granted MEMBERSHIP in analyst_ro, so the function's
+--     SET LOCAL ROLE analyst_ro is legal for them and the caller's SQL
+--     executes with analyst_ro's privileges. Membership is a pure
+--     privilege REDUCTION path: analyst_ro can do strictly less than anon
+--     already can. Non-member callers (e.g. postgres) fail at SET ROLE --
+--     the drop is mandatory, never best-effort.
+--   * SET LOCAL transaction_read_only = on closes the "write via a
+--     SECURITY DEFINER helper reachable from SELECT" path (e.g.
+--     public.refresh_all_marts). The SET clause below gives the call a GUC
+--     nest level, so role + read-only revert at function exit and never
+--     leak into the caller's transaction.
 --   * textual checks (SELECT/WITH prefix, single statement) exist only to
 --     fail fast with clear messages. A data-modifying CTE slips past the
 --     prefix check by design and dies at the permission layer instead.
 --
--- Review deviations from the handoff draft:
+-- Why not the handoff's SECURITY DEFINER + SET LOCAL ROLE: Postgres forbids
+-- SET ROLE inside SECURITY DEFINER functions outright ("cannot set
+-- parameter \"role\" within security-definer function" -- caught by this
+-- file's self-validation on first deploy). Why not DEFINER via function
+-- ownership: ALTER FUNCTION ... OWNER TO analyst_ro requires the migration
+-- role to be able to SET ROLE analyst_ro, and Supabase TERMINATES the
+-- connection on GRANT analyst_ro TO postgres (its managed-role protection
+-- kills the session rather than erroring). Granting membership to
+-- anon/authenticated is permitted -- probed live 2026-07-23.
+--
+-- Review deviations from the handoff draft (still apply in v3):
 --   * LIMIT placement: the draft's `FROM (%s LIMIT 200) q` breaks any query
---     that already ends in LIMIT/OFFSET (`... LIMIT 10 LIMIT 200` is a
---     syntax error). The cap lives on an outer wrapper subquery instead.
---   * statement_timeout: the draft SET LOCAL a timeout inside the function,
---     but statement_timeout is armed when the top-level statement STARTS --
---     changing it mid-statement does not bound the in-flight RPC call, so
---     the line was theater and is omitted. The effective bound is the
---     Supabase role-level timeout on the calling role (anon/authenticated)
---     plus the app's 55s MCP client timeout. The handoff's pg_sleep test is
---     dropped for the same reason.
---   * role creation is guarded for idempotent re-application, and EXECUTE
---     is revoked from PUBLIC (functions default to PUBLIC-executable).
+--     that already ends in LIMIT/OFFSET; the cap lives on an outer wrapper
+--     subquery instead.
+--   * statement_timeout: an in-function SET LOCAL cannot bound the
+--     in-flight statement (the timer arms at top-level statement start), so
+--     none is set. The effective bound is the Supabase role-level timeout
+--     on the calling role plus the app's 55s MCP client timeout.
 --
 -- Caveats (documented, accepted):
 --   * a literal ';' inside a string constant is rejected by the
 --     single-statement check (false positive; rewrite the query).
 --   * duplicate output column names collapse in jsonb (last one wins) --
 --     alias columns when joining.
+--   * migration-time validation cannot exercise the happy path (postgres
+--     is deliberately not an analyst_ro member), so it asserts the grants
+--     catalog-side and proves the mandatory drop; the end-to-end positive
+--     test is any authenticated PostgREST call (the cfb-app tool).
 --
 -- Apply via: python scripts/run_migrations.py --file src/schemas/public/012_run_analyst_query.sql
--- (deploy manifest "apply"). Idempotent. Self-validating: the DO block at
--- the end exercises the RPC and raises (failing the migration) on any
--- behavioral regression.
+-- (deploy manifest "apply"). Idempotent.
 
--- 1. Restricted role ---------------------------------------------------------
+-- 1. Restricted role + memberships -------------------------------------------
 DO $$
 BEGIN
     IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'analyst_ro') THEN
@@ -61,18 +69,24 @@ GRANT USAGE ON SCHEMA api TO analyst_ro;
 GRANT SELECT ON ALL TABLES IN SCHEMA api TO analyst_ro;
 ALTER DEFAULT PRIVILEGES IN SCHEMA api GRANT SELECT ON TABLES TO analyst_ro;
 
--- 2. Guarded executor --------------------------------------------------------
+-- PostgREST roles become members so the function's SET LOCAL ROLE is legal
+-- for them. Do NOT grant analyst_ro to postgres: Supabase kills the
+-- connection on membership changes to its managed postgres role, and the
+-- migration role staying a non-member is what makes the drop provably
+-- mandatory (see self-validation).
+GRANT analyst_ro TO anon, authenticated, service_role;
+
+-- 2. Guarded executor (SECURITY INVOKER) -------------------------------------
 CREATE OR REPLACE FUNCTION public.run_analyst_query(query_sql text)
 RETURNS jsonb
 LANGUAGE plpgsql
-SECURITY DEFINER
 SET search_path = api, public
 AS $$
 DECLARE
     cleaned text := btrim(query_sql);
     result jsonb;
 BEGIN
-    -- Fail-fast checks; the analyst_ro grants below are the real boundary.
+    -- Fail-fast checks; the analyst_ro grants are the real boundary.
     IF cleaned !~* '^(select|with)\M' THEN
         RAISE EXCEPTION 'only SELECT/WITH statements are allowed';
     END IF;
@@ -81,6 +95,7 @@ BEGIN
         RAISE EXCEPTION 'multiple statements are not allowed';
     END IF;
 
+    SET LOCAL ROLE analyst_ro;
     SET LOCAL transaction_read_only = on;
 
     -- Hard row cap on an outer wrapper, so an inner LIMIT/OFFSET still
@@ -95,45 +110,16 @@ BEGIN
 END;
 $$;
 
--- 3. Ownership (the security boundary) + PostgREST exposure ------------------
--- SECURITY DEFINER runs with the OWNER's privileges: analyst_ro. Supabase's
--- postgres role is not a true superuser, so assigning ownership requires
--- membership in the target role and the target role needs CREATE on the
--- schema for the duration of the ALTER (revoked immediately after --
--- ownership survives the revoke).
-GRANT analyst_ro TO CURRENT_USER;
-GRANT CREATE ON SCHEMA public TO analyst_ro;
-ALTER FUNCTION public.run_analyst_query(text) OWNER TO analyst_ro;
-REVOKE CREATE ON SCHEMA public FROM analyst_ro;
-
 REVOKE ALL ON FUNCTION public.run_analyst_query(text) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.run_analyst_query(text) TO anon, authenticated, service_role;
 
--- 4. Self-validation ---------------------------------------------------------
+-- 3. Self-validation ---------------------------------------------------------
 DO $$
 DECLARE
     r jsonb;
 BEGIN
-    -- Plain scalar round-trip.
-    r := public.run_analyst_query('SELECT 1 AS x');
-    IF r <> '[{"x": 1}]'::jsonb THEN
-        RAISE EXCEPTION 'scalar round-trip returned %', r;
-    END IF;
-
-    -- Trailing semicolon tolerated; api-view read works under analyst_ro;
-    -- row cap applies.
-    r := public.run_analyst_query('SELECT team FROM api.team_elo;');
-    IF jsonb_array_length(r) < 1 OR jsonb_array_length(r) > 200 THEN
-        RAISE EXCEPTION 'api.team_elo read returned % rows', jsonb_array_length(r);
-    END IF;
-
-    -- Inner LIMIT survives the wrapper (the draft's construction broke here).
-    r := public.run_analyst_query('SELECT team FROM api.team_elo LIMIT 3');
-    IF jsonb_array_length(r) <> 3 THEN
-        RAISE EXCEPTION 'inner LIMIT handling returned % rows', jsonb_array_length(r);
-    END IF;
-
-    -- Non-SELECT rejected by the prefix check.
+    -- Textual rejections fire before the role drop, so they are testable
+    -- here regardless of membership.
     BEGIN
         PERFORM public.run_analyst_query('DELETE FROM api.team_elo');
         RAISE EXCEPTION 'DELETE was not rejected';
@@ -141,7 +127,6 @@ BEGIN
         IF SQLERRM NOT LIKE '%only SELECT/WITH%' THEN RAISE; END IF;
     END;
 
-    -- Multiple statements rejected.
     BEGIN
         PERFORM public.run_analyst_query('SELECT 1; SELECT 2');
         RAISE EXCEPTION 'multi-statement was not rejected';
@@ -149,23 +134,28 @@ BEGIN
         IF SQLERRM NOT LIKE '%multiple statements%' THEN RAISE; END IF;
     END;
 
-    -- Outside the api schema: blocked by the role, not by text checks.
+    -- The privilege drop is mandatory: a valid query from a NON-member
+    -- (this migration role) must die at SET ROLE, not run unscoped.
     BEGIN
-        PERFORM public.run_analyst_query('SELECT id FROM core.games LIMIT 1');
-        RAISE EXCEPTION 'core.games read was not blocked';
+        r := public.run_analyst_query('SELECT 1 AS x');
+        RAISE EXCEPTION 'non-member call ran unscoped (returned %)', r;
     EXCEPTION WHEN insufficient_privilege THEN
         NULL;
     END;
 
-    -- Data-modifying CTE: passes the prefix check, dies at the
-    -- permission/read-only layer.
-    BEGIN
-        PERFORM public.run_analyst_query(
-            'WITH w AS (DELETE FROM api.team_elo RETURNING *) SELECT * FROM w');
-        RAISE EXCEPTION 'write CTE was not blocked';
-    EXCEPTION WHEN insufficient_privilege OR read_only_sql_transaction THEN
-        NULL;
-    END;
+    -- Grants, catalog-side.
+    IF NOT pg_has_role('anon', 'analyst_ro', 'MEMBER')
+       OR NOT pg_has_role('authenticated', 'analyst_ro', 'MEMBER') THEN
+        RAISE EXCEPTION 'PostgREST roles are not analyst_ro members';
+    END IF;
+    IF NOT has_schema_privilege('analyst_ro', 'api', 'USAGE')
+       OR NOT has_table_privilege('analyst_ro', 'api.team_elo', 'SELECT') THEN
+        RAISE EXCEPTION 'analyst_ro is missing api read grants';
+    END IF;
+    IF has_table_privilege('analyst_ro', 'core.games', 'SELECT')
+       OR has_schema_privilege('analyst_ro', 'marts', 'USAGE') THEN
+        RAISE EXCEPTION 'analyst_ro can reach beyond the api schema';
+    END IF;
 
     RAISE NOTICE 'run_analyst_query self-validation passed';
 END $$;


### PR DESCRIPTION
Live bisection on prod closed both SECURITY DEFINER routes for the analyst RPC:

1. **#35's design** (definer + `SET LOCAL ROLE`): Postgres forbids `SET ROLE` inside SECURITY DEFINER functions — clean error, caught by the migration's self-validation.
2. **#36's design** (definer via `analyst_ro` ownership): `ALTER FUNCTION … OWNER TO analyst_ro` requires the migration role to be able to `SET ROLE analyst_ro`, and Supabase **terminates the connection** (SSL drop, no error) on `GRANT analyst_ro TO postgres` — bisected to that exact statement via staged probe files.

A follow-up probe established that granting `analyst_ro` membership to **anon/authenticated/service_role is permitted** — the kill is specific to the managed `postgres` role. So v3:

- The function is **SECURITY INVOKER**; the PostgREST roles are `analyst_ro` **members**, making the function's `SET LOCAL ROLE analyst_ro` legal for every real caller. The query then runs with api-only read grants; membership is pure privilege *reduction* (analyst_ro ⊂ anon's existing grants).
- Non-members — including `postgres` — fail at `SET ROLE`: the drop is **mandatory**, not best-effort, and the self-validation proves it (a valid SELECT from the migration role must die with `insufficient_privilege`).
- Everything else survives from review: read-only transaction guard, outer-wrapper 200-row cap, fail-fast textual checks, no theatrical statement_timeout, idempotent role creation.
- Migration-time validation now covers: both textual rejections, the mandatory-drop proof, and catalog assertions (membership, api grants present, core/marts unreachable). The happy path can only be exercised by a member — i.e., any authenticated PostgREST call, which is exactly the cfb-app tool's smoke test.

State note: `analyst_ro` and the anon/authenticated/service_role memberships already exist in prod (committed by the probes); this file is idempotent over them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aq5tEVxkthmuRX7JH9qEW

---
_Generated by [Claude Code](https://claude.ai/code/session_018aq5tEVxkthmuRX7JH9qEW)_