### PR TITLE
Analyst RPC: decouple DDL from validation; fix final write-CTE assertion

### DIFF
--- a/src/schemas/public/012_run_analyst_query.sql
+++ b/src/schemas/public/012_run_analyst_query.sql
@@ -56,7 +56,10 @@
 --     alias columns when joining.
 --
 -- Apply via: python scripts/run_migrations.py --file src/schemas/public/012_run_analyst_query.sql
--- (deploy manifest "apply"). Idempotent.
+-- (deploy manifest "apply"). Idempotent. DDL-ONLY by design: the behavioral
+-- test matrix lives in validation_run_analyst_query.sql, applied as a
+-- SEPARATE file (own transaction) so a validation surprise reports instead
+-- of rolling back the function.
 
 -- 1. Restricted role + memberships -------------------------------------------
 DO $$
@@ -118,79 +121,5 @@ REVOKE ALL ON FUNCTION public.run_analyst_query(text) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.run_analyst_query(text)
     TO anon, authenticated, service_role, analyst_ro;
 
--- PostgREST schema reload. Issued BEFORE the self-validation: the first
--- successful RPC call below flips this transaction read-only for its
--- remainder, and NOTIFY is illegal in a read-only transaction.
+-- PostgREST schema reload.
 NOTIFY pgrst, 'reload schema';
-
--- 3. Self-validation ---------------------------------------------------------
-DO $$
-DECLARE
-    r jsonb;
-BEGIN
-    -- Textual rejections fire before the role drop.
-    BEGIN
-        PERFORM public.run_analyst_query('DELETE FROM api.team_elo');
-        RAISE EXCEPTION 'DELETE was not rejected';
-    EXCEPTION WHEN raise_exception THEN
-        IF SQLERRM NOT LIKE '%only SELECT/WITH%' THEN RAISE; END IF;
-    END;
-
-    BEGIN
-        PERFORM public.run_analyst_query('SELECT 1; SELECT 2');
-        RAISE EXCEPTION 'multi-statement was not rejected';
-    EXCEPTION WHEN raise_exception THEN
-        IF SQLERRM NOT LIKE '%multiple statements%' THEN RAISE; END IF;
-    END;
-
-    -- The drop happens: inside the query, current_user must be analyst_ro
-    -- (this migration role reaches it transitively via the API roles).
-    r := public.run_analyst_query('SELECT current_user AS u');
-    IF r <> '[{"u": "analyst_ro"}]'::jsonb THEN
-        RAISE EXCEPTION 'query did not run as analyst_ro: %', r;
-    END IF;
-
-    -- api-view read works under the role; row cap and inner LIMIT parse.
-    r := public.run_analyst_query('SELECT team FROM api.team_elo;');
-    IF jsonb_array_length(r) < 1 OR jsonb_array_length(r) > 200 THEN
-        RAISE EXCEPTION 'api.team_elo read returned % rows', jsonb_array_length(r);
-    END IF;
-    r := public.run_analyst_query('SELECT team FROM api.team_elo LIMIT 3');
-    IF jsonb_array_length(r) <> 3 THEN
-        RAISE EXCEPTION 'inner LIMIT handling returned % rows', jsonb_array_length(r);
-    END IF;
-
-    -- Outside the api schema: blocked by the role, not by text checks.
-    BEGIN
-        PERFORM public.run_analyst_query('SELECT id FROM core.games LIMIT 1');
-        RAISE EXCEPTION 'core.games read was not blocked';
-    EXCEPTION WHEN insufficient_privilege THEN
-        NULL;
-    END;
-
-    -- Data-modifying CTE: passes the prefix check, dies at the
-    -- permission/read-only layer.
-    BEGIN
-        PERFORM public.run_analyst_query(
-            'WITH w AS (DELETE FROM api.team_elo RETURNING *) SELECT * FROM w');
-        RAISE EXCEPTION 'write CTE was not blocked';
-    EXCEPTION WHEN insufficient_privilege OR read_only_sql_transaction THEN
-        NULL;
-    END;
-
-    -- Grants, catalog-side.
-    IF NOT pg_has_role('anon', 'analyst_ro', 'MEMBER')
-       OR NOT pg_has_role('authenticated', 'analyst_ro', 'MEMBER') THEN
-        RAISE EXCEPTION 'PostgREST roles are not analyst_ro members';
-    END IF;
-    IF NOT has_schema_privilege('analyst_ro', 'api', 'USAGE')
-       OR NOT has_table_privilege('analyst_ro', 'api.team_elo', 'SELECT') THEN
-        RAISE EXCEPTION 'analyst_ro is missing api read grants';
-    END IF;
-    IF has_table_privilege('analyst_ro', 'core.games', 'SELECT')
-       OR has_schema_privilege('analyst_ro', 'marts', 'USAGE') THEN
-        RAISE EXCEPTION 'analyst_ro can reach beyond the api schema';
-    END IF;
-
-    RAISE NOTICE 'run_analyst_query self-validation passed';
-END $$;

