### PR TITLE
feat: SP+ split in api.team_history + api grant hardening

### DIFF
--- a/docs/SCHEMA_CONTRACT.md
+++ b/docs/SCHEMA_CONTRACT.md
@@ -4,7 +4,7 @@
 > only depend on objects listed here as **public**. Everything else is internal and may change
 > without notice.
 
-Last updated: 2026-07-22
+Last updated: 2026-07-23
 
 > **Note on cfb-analytics:** the retired OU-only app (rstover-fo/cfb-analytics) was never a
 > warehouse consumer -- it ran its own DuckDB ingestion. Its unique features (rivals page,
@@ -14,6 +14,25 @@ Last updated: 2026-07-22
 ---
 
 ## Recent Contract Changes
+
+- **2026-07-23 — `api.team_history` gains `sp_offense`/`sp_defense` (additive,
+  no consumer action needed); api-wide grant hardening.** A Discord user asked
+  the bot for the defensive SP+ arc since 2022 and the bot concluded the
+  warehouse only stores the offense/defense split for the current season --
+  false (it's in `ratings.sp_ratings` and `marts.team_season_summary` for
+  every loaded season, 2004+), but `api.team_history`, the natural view for
+  multi-season questions, omitted the two columns its backing mart already
+  carries. They are now exposed after `sp_rank` (view is DROP/CREATEd, so no
+  column-order constraint). While shipping this, 23 of 38 api view definition
+  files were found to carry no `GRANT` -- and 11 of those DROP/recreate their
+  view, so any re-apply would strip `anon`/`authenticated` read access (the
+  incident previously hit `api.leaderboard_teams`; there are no default
+  privileges for the PostgREST roles in this database). Every api definition
+  file now ends with `GRANT SELECT ON api.<view> TO anon, authenticated;`,
+  pinned by the new static test `tests/test_api_grants.py`; prod behavior is
+  guarded by the re-runnable `src/schemas/api/validation_team_history.sql`
+  (SP+ split populated for Oklahoma/Clemson 2022-2024 + grant tripwire for
+  `anon`/`authenticated`/`analyst_ro`).
 
 - **2026-07-22 — `classification` on `public.team_epa_season` and
   `api.leaderboard_teams` is now SEASON-ACCURATE (consumer-visible semantics
@@ -371,7 +390,7 @@ These are the primary PostgREST-accessible views. Queries go through Supabase cl
 | View | Status | Rows | Description |
 |------|--------|------|-------------|
 | `api.team_detail` | **Deployed** | 136 | Single team page: current season stats, ratings, EPA. Columns: school, mascot, abbreviation, color, alternate_color, logo_url, conference, classification, current_season, games, wins, losses, conf_wins, conf_losses, ppg, opp_ppg, avg_margin, sp_rating, sp_rank, sp_offense, sp_defense, elo, fpi, epa_per_play, epa_tier, success_rate, explosiveness, recruiting_rank, recruiting_points |
-| `api.team_history` | **Deployed** | 3,667 | Multi-season team history with records, ratings, EPA trends. Columns: team, season, conference, games, wins, losses, conf_wins, conf_losses, ppg, opp_ppg, avg_margin, sp_rating, sp_rank, elo, fpi, epa_per_play, epa_tier, success_rate, explosiveness, total_plays, recruiting_rank, recruiting_points |
+| `api.team_history` | **Deployed** | 3,667 | Multi-season team history with records, ratings, EPA trends. Columns: team, season, conference, games, wins, losses, conf_wins, conf_losses, ppg, opp_ppg, avg_margin, sp_rating, sp_rank, sp_offense, sp_defense, elo, fpi, epa_per_play, epa_tier, success_rate, explosiveness, total_plays, recruiting_rank, recruiting_points (sp_offense/sp_defense added 2026-07-23) |
 | `api.game_detail` | **Deployed** | 45,897 | Single game: teams, scores, betting lines, EPA, venue. Columns: game_id, season, week, season_type, start_date, completed, home_team, away_team, home_points, away_points, winner, point_diff, home_spread, over_under, spread_result, ou_result, home_epa, away_epa, pregame_home_win_prob, venue, attendance, excitement_index |
 | `api.matchup` | **Deployed** | 11,975 | Head-to-head matchup history and current season comparison. Columns: team1, team2, total_games, team1_wins, team2_wins, ties, first_meeting, last_meeting, recent_results (JSONB array), team1/team2 current season stats |
 | `api.leaderboard_teams` | **Deployed** | 3,667 | Team leaderboard with rankings, ratings, EPA. Columns: team, conference, season, classification, wins, losses, win_pct, ppg, opp_ppg, sp_rank, epa_per_play, epa_tier, wins_rank, ppg_rank, defense_ppg_rank, epa_rank. Rank columns are scoped `PARTITION BY season, classification` (see 2026-07-22 changelog entry) -- all rows still returned, no `WHERE fbs` filter. |

--- a/src/schemas/api/001_team_detail.sql
+++ b/src/schemas/api/001_team_detail.sql
@@ -65,3 +65,8 @@ LEFT JOIN LATERAL (
 WHERE t.classification = 'fbs';  -- Only FBS teams by default
 
 COMMENT ON VIEW api.team_detail IS 'Team page data with current season stats, ratings, and EPA metrics';
+
+-- Grants are part of the definition: an apply that DROPs/recreates the
+-- view would otherwise leave the PostgREST roles without read access
+-- (no ALTER DEFAULT PRIVILEGES for them in this database).
+GRANT SELECT ON api.team_detail TO anon, authenticated;

--- a/src/schemas/api/002_team_history.sql
+++ b/src/schemas/api/002_team_history.sql
@@ -25,6 +25,8 @@ SELECT
     -- Ratings
     tss.sp_rating,
     tss.sp_rank,
+    tss.sp_offense,
+    tss.sp_defense,
     tss.elo,
     tss.fpi,
 
@@ -44,4 +46,9 @@ LEFT JOIN marts.team_epa_season epa
     ON epa.team = tss.team AND epa.season = tss.season
 ORDER BY tss.team, tss.season DESC;
 
-COMMENT ON VIEW api.team_history IS 'Multi-season team history with records, ratings, and EPA trends';
+COMMENT ON VIEW api.team_history IS 'Multi-season team history with records, ratings (incl. SP+ offense/defense split), and EPA trends';
+
+-- Re-grant on every apply: this file DROPs the view first, which discards
+-- existing grants (no ALTER DEFAULT PRIVILEGES for the PostgREST roles in
+-- this database).
+GRANT SELECT ON api.team_history TO anon, authenticated;

--- a/src/schemas/api/003_game_detail.sql
+++ b/src/schemas/api/003_game_detail.sql
@@ -97,3 +97,8 @@ LEFT JOIN marts._game_epa_calc away_epa
     ON away_epa.game_id = g.id AND away_epa.team = g.away_team;
 
 COMMENT ON VIEW api.game_detail IS 'Single game detail with teams, betting lines, EPA, and results';
+
+-- Grants are part of the definition: an apply that DROPs/recreates the
+-- view would otherwise leave the PostgREST roles without read access
+-- (no ALTER DEFAULT PRIVILEGES for them in this database).
+GRANT SELECT ON api.game_detail TO anon, authenticated;

--- a/src/schemas/api/004_matchup.sql
+++ b/src/schemas/api/004_matchup.sql
@@ -111,3 +111,8 @@ LEFT JOIN LATERAL (
 ) e2 ON true;
 
 COMMENT ON VIEW api.matchup IS 'Head-to-head matchup history and current season comparison';
+
+-- Grants are part of the definition: an apply that DROPs/recreates the
+-- view would otherwise leave the PostgREST roles without read access
+-- (no ALTER DEFAULT PRIVILEGES for them in this database).
+GRANT SELECT ON api.matchup TO anon, authenticated;

--- a/src/schemas/api/006_roster_lookup.sql
+++ b/src/schemas/api/006_roster_lookup.sql
@@ -22,3 +22,8 @@ FROM core.roster
 WHERE team IS NOT NULL;
 
 COMMENT ON VIEW api.roster_lookup IS 'Stable roster view for cfb-scout player matching';
+
+-- Grants are part of the definition: an apply that DROPs/recreates the
+-- view would otherwise leave the PostgREST roles without read access
+-- (no ALTER DEFAULT PRIVILEGES for them in this database).
+GRANT SELECT ON api.roster_lookup TO anon, authenticated;

--- a/src/schemas/api/007_recruit_lookup.sql
+++ b/src/schemas/api/007_recruit_lookup.sql
@@ -25,3 +25,8 @@ SELECT
 FROM recruiting.recruits;
 
 COMMENT ON VIEW api.recruit_lookup IS 'Stable recruiting view for cfb-scout recruiting data';
+
+-- Grants are part of the definition: an apply that DROPs/recreates the
+-- view would otherwise leave the PostgREST roles without read access
+-- (no ALTER DEFAULT PRIVILEGES for them in this database).
+GRANT SELECT ON api.recruit_lookup TO anon, authenticated;

--- a/src/schemas/api/008_player_season_leaders.sql
+++ b/src/schemas/api/008_player_season_leaders.sql
@@ -251,3 +251,8 @@ SELECT
 FROM defensive;
 
 COMMENT ON VIEW api.player_season_leaders IS 'Player season leaderboards by category (passing, rushing, receiving, defense) with yards_rank';
+
+-- Grants are part of the definition: an apply that DROPs/recreates the
+-- view would otherwise leave the PostgREST roles without read access
+-- (no ALTER DEFAULT PRIVILEGES for them in this database).
+GRANT SELECT ON api.player_season_leaders TO anon, authenticated;

--- a/src/schemas/api/009_player_detail.sql
+++ b/src/schemas/api/009_player_detail.sql
@@ -167,3 +167,8 @@ LEFT JOIN player_defense pd ON pd.player_id::text = r.id::text AND pd.season = r
 LEFT JOIN metrics.ppa_players_season ppa ON ppa.id::text = r.id::text AND ppa.season = r.year;
 
 COMMENT ON VIEW api.player_detail IS 'Comprehensive player profile with roster info, recruiting data, season stats, and PPA metrics';
+
+-- Grants are part of the definition: an apply that DROPs/recreates the
+-- view would otherwise leave the PostgREST roles without read access
+-- (no ALTER DEFAULT PRIVILEGES for them in this database).
+GRANT SELECT ON api.player_detail TO anon, authenticated;

--- a/src/schemas/api/010_game_player_leaders.sql
+++ b/src/schemas/api/010_game_player_leaders.sql
@@ -25,3 +25,8 @@ JOIN core.game_player_stats__teams__categories__types types ON types._dlt_parent
 JOIN core.game_player_stats__teams__categories__types__athletes athletes ON athletes._dlt_parent_id = types._dlt_id;
 
 COMMENT ON VIEW api.game_player_leaders IS 'Per-game player stats flattened from dlt hierarchy. Replaces core_staging dependency for cfb-app.';
+
+-- Grants are part of the definition: an apply that DROPs/recreates the
+-- view would otherwise leave the PostgREST roles without read access
+-- (no ALTER DEFAULT PRIVILEGES for them in this database).
+GRANT SELECT ON api.game_player_leaders TO anon, authenticated;

--- a/src/schemas/api/011_game_box_score.sql
+++ b/src/schemas/api/011_game_box_score.sql
@@ -18,3 +18,8 @@ JOIN core.game_team_stats__teams teams ON teams._dlt_parent_id = gts._dlt_id
 JOIN core.game_team_stats__teams__stats stats ON stats._dlt_parent_id = teams._dlt_id;
 
 COMMENT ON VIEW api.game_box_score IS 'Per-game team stats in EAV format. One row per stat per team per game.';
+
+-- Grants are part of the definition: an apply that DROPs/recreates the
+-- view would otherwise leave the PostgREST roles without read access
+-- (no ALTER DEFAULT PRIVILEGES for them in this database).
+GRANT SELECT ON api.game_box_score TO anon, authenticated;

--- a/src/schemas/api/012_game_line_scores.sql
+++ b/src/schemas/api/012_game_line_scores.sql
@@ -51,3 +51,8 @@ LEFT JOIN LATERAL (
 ) away_ot ON true;
 
 COMMENT ON VIEW api.game_line_scores IS 'Game line scores pivoted into Q1-Q4 columns with OT periods summed.';
+
+-- Grants are part of the definition: an apply that DROPs/recreates the
+-- view would otherwise leave the PostgREST roles without read access
+-- (no ALTER DEFAULT PRIVILEGES for them in this database).
+GRANT SELECT ON api.game_line_scores TO anon, authenticated;

--- a/src/schemas/api/013_player_comparison.sql
+++ b/src/schemas/api/013_player_comparison.sql
@@ -23,3 +23,8 @@ SELECT
 FROM marts.player_comparison;
 
 COMMENT ON VIEW api.player_comparison IS 'Player stats with positional percentiles for comparison. Backed by materialized view for fast lookups. Filter by player_id, name, team, season, or position_group.';
+
+-- Grants are part of the definition: an apply that DROPs/recreates the
+-- view would otherwise leave the PostgREST roles without read access
+-- (no ALTER DEFAULT PRIVILEGES for them in this database).
+GRANT SELECT ON api.player_comparison TO anon, authenticated;

--- a/src/schemas/api/014_team_playcalling_profile.sql
+++ b/src/schemas/api/014_team_playcalling_profile.sql
@@ -131,3 +131,8 @@ COMMENT ON VIEW api.team_playcalling_profile IS
 'One row per team-season. Filter by team, season, conference. '
 'Percentiles are per-season. NULL rates indicate insufficient plays in that situation. '
 'Backed by materialized views (tendencies + success).';
+
+-- Grants are part of the definition: an apply that DROPs/recreates the
+-- view would otherwise leave the PostgREST roles without read access
+-- (no ALTER DEFAULT PRIVILEGES for them in this database).
+GRANT SELECT ON api.team_playcalling_profile TO anon, authenticated;

--- a/src/schemas/api/015_coaching_history.sql
+++ b/src/schemas/api/015_coaching_history.sql
@@ -40,3 +40,8 @@ COMMENT ON VIEW api.coaching_history IS
 'Coaching history with tenure performance summaries. One row per coach-team-tenure. '
 'Filter by team, coach_name, last_name, is_active. '
 'talent_improvement = inherited_rank - year3_rank (positive = improved recruiting).';
+
+-- Grants are part of the definition: an apply that DROPs/recreates the
+-- view would otherwise leave the PostgREST roles without read access
+-- (no ALTER DEFAULT PRIVILEGES for them in this database).
+GRANT SELECT ON api.coaching_history TO anon, authenticated;

--- a/src/schemas/api/016_recruiting_roi.sql
+++ b/src/schemas/api/016_recruiting_roi.sql
@@ -34,3 +34,8 @@ COMMENT ON VIEW api.recruiting_roi IS
 'One row per team-season. blue_chip_ratio = 4+5 star ratio. '
 'recruiting_efficiency = wins / avg_class_rank. '
 'wins_over_expected = actual wins - median wins for teams with similar recruiting rank.';
+
+-- Grants are part of the definition: an apply that DROPs/recreates the
+-- view would otherwise leave the PostgREST roles without read access
+-- (no ALTER DEFAULT PRIVILEGES for them in this database).
+GRANT SELECT ON api.recruiting_roi TO anon, authenticated;

--- a/src/schemas/api/017_transfer_portal_impact.sql
+++ b/src/schemas/api/017_transfer_portal_impact.sql
@@ -32,3 +32,8 @@ COMMENT ON VIEW api.transfer_portal_impact IS
 'One row per team-season (portal era ~2021+). '
 'portal_dependency = transfers_in / roster_size. '
 'win_delta = current_wins - prior_season_wins.';
+
+-- Grants are part of the definition: an apply that DROPs/recreates the
+-- view would otherwise leave the PostgREST roles without read access
+-- (no ALTER DEFAULT PRIVILEGES for them in this database).
+GRANT SELECT ON api.transfer_portal_impact TO anon, authenticated;

--- a/src/schemas/api/018_conference_comparison.sql
+++ b/src/schemas/api/018_conference_comparison.sql
@@ -34,3 +34,8 @@ COMMENT ON VIEW api.conference_comparison IS
 'One row per conference-season. Enables SEC vs Big Ten comparisons. '
 'non_conf_win_pct = record against other conferences. '
 'std_dev_sp measures parity (lower = more competitive balance).';
+
+-- Grants are part of the definition: an apply that DROPs/recreates the
+-- view would otherwise leave the PostgREST roles without read access
+-- (no ALTER DEFAULT PRIVILEGES for them in this database).
+GRANT SELECT ON api.conference_comparison TO anon, authenticated;

--- a/src/schemas/api/019_team_wepa_season.sql
+++ b/src/schemas/api/019_team_wepa_season.sql
@@ -10,3 +10,8 @@ SELECT *
 FROM marts.team_wepa_season;
 
 COMMENT ON VIEW api.team_wepa_season IS 'Opponent-adjusted EPA (WEPA) by team-season: EPA/success-rate/explosiveness for and against, rushing yardage splits, and epa_rank/defense_rank. Backed by marts.team_wepa_season.';
+
+-- Grants are part of the definition: an apply that DROPs/recreates the
+-- view would otherwise leave the PostgREST roles without read access
+-- (no ALTER DEFAULT PRIVILEGES for them in this database).
+GRANT SELECT ON api.team_wepa_season TO anon, authenticated;

--- a/src/schemas/api/020_player_wepa_leaders.sql
+++ b/src/schemas/api/020_player_wepa_leaders.sql
@@ -10,3 +10,8 @@ SELECT *
 FROM marts.player_wepa_season;
 
 COMMENT ON VIEW api.player_wepa_leaders IS 'Player WEPA leaders: passing/rushing WEPA and kicker PAAR, tall grain (season, athlete_id, category), ranked within season+category via season_rank. Backed by marts.player_wepa_season.';
+
+-- Grants are part of the definition: an apply that DROPs/recreates the
+-- view would otherwise leave the PostgREST roles without read access
+-- (no ALTER DEFAULT PRIVILEGES for them in this database).
+GRANT SELECT ON api.player_wepa_leaders TO anon, authenticated;

--- a/src/schemas/api/021_team_returning_production.sql
+++ b/src/schemas/api/021_team_returning_production.sql
@@ -10,3 +10,8 @@ SELECT *
 FROM marts.returning_production;
 
 COMMENT ON VIEW api.team_returning_production IS 'Returning production by team-season: total and percent of last season''s PPA (overall/passing/receiving/rushing) and usage returning, with returning_rank within season. Backed by marts.returning_production.';
+
+-- Grants are part of the definition: an apply that DROPs/recreates the
+-- view would otherwise leave the PostgREST roles without read access
+-- (no ALTER DEFAULT PRIVILEGES for them in this database).
+GRANT SELECT ON api.team_returning_production TO anon, authenticated;

--- a/src/schemas/api/022_player_usage_leaders.sql
+++ b/src/schemas/api/022_player_usage_leaders.sql
@@ -10,3 +10,8 @@ SELECT *
 FROM marts.player_usage;
 
 COMMENT ON VIEW api.player_usage_leaders IS 'Player usage rates by season: share of team plays (overall, pass, rush, and down-split: first/second/third down, standard/passing downs) per athlete. Backed by marts.player_usage.';
+
+-- Grants are part of the definition: an apply that DROPs/recreates the
+-- view would otherwise leave the PostgREST roles without read access
+-- (no ALTER DEFAULT PRIVILEGES for them in this database).
+GRANT SELECT ON api.player_usage_leaders TO anon, authenticated;

--- a/src/schemas/api/023_team_ats.sql
+++ b/src/schemas/api/023_team_ats.sql
@@ -10,3 +10,8 @@ SELECT *
 FROM marts.team_ats_records;
 
 COMMENT ON VIEW api.team_ats IS 'Team against-the-spread records by season: games, ats_wins/ats_losses/ats_pushes, avg_cover_margin, and computed ats_win_pct. Backed by marts.team_ats_records.';
+
+-- Grants are part of the definition: an apply that DROPs/recreates the
+-- view would otherwise leave the PostgREST roles without read access
+-- (no ALTER DEFAULT PRIVILEGES for them in this database).
+GRANT SELECT ON api.team_ats TO anon, authenticated;

--- a/src/schemas/api/024_line_movement.sql
+++ b/src/schemas/api/024_line_movement.sql
@@ -26,3 +26,8 @@ ORDER BY game_id, provider, captured_at;
 COMMENT ON VIEW api.line_movement IS
 'Betting line movement history from append-only daily snapshots of pending games. '
 'line_hash lets consumers detect no-movement streaks between captures.';
+
+-- Grants are part of the definition: an apply that DROPs/recreates the
+-- view would otherwise leave the PostgREST roles without read access
+-- (no ALTER DEFAULT PRIVILEGES for them in this database).
+GRANT SELECT ON api.line_movement TO anon, authenticated;

--- a/src/schemas/api/validation_team_history.sql
+++ b/src/schemas/api/validation_team_history.sql
@@ -1,0 +1,41 @@
+-- Behavioral validation for api.team_history -- applied as its OWN
+-- file/transaction (after 002_team_history.sql) so a failed assertion
+-- reports without rolling back the view DDL. Read-only; safe to re-run any
+-- time as a health check.
+--
+-- Guards the 2026-07-23 change: the view now exposes the historical SP+
+-- offense/defense split (sp_offense/sp_defense from
+-- marts.team_season_summary), and the definition file re-grants the
+-- PostgREST roles after its DROP/CREATE (no default privileges for them in
+-- this database -- a bare re-apply used to strip read access).
+
+DO $$
+DECLARE
+    missing BIGINT;
+    role_name TEXT;
+BEGIN
+    -- The exact question that exposed the gap: Venables-era (2022-2024)
+    -- defensive SP+ for Oklahoma, juxtaposed with Clemson. Every one of
+    -- those six team-seasons must now carry the split.
+    SELECT COUNT(*) INTO missing
+    FROM (VALUES ('Oklahoma'), ('Clemson')) teams(team)
+    CROSS JOIN generate_series(2022, 2024) AS s(season)
+    LEFT JOIN api.team_history th
+      ON th.team = teams.team AND th.season = s.season
+     AND th.sp_defense IS NOT NULL AND th.sp_offense IS NOT NULL
+    WHERE th.team IS NULL;
+
+    IF missing > 0 THEN
+        RAISE EXCEPTION 'team_history: % OU/Clemson 2022-2024 rows lack the SP+ split', missing;
+    END IF;
+
+    -- Grant tripwire: the DROP/CREATE in 002 discards grants; the file must
+    -- have restored read access for every consumer role.
+    FOREACH role_name IN ARRAY ARRAY['anon', 'authenticated', 'analyst_ro'] LOOP
+        IF NOT has_table_privilege(role_name, 'api.team_history', 'SELECT') THEN
+            RAISE EXCEPTION 'team_history: role % lost SELECT after re-apply', role_name;
+        END IF;
+    END LOOP;
+
+    RAISE NOTICE 'team_history validation passed';
+END $$;

--- a/tests/test_api_grants.py
+++ b/tests/test_api_grants.py
@@ -1,0 +1,41 @@
+"""Static grant-coverage guard for the api view layer.
+
+Prod has NO default privileges for the PostgREST roles (anon/authenticated)
+-- see the incident note in src/schemas/api/005_leaderboard_teams.sql. Any
+definition file that DROPs and recreates its view therefore strips read
+access unless the file itself re-grants it. This pins the invariant that
+EVERY api view definition carries its grant, so a re-apply (or a future
+CREATE OR REPLACE -> DROP/CREATE refactor) can never silently take a view
+away from cfb-app or the analyst RPC's consumers.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+API_DIR = Path(__file__).resolve().parent.parent / "src" / "schemas" / "api"
+DEFINITION_FILES = sorted(API_DIR.glob("[0-9]*.sql"))
+
+VIEW_RE = re.compile(r"CREATE (?:OR REPLACE )?VIEW (api\.\w+)")
+
+
+def _strip_comments(sql: str) -> str:
+    return "\n".join(line.split("--", 1)[0] for line in sql.splitlines())
+
+
+def test_definition_files_found():
+    assert len(DEFINITION_FILES) >= 38, "api definition files went missing"
+
+
+@pytest.mark.parametrize("path", DEFINITION_FILES, ids=lambda p: p.name)
+def test_every_view_grants_postgrest_roles(path):
+    sql = _strip_comments(path.read_text())
+    views = list(dict.fromkeys(VIEW_RE.findall(sql)))
+    assert views, f"{path.name}: no CREATE VIEW api.* statement found"
+    for view in views:
+        pattern = rf"GRANT SELECT ON {re.escape(view)}\s+TO anon, authenticated;"
+        assert re.search(pattern, sql), (
+            f"{path.name}: missing 'GRANT SELECT ON {view} TO anon, authenticated;'"
+            " -- a DROP/CREATE apply would strip PostgREST read access"
+        )


### PR DESCRIPTION
## Summary

- **`api.team_history` gains `sp_offense`/`sp_defense`** (additive). The Discord bot told a user the warehouse only stores the offense/defense SP+ split for the current season — false: it exists for every loaded season (2004+) in `ratings.sp_ratings` and `marts.team_season_summary`. But `api.team_history`, the natural view for "story since 2022" questions, omitted the two columns its own backing mart carries. Now exposed after `sp_rank`.
- **API-wide grant hardening.** 23 of 38 `src/schemas/api/*.sql` files carried no `GRANT`, and 11 of those `DROP VIEW` + `CREATE VIEW` — re-applying any of them strips `anon`/`authenticated` read access, since this database has no default privileges for the PostgREST roles (this previously bit `api.leaderboard_teams`, see the incident note in `005_leaderboard_teams.sql`). Every api view definition file now ends with an explicit `GRANT SELECT ON api.<view> TO anon, authenticated;`.
- **New static test `tests/test_api_grants.py`**: every numbered api definition file must grant its view(s) to the PostgREST roles — so a future `CREATE OR REPLACE` → `DROP/CREATE` refactor can't reintroduce the trap.
- **New re-runnable validation `src/schemas/api/validation_team_history.sql`** (decoupled-validation pattern, own transaction): asserts the SP+ split is populated in `api.team_history` for Oklahoma and Clemson 2022–2024 (the exact question that exposed the gap), and that `anon`/`authenticated`/`analyst_ro` retain SELECT after the DROP/CREATE re-apply.
- `docs/SCHEMA_CONTRACT.md`: column list + changelog entry.

## Deploy plan (post-merge)

Apply on `deploy/daily-load-fixes`: `{"action":"apply","files":["src/schemas/api/002_team_history.sql","src/schemas/api/validation_team_history.sql"]}`. Only 002 needs prod re-apply; the other 22 grant lines take effect whenever their files next deploy (grants already exist in prod for currently-deployed views).

## Testing

- `ruff check` / `ruff format --check` clean.
- `pytest -q`: 765 passed (38 new grant-coverage cases), 367 skipped (live-DB integration, as usual off-network).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aq5tEVxkthmuRX7JH9qEW

---
_Generated by [Claude Code](https://claude.ai/code/session_018aq5tEVxkthmuRX7JH9qEW)_