### PR TITLE
Fix get_red_zone_splits: trips = drives that reach the 20 (+ split-RPC sweep hardening)

### DIFF
--- a/docs/SCHEMA_CONTRACT.md
+++ b/docs/SCHEMA_CONTRACT.md
@@ -300,6 +300,18 @@ Last updated: 2026-07-22
   latest season present in `public.team_season_trajectory`. Callers omitting the argument
   will start receiving 2026 rows as they materialize; explicit arguments behave unchanged.
 
+- **2026-07-23 — `get_red_zone_splits` correctness fix (behavioral change, no signature change).**
+  The trips CTE filtered `core.drives` on the absolute `start_yardline` column (`>= 80`), a
+  direction-dependent junk predicate: trip counts matched no real red-zone definition and
+  defensive red-zone TDs allowed collapsed to ~0. A red-zone trip is now play-derived (any
+  snap at `yards_to_goal <= 20`), with outcomes taken from the drive row joined on
+  `(game_id, drive_number)` and casing-tolerant `drive_result` matching; the EPA sub-CTE's
+  identical absolute-yardline bug is fixed the same way. All consumers (cfb-app team pages,
+  MCP `situational_splits`, Discord bot) receive corrected numbers automatically — expect
+  large jumps (e.g. Oklahoma 2025 offense 12 → 38 trips). The four sibling split RPCs were
+  audited and do not share the defect. Guarded by `tests/test_split_rpcs.py` and the
+  re-runnable `src/schemas/public/validation_situational_splits.sql`.
+
 - **2026-07-19 — Tier 1 analytics unlock.**
   - **Garbage-time exclusion (behavioral change, no signature change):** the five split RPCs
     (`get_home_away_splits`, `get_conference_splits`, `get_red_zone_splits`,

--- a/src/schemas/public/006_play_analysis_functions.sql
+++ b/src/schemas/public/006_play_analysis_functions.sql
@@ -186,7 +186,10 @@ BEGIN
             p.drive_number
         FROM core.plays p
         JOIN core.games g ON p.game_id = g.id
-        WHERE g.season = p_season
+        -- p.season predicate enables partition pruning on core.plays
+        -- (season-partitioned); g.season alone cannot prune.
+        WHERE p.season = p_season
+          AND g.season = p_season
           AND (p.offense = p_team OR p.defense = p_team)
           AND p.yards_to_goal <= 20
           AND p.drive_number IS NOT NULL
@@ -209,7 +212,8 @@ BEGIN
             p.ppa
         FROM core.plays p
         JOIN core.games g ON p.game_id = g.id
-        WHERE g.season = p_season
+        WHERE p.season = p_season
+          AND g.season = p_season
           AND (p.offense = p_team OR p.defense = p_team)
           AND p.yards_to_goal <= 20
           AND NOT public.is_garbage_time(p.period::integer, p.score_diff::integer)

--- a/src/schemas/public/006_play_analysis_functions.sql
+++ b/src/schemas/public/006_play_analysis_functions.sql
@@ -164,23 +164,44 @@ SET search_path = ''
 AS $function$
 BEGIN
     RETURN QUERY
-    WITH red_zone_drives AS (
-        -- Garbage-time exclusion is intentionally NOT applied here: core.drives
-        -- has no play-level period/score_diff joined in (only its own
-        -- start_period/start_offense_score/start_defense_score, which do not
-        -- match is_garbage_time's per-play grain), so drive-level trips/scores
-        -- stay unfiltered per the Phase 1 garbage-time centralization plan.
-        SELECT
-            CASE WHEN d.offense = p_team THEN 'offense' ELSE 'defense' END AS side,
-            d.id AS drive_id,
-            d.scoring,
-            d.drive_result,
-            d.start_yardline
-        FROM core.drives d
-        JOIN core.games g ON d.game_id = g.id
+    -- Fixed 2026-07-23: the previous version filtered core.drives on
+    -- start_yardline >= 80 -- the ABSOLUTE yardline column (direction-
+    -- dependent, the only start_yardline reference in the repo) and a
+    -- drive-START condition, when a red-zone trip is a drive that REACHES
+    -- yards_to_goal <= 20. It undercounted both sides and reported ~0
+    -- defensive TDs allowed. Trips are now play-derived (any snap at
+    -- yards_to_goal <= 20), with outcomes taken from the drive row joined
+    -- on (game_id, drive_number) -- verified against api.game_plays ground
+    -- truth (Oklahoma 2025: offense 38 trips/26 TD, defense 32/13). The
+    -- EPA sub-CTE had the same absolute-yardline bug (yardline >= 80) and
+    -- now uses yards_to_goal <= 20. drive_result matching mirrors
+    -- marts/006_scoring_opportunities.sql's casing-tolerant sets.
+    WITH red_zone_trips AS (
+        -- Garbage-time exclusion is intentionally NOT applied here:
+        -- trips/scores are drive-level facts and stay unfiltered per the
+        -- Phase 1 garbage-time centralization plan.
+        SELECT DISTINCT
+            CASE WHEN p.offense = p_team THEN 'offense' ELSE 'defense' END AS side,
+            p.game_id,
+            p.drive_number
+        FROM core.plays p
+        JOIN core.games g ON p.game_id = g.id
         WHERE g.season = p_season
-          AND (d.offense = p_team OR d.defense = p_team)
-          AND d.start_yardline >= 80
+          AND (p.offense = p_team OR p.defense = p_team)
+          AND p.yards_to_goal <= 20
+          AND p.drive_number IS NOT NULL
+    ),
+    red_zone_drives AS (
+        SELECT
+            t.side,
+            t.game_id,
+            t.drive_number,
+            d.drive_result
+        FROM red_zone_trips t
+        -- LEFT JOIN: a trip observed in plays still counts even if its
+        -- drive row is absent (it then contributes no outcome).
+        LEFT JOIN core.drives d
+          ON d.game_id = t.game_id AND d.drive_number = t.drive_number
     ),
     red_zone_plays AS (
         SELECT
@@ -190,19 +211,19 @@ BEGIN
         JOIN core.games g ON p.game_id = g.id
         WHERE g.season = p_season
           AND (p.offense = p_team OR p.defense = p_team)
-          AND p.yardline >= 80
+          AND p.yards_to_goal <= 20
           AND NOT public.is_garbage_time(p.period::integer, p.score_diff::integer)
     )
     SELECT
         rzd.side::TEXT,
-        COUNT(DISTINCT rzd.drive_id)::BIGINT AS trips,
-        COUNT(DISTINCT CASE WHEN rzd.drive_result = 'TD' THEN rzd.drive_id END)::BIGINT AS touchdowns,
-        COUNT(DISTINCT CASE WHEN rzd.drive_result = 'FG' THEN rzd.drive_id END)::BIGINT AS field_goals,
-        COUNT(DISTINCT CASE WHEN rzd.drive_result IN ('INT', 'FUMBLE', 'INT TD', 'FUMBLE RETURN TD') THEN rzd.drive_id END)::BIGINT AS turnovers,
-        ROUND(COUNT(DISTINCT CASE WHEN rzd.drive_result = 'TD' THEN rzd.drive_id END)::NUMERIC / NULLIF(COUNT(DISTINCT rzd.drive_id), 0), 3) AS td_rate,
-        ROUND(COUNT(DISTINCT CASE WHEN rzd.drive_result = 'FG' THEN rzd.drive_id END)::NUMERIC / NULLIF(COUNT(DISTINCT rzd.drive_id), 0), 3) AS fg_rate,
-        ROUND(COUNT(DISTINCT CASE WHEN rzd.drive_result IN ('TD', 'FG') THEN rzd.drive_id END)::NUMERIC / NULLIF(COUNT(DISTINCT rzd.drive_id), 0), 3) AS scoring_rate,
-        ROUND((COUNT(DISTINCT CASE WHEN rzd.drive_result = 'TD' THEN rzd.drive_id END) * 7 + COUNT(DISTINCT CASE WHEN rzd.drive_result = 'FG' THEN rzd.drive_id END) * 3)::NUMERIC / NULLIF(COUNT(DISTINCT rzd.drive_id), 0), 2) AS points_per_trip,
+        COUNT(*)::BIGINT AS trips,
+        COUNT(*) FILTER (WHERE rzd.drive_result IN ('TD', 'Touchdown'))::BIGINT AS touchdowns,
+        COUNT(*) FILTER (WHERE rzd.drive_result IN ('FG', 'Field Goal'))::BIGINT AS field_goals,
+        COUNT(*) FILTER (WHERE rzd.drive_result IN ('INT', 'FUMBLE', 'INT TD', 'FUMBLE RETURN TD', 'Interception', 'Fumble', 'Fumble Lost', 'Interception Return'))::BIGINT AS turnovers,
+        ROUND(COUNT(*) FILTER (WHERE rzd.drive_result IN ('TD', 'Touchdown'))::NUMERIC / NULLIF(COUNT(*), 0), 3) AS td_rate,
+        ROUND(COUNT(*) FILTER (WHERE rzd.drive_result IN ('FG', 'Field Goal'))::NUMERIC / NULLIF(COUNT(*), 0), 3) AS fg_rate,
+        ROUND(COUNT(*) FILTER (WHERE rzd.drive_result IN ('TD', 'FG', 'Touchdown', 'Field Goal'))::NUMERIC / NULLIF(COUNT(*), 0), 3) AS scoring_rate,
+        ROUND((COUNT(*) FILTER (WHERE rzd.drive_result IN ('TD', 'Touchdown')) * 7 + COUNT(*) FILTER (WHERE rzd.drive_result IN ('FG', 'Field Goal')) * 3)::NUMERIC / NULLIF(COUNT(*), 0), 2) AS points_per_trip,
         ROUND((SELECT AVG(rzp.ppa) FROM red_zone_plays rzp WHERE rzp.side = rzd.side)::NUMERIC, 3) AS epa_per_play
     FROM red_zone_drives rzd
     GROUP BY rzd.side;

--- a/src/schemas/public/validation_situational_splits.sql
+++ b/src/schemas/public/validation_situational_splits.sql
@@ -1,0 +1,67 @@
+-- Behavioral validation for public.get_red_zone_splits -- applied as its OWN
+-- file/transaction (after 006_play_analysis_functions.sql) so a failed
+-- assertion reports without rolling back the function DDL. Read-only; safe
+-- to re-run any time as a health check.
+--
+-- Guards the 2026-07-23 fix: the old version filtered core.drives on the
+-- absolute start_yardline (>= 80), undercounting trips on both sides and
+-- reporting ~0 defensive red-zone TDs allowed. Assertions recompute the
+-- correct definition inline (trip = drive with any snap at
+-- yards_to_goal <= 20; outcome = that drive's drive_result) over two frozen
+-- team-seasons and require the RPC to match exactly, plus structural
+-- sanity floors that the bug class would violate.
+
+DO $$
+DECLARE
+    exp_trips BIGINT;
+    exp_td BIGINT;
+    got RECORD;
+    fixture RECORD;
+BEGIN
+    FOR fixture IN
+        SELECT * FROM (VALUES
+            ('Oklahoma',   2025, 'offense'),
+            ('Oklahoma',   2025, 'defense'),
+            ('Ohio State', 2024, 'offense'),
+            ('Ohio State', 2024, 'defense')
+        ) AS f(team, season, side)
+    LOOP
+        WITH trips AS (
+            SELECT DISTINCT p.game_id, p.drive_number
+            FROM core.plays p
+            JOIN core.games g ON p.game_id = g.id
+            WHERE g.season = fixture.season
+              AND p.yards_to_goal <= 20
+              AND p.drive_number IS NOT NULL
+              AND CASE WHEN fixture.side = 'offense'
+                       THEN p.offense = fixture.team
+                       ELSE p.defense = fixture.team END
+        )
+        SELECT COUNT(*),
+               COUNT(*) FILTER (WHERE d.drive_result IN ('TD', 'Touchdown'))
+        INTO exp_trips, exp_td
+        FROM trips t
+        LEFT JOIN core.drives d
+          ON d.game_id = t.game_id AND d.drive_number = t.drive_number;
+
+        SELECT r.trips, r.touchdowns INTO got
+        FROM public.get_red_zone_splits(fixture.team, fixture.season) r
+        WHERE r.side = fixture.side;
+
+        IF got.trips IS DISTINCT FROM exp_trips
+           OR got.touchdowns IS DISTINCT FROM exp_td THEN
+            RAISE EXCEPTION '% % %: RPC trips/TD = %/%, expected %/%',
+                fixture.team, fixture.season, fixture.side,
+                got.trips, got.touchdowns, exp_trips, exp_td;
+        END IF;
+
+        -- Structural floors the old bug violated: a full season has real
+        -- red-zone volume and nonzero TDs on BOTH sides.
+        IF exp_trips < 15 OR exp_td < 1 THEN
+            RAISE EXCEPTION '% % %: implausible ground truth (trips=%, td=%)',
+                fixture.team, fixture.season, fixture.side, exp_trips, exp_td;
+        END IF;
+    END LOOP;
+
+    RAISE NOTICE 'situational splits validation passed';
+END $$;

--- a/tests/test_split_rpcs.py
+++ b/tests/test_split_rpcs.py
@@ -1,0 +1,91 @@
+"""Static drift-guards for the five situational-split RPCs.
+
+Born from the 2026-07-23 get_red_zone_splits bug: its trips CTE filtered
+core.drives on start_yardline >= 80 -- the ABSOLUTE yardline column (the only
+reference to it in the repo) and a drive-START condition, when a red-zone
+trip is a drive that REACHES yards_to_goal <= 20. Defense TDs-allowed
+collapsed to ~0 and trip counts matched no real definition. These tests pin
+the repaired shape so it cannot silently regress; behavioral correctness is
+proven in prod by src/schemas/public/validation_situational_splits.sql.
+"""
+
+import re
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+SCHEMAS_DIR = PROJECT_ROOT / "src" / "schemas"
+PLAY_ANALYSIS = SCHEMAS_DIR / "public" / "006_play_analysis_functions.sql"
+TEAM_SPLITS = SCHEMAS_DIR / "public" / "005_team_split_functions.sql"
+
+
+def _strip_comments(sql: str) -> str:
+    """Drop line comments so prose (e.g. bug-history notes) never trips the
+    code-shape assertions."""
+    return "\n".join(line.split("--", 1)[0] for line in sql.splitlines())
+
+
+def _sql_files():
+    return sorted(SCHEMAS_DIR.rglob("*.sql"))
+
+
+class TestAbsoluteYardlineBan:
+    def test_no_start_yardline_anywhere(self):
+        """start_yardline (absolute, direction-dependent) is a proven
+        foot-gun; every legitimate consumer uses start_yards_to_goal."""
+        offenders = [
+            str(f.relative_to(PROJECT_ROOT))
+            for f in _sql_files()
+            if "start_yardline" in _strip_comments(f.read_text())
+        ]
+        assert offenders == [], f"start_yardline referenced in: {offenders}"
+
+    def test_split_functions_use_yards_to_goal_not_yardline(self):
+        """Within the split-RPC files, any yardline mention must be the
+        offense-relative yards_to_goal, never the absolute p.yardline."""
+        for path in (PLAY_ANALYSIS, TEAM_SPLITS):
+            sql = _strip_comments(path.read_text())
+            bare = re.findall(r"\byardline\b", sql)
+            assert bare == [], f"absolute yardline reference in {path.name}"
+
+
+class TestGarbageTimeWiring:
+    """Each split RPC applies the canonical garbage-time exclusion on its
+    play-level stats (as a function call or the marts.play_epa boolean).
+    Guards against the filter being dropped in a rewrite; the predicate's
+    VALUE drift is guarded by test_garbage_time_consistency.py."""
+
+    def _body(self, sql: str, fn: str) -> str:
+        start = sql.index(f"FUNCTION public.{fn}")
+        end = sql.find("CREATE OR REPLACE FUNCTION", start + 1)
+        return sql[start : end if end != -1 else len(sql)]
+
+    def test_all_five_reference_garbage_time(self):
+        combined = {
+            "get_down_distance_splits": PLAY_ANALYSIS,
+            "get_field_position_splits": PLAY_ANALYSIS,
+            "get_red_zone_splits": PLAY_ANALYSIS,
+            "get_home_away_splits": TEAM_SPLITS,
+            "get_conference_splits": TEAM_SPLITS,
+        }
+        for fn, path in combined.items():
+            body = self._body(path.read_text(), fn)
+            assert "is_garbage_time" in body, f"{fn} lost its garbage-time exclusion"
+
+
+class TestRedZoneShape:
+    def test_trips_are_play_derived_reached_the_20(self):
+        body = PLAY_ANALYSIS.read_text()
+        start = body.index("FUNCTION public.get_red_zone_splits")
+        rz = body[start:]
+        assert "yards_to_goal <= 20" in rz
+        # Outcome attribution joins drives on the proven natural key.
+        assert re.search(r"d\.game_id = t\.game_id AND d\.drive_number = t\.drive_number", rz)
+
+    def test_drive_result_matching_is_casing_tolerant(self):
+        body = PLAY_ANALYSIS.read_text()
+        start = body.index("FUNCTION public.get_red_zone_splits")
+        rz = body[start:]
+        # Mirrors marts/006_scoring_opportunities.sql's sets: both the
+        # uppercase (2025-era) and title-case (earlier seasons) labels.
+        assert "'TD', 'Touchdown'" in rz
+        assert "'FG', 'Field Goal'" in rz


### PR DESCRIPTION
Fixes the reported red-zone bug (Oklahoma 2025: 12/31 trips, 0 defensive TDs allowed) and closes out the requested sweep of the four sibling RPCs.

## Root cause (proven live before writing the fix)

The trips CTE filtered `core.drives` on **`start_yardline >= 80`** — wrong twice over:
- `start_yardline` is the **absolute** yardline (direction-dependent); the repo convention is `start_yards_to_goal`, and this was the only `start_yardline` reference in the entire codebase.
- Red-zone trips are drives that **reach** `yards_to_goal <= 20` (a play-level fact) — even the corrected column would count only drives *starting* inside the 20 (3, not 38, for OU 2025 offense).

The junk predicate explains every symptom the live diagnosis measured: undercounts matching no definition (offense 12 vs 38; OSU 2024 28 vs 71), defensive TDs-allowed ≈ 0 across teams, and the "constant 31" being a coincidental collision (Texas 21, Georgia 25, Alabama 24). The EPA sub-CTE carried the same bug (`yardline >= 80`) and is fixed the same way.

## Fix

- Trips = `DISTINCT (game_id, drive_number)` with any snap at `yards_to_goal <= 20` (garbage-time deliberately unfiltered, as before, and matching ground truth).
- Outcomes from the drive row **LEFT JOIN**ed on `(game_id, drive_number)` — the key that reproduced ground truth exactly in live diagnosis; a trip with a missing drive row still counts.
- `drive_result` matching is casing-tolerant (`'TD','Touchdown'` / `'FG','Field Goal'` / widened turnover set), mirroring `marts/006_scoring_opportunities.sql` — 2025 data is uppercase but earlier seasons are mixed.
- Signature and output columns unchanged; consumers (cfb-app team pages, MCP `situational_splits`, Discord bot) get corrected numbers automatically.

## Sweep verdict

`get_down_distance_splits`, `get_field_position_splits`, `get_home_away_splits`, `get_conference_splits` audited in code and against prod: none reads `core.drives`, none references `start_yardline`, side/garbage-time logic verified — **no shared defect**.

## Hardening

- `tests/test_split_rpcs.py`: bans `start_yardline` across `src/schemas/` (comment-stripped scan), forbids absolute-`yardline` references in the split files, pins garbage-time wiring in all five RPCs and the casing-tolerant outcome sets.
- `src/schemas/public/validation_situational_splits.sql` (decoupled-validation pattern): recomputes ground truth inline for four frozen fixtures (OU 2025 + OSU 2024, both sides) and asserts RPC equality on trips/TDs plus plausibility floors the old bug violated. Runs in its own transaction after the function apply; re-runnable health check.
- SCHEMA_CONTRACT changelog entry (behavioral change, no signature change).

Full no-DB suite: 726 passed.

## Deploy plan

After merge: apply `[006_play_analysis_functions.sql, validation_situational_splits.sql]`, then end-to-end spot-check via the MCP `situational_splits` tool (expect OU 2025 offense ≈ 38 trips / 26 TDs, defense ≈ 32 / 13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aq5tEVxkthmuRX7JH9qEW

---
_Generated by [Claude Code](https://claude.ai/code/session_018aq5tEVxkthmuRX7JH9qEW)_