--- a/src/schemas/public/validation_run_analyst_query.sql
+++ b/src/schemas/public/validation_run_analyst_query.sql
@@ -1,0 +1,94 @@
+-- Behavioral test matrix for public.run_analyst_query -- applied as its OWN
+-- file/transaction (after 012_run_analyst_query.sql) so a failed assertion
+-- reports without rolling back the function's DDL. Read-only side effects
+-- only; safe to re-run any time as a health check.
+--
+-- Findings encoded here, all proven on prod during the 012 deploy rounds:
+--   * the migration role reaches analyst_ro transitively (postgres is a
+--     member of the API roles), so the happy path is testable here;
+--   * SET LOCAL ROLE + read-only persist to end-of-transaction after the
+--     first call (harmless: later calls run as analyst_ro, which holds
+--     EXECUTE for exactly this reason);
+--   * a write CTE against an api view dies as "cannot delete from view"
+--     (55000 object_not_in_prerequisite_state -- api views wrap matviews
+--     and are not auto-updatable), which blocks writes even before the
+--     role/read-only layers get their turn; against a real table it dies
+--     at the permission layer. All three error classes are accepted.
+
+DO $$
+DECLARE
+    r jsonb;
+BEGIN
+    -- Textual rejections (fire before the role drop).
+    BEGIN
+        PERFORM public.run_analyst_query('DELETE FROM api.team_elo');
+        RAISE EXCEPTION 'DELETE was not rejected';
+    EXCEPTION WHEN raise_exception THEN
+        IF SQLERRM NOT LIKE '%only SELECT/WITH%' THEN RAISE; END IF;
+    END;
+
+    BEGIN
+        PERFORM public.run_analyst_query('SELECT 1; SELECT 2');
+        RAISE EXCEPTION 'multi-statement was not rejected';
+    EXCEPTION WHEN raise_exception THEN
+        IF SQLERRM NOT LIKE '%multiple statements%' THEN RAISE; END IF;
+    END;
+
+    -- The drop happens: inside the query, current_user must be analyst_ro.
+    r := public.run_analyst_query('SELECT current_user AS u');
+    IF r <> '[{"u": "analyst_ro"}]'::jsonb THEN
+        RAISE EXCEPTION 'query did not run as analyst_ro: %', r;
+    END IF;
+
+    -- api-view read works under the role; row cap and inner LIMIT parse.
+    r := public.run_analyst_query('SELECT team FROM api.team_elo;');
+    IF jsonb_array_length(r) < 1 OR jsonb_array_length(r) > 200 THEN
+        RAISE EXCEPTION 'api.team_elo read returned % rows', jsonb_array_length(r);
+    END IF;
+    r := public.run_analyst_query('SELECT team FROM api.team_elo LIMIT 3');
+    IF jsonb_array_length(r) <> 3 THEN
+        RAISE EXCEPTION 'inner LIMIT handling returned % rows', jsonb_array_length(r);
+    END IF;
+
+    -- Outside the api schema: blocked by the role.
+    BEGIN
+        PERFORM public.run_analyst_query('SELECT id FROM core.games LIMIT 1');
+        RAISE EXCEPTION 'core.games read was not blocked';
+    EXCEPTION WHEN insufficient_privilege THEN
+        NULL;
+    END;
+
+    -- Write CTEs: blocked by non-updatable views (55000) against api,
+    -- and by permissions/read-only against anything else.
+    BEGIN
+        PERFORM public.run_analyst_query(
+            'WITH w AS (DELETE FROM api.team_elo RETURNING *) SELECT * FROM w');
+        RAISE EXCEPTION 'write CTE (api view) was not blocked';
+    EXCEPTION WHEN insufficient_privilege OR read_only_sql_transaction
+              OR object_not_in_prerequisite_state THEN
+        NULL;
+    END;
+    BEGIN
+        PERFORM public.run_analyst_query(
+            'WITH w AS (DELETE FROM core.games RETURNING id) SELECT * FROM w');
+        RAISE EXCEPTION 'write CTE (core table) was not blocked';
+    EXCEPTION WHEN insufficient_privilege OR read_only_sql_transaction THEN
+        NULL;
+    END;
+
+    -- Grants, catalog-side.
+    IF NOT pg_has_role('anon', 'analyst_ro', 'MEMBER')
+       OR NOT pg_has_role('authenticated', 'analyst_ro', 'MEMBER') THEN
+        RAISE EXCEPTION 'PostgREST roles are not analyst_ro members';
+    END IF;
+    IF NOT has_schema_privilege('analyst_ro', 'api', 'USAGE')
+       OR NOT has_table_privilege('analyst_ro', 'api.team_elo', 'SELECT') THEN
+        RAISE EXCEPTION 'analyst_ro is missing api read grants';
+    END IF;
+    IF has_table_privilege('analyst_ro', 'core.games', 'SELECT')
+       OR has_schema_privilege('analyst_ro', 'marts', 'USAGE') THEN
+        RAISE EXCEPTION 'analyst_ro can reach beyond the api schema';
+    END IF;
+
+    RAISE NOTICE 'run_analyst_query validation matrix passed';
+END $$;


