### PR TITLE
Analyst validation: catalog assertions before role stickiness

### DIFF
--- a/src/schemas/public/validation_run_analyst_query.sql
+++ b/src/schemas/public/validation_run_analyst_query.sql
@@ -20,6 +20,24 @@ DO $$
 DECLARE
     r jsonb;
 BEGIN
+    -- Catalog assertions FIRST: after the first RPC call the transaction
+    -- stays dropped to analyst_ro (role stickiness), which cannot even
+    -- resolve names like core.games for has_table_privilege (no USAGE on
+    -- the schema) -- proven live; these checks need the migration role.
+    -- Grants, catalog-side.
+    IF NOT pg_has_role('anon', 'analyst_ro', 'MEMBER')
+       OR NOT pg_has_role('authenticated', 'analyst_ro', 'MEMBER') THEN
+        RAISE EXCEPTION 'PostgREST roles are not analyst_ro members';
+    END IF;
+    IF NOT has_schema_privilege('analyst_ro', 'api', 'USAGE')
+       OR NOT has_table_privilege('analyst_ro', 'api.team_elo', 'SELECT') THEN
+        RAISE EXCEPTION 'analyst_ro is missing api read grants';
+    END IF;
+    IF has_table_privilege('analyst_ro', 'core.games', 'SELECT')
+       OR has_schema_privilege('analyst_ro', 'marts', 'USAGE') THEN
+        RAISE EXCEPTION 'analyst_ro can reach beyond the api schema';
+    END IF;
+
     -- Textual rejections (fire before the role drop).
     BEGIN
         PERFORM public.run_analyst_query('DELETE FROM api.team_elo');
@@ -77,20 +95,6 @@ BEGIN
               OR read_only_sql_transaction THEN
         NULL;
     END;
-
-    -- Grants, catalog-side.
-    IF NOT pg_has_role('anon', 'analyst_ro', 'MEMBER')
-       OR NOT pg_has_role('authenticated', 'analyst_ro', 'MEMBER') THEN
-        RAISE EXCEPTION 'PostgREST roles are not analyst_ro members';
-    END IF;
-    IF NOT has_schema_privilege('analyst_ro', 'api', 'USAGE')
-       OR NOT has_table_privilege('analyst_ro', 'api.team_elo', 'SELECT') THEN
-        RAISE EXCEPTION 'analyst_ro is missing api read grants';
-    END IF;
-    IF has_table_privilege('analyst_ro', 'core.games', 'SELECT')
-       OR has_schema_privilege('analyst_ro', 'marts', 'USAGE') THEN
-        RAISE EXCEPTION 'analyst_ro can reach beyond the api schema';
-    END IF;
 
     RAISE NOTICE 'run_analyst_query validation matrix passed';
 END $$;


### PR DESCRIPTION
Validation-file-only reorder. The last run got all the way to the final catalog block, where `has_table_privilege('analyst_ro', 'core.games', 'SELECT')` itself raised `permission denied for schema core` — because after the first RPC call the transaction is stuck as `analyst_ro` (the proven stickiness), and that role cannot resolve `core.games` to an OID for the privilege probe (no USAGE on the schema). The isolation is working; the checker just needs the migration role's eyes.

The catalog assertions now run **first**, before any RPC call drops the transaction; the behavioral matrix follows unchanged. The live function is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aq5tEVxkthmuRX7JH9qEW

---
_Generated by [Claude Code](https://claude.ai/code/session_018aq5tEVxkthmuRX7JH9qEW)_