### PR DESCRIPTION
Step-back restructuring after five apply rounds. The design itself is done — the last run proved the role drop (`current_user` = `analyst_ro`), api reads, row cap, inner-LIMIT parsing, and the `core.games` block all working in prod. What kept failing was the *test harness embedded in the migration transaction*: every time an assertion met an undocumented Supabase/Postgres behavior, it rolled back perfectly good DDL.

Two changes:

1. **Decoupling**: `012_run_analyst_query.sql` is now DDL-only and commits on its own. The behavioral matrix moves to `validation_run_analyst_query.sql`, applied as a separate manifest file (its own transaction). A validation surprise now produces a failure *report* while the function stays live; the file is side-effect-free and doubles as a re-runnable health check.

2. **The actual final bug**: the write-CTE test targeted `api.team_elo`, but api views wrap materialized views and are **not auto-updatable** — `DELETE` dies with `55000 object_not_in_prerequisite_state` ("cannot delete from view") before permissions or read-only ever get their turn. The write path is blocked even harder than asserted; the catch list now accepts all three error classes, and a second write-CTE case against `core.games` covers the permission path deterministically.

Validation matrix retained in full: both textual rejections, drop proof, api read + caps, cross-schema block, two write-CTE cases, catalog assertions on membership/grants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aq5tEVxkthmuRX7JH9qEW

---
_Generated by [Claude Code](https://claude.ai/code/session_018aq5tEVxkthmuRX7JH9qEW)_