### PR TITLE
Unbreak offseason compute chain and add season projections

### DIFF
--- a/.github/workflows/daily-load.yml
+++ b/.github/workflows/daily-load.yml
@@ -72,7 +72,7 @@ jobs:
           if [ -n "${{ inputs.season }}" ]; then
             python scripts/compute_adjusted_epa.py --season "${{ inputs.season }}"
           else
-            python scripts/compute_adjusted_epa.py --season "$(python -c "from src.pipelines.config.years import get_current_season; print(get_current_season())")"
+            python scripts/compute_adjusted_epa.py --incremental
           fi
       - name: Update as-of weekly EPA
         run: python scripts/compute_adjusted_epa_week.py --incremental
@@ -80,6 +80,8 @@ jobs:
         run: python scripts/compute_predictions.py
       - name: Rebuild feature substrate
         run: python scripts/build_features.py --incremental
+      - name: Refit fitted_v1 if stale
+        run: python scripts/train_model.py --refit-if-stale
       - name: Score fitted model (upcoming)
         run: python scripts/score_fitted.py --upcoming
       - name: Refresh Tier 2 + Tier 3 marts

--- a/.github/workflows/daily-load.yml
+++ b/.github/workflows/daily-load.yml
@@ -84,6 +84,8 @@ jobs:
         run: python scripts/train_model.py --refit-if-stale
       - name: Score fitted model (upcoming)
         run: python scripts/score_fitted.py --upcoming
+      - name: Simulate season projections
+        run: python scripts/simulate_season.py
       - name: Refresh Tier 2 + Tier 3 marts
         run: python scripts/refresh_marts.py --views marts.house_elo,marts.house_elo_game,marts.team_adjusted_epa,marts.scored_matchup_edges,marts.prediction_accuracy,marts.team_week_features,marts.adjusted_epa_week
       - name: Verify load

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,9 +74,17 @@ Or use the `refresh_all_marts()` RPC.
 
 `.github/workflows/daily-load.yml` runs daily at 10:00 UTC from `main`: loads the
 current season (`scripts/load_season.py --weekly`, mart refresh included), refits house
-Elo/adjusted EPA (including the as-of weekly EPA build) and the fitted_v1 model's upcoming
-scores, then runs post-load checks (`scripts/verify_load.py`). Failures open/update a
-rolling GitHub issue. Requires repo secrets `CFBD_API_KEY` and `SUPABASE_DB_URL` (session
+Elo/adjusted EPA (including the as-of weekly EPA build), refits fitted_v1 when it is stale
+(`train_model.py --refit-if-stale`, a no-op on all but one day a year) and writes the
+model's upcoming scores, then runs post-load checks (`scripts/verify_load.py`). Failures
+open/update a rolling GitHub issue.
+
+**Season targeting:** the compute chain's `--incremental` resolves target seasons from
+`core.games` via `get_projection_seasons()` -- the most recent season with completed games
+plus every later season with a published schedule -- **not** from `get_current_season()`,
+which is a calendar rule returning `year - 1` until August and is correct only for ingest
+year windows. `verify_load.py` asserts fitted_v1 covers >=90% of pending games so a missing
+feature substrate cannot fail silently. Requires repo secrets `CFBD_API_KEY` and `SUPABASE_DB_URL` (session
 pooler). `.github/workflows/flat-files.yml` runs daily at 11:00 UTC to load flat-file
 sources (massey ratings, nflverse draft/combine, SBR lines, availability reports) using a
 hash-skip ledger in `meta.flat_file_loads` to avoid re-processing unchanged files. Requires
@@ -133,9 +141,10 @@ cfb-database/
 │   ├── compute_predictions.py    # Generate game predictions and edges
 │   ├── check_backtest.py         # Backtest prediction accuracy and scoring
 │   ├── build_features.py         # Build features.team_week substrate (--incremental)
-│   ├── train_model.py            # Fit fitted_v1 walk-forward model coefficients
+│   ├── train_model.py            # Fit fitted_v1 walk-forward coefficients (--refit-if-stale)
 │   ├── tune_params.py            # Hyperparameter search for fitted_v1
 │   ├── score_fitted.py           # Score games with fitted_v1 (--upcoming default)
+│   ├── probe_offseason_availability.py # Report which CFBD offseason inputs a season has
 │   ├── calibrate_live_wp.py      # Fit live.wp_params sigma against historical win prob
 │   ├── poll_scoreboard.py        # Poll CFBD /scoreboard, write live.scoreboard_snapshots
 │   ├── load_flat_files.py        # Load flat-file sources (massey, nflverse, SBR, availability)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ The database uses multiple Postgres schemas organized by data domain:
 | `live` | In-game polling | scoreboard_snapshots, wp_params (house live win prob) |
 | `marts` | Materialized views (39) | Denormalized, query-optimized |
 | `api` | API view layer (35) | Contract surface for cfb-app/cfb-scout |
-| `predictions` | Prediction snapshots | game_predictions (append-only daily) |
+| `predictions` | Prediction snapshots | game_predictions, season_projections (append-only daily) |
 | `public` | Convenience views/RPCs (12) | Downstream consumer interface |
 | `meta` | Flat-file load ledger | flat_file_loads |
 | `raw` | Raw archived source files | availability_reports |
@@ -139,6 +139,8 @@ cfb-database/
 │   ├── compute_adjusted_epa.py   # Compute team adjusted EPA ratings
 │   ├── compute_adjusted_epa_week.py # Walk-forward as-of weekly adjusted EPA (--incremental)
 │   ├── compute_predictions.py    # Generate game predictions and edges
+│   ├── simulate_season.py        # Monte Carlo season win totals + distributions
+│   ├── screen_preseason_features.py # Partial-correlation screen for candidate features
 │   ├── check_backtest.py         # Backtest prediction accuracy and scoring
 │   ├── build_features.py         # Build features.team_week substrate (--incremental)
 │   ├── train_model.py            # Fit fitted_v1 walk-forward coefficients (--refit-if-stale)

--- a/docs/plans/2026-07-25-preseason-outlook-model-plan.md
+++ b/docs/plans/2026-07-25-preseason-outlook-model-plan.md
@@ -194,6 +194,7 @@ Extend the loaders behind `stats.player_returning`, `ratings.sp_ratings`,
 
 ### 1.5 Phase 1 gates
 
+- **BLOCKING — adversarial pass run against the diff, findings fixed, pass re-run against the fixes, BEFORE the PR opens** (see "Opus review gates")
 - `features.team_week` has ≥ 3,200 rows for 2026 (2 sides × 1,638 games)
 - `predictions.game_predictions` has `fitted_v1` rows for ≥ 90% of pending 2026 games
 - `features.model_metadata` contains `train_through_season = 2025`
@@ -470,6 +471,7 @@ If not, the proxy stands and stays documented.
 
 ### 2.8 Phase 2 gates
 
+- **BLOCKING — adversarial pass run against the diff, findings fixed, pass re-run against the fixes, BEFORE the PR opens** (see "Opus review gates")
 - §2.5 partial-correlation screen passed, per column, with results recorded
 - Backfill 2015–2026; per-season NULL rates logged per new column
 - Leak audit: every new column verifiably knowable before week 1 of S — with
@@ -528,6 +530,7 @@ whether the blend beats it.
 
 ### 3.4 Phase 3 gates
 
+- **BLOCKING — adversarial pass run against the diff, findings fixed, pass re-run against the fixes, BEFORE the PR opens** (see "Opus review gates")
 - Backtest on week-1/2 games 2018–2025: `preseason_v1` MAE and Brier vs
   `fitted_v1` on the identical game set
 - Calibration curve for win prob in 10 buckets
@@ -614,6 +617,7 @@ shipping a number nobody can defend.
 
 ### 4.5 Phase 4 gates
 
+- **BLOCKING — adversarial pass run against the diff, findings fixed, pass re-run against the fixes, BEFORE the PR opens** (see "Opus review gates")
 - **Backfill validation:** simulate 2018–2025 preseason, compare projected
   wins to actual. Report MAE in wins and the calibration of `p_bowl_eligible`
   and `p_ten_plus`. A preseason win-total model landing within ~1.5 wins MAE
@@ -863,6 +867,7 @@ most speculative item in the plan. It should not block the outlook shipping.
 
 ### 6.4 Phase 6 gates
 
+- **BLOCKING — adversarial pass run against the diff, findings fixed, pass re-run against the fixes, BEFORE the PR opens** (see "Opus review gates")
 - Backtest: AUC and calibration of `draft_prob_v1` on held-out seasons,
   walk-forward. A model that cannot separate drafted from undrafted players
   better than recruiting stars alone is not worth its complexity — that is the
@@ -1011,11 +1016,69 @@ exhausted).
 **Consequence of losing fable:** opus 5 now both orchestrates and owns
 correctness design, so disciplined delegation to haiku/sonnet matters more for
 cost. It also means the review gates below are **self-review by the
-orchestrating model**, which is weaker than independent review. Mitigation: run
-each review as a separate focused pass with fresh context against the diff —
-not inline while orchestrating.
+orchestrating model**, which is measurably weaker than independent review.
+
+**The main loop's definition of done for any phase is: pass green, adversarial
+pass run, findings fixed, pass re-run against the fixes, PR opened.** Opening a
+PR before that sequence completes is a process failure regardless of how the
+diff looks — see the blocking gate under "Opus review gates". The pass must be
+a separate invocation with fresh context against the diff, never inline while
+orchestrating, because the author's context is exactly what hides the defect.
 
 ## Opus review gates
+
+### BLOCKING: the adversarial pass runs BEFORE the PR is opened
+
+**No PR to `main` may be opened until an adversarial review pass has run
+against the full diff.** This is a hard prerequisite, not a recommendation, and
+it is stated this way because the softer version already failed.
+
+The rule, concretely:
+
+1. Finish the work and get `ruff` + `pytest` green.
+2. **Stop.** Run the adversarial pass as a *separate* invocation with fresh
+   context, reading the diff as an adversary trying to find a number that is
+   wrong but plausible — not as the author confirming intent.
+3. Fix what it finds.
+4. **Re-run the pass against the fixes**, which are themselves unreviewed code
+   in correctness-critical paths.
+5. Only then open the PR.
+
+Step 4 is not padding. When this was run for the first time on PR #48 — late,
+after the PR was already open — the pass against the *fix commit* found two
+further defects that the fixes had introduced.
+
+**What "adversarial" means here.** Not "does this match what I intended" but:
+*where does this produce a confident, well-formatted, wrong answer?* Every
+defect this project has hit shares that shape — the silent zero-row score, the
+in-sample refit, sigma double-counting, unscored games as certain losses,
+teams with no scorable games projected at 0.0 wins. None of them raised;
+all of them looked fine.
+
+**Evidence this gate is load-bearing** (PR #48, 2026-07-26):
+
+| Pass | Findings |
+|---|---|
+| Author self-check while building | 0 |
+| External review (Codex) of the original diff | **6**, all valid, 2 of them P1 |
+| Adversarial pass against the fix commit | **2** more, introduced by the fixes |
+
+Two of Codex's six were named *in advance* by the table below — "wrong sigma
+yields confident, well-formatted, wrong win totals" and "a leak is invisible in
+output" — and shipped anyway. Writing the gate down is not running it.
+
+**External review does not substitute for this pass, and this pass does not
+substitute for external review.** They caught disjoint sets. Where an
+independent reviewer is available (Codex, a human), use both: the pre-PR pass
+first, the external one on the opened PR.
+
+**Self-review caveat, restated.** With opus 5 as both orchestrator and
+correctness owner, this pass is self-review and is measurably weaker than the
+external one — 6 findings vs 2 on the same body of work. Run it anyway; it is
+cheap and it is not zero. But do not treat a clean self-pass as evidence the
+diff is clean.
+
+### Artifact gates
 
 Required before landing, independent of who authored:
 
@@ -1030,10 +1093,18 @@ Required before landing, independent of who authored:
 | Phase 6 label + join-rate audit | Censoring and join failures both produce plausible sums from broken data |
 | Deploy sequencing before each PR to main | Tier 1–3 precedent |
 
-Review is **advisory on ship/no-ship gates** — §2.5 column selection, §3.4
-`preseason_v1` ship decision, §4.5 calibration acceptance. Opus produces the
-analysis and recommendation; **the user rules.** Matches Tier 3's "tuning grid:
-advisory table; user decides ledger changes."
+Two different things are called "review" here, and conflating them is what let
+the pass get skipped. Keep them distinct:
+
+- **The adversarial pass is BLOCKING.** It gates whether a PR opens at all.
+  Not a judgment call, not the user's to waive by default.
+- **Ship/no-ship decisions are ADVISORY** — §2.5 column selection, §3.4
+  `preseason_v1` ship decision, §4.5 calibration acceptance. Opus produces the
+  analysis and recommendation; **the user rules.** Matches Tier 3's "tuning
+  grid: advisory table; user decides ledger changes."
+
+The first is about whether the code is correct. The second is about whether a
+correct result is worth shipping. Only the second is a matter of taste.
 
 ## Risks and open questions
 
@@ -1153,6 +1224,34 @@ beats plain recruiting by +0.002.
 `draft_departures`. Rejected candidates stay in
 `screen_preseason_features.py`'s `CANDIDATE_COLUMNS` so the nulls remain
 reproducible; `SHIPPED_COLUMNS` is what migration 042 consumes.
+
+**A5. Review-gate evidence (PR #48, 2026-07-26).** The blocking pre-PR
+adversarial pass exists because of this sequence, recorded so the rule is not
+re-litigated as overhead:
+
+| Pass | Findings |
+|---|---|
+| Author self-check while building | 0 |
+| External review (Codex) of the original diff | **6** — 2×P1, 4×P2, all valid |
+| Adversarial pass against the fix commit | **2** more, introduced by the fixes |
+
+The six: refit trained on a partial season then scored it in-sample; conference
+title odds computed from overall record; unscored games counted as certain
+losses; postseason games inflating a regular-season outlook; residual sigma
+double-counting append-only snapshots; the screen not reproducing its own
+verdicts.
+
+The two: teams with no scorable game written as 0.0-win projections; a
+non-positive sigma passing the guard and making every game deterministic.
+
+**Two of the six were named in advance** by the review-gate table — "wrong
+sigma yields confident, well-formatted, wrong win totals" and "a leak is
+invisible in output" — and shipped regardless. The gate was written and not
+run. That is the specific failure the BLOCKING language now addresses.
+
+**Every one of the eight shares a shape:** a confident, well-formatted, wrong
+number rather than an error. That is what the adversarial pass is looking for,
+and it is why "the tests pass" is not evidence of correctness here.
 
 **Unaffected by any of this:** §2.0's finding that `returning_ppa_pct` cannot
 see the lines is structural — it follows from PPA's definition, not from these

--- a/docs/plans/2026-07-25-preseason-outlook-model-plan.md
+++ b/docs/plans/2026-07-25-preseason-outlook-model-plan.md
@@ -205,7 +205,36 @@ Extend the loaders behind `stats.player_returning`, `ratings.sp_ratings`,
 
 ## Phase 2 — Preseason feature enrichment (B)
 
-Goal: make the week-1 feature vector actually informative.
+Goal: make the week-1 feature vector actually informative, organized around the
+stated thesis — **what a team did after 2025** (recruiting, portal, returning
+production), **its schedule**, **roster makeup in the trenches with continuity
+and development**, and **QB play**.
+
+### 2.0 The structural finding that justifies this phase
+
+`stats.player_returning` — the source of the *only* returning-production
+feature in the model — has exactly these measures:
+
+```
+total_ppa, total_passing_ppa, total_receiving_ppa, total_rushing_ppa,
+percent_ppa, percent_passing_ppa, percent_receiving_ppa, percent_rushing_ppa,
+usage, passing_usage, receiving_usage, rushing_usage
+```
+
+Every one is PPA- or usage-based, and **PPA and usage accrue only to players
+who touch the football.** An offensive lineman generates zero PPA and zero
+usage in every season he plays. Defensive linemen likewise accrue no PPA
+(it is credited to the offense).
+
+So `returning_ppa_pct` is not merely a weak trench signal — it is
+**structurally incapable of seeing the trenches at all.** A team returning all
+five offensive line starters and a team returning none can have identical
+`returning_ppa_pct`. The model's single returning-production input is a
+skill-position measure wearing a team-level name.
+
+This is a schema fact, not a statistical inference, and it is the strongest
+argument in this plan for the phase. The thesis is pointing directly at the
+hole.
 
 ### 2.1 The problem, stated precisely
 
@@ -224,7 +253,34 @@ d_elo + d_adj_epa_off + d_adj_epa_def + d_returning_ppa_pct + d_preseason_sp_rat
 is, by the design doc's own admission (§1f), *last season's final* SP+ used as
 a proxy. In the portal era that is a thin basis for a season outlook.
 
-### 2.2 New `features.team_week` columns (migration 042)
+### 2.2 What is knowable in July vs August — the binding constraint
+
+The outlook must be answerable **now**, in July. Verified availability for
+2026:
+
+| Available today (July) | Not until ~August |
+|---|---|
+| `recruiting.transfer_portal` — 4,410 rows, with `position` | `core.roster` (no 2026 rows) |
+| `draft.draft_picks` — 257 rows, with `position` | `stats.player_returning` |
+| `recruiting.recruits` — 3,107 rows, with `position` | `recruiting.team_talent` |
+
+This splits the feature set in two, and the split drives the design:
+
+- **Churn features** (portal in/out, draft departures, recruiting) are
+  derivable **today** from tables already loaded. They answer "what did this
+  team do after 2025" directly.
+- **Continuity features** (who is actually back on the roster) require the
+  season-S roster and cannot be computed until CFBD publishes it.
+
+**Design consequence:** build the July-computable churn features first and
+treat roster-continuity as an August enrichment that sharpens the same
+columns. A team's outlook should exist in July and improve in August, not
+appear in August. Every continuity column therefore needs a defined
+pre-roster fallback, and `adj_epa_source`-style provenance flags
+(`trench_source = 'churn' | 'roster'`) so consumers know which they are
+reading.
+
+### 2.3 New `features.team_week` columns (migration 042)
 
 All preseason-known and constant within a season, following the §1f pattern.
 Sourced from **raw tables, not marts 017/025** — `marts.transfer_portal_impact`
@@ -232,50 +288,160 @@ joins season-S wins and SP+ (`current_wins`, `current_sp_rating`,
 `win_delta`), which is season-S outcome data and would leak. The portal
 features must be derived directly from `recruiting.transfer_portal`.
 
-| Column | Type | Source | Leak rule |
+**Trenches** — the gap §2.0 identifies. Position-group scoped, offense and
+defense separately:
+
+| Column | Type | Source | Available |
 |---|---|---|---|
-| `portal_in_count` | BIGINT | `recruiting.transfer_portal` (season=S, destination=team) | portal activity precedes S |
-| `portal_out_count` | BIGINT | same, origin=team | preseason-known |
-| `portal_net_stars` | NUMERIC(8,3) | Σ incoming stars − Σ outgoing stars | preseason-known |
-| `portal_net_rating` | NUMERIC(8,5) | same with `rating` | preseason-known |
-| `talent_composite` | NUMERIC(8,3) | `recruiting.team_talent` (year=S) | preseason-known |
-| `recruiting_points_3yr` | NUMERIC(10,3) | `recruiting.team_recruiting`, decayed sum over S−2..S | preseason-known |
-| `draft_departures` | BIGINT | `draft.draft_picks` (year=S, college team) | April draft precedes S |
-| `draft_departure_capital` | NUMERIC(8,3) | pick-value-weighted departures | preseason-known |
-| `returning_qb_usage` | NUMERIC(8,4) | share of S−1 passing usage on the S roster | preseason-known |
-| `hc_first_year` | BOOLEAN | `ref.coaches__seasons` — no S−1 season at this team | preseason-known |
-| `hc_tenure_years` | BIGINT | consecutive prior seasons at team | preseason-known |
+| `ol_portal_in` / `ol_portal_out` | BIGINT | `recruiting.transfer_portal`, OL group | July |
+| `dl_portal_in` / `dl_portal_out` | BIGINT | same, DL group | July |
+| `ol_portal_net_rating` | NUMERIC(8,5) | Σ in − Σ out, `rating`-weighted | July |
+| `dl_portal_net_rating` | NUMERIC(8,5) | same | July |
+| `ol_draft_departures` | BIGINT | `draft.draft_picks`, OL group | July |
+| `dl_draft_departures` | BIGINT | same, DL group | July |
+| `ol_continuity` | NUMERIC(8,4) | share of S−1 OL roster on S roster | August |
+| `dl_continuity` | NUMERIC(8,4) | same for DL | August |
+| `prior_line_yards` | NUMERIC(8,4) | `stats.advanced_team_stats.offense__line_yards` (S−1) | July |
+| `prior_stuff_rate_allowed` | NUMERIC(8,4) | `offense__stuff_rate` (S−1) | July |
+| `prior_def_line_yards` | NUMERIC(8,4) | `defense__line_yards` (S−1) | July |
+| `prior_front_seven_havoc` | NUMERIC(8,4) | `defense__havoc__front_seven` (S−1) | July |
+| `trench_source` | VARCHAR | `'churn'` \| `'roster'` provenance | — |
 
-`returning_qb_usage` is the one requiring real work (`core.roster` ⋈
-`stats.player_usage` ⋈ position filter). It is also, on priors, the single
-most valuable preseason signal here — worth the effort, but if roster data for
-S is unavailable in July it must degrade to NULL rather than block the phase.
+The `prior_*` line-play columns matter independently of continuity: they carry
+*how good the trenches actually were*, which the PPA-based returning
+production never encodes. `stats.advanced_team_stats` already holds
+`line_yards`, `power_success`, `stuff_rate`, `second_level_yards`,
+`open_field_yards`, and `havoc__front_seven` on both sides of the ball, going
+back to 2004. This is the single cheapest win in the phase — no new ingest, no
+roster dependency, and it directly measures the thing the thesis cares about.
 
-### 2.3 Resolve the preseason SP+ proxy debt
+**QB** — the other named priority:
+
+| Column | Type | Source | Available |
+|---|---|---|---|
+| `qb_portal_in_rating` | NUMERIC(8,5) | best incoming QB `rating`, portal | July |
+| `qb_portal_out_rating` | NUMERIC(8,5) | best departing QB `rating` | July |
+| `qb_draft_departure` | BOOLEAN | QB drafted off this team, year S | July |
+| `returning_qb_usage` | NUMERIC(8,4) | share of S−1 passing usage on the S roster | August |
+| `prior_passing_ppa` | NUMERIC(8,5) | `offense__passing_plays__ppa` (S−1) | July |
+| `qb_source` | VARCHAR | `'returning'` \| `'portal'` \| `'unknown'` | — |
+
+**Cohesion / development** — the harder half of the thesis, and the part most
+likely to be genuinely novel:
+
+| Column | Type | Source | Available |
+|---|---|---|---|
+| `roster_churn_rate` | NUMERIC(8,4) | total portal out ÷ prior roster size | July |
+| `portal_dependency` | NUMERIC(8,4) | portal-in ÷ (portal-in + HS signees) | July |
+| `hc_first_year` | BOOLEAN | `ref.coaches__seasons` | July |
+| `hc_tenure_years` | BIGINT | consecutive prior seasons at team | July |
+| `dev_index` | NUMERIC(8,5) | prior-season SP+ residual vs 3-yr recruiting talent | July |
+
+`portal_dependency` and `dev_index` are the "assembled vs developed" contrast
+the thesis is reaching for: `dev_index` asks whether a program has
+historically outperformed its recruiting inputs (development) and
+`portal_dependency` asks whether this year's roster was built or bought.
+Neither exists anywhere in the warehouse today.
+
+**Team-level** (from the original plan, retained):
+`portal_net_rating`, `talent_composite`, `recruiting_points_3yr`,
+`draft_departures`, `draft_departure_capital`.
+
+### 2.4 Position crosswalk (prerequisite)
+
+Position vocabularies differ across every source and must be normalized before
+any of the above is computable. Verified 2026 values:
+
+| Source | OL group | DL group |
+|---|---|---|
+| `core.roster` | `OL`, `OT`, `G`, `C` | `DL`, `DE`, `DT`, `NT`, `EDGE` |
+| `recruiting.transfer_portal` | `IOL`, `OT` | `DL`, `EDGE` |
+| `draft.draft_picks` | `Offensive Tackle`, `Offensive Guard`, `Center` | `Defensive Tackle`, `Defensive Edge` |
+
+Ship as a small reference table (`ref.position_groups`) rather than repeated
+CASE expressions, following the `seed_team_xwalk.py` precedent. Note
+`core.roster` also carries ~1,189 NULL and 35 `'?'` positions per season —
+the crosswalk must handle unmapped values explicitly, not silently drop them
+(dropping them would inflate continuity denominators).
+
+### 2.5 Validation gate — prove incremental value before building
+
+**This gate exists because the naive version of the thesis already failed a
+first test.** Preliminary correlations run against prod (full results in the
+appendix) found roster-headcount trench continuity essentially uncorrelated
+with next-season SP+ change (OL −0.015, DL +0.013) while the existing
+`returning_ppa_pct` scored +0.24. Returning the primary passer scored +0.019.
+
+Two readings, and they are not mutually exclusive:
+
+1. **The measures were bad.** Headcount continuity counts walk-ons and fourth-
+   stringers equally with starters, and CFBD gives no OL snap counts. This is a
+   genuinely poor proxy for "the line is back."
+2. **The framing was bad.** Correlating against *year-over-year deltas* is
+   dominated by mean reversion, and the candidate features correlate with prior
+   -season quality too. Delta correlation is close to the wrong instrument.
+
+Supporting reading (1) over pure noise: against *direct trench outcomes*
+rather than overall SP+, OL continuity moved consistently in the predicted
+direction — line yards +0.070, power success +0.050, stuff-rate improvement
++0.083. Weak, but the mechanism appears where the theory says it should,
+which is what a real-but-badly-measured effect looks like.
+
+**The gate:** before migration 042 ships any column, run a partial-correlation
+screen — regress season-S SP+ on season-S−1 SP+ and test each candidate
+against the residual. That answers the only question that matters for a
+prediction model: *does this add signal beyond what we already know?* A raw
+correlation with a delta does not.
+
+```
+partial_r(x, sp_S | sp_S-1)  for each candidate column, 2015-2025
+```
+
+Columns that fail to clear a pre-registered threshold do not ship. Record the
+failures in this plan rather than deleting them — a documented null result on
+trench continuity is worth more than a quietly dropped column, and it tells us
+whether the ceiling is the metric or the data.
+
+**Pre-registered expectation:** the churn-based and `prior_*` line-play
+columns are more likely to clear than the roster-continuity columns, because
+they measure contributors (portal entrants and draft picks played) and actual
+line performance rather than bodies on a list.
+
+### 2.6 Resolve the preseason SP+ proxy debt
 
 If §1.4's probe confirms CFBD exposes a genuine preseason SP+ snapshot, load it
 into a preseason-specific row and repoint `preseason_sp_*` at it, retiring the
 "prior-season final as proxy" decision the design doc flags as follow-up work.
 If not, the proxy stands and stays documented.
 
-### 2.4 Design-doc amendments (required — it is authoritative)
+### 2.7 Design-doc amendments (required — it is authoritative)
 
 `docs/brainstorms/2026-07-21-team-week-feature-design.md` must be updated
 **before** migration 042 lands, per migration 028's header instruction:
 
-- §1f — add the eleven columns with sources and leak rules
-- §1i — extend the NULL-semantics table
+- §1f — add the surviving columns with sources and leak rules
+- §1i — extend the NULL-semantics table, including the July/August split and
+  the `trench_source` / `qb_source` provenance flags
 - §2a — the `fitted_v1` vector is a **fixed 15-feature contract**. See §3.2
   for how the new columns enter without breaking frozen fits.
-- Column count (31 → 42) and the `Decisions made` list
-- New decision entry: *portal/talent features come from raw tables, not marts
-  017/025, because those marts mix in season-S outcomes.*
+- Column count and the `Decisions made` list
+- New decision entries:
+  - *portal/talent features come from raw tables, not marts 017/025, because
+    those marts mix in season-S outcomes*
+  - *returning production is PPA-based and therefore blind to both lines;
+    trench signal comes from position-scoped churn and prior line-play metrics*
+  - *continuity columns carry a provenance flag and a pre-roster fallback, so a
+    July outlook exists before rosters publish*
 
-### 2.5 Phase 2 gates
+### 2.8 Phase 2 gates
 
+- §2.5 partial-correlation screen passed, per column, with results recorded
 - Backfill 2015–2026; per-season NULL rates logged per new column
-- Leak audit: every new column is verifiably knowable before week 1 of S
+- Leak audit: every new column verifiably knowable before week 1 of S — with
+  particular care on `recruiting.transfer_portal.season` semantics (confirm
+  season=S means "arriving for season S", not "departed after S")
 - `FEATURES_GATE` line extended with the new NULL counts
+- Position crosswalk covers ≥ 99% of non-NULL positions in all four sources
 - No change to any existing `fitted_v1` prediction (new columns are inert
   until Phase 3 consumes them)
 
@@ -447,7 +613,35 @@ repo ships the `api` views; the tool definition lands wherever the MCP server
 lives. Deliverable here is `docs/handoffs/2026-07-25-season-outlook-handoff.md`
 specifying the view contract, plus a `docs/SCHEMA_CONTRACT.md` update.
 
-### 5.3 Make the caveat quantitative
+### 5.3 The opinionated layer — `api.season_outlook_drivers`
+
+A projected-wins number is not yet a view. The thesis asks *why* a team is
+where it is, in terms of what it did after 2025. Ship a per-team ranked driver
+list: each Phase 2 feature expressed as a z-score against the FBS distribution,
+signed by its model coefficient, so the surface can state what is actually
+moving the projection.
+
+```
+season, team, driver, category, value, z_score, contribution_pts, direction
+```
+
+`category` ∈ `{trenches, qb, portal, recruiting, continuity, schedule,
+coaching}` — the thesis's own vocabulary, so an answer can be assembled by
+category rather than by raw feature name. `contribution_pts` is the feature's
+standardized value times its fitted coefficient, i.e. its actual contribution
+to the margin projection in points, which makes the ranking defensible rather
+than decorative.
+
+This is what lets the answer become "OU projects 8.7 wins; the offensive line
+returns the most snap-equivalent production in the conference (+1.2 pts/game)
+and the schedule ranks 7th-toughest (−0.9)" instead of "9-3ish on vibes."
+The stance comes from the coefficients, not from prose.
+
+Schedule earns its own driver via Phase 4's SOS: strength of schedule is a
+first-class explanation of a win total, and is fully known in July for the 230
+teams with complete slates.
+
+### 5.4 Make the caveat quantitative
 
 The agent's instinct to hedge was right; the hedge should carry a number.
 Phase 4.5's backtest yields the historical preseason win-projection error, so
@@ -466,10 +660,14 @@ src/schemas/migrations/043_season_projections.sql
 src/schemas/marts/043_season_outlook.sql
 src/schemas/api/041_season_outlook.sql
 src/schemas/api/042_season_outlook_games.sql
+src/schemas/api/043_season_outlook_drivers.sql
+src/schemas/migrations/044_position_groups.sql   # ref.position_groups crosswalk
 scripts/simulate_season.py
 scripts/probe_offseason_availability.py
+scripts/screen_preseason_features.py             # §2.5 partial-correlation gate
 tests/test_simulate_season.py
 tests/test_preseason_model.py
+tests/test_position_groups.py
 docs/handoffs/2026-07-25-season-outlook-handoff.md
 ```
 
@@ -526,8 +724,66 @@ work, and Phases 2–3 then improve a surface that already exists.
 | Incomplete 2026 schedules (68 teams < 8 games) | `schedule_complete` flag; never extrapolate |
 | Conference realignment breaks team-name joins | `seed_team_xwalk.py` crosswalk already exists; verify against 2026 conferences |
 | `preseason_v1` fails to beat `fitted_v1` | Explicit stopping rule (§3.4) — fold Phase 2 columns into `fitted_v1` and record the negative result |
+| Trench/QB features fail the §2.5 screen | Pre-registered threshold; ship only survivors. `prior_*` line-play columns are low-risk regardless (measured performance, no roster dependency) |
+| 2026 rosters unpublished until August | July outlook runs on churn features; continuity columns carry `trench_source`/`qb_source` provenance and a pre-roster fallback |
+| `transfer_portal.season` semantics ambiguous | Confirm direction (arriving-for-S vs departed-after-S) before any portal feature ships — a sign error here silently inverts the entire trench signal |
+| Position vocabularies differ across four sources | `ref.position_groups` crosswalk with explicit unmapped handling; NULL/`'?'` positions must not deflate continuity denominators |
 | Design-doc drift | Migration 028's header forbids column changes without a doc update; §2.4 is a hard prerequisite |
 
 **Open question for review:** should `playoff_prob` ship as NULL in v1 (my
 recommendation — the 12-team format's autobids and seeding are their own
 project) or is a crude top-12-by-rating proxy more useful than nothing?
+
+---
+
+## Appendix — preliminary empirical results
+
+Run against prod on 2026-07-25 while scoping Phase 2. **These are screening
+results, not conclusions**, and the framing of the first three is flawed in a
+way §2.5 corrects. Recorded here so the Phase 2 work starts from evidence
+rather than from priors — including evidence that cuts against the design.
+
+**A1. Trench continuity vs next-season SP+ change** (1,425 team-seasons,
+2015–2025, teams with ≥8 prior-season OL):
+
+| measure | corr with SP+ delta |
+|---|---|
+| OL roster continuity | −0.0150 |
+| DL roster continuity | +0.0134 |
+| `returning_ppa_pct` (existing feature) | +0.2415 |
+| OL continuity vs `returning_ppa_pct` | +0.1562 |
+
+**A2. Trench continuity vs direct trench outcomes** (1,429 team-seasons) —
+the same measures against the metrics the mechanism should move first:
+
+| measure | corr |
+|---|---|
+| OL continuity → offensive line-yards change | +0.0700 |
+| OL continuity → power-success change | +0.0497 |
+| OL continuity → stuff-rate improvement | +0.0826 |
+| DL continuity → defensive line-yards improvement | −0.0627 |
+
+**A3. Returning starting QB** (1,421 team-seasons): 57.5% of team-seasons
+return their primary passer. Correlation with offensive PPA change +0.0089,
+with SP+ change +0.0187.
+
+**Reading.** A1 and A3 look like flat nulls; A2 shows the OL effect appearing
+weakly but consistently in exactly the three metrics that measure run
+blocking, with the DL result contradictory. The most likely explanation is a
+real effect buried under two measurement problems — headcount continuity is a
+poor proxy for returning *starters*, and delta correlation is the wrong
+instrument on mean-reverting data. But "the thesis is right and my test was
+bad" is exactly what a wrong thesis also looks like, which is why §2.5 makes
+the partial-correlation screen a hard gate rather than a formality.
+
+**Not yet run:** the partial-correlation screen itself (`partial_r(x, sp_S |
+sp_S−1)`) — the session lost direct SQL access before it could be executed. It
+is the first task of Phase 2, and its results should be appended here.
+
+**Unaffected by any of this:** §2.0's finding that `returning_ppa_pct` cannot
+see the lines is structural — it follows from PPA's definition, not from these
+correlations, and holds regardless of how the screen resolves. The line-play
+columns (`prior_line_yards`, `prior_stuff_rate_allowed`,
+`prior_def_line_yards`, `prior_front_seven_havoc`) are also low-risk
+independent of the screen: they are measured performance rather than inferred
+continuity, cost no new ingest, and have no roster dependency.

--- a/docs/plans/2026-07-25-preseason-outlook-model-plan.md
+++ b/docs/plans/2026-07-25-preseason-outlook-model-plan.md
@@ -721,6 +721,13 @@ and bottom-half draft output is not the same team as the reverse, and
 Columns: `pipeline_index`, `talent_stock`, `draft_yield` (§2.4b),
 `blue_chip_pipeline` (4–5★ share of the four-year window).
 
+> **SUPERSEDED BY THE SCREEN (appendix A4, run 2026-07-26).** This section was
+> written before evidence existed. `pipeline_index` and `talent_stock` both
+> failed and must not ship; `conversion`/`draft_yield` failed even after
+> regime-scoping. What survives is `recruiting_points_3yr`,
+> `blue_chip_pipeline`, and the §6.0b variant `recruiting_points_regime`. The
+> design below is retained as the record of what was tested and why.
+
 | | Tier A hybrid | Tier B `draft_prob_v1` | Tier C external board |
 |---|---|---|---|
 | Available for 2026 | **July, today** | August (roster) | July, unvalidated |
@@ -1094,9 +1101,58 @@ instrument on mean-reverting data. But "the thesis is right and my test was
 bad" is exactly what a wrong thesis also looks like, which is why §2.5 makes
 the partial-correlation screen a hard gate rather than a formality.
 
-**Not yet run:** the partial-correlation screen itself (`partial_r(x, sp_S |
-sp_S−1)`) — the session lost direct SQL access before it could be executed. It
-is the first task of Phase 2, and its results should be appended here.
+**A4. The partial-correlation screen — RUN 2026-07-26 against prod.**
+Seasons 2015–2025, n = 1,439 team-seasons. Column 2 controls for prior-season
+SP+; column 3 additionally controls for `recruiting_points_3yr`, the strongest
+single candidate and therefore the bar every other candidate must clear.
+
+| candidate | vs prior SP+ | + recruiting | verdict |
+|---|---|---|---|
+| `recruiting_points_3yr` | **+0.2642** | *(is the control)* | **SHIP** |
+| `blue_chip_pipeline` | +0.2532 | **+0.0931** | **SHIP** |
+| `recruiting_points_regime` | +0.1525 | **+0.0955** | **SHIP** |
+| `talent_stock` | +0.2664 | ~+0.002 | reject |
+| `pipeline_index` | +0.0952 | — | reject |
+| `draft_picks_3yr` | +0.0949 | **+0.0068** | reject |
+| `conversion` / `draft_yield` | +0.0760 | **−0.0007** | reject |
+| `conversion_regime` | +0.0876 | +0.0344 | reject |
+| `draft_departures` | +0.0088 | — | reject |
+| `portal_net_rating` (2021–25, n=663) | +0.0274 | +0.0731 | reject, **re-test** |
+| `portal_out_n` (2021–25) | +0.0586 | −0.0139 | reject |
+
+Portal-era recruiting partial is **+0.2840** — the signal is *stronger* after
+2021, not weaker.
+
+**What this settles.**
+
+1. **Trailing recruiting pipeline is the strongest preseason signal found**,
+   at 3× the pre-registered floor.
+2. **Draft production is redundant, not absent.** +0.0949 alone, +0.0068 once
+   recruiting is controlled. It identifies programs that *recruit* well, not
+   ones that *develop*.
+3. **Regime-scoping is real (§6.0b validated).** Restricting the recruiting
+   window to classes signed under the current head coach scores lower alone
+   (+0.1525 vs +0.2848) but adds **+0.0955 beyond** the flat window — the pair
+   beats either alone, because a short window itself encodes "new staff,
+   inherited roster."
+4. **The development term survives regime-scoping but still fails.**
+   `conversion` moves from −0.0007 to +0.0344 when scoped to the current staff
+   — right direction, under half the floor. Draft counts are a coarse, laggy
+   proxy and season-level SP+ may not isolate development; the negative result
+   is on **this measurement**, not on the concept.
+5. **`draft_departures` justifies the whole gate:** raw +0.3474, partial
+   +0.0088.
+
+**Both composites in §6.0 failed.** `pipeline_index` scores +0.0952 against
+its own input's +0.2664 — the multiplication destroys signal. `talent_stock`
+beats plain recruiting by +0.002.
+
+**Revised Tier A — ship three columns, not five:** `recruiting_points_3yr`,
+`blue_chip_pipeline`, `recruiting_points_regime`. Drop `talent_stock`,
+`pipeline_index`, `conversion`/`draft_yield`, `draft_picks_3yr`,
+`draft_departures`. Rejected candidates stay in
+`screen_preseason_features.py`'s `CANDIDATE_COLUMNS` so the nulls remain
+reproducible; `SHIPPED_COLUMNS` is what migration 042 consumes.
 
 **Unaffected by any of this:** §2.0's finding that `returning_ppa_pct` cannot
 see the lines is structural — it follows from PPA's definition, not from these

--- a/docs/plans/2026-07-25-preseason-outlook-model-plan.md
+++ b/docs/plans/2026-07-25-preseason-outlook-model-plan.md
@@ -692,6 +692,105 @@ Goal: answer "how much NFL talent is on this roster **right now**" — a
 forward-looking prospectus, as distinct from §2.4b's backward-looking record of
 picks already produced.
 
+Three tiers, each strictly more informative and strictly harder/later. **Tier A
+needs no roster and no subscription, so it ships in Phase 2's July window.**
+
+### 6.0 Tier A — hybrid pipeline × conversion index (July, backtests fully)
+
+A roster at time T is the accumulation of the last four-to-five recruiting
+classes plus portal, minus what has left. So model the *stock* without
+observing it:
+
+```
+talent_stock(S)   = decayed sum of recruiting class quality, S-1..S-4
+                    + portal_in(S) rating-weighted
+                    - draft_departures(S)
+                    - portal_out(S)
+conversion(S)     = draft picks produced S-1..S-3, residualized on the
+                    same window's recruiting inputs        [= draft_yield]
+pipeline_index(S) = talent_stock(S) × conversion(S)
+```
+
+The two terms answer different questions and neither is sufficient alone.
+`talent_stock` asks *how much raw material is on hand*; `conversion` asks
+*whether this staff turns raw material into NFL players* — the development
+thesis expressed as a rate rather than a count. A program with top-15 classes
+and bottom-half draft output is not the same team as the reverse, and
+`talent_composite` alone cannot tell them apart.
+
+Columns: `pipeline_index`, `talent_stock`, `draft_yield` (§2.4b),
+`blue_chip_pipeline` (4–5★ share of the four-year window).
+
+| | Tier A hybrid | Tier B `draft_prob_v1` | Tier C external board |
+|---|---|---|---|
+| Available for 2026 | **July, today** | August (roster) | July, unvalidated |
+| Backtests | **2015–2025 now** | 2015–2025 | not until ~2028 |
+| Cost / ToS exposure | **none** | none | $120/yr + gray area |
+| Grain | program | player | player |
+
+**Prior art:** a formalization of the blue-chip-ratio idea familiar from public
+CFB analysis, with a development term added. We are not inventing a new claim,
+only measuring one properly.
+
+**Honest risk:** program-level and slow-moving, so heavily collinear with
+`talent_composite` and prior SP+ — it may add nothing beyond them. That is what
+§2.5's screen decides. `draft_yield` and `conversion` are the terms most likely
+to survive, because residualizing against recruiting inputs removes the
+collinearity.
+
+### 6.0b Regime awareness — the naive trailing window is wrong
+
+A flat decayed sum over S-1..S-4 blends two different programs whenever a
+coaching change falls inside the window, and `conversion` over S-1..S-3
+attributes development to a staff that may not have done it. Riley-era and
+Venables-era Oklahoma are not the same program; averaging them describes
+neither.
+
+**The key asymmetry — stock transfers, conversion does not.**
+
+| Term | On a coaching change | Why |
+|---|---|---|
+| `talent_stock` | **carries over** (net of portal exodus) | The players are still on campus. Recruiting inputs are physical. |
+| `conversion` | **does not carry over** | Development is staff-dependent. This is the whole claim. |
+
+So on a regime change: keep `talent_stock`, and regress `conversion` toward the
+**new head coach's career prior** — his `draft_yield` at previous stops —
+rather than inheriting the predecessor's. A first-year HC with a strong
+development record elsewhere and an inherited top-10 roster is a genuinely
+different projection from the same roster under an unproven staff, and a flat
+window cannot express that at all.
+
+Reuse rather than rebuild: `ref.coaches__seasons`, `marts.coaching_tenure`
+(023), `marts.coach_record` (009), `api.coaching_history` (015) /
+`api.coach_records` (038) already carry tenure boundaries and career records.
+`hc_tenure_years` / `hc_first_year` (§2.3) become **interaction** terms with the
+pipeline columns rather than independent ones.
+
+Ship two variants of each trailing term and let the screen choose: `*_raw`
+(flat window) and `*_regime` (window truncated at the current HC's tenure
+start, backfilled with his career prior). If `*_regime` does not beat `*_raw`,
+that is itself a finding worth recording.
+
+**The era break is the harder half.** The portal/NIL era is a structural change,
+not a drift: one-time transfer plus NIL from 2021, rev-share and GM front
+offices after. Roster construction gained an acquisition channel that did not
+exist, so pre-2021 conversion rates may not describe post-2021 programs.
+
+The tension is real: restricting training to 2021+ leaves ~5 seasons of a
+slow-moving, highly autocorrelated program-level feature — a very thin
+effective sample, and era-specific coefficients on it would likely overfit.
+**Preferred approach:** keep the full window, add a `portal_era` indicator and
+era × pipeline interaction terms, and let §2.5 decide whether the interaction
+earns its degrees of freedom. Fall back to an era-restricted fit only if the
+interaction is strong and stable. `ref.eras` already exists for the indicator.
+
+**Front-office structure (GMs) is not automatable.** CFBD has no GM or
+personnel-staff field, and no scouted source carries one. If it matters enough
+to model, it would be a small hand-maintained reference table following the
+`recruiting.nil_market_benchmarks` precedent in the source-scouting doc
+(refreshed ~2×/yr). Out of scope for v1; noted so the omission is deliberate
+rather than an oversight.
+
 ### 6.1 There is no source for this — it has to be derived
 
 Verified: every draft-related source in or scouted for this warehouse is
@@ -768,6 +867,48 @@ most speculative item in the plan. It should not block the outlook shipping.
   before it could be checked) — this is the first task of Phase 6.
 - §2.5 partial-correlation screen on the resulting team-level columns, same as
   every other candidate feature.
+
+### 6.5 Tier C — external prospect sources (investigated July 2026)
+
+| Source | Access | History | Verdict |
+|---|---|---|---|
+| **NFLMDD commercial API** — consensus of 200 big boards, 1,500 expert mocks, 850+ sources | Licensed API key, **~$5k/yr** | 8 years | **Out on cost** |
+| **NFLMDD Mock+ Gold** — same consensus board | **$9.99/mo**, includes **"10 Consensus Big Board CSV downloads/mo"** | Current class only | **Recommended path** |
+| **Grinding the Mocks** — Bayesian Expected Draft Position; EDP explains ~85% of draft-outcome variance | Shiny dashboard, JS-rendered; needs Playwright or an ask | Multi-year research published | Ask first; keep as upgrade |
+| `array-carpenter/nfl-draft-data` | Free GitHub | 2007–2026 combine + pro day + NFL.com grades | Draft-year, not preseason |
+| `JackLich10/nfl-draft-data`, `phcs971/nfl-draft-dataset`, `nflverse/nfldata` | Free GitHub | 1967+/1987+/2000+ | **Retrospective only** — good for *labels* |
+
+**The $9.99 tier removes the scraping question.** A sanctioned CSV export, ten
+per month, exceeds what a weekly snapshot needs (4–5/mo) at ~$120/yr against
+the API's ~$5k. No Cloudflare fight, no watermark exposure, no ToS argument —
+it is the vendor's own export button. Scraping NFLMDD is explicitly **not**
+recommended: ToS prohibits redistribution, responses carry a `_meta.client_id`
+watermark, and the site 403s plain HTTP.
+
+**Fits existing infrastructure.** A periodically-dropped CSV parsed into staging
+is the flat-file pattern in `src/pipelines/sources/flat_files.py` —
+`FlatFileSpec` registry, `scripts/load_flat_files.py --due` cadence, and the
+`meta.flat_file_loads` hash-skip ledger. Add a `prospect_board` spec plus a
+parser under `src/pipelines/sources/flatfile_parsers/`, landing in
+`raw.prospect_boards`. Same shape as the PFF "weekly CSV drop → staging loader"
+roadmap item and the `raw.availability_reports` archiver.
+
+**Decide knowingly.** Mock+ Gold is a consumer tier; the ~$5k API is what the
+vendor sells for programmatic/commercial use. Feeding an internal warehouse from
+consumer exports is a gray area — low exposure if cfb-app/cfb-scout stay
+internal and nothing is redistributed, materially higher if anything becomes
+public-facing. Mitigations: keep `raw.prospect_boards` internal, never expose
+board rankings through `api.*` or MCP, surface only derived team aggregates.
+
+**The blocker is the backtest, not the signal.** A July-2026 snapshot of the
+**2027** board is leak-free for the 2026 season — note the class-year offset:
+players on 2026 rosters are drafted in April 2027, so the already-loaded 2026
+draft is the wrong class entirely. But boards are overwritten daily and nobody
+archives preseason snapshots, so we can obtain a 2026 signal today and cannot
+validate it historically. Therefore: **start snapshotting now** (history accrues
+only forward — the Massey precedent), keep Tier A/B as primary, and treat any
+board as an unvalidated overlay excluded from the fitted vector until it clears
+§2.5.
 
 ---
 
@@ -847,6 +988,45 @@ dependent work last is not a preference — it is the only order the calendar
 allows.
 
 ---
+
+## Delegation map
+
+Matches the Tier 1–3 ladder, with **opus 5 as main loop** (fable usage
+exhausted).
+
+| Model | Work |
+|---|---|
+| **haiku** | `ref.position_groups` crosswalk seed rows, registry/inventory adds, `refresh_marts.py --views` entries, `FEATURES_GATE` line additions, mart/view count bumps in `CLAUDE.md`, `docs/pipeline-manifest.md` rows, index SQL |
+| **sonnet** | All script scaffolds at the IO/CLI/idempotency layer (`simulate_season.py`, `probe_offseason_availability.py`, `screen_preseason_features.py`, `train_draft_probability.py`); migrations 042–045 DDL; thin marts + api views 041–043; `get_projection_seasons()`; `--incremental` rewiring; workflow edits; all tests; handoff doc + `SCHEMA_CONTRACT.md` |
+| **opus 5** | §1.2 coverage-gate semantics; §2.5 screen methodology (residualization, threshold pre-registration, multiple comparisons — the §6.0b regime variants roughly double the candidate count); leak rules for every new column + `transfer_portal.season` direction; `dev_index`/`draft_yield`/`conversion` residualization; §6.0b regime-scoping and era-interaction design; `preseason_v1` contract + walk-forward + CARRYOVER sweep + crossover rule; Monte Carlo math (sigma, draw structure, percentiles, tiebreak, calibration); §5.3 driver contribution math; Phase 6 label + censoring; design-doc §1f/§1i/§2a amendments |
+| **opus 5 (main loop)** | Orchestration, delegation, deploy branches, commits, log reading, gate go/no-go, ledger decisions, PR |
+
+**Consequence of losing fable:** opus 5 now both orchestrates and owns
+correctness design, so disciplined delegation to haiku/sonnet matters more for
+cost. It also means the review gates below are **self-review by the
+orchestrating model**, which is weaker than independent review. Mitigation: run
+each review as a separate focused pass with fresh context against the diff —
+not inline while orchestrating.
+
+## Opus review gates
+
+Required before landing, independent of who authored:
+
+| Artifact | Why |
+|---|---|
+| Any `features.team_week` column contract change | Migration 028's header forbids it without a design-doc update; the doc is authoritative |
+| Any as-of / leak predicate | A leak is invisible in output and inflates every downstream metric |
+| §2.5 screen results | Decides which of ~25 candidate columns ship; the naive thesis already failed once |
+| Walk-forward / frozen-fit selection | `score_fitted.py` hard-errors on a *missing* fit but silently accepts a wrong-vintage one |
+| Simulation sigma + draw structure | Wrong sigma yields confident, well-formatted, wrong win totals |
+| §6.0b regime + era design | Silently blending coaching regimes or eras produces a feature that describes no real program |
+| Phase 6 label + join-rate audit | Censoring and join failures both produce plausible sums from broken data |
+| Deploy sequencing before each PR to main | Tier 1–3 precedent |
+
+Review is **advisory on ship/no-ship gates** — §2.5 column selection, §3.4
+`preseason_v1` ship decision, §4.5 calibration acceptance. Opus produces the
+analysis and recommendation; **the user rules.** Matches Tier 3's "tuning grid:
+advisory table; user decides ledger changes."
 
 ## Risks and open questions
 

--- a/docs/plans/2026-07-25-preseason-outlook-model-plan.md
+++ b/docs/plans/2026-07-25-preseason-outlook-model-plan.md
@@ -364,6 +364,41 @@ CASE expressions, following the `seed_team_xwalk.py` precedent. Note
 the crosswalk must handle unmapped values explicitly, not silently drop them
 (dropping them would inflate continuity denominators).
 
+### 2.4b Draft production — program-level, available in July
+
+"Draft picks produced" is available today: `draft.draft_picks` carries
+`college_team`, `year`, `round`, `overall`, and `position`, and the 2026 draft
+(257 picks) is already loaded.
+
+Two distinct signals live here and **must not be collapsed into one column** —
+they have opposite signs:
+
+| Column | Meaning | Expected sign |
+|---|---|---|
+| `draft_picks_3yr` / `draft_picks_5yr` | picks produced in S−1…S−3 (excludes S) | **+** program talent/development index |
+| `draft_capital_3yr` | round-weighted equivalent | **+** |
+| `draft_departures` (already planned) | picks lost in year S | **−** talent that just left |
+
+A team that produced nine picks over three years is a program that recruits and
+develops NFL players. A team that lost six picks *this* April just lost its
+best players. The same underlying table, opposite implications for season S.
+Conflating them would net the effects to roughly zero — which may well be part
+of why raw draft counts look unpredictive in naive tests.
+
+**The development synthesis.** This connects directly to `dev_index` (§2.3):
+draft picks produced *relative to recruiting rank* is a cleaner development
+measure than either alone. A program signing 30th-ranked classes and producing
+top-10 draft output is developing; the reverse is squandering. Ship this as
+`draft_yield` — picks produced over 3 years residualized against 3-year
+recruiting points — and prefer it over the raw count if the §2.5 screen shows
+the raw count is just re-expressing recruiting talent.
+
+**Honest caveat:** raw draft production is heavily confounded with
+`talent_composite` and prior SP+, and may add little beyond them. It goes
+through the same §2.5 partial-correlation screen as everything else, and
+`draft_yield` is the variant most likely to survive it precisely because
+residualizing removes the confound.
+
 ### 2.5 Validation gate — prove incremental value before building
 
 **This gate exists because the naive version of the thesis already failed a
@@ -651,6 +686,91 @@ week kicks off."
 
 ---
 
+## Phase 6 — Draft prospect capital on current rosters
+
+Goal: answer "how much NFL talent is on this roster **right now**" — a
+forward-looking prospectus, as distinct from §2.4b's backward-looking record of
+picks already produced.
+
+### 6.1 There is no source for this — it has to be derived
+
+Verified: every draft-related source in or scouted for this warehouse is
+**retrospective**.
+
+- `draft.draft_picks` — players already drafted
+- `draft.combine` / `draft.nflverse_draft_picks` (flat-file, already loaded) —
+  post-season measurables, 1980+/2000+
+- `docs/brainstorms/2026-07-23-warehouse-extension-data-sources.md` §4 scouted
+  the talent pipeline in depth and surfaced **no forward-looking prospect
+  board**
+
+The one pre-draft evaluation present is `draft.draft_picks.pre_draft_ranking`,
+`pre_draft_position_ranking`, and `pre_draft_grade` — but those exist only for
+players who *were* drafted, only in their draft year. Using them as a roster
+feature would be textbook survivorship bias: the players who busted have no row.
+
+External consensus boards (NFL Mock Draft Database, PFF, Kiper, Brugler) are
+paywalled, ToS-risky, or both — the same category the source-scouting doc
+flagged as "high value, high risk" for On3. Not a dependency worth taking for a
+signal we can derive internally.
+
+### 6.2 Derive it — `predictions.draft_probability`
+
+This is a clean supervised-learning problem with a real, already-loaded label.
+`draft.draft_picks.college_athlete_id` is the outcome key, and it joins to
+`core.roster.id` and `recruiting.recruits.athlete_id`.
+
+**Label:** for each (player, season) on a roster, did that player get drafted
+within the following 3 NFL drafts?
+
+**Features** (all knowable before season S):
+- recruiting: `stars`, `rating`, `ranking` from `recruiting.recruits`
+- position group (`ref.position_groups`, §2.4)
+- class standing / years on roster (derived from `core.roster` history)
+- production: `stats.player_usage`, `marts.player_season_epa`,
+  `stats.player_season_stats` through S−1
+- physical: height/weight from `core.roster`
+- program: `draft_picks_3yr` (§2.4b) — programs do place players
+
+**Model:** logistic regression, reusing the IRLS + Platt core already in
+`train_model.py` rather than adding a dependency. Walk-forward by season, same
+protocol as §3 of the design doc. Coefficients land in
+`features.model_coefficients` under `model_version = 'draft_prob_v1'` — no new
+DDL for the fit itself.
+
+**Team feature:** `Σ P(drafted)` over the season-S roster, plus a
+blue-chip-weighted variant and a trenches-only variant
+(`ol_draft_capital`, `dl_draft_capital`) — which is precisely the "NFL talent
+in the trenches" measure the thesis wants and that nothing else in the plan
+delivers.
+
+### 6.3 The roster dependency is real
+
+This requires the season-S roster, so like §2.2's continuity features it
+**cannot run for 2026 until CFBD publishes 2026 rosters** (~August). The July
+fallback is the recruiting-based approximation already in Phase 2
+(`talent_composite`, `recruiting_points_3yr`, `draft_picks_3yr`), all of which
+are program-level rather than roster-level.
+
+This is why Phase 6 is last: it is the highest-effort, highest-latency, and
+most speculative item in the plan. It should not block the outlook shipping.
+
+### 6.4 Phase 6 gates
+
+- Backtest: AUC and calibration of `draft_prob_v1` on held-out seasons,
+  walk-forward. A model that cannot separate drafted from undrafted players
+  better than recruiting stars alone is not worth its complexity — that is the
+  stopping rule.
+- Join-rate audit: what fraction of roster rows resolve to a recruit record and
+  to a draft outcome. `core.roster` carries ~1,189 NULL positions per season and
+  the recruit join is via `athlete_id`; both need measuring before trusting any
+  team-level sum. **Unverified in this session** (SQL access was approval-gated
+  before it could be checked) — this is the first task of Phase 6.
+- §2.5 partial-correlation screen on the resulting team-level columns, same as
+  every other candidate feature.
+
+---
+
 ## File inventory
 
 **New**
@@ -665,6 +785,9 @@ src/schemas/migrations/044_position_groups.sql   # ref.position_groups crosswalk
 scripts/simulate_season.py
 scripts/probe_offseason_availability.py
 scripts/screen_preseason_features.py             # §2.5 partial-correlation gate
+scripts/train_draft_probability.py               # Phase 6 player-level model
+src/schemas/migrations/045_draft_probability.sql # predictions.draft_probability
+tests/test_draft_probability.py
 tests/test_simulate_season.py
 tests/test_preseason_model.py
 tests/test_position_groups.py
@@ -704,13 +827,24 @@ Phase 1  (independent)          -> 2026 fitted_v1 numbers exist
         +-- Phase 5             -> api + MCP surface
 ```
 
+Phase 6 (draft prospect capital) hangs off Phase 2's crosswalk and feeds team-
+level columns back into it, but gates on August roster publication and is
+deliberately last.
+
 Phase 4 deliberately depends only on Phase 1. If Phases 2–3 stall on CFBD data
 availability, the simulator still ships on `fitted_v1` and the outlook product
 still lands.
 
-**Recommended sequencing:** Phase 1 → Phase 4 → Phase 5 → Phase 2 → Phase 3.
-This puts a working 2026 outlook in front of users before the model-quality
-work, and Phases 2–3 then improve a surface that already exists.
+**Recommended sequencing:** Phase 1 → Phase 4 → Phase 5 → Phase 2 → Phase 3 →
+Phase 6. This puts a working 2026 outlook in front of users before the
+model-quality work, and Phases 2–3 then improve a surface that already exists.
+
+**July/August split across the whole plan.** Everything shippable before rosters
+publish: Phases 1, 4, 5, and the churn/line-play/draft-production half of Phase
+2. Everything gated on August rosters: Phase 2's continuity and
+`returning_qb_usage` columns, and all of Phase 6. Sequencing the roster-
+dependent work last is not a preference — it is the only order the calendar
+allows.
 
 ---
 
@@ -728,6 +862,10 @@ work, and Phases 2–3 then improve a surface that already exists.
 | 2026 rosters unpublished until August | July outlook runs on churn features; continuity columns carry `trench_source`/`qb_source` provenance and a pre-roster fallback |
 | `transfer_portal.season` semantics ambiguous | Confirm direction (arriving-for-S vs departed-after-S) before any portal feature ships — a sign error here silently inverts the entire trench signal |
 | Position vocabularies differ across four sources | `ref.position_groups` crosswalk with explicit unmapped handling; NULL/`'?'` positions must not deflate continuity denominators |
+| No forward-looking draft prospect source exists | Derive `draft_prob_v1` internally (§6.2); external boards are paywalled/ToS-risky and not worth the dependency |
+| `pre_draft_grade` looks like a prospect feature but is survivorship-biased | Only drafted players have rows; explicitly excluded as a roster feature (§6.1) |
+| Draft production confounded with recruiting talent | Split into produced-vs-departed with opposite signs (§2.4b); prefer `draft_yield` (residualized) over raw counts |
+| Roster→recruit→draft join rates unmeasured | Hard gate before any team-level draft-capital sum is trusted (§6.4) |
 | Design-doc drift | Migration 028's header forbids column changes without a doc update; §2.4 is a hard prerequisite |
 
 **Open question for review:** should `playoff_prob` ship as NULL in v1 (my

--- a/docs/plans/2026-07-25-preseason-outlook-model-plan.md
+++ b/docs/plans/2026-07-25-preseason-outlook-model-plan.md
@@ -1,0 +1,533 @@
+# cfb-database: Preseason Outlook Model — Unbreak, Enrich, Simulate, Surface
+
+**Status:** proposed (awaiting review)
+**Branch:** `claude/2026-outlook-prediction-model-86n2wn`
+**Supersedes nothing.** Extends `docs/plans/2026-07-21-tier3-analytics-plan.md`
+(Pillars B/C) and the authoritative feature spec
+`docs/brainstorms/2026-07-21-team-week-feature-design.md`.
+
+## Context
+
+A downstream agent was asked for a 2026 Oklahoma outlook and answered, in
+substance, "I can't — zero 2026 games completed means zero EPA, zero Elo
+trajectory, zero predictive edges," then offered "9-3ish on vibes."
+
+That framing is wrong in a specific and correctable way. `fitted_v1` was
+designed to score a week-1 game with no games played: §1f of the feature
+design doc defines a whole family of preseason-known constants, and §1i fixes
+the week-1 NULL semantics so the model layer imputes cleanly. The model is
+*supposed* to have an opinion in July.
+
+It has none because the offseason pipeline has been quietly dark since
+January, and because nothing in the warehouse represents a *season* as an
+object. This plan fixes both, then builds the outlook product on top.
+
+---
+
+## Phase 0 — Diagnosis (complete; findings below are verified against prod)
+
+### 0.1 The offseason blackout
+
+`src/pipelines/config/years.py:50` — `get_current_season()` returns
+`now.year - 1` before August. On 2026-07-25 that is **2025**. Every
+`--incremental` step in `.github/workflows/daily-load.yml` has therefore spent
+the entire offseason rebuilding last season:
+
+| Step | Intended target | Actual target |
+|---|---|---|
+| `compute_adjusted_epa.py --season $(get_current_season())` | 2026 | 2025 |
+| `compute_adjusted_epa_week.py --incremental` | 2026 | 2025 |
+| `build_features.py --incremental` | 2026 | 2025 |
+
+Verified state of `features.team_week`: 7,662 rows for 2025, **0 rows for
+2026**.
+
+Note that `compute_predictions.py` is *not* affected — its
+`TARGET_GAMES_QUERY` (`scripts/compute_predictions.py:363`) selects
+`season >= (SELECT MAX(season) FROM core.games WHERE completed)`, a
+calendar-independent idiom. That is why `elo_v1` and `elo_epa_blend_v1` have
+all 1,638 published 2026 games while `fitted_v1` has none. **The fix is to
+adopt the idiom that already works.**
+
+### 0.2 The failure is silent
+
+`score_fitted.py` INNER JOINs `features.team_week` on both sides
+(`scripts/score_fitted.py:173`). With no 2026 feature rows, zero games match,
+and `run_upcoming` logs `"No pending games with team_week features; nothing to
+write"` and **returns normally** (`scripts/score_fitted.py:376`). The workflow
+exits 0. Six months of green checkmarks, no output.
+
+### 0.3 The frozen fit is two seasons stale
+
+`features.model_metadata` holds fits for `train_through_season` 2017–2024.
+The 2025 season completed in January 2026; `train_model.py` was never re-run.
+`select_train_through("upcoming", ...)` takes `MAX(train_through_season)`, so
+2026 scoring would today use a **2024** fit — walk-forward-legal but leaving a
+full season of signal on the floor.
+
+### 0.4 The dark model is the good one
+
+Measured on all 3,829 completed 2025 games:
+
+| model | MAE | residual SD | straight-up acc |
+|---|---|---|---|
+| **`fitted_v1`** | **14.69** | **18.51** | 74.8% |
+| `elo_epa_blend_v1` | 15.69 | 19.96 | 74.9% |
+| `elo_v1` | 15.88 | 20.21 | 74.9% |
+
+The two models that survived the blackout are the two with no preseason
+signal at all.
+
+### 0.5 Offseason inputs are half-loaded
+
+2026 rows exist for some sources and not others, because loaders are split
+between `YEAR_RANGES` (`end=2026`) and `get_current_season()`:
+
+| Source | 2026 rows | Needed for |
+|---|---|---|
+| `recruiting.recruits` | ✅ 3,107 | talent, class quality |
+| `recruiting.transfer_portal` | ✅ 4,410 | portal net rating |
+| `draft.draft_picks` | ✅ 257 | production lost to NFL |
+| `stats.player_returning` | ❌ | `returning_*` (§1f) |
+| `ratings.sp_ratings` | ❌ | `preseason_sp_*` (§1f) |
+| `recruiting.team_talent` | ❌ | talent composite |
+| `recruiting.team_recruiting` | ❌ | class rank/points |
+| `core.roster` | ❌ | QB continuity |
+| `ref.coaches__seasons` | ❌ | coaching change |
+
+**Consequence:** even after Phase 1 lights up the feature build, `2026`'s
+`returning_ppa_pct` and `preseason_sp_rating` would be NULL for every team and
+get imputed to the league mean — i.e. the preseason features would contribute
+nothing. Phase 1 is not complete without these loads.
+
+### 0.6 There is no season-level object
+
+`predictions.game_predictions` is per-game point estimates. Nothing in the
+warehouse expresses projected wins, a win distribution, schedule strength, or
+title odds. Twelve `get_game_prediction` calls do not compose into an outlook,
+and no API view or MCP tool attempts it. This — not the missing 2026 rows — is
+why the answer degraded to "vibes."
+
+### 0.7 Schedule completeness (constrains Phase 4)
+
+2026 regular season, teams with a conference affiliation: 337 teams, mean 9.66
+games listed, **230 with ≥12**, 39 with 8–11, **68 with <8**. Full-season win
+totals are viable for the large majority, but a team with 6 listed games must
+not silently receive a 6-game win projection. Projections carry
+`games_scheduled` and a completeness flag (§4.3).
+
+---
+
+## Phase 1 — Unbreak the offseason (A)
+
+Goal: `fitted_v1` produces 2026 numbers daily, on a fit trained through 2025,
+with real preseason inputs, and fails loudly if it doesn't.
+
+### 1.1 Calendar-independent season targeting
+
+Add to `src/pipelines/config/years.py`:
+
+```python
+def get_projection_seasons(conn) -> list[int]:
+    """Seasons the compute chain must maintain: the most recent season with
+    completed games, plus every later season that has scheduled games.
+    Calendar-independent -- mirrors compute_predictions.TARGET_GAMES_QUERY."""
+```
+
+Backed by `SELECT DISTINCT season FROM core.games WHERE season >= (SELECT
+COALESCE(MAX(season),0) FROM core.games WHERE completed)`.
+
+`get_current_season()` is left alone — it is correct for *ingest* year
+windows and is used widely. The new helper is for the *compute* chain only.
+
+Rewire `--incremental` in:
+- `scripts/build_features.py`
+- `scripts/compute_adjusted_epa_week.py`
+- the `compute_adjusted_epa.py` invocation in the daily workflow
+
+so each iterates `get_projection_seasons()`. In July 2026 that is
+`[2025, 2026]`; in October 2026 it is `[2026]`. Self-healing, no calendar
+branch.
+
+### 1.2 Turn the silent zero into a gate
+
+`score_fitted.py::run_upcoming` must distinguish two cases:
+
+- **no pending games at all** → exit 0 (legitimate: mid-January)
+- **pending games exist, but < `MIN_COVERAGE` have `team_week` rows** → log
+  the count and `sys.exit(1)`
+
+Implement by counting pending games from `core.games` directly (the
+`compute_predictions` idiom) *before* the feature join, then comparing.
+Proposed `MIN_COVERAGE = 0.90` of pending games in the projection window.
+Emit a gate line consistent with the repo's existing style:
+
+```
+FITTED_COVERAGE_GATE pending={n} scored={m} coverage={pct} threshold=0.90
+```
+
+Add the same assertion to `scripts/verify_load.py` so the daily post-load
+check fails independently.
+
+### 1.3 Self-healing annual refit
+
+Add a `train_model.py` invocation to the daily workflow guarded by staleness:
+refit when `MAX(train_through_season) < MAX(season)` over completed seasons.
+Cheap to check, runs once a year in practice, removes a manual chore that has
+already been missed once. Immediately produces the `train_through=2025` fit
+that 2026 scoring should be using.
+
+### 1.4 Load the missing offseason inputs
+
+Extend the loaders behind `stats.player_returning`, `ratings.sp_ratings`,
+`recruiting.team_talent`, `recruiting.team_recruiting`, `core.roster`, and
+`ref.coaches__seasons` to fetch the projection season, not
+`get_current_season()`.
+
+> **Verification required before implementation.** This environment has no
+> `CFBD_API_KEY`, so CFBD's 2026 availability for each endpoint is unconfirmed.
+> First implementation step is a probe script that reports, per endpoint,
+> whether `year=2026` returns rows. Endpoints that are not yet published
+> (preseason SP+ typically lands in spring; rosters firm up in August) must
+> degrade to a logged skip, never a hard failure — the loader should re-attempt
+> daily and pick them up when they appear.
+
+### 1.5 Phase 1 gates
+
+- `features.team_week` has ≥ 3,200 rows for 2026 (2 sides × 1,638 games)
+- `predictions.game_predictions` has `fitted_v1` rows for ≥ 90% of pending 2026 games
+- `features.model_metadata` contains `train_through_season = 2025`
+- `returning_ppa_pct` non-NULL for ≥ 125 FBS teams in 2026 (or a logged,
+  explicit "CFBD has not published this yet" skip)
+- Re-run of the daily workflow is idempotent
+
+---
+
+## Phase 2 — Preseason feature enrichment (B)
+
+Goal: make the week-1 feature vector actually informative.
+
+### 2.1 The problem, stated precisely
+
+In a week-1 row every §1d/§1e column is NULL by construction, so
+`build_feature_vector` imputes all seven production features and both havoc
+features to the frozen train-window league mean. The home-minus-away diff of
+two identical imputed values is **exactly zero**. Nine of the thirteen diff
+features are therefore structurally dead in week 1, and the prediction reduces
+to:
+
+```
+d_elo + d_adj_epa_off + d_adj_epa_def + d_returning_ppa_pct + d_preseason_sp_rating
+```
+
+— where the adj-EPA pair is the prior-season fallback and `preseason_sp_rating`
+is, by the design doc's own admission (§1f), *last season's final* SP+ used as
+a proxy. In the portal era that is a thin basis for a season outlook.
+
+### 2.2 New `features.team_week` columns (migration 042)
+
+All preseason-known and constant within a season, following the §1f pattern.
+Sourced from **raw tables, not marts 017/025** — `marts.transfer_portal_impact`
+joins season-S wins and SP+ (`current_wins`, `current_sp_rating`,
+`win_delta`), which is season-S outcome data and would leak. The portal
+features must be derived directly from `recruiting.transfer_portal`.
+
+| Column | Type | Source | Leak rule |
+|---|---|---|---|
+| `portal_in_count` | BIGINT | `recruiting.transfer_portal` (season=S, destination=team) | portal activity precedes S |
+| `portal_out_count` | BIGINT | same, origin=team | preseason-known |
+| `portal_net_stars` | NUMERIC(8,3) | Σ incoming stars − Σ outgoing stars | preseason-known |
+| `portal_net_rating` | NUMERIC(8,5) | same with `rating` | preseason-known |
+| `talent_composite` | NUMERIC(8,3) | `recruiting.team_talent` (year=S) | preseason-known |
+| `recruiting_points_3yr` | NUMERIC(10,3) | `recruiting.team_recruiting`, decayed sum over S−2..S | preseason-known |
+| `draft_departures` | BIGINT | `draft.draft_picks` (year=S, college team) | April draft precedes S |
+| `draft_departure_capital` | NUMERIC(8,3) | pick-value-weighted departures | preseason-known |
+| `returning_qb_usage` | NUMERIC(8,4) | share of S−1 passing usage on the S roster | preseason-known |
+| `hc_first_year` | BOOLEAN | `ref.coaches__seasons` — no S−1 season at this team | preseason-known |
+| `hc_tenure_years` | BIGINT | consecutive prior seasons at team | preseason-known |
+
+`returning_qb_usage` is the one requiring real work (`core.roster` ⋈
+`stats.player_usage` ⋈ position filter). It is also, on priors, the single
+most valuable preseason signal here — worth the effort, but if roster data for
+S is unavailable in July it must degrade to NULL rather than block the phase.
+
+### 2.3 Resolve the preseason SP+ proxy debt
+
+If §1.4's probe confirms CFBD exposes a genuine preseason SP+ snapshot, load it
+into a preseason-specific row and repoint `preseason_sp_*` at it, retiring the
+"prior-season final as proxy" decision the design doc flags as follow-up work.
+If not, the proxy stands and stays documented.
+
+### 2.4 Design-doc amendments (required — it is authoritative)
+
+`docs/brainstorms/2026-07-21-team-week-feature-design.md` must be updated
+**before** migration 042 lands, per migration 028's header instruction:
+
+- §1f — add the eleven columns with sources and leak rules
+- §1i — extend the NULL-semantics table
+- §2a — the `fitted_v1` vector is a **fixed 15-feature contract**. See §3.2
+  for how the new columns enter without breaking frozen fits.
+- Column count (31 → 42) and the `Decisions made` list
+- New decision entry: *portal/talent features come from raw tables, not marts
+  017/025, because those marts mix in season-S outcomes.*
+
+### 2.5 Phase 2 gates
+
+- Backfill 2015–2026; per-season NULL rates logged per new column
+- Leak audit: every new column is verifiably knowable before week 1 of S
+- `FEATURES_GATE` line extended with the new NULL counts
+- No change to any existing `fitted_v1` prediction (new columns are inert
+  until Phase 3 consumes them)
+
+---
+
+## Phase 3 — `preseason_v1` (C)
+
+### 3.1 Rationale
+
+`fitted_v1` trains on all weeks pooled. Its coefficients are dominated by the
+~90% of games where the season-to-date features are live, so the
+preseason-known features are fit to be *marginal corrections to in-season
+form* — precisely the wrong weighting when they are the only signal present.
+A model trained only on games where they are the only signal will weight them
+correctly.
+
+### 3.2 Design
+
+Needs **no DDL**: `features.model_coefficients` and `model_metadata` are
+already keyed by `model_version`, and §2a's fixed-15 contract is a property of
+`fitted_v1`, not of the tables. `preseason_v1` declares its own
+`DIFF_FEATURE_COLUMNS` and its own `FEATURE_NAMES`; the frozen-fit loader
+already reads `feature_name` by name.
+
+- **Train set:** games where both sides have `games_played_to_date <= 1`,
+  seasons 2015–2025, walk-forward (fit through S−1 scores S), same protocol as
+  §3 of the design doc.
+- **Features:** Elo (carryover-regressed), prior-season adj-EPA off/def,
+  `preseason_sp_*`, `returning_*`, plus every Phase 2 column. No season-to-date
+  or havoc columns — they are structurally NULL in scope.
+- **Form:** same ridge margin + IRLS logistic + Platt as `fitted_v1`, so the
+  math core is reused rather than reimplemented. Refit `RIDGE_ALPHA` via
+  `tune_params.py` — the train set is ~1/10 the size, so the optimal penalty
+  will differ.
+- **Elo carryover is itself a hyperparameter here.** `EloEngine.CARRYOVER =
+  2/3` was chosen for in-season Elo, never validated as a preseason prior.
+  Include it in the sweep.
+
+### 3.3 Model selection at score time
+
+```
+games_played_to_date < 3  ->  preseason_v1
+otherwise                 ->  fitted_v1
+```
+
+with the crossover justified by backtest, not asserted. A ramped blend over
+weeks 1–4 is the obvious refinement; ship the hard switch first and measure
+whether the blend beats it.
+
+### 3.4 Phase 3 gates
+
+- Backtest on week-1/2 games 2018–2025: `preseason_v1` MAE and Brier vs
+  `fitted_v1` on the identical game set
+- Calibration curve for win prob in 10 buckets
+- **Honest stopping rule:** if `preseason_v1` does not beat `fitted_v1` on
+  week-1 MAE, ship Phase 2's columns into `fitted_v1` instead and record the
+  negative result in the plan. Do not ship a second model that isn't better.
+
+---
+
+## Phase 4 — Season simulation (D)
+
+The actual missing product.
+
+### 4.1 Storage — migration 043
+
+`predictions.season_projections`, append-only daily snapshots mirroring
+`predictions.game_predictions`' conventions (immutable row per
+`(season, team, model_version, projection_date)`, `DISTINCT ON` latest-snapshot
+view on top):
+
+```
+season, team, conference, model_version, projection_date, computed_at,
+games_scheduled, games_completed, actual_wins,
+projected_wins, projected_losses, median_wins,
+wins_p10, wins_p25, wins_p75, wins_p90,
+p_win_dist            JSONB   -- {"0":0.001, ..., "12":0.04}
+p_bowl_eligible       NUMERIC -- P(wins >= 6)
+p_ten_plus            NUMERIC
+sos_rank, sos_rating,
+conf_title_prob, playoff_prob,
+n_sims, residual_sigma, schedule_complete BOOLEAN
+```
+
+### 4.2 `scripts/simulate_season.py`
+
+Monte Carlo, 10,000 sims:
+
+1. Pull every game for the season with a prediction from the selected model.
+2. Completed games contribute their actual result (in-season mode).
+3. For each remaining game and each sim, draw
+   `margin ~ Normal(expected_home_margin, sigma)`; home wins iff `margin > 0`.
+   `sigma` comes from the measured backtest residual SD — **18.51** for
+   `fitted_v1` on 2025, refit per model and stored in `residual_sigma` rather
+   than hardcoded.
+4. Accumulate wins per team per sim → full distribution, not just a mean.
+
+**v1 draws games independently.** This is a known, documented simplification:
+real season outcomes are correlated (a team that is better than its rating
+beats *everyone* more often), so independent draws understate the tails —
+10-win and 3-win seasons will both be underpredicted. The correlated variant
+(draw a per-team season-strength offset once per sim, apply to all that team's
+games) is a ~15-line change and should be the v1.1 follow-up; note the
+limitation in the column comment so consumers don't overtrust the tails.
+
+Using `home_win_prob` directly instead of the margin draw is the alternative
+formulation. Prefer the margin draw: it keeps a single sigma explicit and
+tunable, and win prob is Platt-calibrated per game rather than jointly.
+
+### 4.3 Schedule completeness
+
+Per §0.7, 68 teams have fewer than 8 games listed. Rules:
+
+- `games_scheduled` and `schedule_complete` (`>= 11` regular-season games) on
+  every row
+- Projections are always over *listed* games; never extrapolate to a
+  hypothetical 12-game slate
+- Consumers (§5) must surface "based on N scheduled games" whenever
+  `schedule_complete` is false
+
+### 4.4 Conference title and playoff odds
+
+Scope honestly:
+
+- **v1 conference title:** highest conference win percentage within each
+  conference per sim, ties split evenly. Ignores real tiebreakers and
+  championship-game formats.
+- **v1 playoff:** deferred, or a documented crude proxy. The 12-team format's
+  automatic bids and seeding are a real rules-modeling project and do not
+  belong in the same phase as the simulator.
+
+Both columns exist in the schema from the start so adding them later needs no
+migration, but `playoff_prob` ships NULL until modeled properly rather than
+shipping a number nobody can defend.
+
+### 4.5 Phase 4 gates
+
+- **Backfill validation:** simulate 2018–2025 preseason, compare projected
+  wins to actual. Report MAE in wins and the calibration of `p_bowl_eligible`
+  and `p_ten_plus`. A preseason win-total model landing within ~1.5 wins MAE
+  is respectable; report what we actually get.
+- Distribution sanity: each team's `p_win_dist` sums to 1; median within
+  [p10, p90]
+- Determinism under a fixed seed
+- Idempotent daily re-run
+
+---
+
+## Phase 5 — Surfacing (E)
+
+Without this the work is invisible to the agent that prompted it.
+
+### 5.1 Views
+
+- `marts.season_outlook` — latest projection per (season, team) joined to
+  team/conference identity, SOS, and Elo
+- `api.season_outlook` — contract-surface passthrough
+- `api.season_outlook_games` — a team's schedule with per-game win prob,
+  opponent rating, and home/away/neutral, ordered by week. This is what turns
+  a number into a narrative ("hardest game at Georgia, 31%").
+
+### 5.2 MCP tool
+
+`get_season_outlook(team, season)` returning projected wins with an interval,
+the win distribution, SOS, and the game-by-game list.
+
+**Cross-repo:** the `mcp__CFBD__*` tools are not defined in this repo. This
+repo ships the `api` views; the tool definition lands wherever the MCP server
+lives. Deliverable here is `docs/handoffs/2026-07-25-season-outlook-handoff.md`
+specifying the view contract, plus a `docs/SCHEMA_CONTRACT.md` update.
+
+### 5.3 Make the caveat quantitative
+
+The agent's instinct to hedge was right; the hedge should carry a number.
+Phase 4.5's backtest yields the historical preseason win-projection error, so
+the surface can report "8.7 projected wins; preseason projections have been
+off by ~1.4 wins on average since 2018" instead of "ask me again once Michigan
+week kicks off."
+
+---
+
+## File inventory
+
+**New**
+```
+src/schemas/migrations/042_preseason_features.sql
+src/schemas/migrations/043_season_projections.sql
+src/schemas/marts/043_season_outlook.sql
+src/schemas/api/041_season_outlook.sql
+src/schemas/api/042_season_outlook_games.sql
+scripts/simulate_season.py
+scripts/probe_offseason_availability.py
+tests/test_simulate_season.py
+tests/test_preseason_model.py
+docs/handoffs/2026-07-25-season-outlook-handoff.md
+```
+
+**Modified**
+```
+src/pipelines/config/years.py            # get_projection_seasons
+scripts/build_features.py                # projection-season targeting + new columns
+scripts/compute_adjusted_epa_week.py     # projection-season targeting
+scripts/score_fitted.py                  # coverage gate; model selection
+scripts/train_model.py                   # preseason_v1 feature set
+scripts/tune_params.py                   # preseason_v1 sweep + CARRYOVER
+scripts/verify_load.py                   # fitted coverage + projection freshness
+scripts/refresh_marts.py                 # season_outlook
+.github/workflows/daily-load.yml         # staleness-guarded refit, simulate step
+docs/brainstorms/2026-07-21-team-week-feature-design.md   # §1f/§1i/§2a/decisions
+docs/SCHEMA_CONTRACT.md
+docs/pipeline-manifest.md
+CLAUDE.md                                # scripts table, schema table
+```
+
+---
+
+## Execution order and dependencies
+
+```
+Phase 1  (independent)          -> 2026 fitted_v1 numbers exist
+  |
+  +-- Phase 2 (needs 1.4 loads) -> richer preseason vector
+  |     |
+  |     +-- Phase 3             -> preseason_v1, gated on beating fitted_v1
+  |
+  +-- Phase 4 (needs Phase 1 only, improves with 3) -> win totals
+        |
+        +-- Phase 5             -> api + MCP surface
+```
+
+Phase 4 deliberately depends only on Phase 1. If Phases 2–3 stall on CFBD data
+availability, the simulator still ships on `fitted_v1` and the outlook product
+still lands.
+
+**Recommended sequencing:** Phase 1 → Phase 4 → Phase 5 → Phase 2 → Phase 3.
+This puts a working 2026 outlook in front of users before the model-quality
+work, and Phases 2–3 then improve a surface that already exists.
+
+---
+
+## Risks and open questions
+
+| Risk | Mitigation |
+|---|---|
+| CFBD has not published 2026 rosters/SP+/returning production yet | §1.4 probe first; degrade to logged skip and retry daily |
+| No `CFBD_API_KEY` in this environment | Probe must run where credentials exist; treat §1.4 as unverified until then |
+| Independent-draw Monte Carlo understates tails | Documented in column comment; correlated variant queued as v1.1 |
+| Incomplete 2026 schedules (68 teams < 8 games) | `schedule_complete` flag; never extrapolate |
+| Conference realignment breaks team-name joins | `seed_team_xwalk.py` crosswalk already exists; verify against 2026 conferences |
+| `preseason_v1` fails to beat `fitted_v1` | Explicit stopping rule (§3.4) — fold Phase 2 columns into `fitted_v1` and record the negative result |
+| Design-doc drift | Migration 028's header forbids column changes without a doc update; §2.4 is a hard prerequisite |
+
+**Open question for review:** should `playoff_prob` ship as NULL in v1 (my
+recommendation — the 12-team format's autobids and seeding are their own
+project) or is a crude top-12-by-rating proxy more useful than nothing?

--- a/scripts/build_features.py
+++ b/scripts/build_features.py
@@ -246,6 +246,21 @@ def get_db_url() -> str:
     return url
 
 
+def _resolve_projection_seasons() -> list[int]:
+    """Open a short-lived connection to resolve `--incremental`'s target
+    seasons via src.pipelines.config.years.get_projection_seasons (which takes
+    a connection so the config module stays DB-free)."""
+    import psycopg2
+
+    from src.pipelines.config.years import get_projection_seasons
+
+    conn = psycopg2.connect(get_db_url())
+    try:
+        return get_projection_seasons(conn)
+    finally:
+        conn.close()
+
+
 # One big per-season SELECT: spine (both sides of every core.games row for
 # the season) plus every SQL-computable feature family (design doc sections
 # 1a, 1b-completed-games-only, 1d, 1e, 1f). Adjusted-EPA (1c) and the
@@ -687,7 +702,10 @@ def main() -> None:
     group.add_argument(
         "--incremental",
         action="store_true",
-        help="Build only the current season (src.pipelines.config.years.get_current_season())",
+        help="Build every projection season -- the most recent season with completed "
+        "games plus every later season with a published schedule "
+        "(src.pipelines.config.years.get_projection_seasons()). What the daily "
+        "workflow runs.",
     )
     args = parser.parse_args()
 
@@ -696,7 +714,11 @@ def main() -> None:
     if args.season is not None:
         seasons = [args.season]
     elif args.incremental:
-        seasons = [get_current_season()]
+        # Resolved from core.games, not the calendar: get_current_season()
+        # returns year-1 until August, which left features.team_week with zero
+        # rows for the upcoming season all offseason (see
+        # get_projection_seasons' docstring).
+        seasons = _resolve_projection_seasons()
     else:
         current_season = get_current_season()
         if args.from_season > current_season:

--- a/scripts/compute_adjusted_epa.py
+++ b/scripts/compute_adjusted_epa.py
@@ -366,10 +366,30 @@ def main() -> None:
         type=int,
         help="Fit a single season",
     )
+    group.add_argument(
+        "--incremental",
+        action="store_true",
+        help="Fit every projection season -- the most recent season with completed "
+        "games plus every later season with a published schedule "
+        "(src.pipelines.config.years.get_projection_seasons()). What the daily "
+        "workflow runs.",
+    )
     args = parser.parse_args()
 
     if args.season is not None:
         seasons = [args.season]
+    elif args.incremental:
+        # Resolved from core.games, not the calendar -- get_current_season()
+        # returns year-1 until August (see get_projection_seasons' docstring).
+        import psycopg2
+
+        from src.pipelines.config.years import get_projection_seasons
+
+        conn = psycopg2.connect(get_db_url())
+        try:
+            seasons = get_projection_seasons(conn)
+        finally:
+            conn.close()
     else:
         import psycopg2
 

--- a/scripts/compute_adjusted_epa_week.py
+++ b/scripts/compute_adjusted_epa_week.py
@@ -346,16 +346,27 @@ def main() -> None:
     group.add_argument(
         "--incremental",
         action="store_true",
-        help="Fit only the current season (src.pipelines.config.years.get_current_season())",
+        help="Fit every projection season -- the most recent season with completed "
+        "games plus every later season with a published schedule "
+        "(src.pipelines.config.years.get_projection_seasons()).",
     )
     args = parser.parse_args()
 
     if args.season is not None:
         seasons = [args.season]
     elif args.incremental:
-        from src.pipelines.config.years import get_current_season
+        # Resolved from core.games, not the calendar -- get_current_season()
+        # returns year-1 until August, so a calendar-keyed --incremental never
+        # fits the upcoming season (see get_projection_seasons' docstring).
+        import psycopg2
 
-        seasons = [get_current_season()]
+        from src.pipelines.config.years import get_projection_seasons
+
+        conn = psycopg2.connect(get_db_url())
+        try:
+            seasons = get_projection_seasons(conn)
+        finally:
+            conn.close()
     else:
         import psycopg2
 

--- a/scripts/probe_offseason_availability.py
+++ b/scripts/probe_offseason_availability.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Probe whether CFBD has published a season's offseason inputs yet.
+
+Plan: docs/plans/2026-07-25-preseason-outlook-model-plan.md section 1.4.
+
+Six sources feed the preseason-known features in `features.team_week`
+(design doc section 1f) and the Phase 2 enrichment columns, and all six lag
+behind the schedule: as of 2026-07-25 the 2026 schedule (1,638 games), portal
+(4,410 rows), draft (257) and recruits (3,107) were all loaded while
+`stats.player_returning`, `ratings.sp_ratings`, `recruiting.team_talent`,
+`recruiting.team_recruiting`, `core.roster` and `ref.coaches__seasons` had no
+2026 rows at all.
+
+Some of that was the calendar bug (`get_current_season()` returning year-1
+until August, now fixed by `get_projection_seasons()`), but some of it is
+simply that CFBD has not published the data yet -- preseason SP+ lands in
+spring, rosters firm up in August. Those two causes look identical from the
+warehouse side, and the difference decides whether a loader is broken or
+merely early.
+
+This script answers that: for each endpoint it asks CFBD directly whether
+`year=<season>` returns rows, and reports. It is read-only -- it never writes
+to the warehouse.
+
+**A source that is not yet published is NOT a failure.** The loaders must log
+a skip and retry the next day rather than hard-failing the daily workflow;
+this probe exists so that decision is made against evidence instead of a
+guess. Exit status is 0 whenever every endpoint could be reached, regardless
+of how many are still unpublished; it is 1 only when a request itself failed
+(auth, network, unexpected shape) -- i.e. when we could not determine
+availability.
+
+Usage:
+    python scripts/probe_offseason_availability.py                # current projection season
+    python scripts/probe_offseason_availability.py --season 2026
+
+Prints one machine-readable line per endpoint:
+    AVAILABILITY_PROBE season={s} endpoint={e} rows={n} status={available|unpublished}
+followed by a summary line:
+    AVAILABILITY_SUMMARY season={s} available={a} unpublished={u} errors={e}
+
+Requires a CFBD API key (`.dlt/secrets.toml` `[sources.cfbd] api_key`, or the
+`CFBD_API_KEY` environment variable) -- the same credential the pipelines use.
+"""
+
+import argparse
+import logging
+import sys
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+# (label, endpoint path, target table) for every source that feeds a
+# preseason-known feature and lags the schedule. `year` is the query param for
+# all six -- verified against src/pipelines/config/endpoints.py and the
+# per-endpoint source modules.
+OFFSEASON_ENDPOINTS: list[tuple[str, str, str]] = [
+    ("player_returning", "/player/returning", "stats.player_returning"),
+    ("sp_ratings", "/ratings/sp", "ratings.sp_ratings"),
+    ("team_talent", "/talent", "recruiting.team_talent"),
+    ("team_recruiting", "/recruiting/teams", "recruiting.team_recruiting"),
+    ("roster", "/roster", "core.roster"),
+    ("coaches", "/coaches", "ref.coaches__seasons"),
+]
+
+AVAILABLE = "available"
+UNPUBLISHED = "unpublished"
+ERROR = "error"
+
+
+def classify(rows: list | None) -> str:
+    """Grade one probe response.
+
+    An empty list is a *successful* request that returned nothing -- CFBD has
+    not published this endpoint for the season yet. `None` means the request
+    itself failed, which is the only condition that should trouble a caller.
+    Pure, so the three-way outcome is testable without network access.
+    """
+    if rows is None:
+        return ERROR
+    return AVAILABLE if len(rows) > 0 else UNPUBLISHED
+
+
+def probe_endpoint(client, endpoint: str, season: int) -> list | None:
+    """One `year=<season>` request. Returns the rows, or None if the request
+    failed (logged, never raised -- one dead endpoint must not abort the
+    sweep)."""
+    from src.pipelines.sources.base import make_request
+
+    try:
+        rows = make_request(client, endpoint, params={"year": season})
+    except Exception as e:
+        logger.error("%s: request failed: %s", endpoint, e)
+        return None
+
+    if not isinstance(rows, list):
+        logger.error("%s: expected a list response, got %s", endpoint, type(rows).__name__)
+        return None
+    return rows
+
+
+def run_probe(client, season: int) -> dict[str, int]:
+    """Probe every offseason endpoint for `season`; print a line each. Returns
+    the {status: count} tally backing the summary line."""
+    tally = {AVAILABLE: 0, UNPUBLISHED: 0, ERROR: 0}
+
+    for label, endpoint, table in OFFSEASON_ENDPOINTS:
+        rows = probe_endpoint(client, endpoint, season)
+        status = classify(rows)
+        tally[status] += 1
+        n = len(rows) if rows is not None else 0
+        print(f"AVAILABILITY_PROBE season={season} endpoint={label} rows={n} status={status}")
+        if status == AVAILABLE:
+            logger.info("%s -> %s: %d row(s) available for %d", endpoint, table, n, season)
+        elif status == UNPUBLISHED:
+            logger.info(
+                "%s -> %s: not published for %d yet (loader should skip and retry)",
+                endpoint,
+                table,
+                season,
+            )
+
+    print(
+        f"AVAILABILITY_SUMMARY season={season} available={tally[AVAILABLE]} "
+        f"unpublished={tally[UNPUBLISHED]} errors={tally[ERROR]}"
+    )
+    return tally
+
+
+def resolve_season() -> int:
+    """Default season to probe: the latest projection season -- the upcoming
+    one whose inputs we are waiting on."""
+    import psycopg2
+
+    from scripts.build_features import get_db_url
+    from src.pipelines.config.years import get_projection_seasons
+
+    conn = psycopg2.connect(get_db_url())
+    try:
+        seasons = get_projection_seasons(conn)
+    finally:
+        conn.close()
+
+    if not seasons:
+        raise RuntimeError("core.games has no rows; pass --season explicitly")
+    return seasons[-1]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Probe whether CFBD has published a season's offseason inputs"
+    )
+    parser.add_argument(
+        "--season",
+        type=int,
+        default=None,
+        help="Season to probe (default: the latest projection season)",
+    )
+    args = parser.parse_args()
+
+    season = args.season if args.season is not None else resolve_season()
+    logger.info("Probing CFBD offseason input availability for season %d", season)
+
+    from src.pipelines.utils.api_client import get_client
+
+    client = get_client()
+    try:
+        tally = run_probe(client, season)
+    finally:
+        client.close()
+
+    # Unpublished is an expected, reportable state -- only an unreachable
+    # endpoint means we failed to determine availability.
+    sys.exit(1 if tally[ERROR] else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/score_fitted.py
+++ b/scripts/score_fitted.py
@@ -72,6 +72,37 @@ logger = logging.getLogger(__name__)
 # =============================================================================
 
 
+# Minimum share of pending games that must actually score for an upcoming run
+# to be considered healthy. Below this, run_upcoming exits non-zero rather than
+# logging "nothing to write" and returning success -- the exact silent path
+# that left fitted_v1 with zero 2026 rows for six months of green workflow runs
+# (features.team_week was never built for the upcoming season, so the INNER
+# JOIN in _score_games_query matched nothing).
+MIN_UPCOMING_COVERAGE = 0.90
+
+
+def coverage_verdict(
+    n_pending: int, n_scored: int, min_coverage: float = MIN_UPCOMING_COVERAGE
+) -> tuple[bool, float]:
+    """Decide whether an upcoming-scoring run is healthy, and its coverage.
+
+    Two genuinely different situations must not be conflated:
+
+    - ``n_pending == 0`` -- no pending games exist at all (e.g. mid-January,
+      after bowls, before next season's schedule publishes). Nothing to do;
+      that is success, and coverage is reported as 1.0.
+    - ``n_pending > 0`` but few or none scored -- pending games exist and the
+      feature substrate is missing for them. That is a *failure* even though
+      the old code path returned normally.
+
+    Returns ``(ok, coverage)``. Pure so both branches are testable without a DB.
+    """
+    if n_pending == 0:
+        return True, 1.0
+    coverage = n_scored / n_pending
+    return coverage >= min_coverage, coverage
+
+
 def select_train_through(
     mode: str, score_season: int | None = None, available_train_through: list[int] | None = None
 ) -> int:
@@ -230,6 +261,28 @@ def fetch_upcoming_games(conn) -> list[dict]:
         return _rows_to_games(cur.fetchall())
 
 
+def fetch_pending_game_count(conn) -> int:
+    """Pending games in the projection window, counted from ``core.games``
+    ALONE -- deliberately without the ``features.team_week`` join.
+
+    This is the denominator the coverage gate needs: joining team_week here
+    would make the count agree with the scored count by construction and the
+    gate could never fire. Predicate matches ``_UPCOMING_WHERE`` exactly.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT COUNT(*)
+            FROM core.games g
+            WHERE NOT COALESCE(g.completed, false)
+              AND g.season >= (
+                  SELECT COALESCE(MAX(season), 0) FROM core.games WHERE completed
+              )
+            """
+        )
+        return int(cur.fetchone()[0])
+
+
 def fetch_available_train_through(conn) -> list[int]:
     """Every ``train_through_season`` with a persisted fitted_v1 fit."""
     with conn.cursor() as cur:
@@ -371,10 +424,26 @@ def run_upcoming(conn) -> None:
     fit = load_fit(conn, train_through)
     logger.info("Upcoming scoring with latest frozen fit train_through=%d", train_through)
 
+    # Counted before the feature join -- see fetch_pending_game_count.
+    n_pending = fetch_pending_game_count(conn)
     games = fetch_upcoming_games(conn)
+
     if not games:
-        logger.info("No pending games with team_week features; nothing to write")
-        return
+        ok, coverage = coverage_verdict(n_pending, 0)
+        print(
+            f"FITTED_COVERAGE_GATE pending={n_pending} scored=0 "
+            f"coverage={coverage:.3f} threshold={MIN_UPCOMING_COVERAGE:.2f}"
+        )
+        if ok:
+            logger.info("No pending games at all; nothing to write")
+            return
+        logger.error(
+            "%d pending game(s) exist but NONE have features.team_week rows -- the "
+            "feature substrate has not been built for the upcoming season. Run "
+            "scripts/build_features.py --incremental.",
+            n_pending,
+        )
+        sys.exit(1)
 
     game_ids = [g["game_id"] for g in games]
     if table_exists(conn, "betting", "line_snapshots"):
@@ -407,6 +476,24 @@ def run_upcoming(conn) -> None:
             f"SCORED_GATE season={season} rows={per_season[season]} model={MODEL_VERSION} "
             f"train_through={train_through}"
         )
+
+    # Rows already written above -- partial output is more useful than none --
+    # but a shortfall still fails the run so it cannot pass silently.
+    ok, coverage = coverage_verdict(n_pending, len(games))
+    print(
+        f"FITTED_COVERAGE_GATE pending={n_pending} scored={len(games)} "
+        f"coverage={coverage:.3f} threshold={MIN_UPCOMING_COVERAGE:.2f}"
+    )
+    if not ok:
+        logger.error(
+            "fitted_v1 scored only %d of %d pending game(s) (%.1f%% < %.0f%%); "
+            "features.team_week is incomplete for the upcoming season",
+            len(games),
+            n_pending,
+            coverage * 100,
+            MIN_UPCOMING_COVERAGE * 100,
+        )
+        sys.exit(1)
 
 
 def main() -> None:

--- a/scripts/screen_preseason_features.py
+++ b/scripts/screen_preseason_features.py
@@ -141,6 +141,13 @@ DEFAULT_TO_SEASON = 2025
 # (see partial_corr_pvalue) stops being safe and the p-value is not reported.
 MIN_DF_FOR_NORMAL_APPROX = 200
 
+# The second control every other candidate is screened against, alongside
+# prior-season rating. It is the strongest single candidate, so "adds signal
+# beyond prior rating" is too weak a bar -- a candidate must add signal beyond
+# the best thing already available. Screening against prior rating alone would
+# ship `draft_picks_3yr` at +0.0949 when its value after recruiting is +0.0068.
+PRIMARY_CONTROL = "recruiting_points_3yr"
+
 
 # =============================================================================
 # Pure math -- no I/O, no DB, unit-tested directly (tests/test_screen_features.py).
@@ -196,6 +203,38 @@ def _pearson(a: list[float], b: list[float]) -> float:
     if den == 0.0:
         return 0.0
     return num / den
+
+
+def second_order_partial_correlation(
+    x: list[float], y: list[float], z: list[float], w: list[float]
+) -> float:
+    """Partial correlation of `x` and `y` controlling for BOTH `z` and `w`.
+
+    Applies the recursive formula to the three first-order partials (each
+    already controlling for `z`):
+
+        r_xy.zw = (r_xy.z - r_xw.z * r_yw.z)
+                  / sqrt((1 - r_xw.z^2) * (1 - r_yw.z^2))
+
+    In this screen `z` is prior-season rating and `w` is
+    `recruiting_points_3yr` -- the strongest single candidate, and therefore
+    the bar every other candidate has to clear. Controlling for prior rating
+    alone is not enough: `draft_picks_3yr` scores +0.0949 against prior rating
+    and would ship, but only +0.0068 once recruiting is also held constant,
+    because it is largely a restatement of how well a program recruits.
+
+    Returns 0.0 where the recursion is degenerate, matching
+    `partial_correlation`'s convention that an undefined partial reads as
+    "no incremental signal".
+    """
+    r_xy_z = partial_correlation(x, y, z)
+    r_xw_z = partial_correlation(x, w, z)
+    r_yw_z = partial_correlation(y, w, z)
+
+    denom = math.sqrt(max(0.0, (1.0 - r_xw_z**2) * (1.0 - r_yw_z**2)))
+    if denom == 0.0:
+        return 0.0
+    return (r_xy_z - r_xw_z * r_yw_z) / denom
 
 
 def partial_corr_pvalue(r: float, n: int, n_controls: int = 1) -> float | None:
@@ -605,14 +644,32 @@ def screen(frame: list[dict], candidates: list[str]) -> list[dict]:
     ordered by descending |partial_r| so the strongest signals read first."""
     y = [r["sp_rating"] for r in frame]
     z = [r["prior_sp_rating"] for r in frame]
+    w = [r[PRIMARY_CONTROL] for r in frame]
     n = len(frame)
 
     raw: list[dict] = []
     for name in candidates:
         x = [r[name] for r in frame]
-        r_partial = partial_correlation(x, y, z)
-        p = partial_corr_pvalue(r_partial, n)
-        raw.append({"feature": name, "n": n, "partial_r": r_partial, "p": p})
+        r_first = partial_correlation(x, y, z)
+
+        if name == PRIMARY_CONTROL:
+            # The control cannot be screened against itself; it is judged on
+            # the first-order partial alone.
+            r_decisive, n_controls = r_first, 1
+        else:
+            r_decisive = second_order_partial_correlation(x, y, z, w)
+            n_controls = 2
+
+        p = partial_corr_pvalue(r_decisive, n, n_controls=n_controls)
+        raw.append(
+            {
+                "feature": name,
+                "n": n,
+                "partial_r_vs_prior": r_first,
+                "partial_r": r_decisive,
+                "p": p,
+            }
+        )
 
     # FDR across the whole set. Untestable candidates (p is None) are held out
     # of the correction -- they cannot be false discoveries because they will
@@ -637,6 +694,7 @@ def report(results: list[dict], from_season: int, to_season: int) -> int:
         q_str = f"{c['q']:.5f}" if c["q"] is not None else "na"
         print(
             f"SCREEN_RESULT feature={c['feature']} n={c['n']} "
+            f"partial_r_vs_prior={c['partial_r_vs_prior']:+.4f} "
             f"partial_r={c['partial_r']:+.4f} p={p_str} q={q_str} "
             f"verdict={c['verdict']}"
         )

--- a/scripts/screen_preseason_features.py
+++ b/scripts/screen_preseason_features.py
@@ -47,7 +47,56 @@ REPORTING NULLS
 ---------------
 Failures are printed, not silently dropped. A documented null on trench
 continuity is a finding: it tells us whether the ceiling is the metric or the
-data.
+data. Rejected candidates are deliberately RETAINED in CANDIDATE_COLUMNS below
+so a re-run reproduces the full table -- deleting them would make the null
+results unreproducible, which is the same failure mode this gate exists to
+prevent.
+
+RESULTS -- run 2026-07-26 against prod, seasons 2015-2025 (n=1,439)
+------------------------------------------------------------------
+Column 2 controls for prior-season SP+ only; column 3 additionally controls for
+`recruiting_points_3yr`, which is the strongest single candidate and therefore
+the bar every other candidate has to clear.
+
+    candidate                   vs prior SP+   + recruiting   verdict
+    recruiting_points_3yr          +0.2642     (is control)   SHIP
+    blue_chip_pipeline             +0.2532        +0.0931     SHIP
+    recruiting_points_regime       +0.1525        +0.0955     SHIP  (see below)
+    talent_stock                   +0.2664     ~+0.002        reject
+    pipeline_index                 +0.0952           --       reject
+    draft_picks_3yr                +0.0949        +0.0068     reject
+    conversion / draft_yield       +0.0760        -0.0007     reject
+    conversion_regime              +0.0876        +0.0344     reject
+    draft_departures               +0.0088           --       reject
+    portal_net_rating (2021-25)    +0.0274        +0.0731     reject, RE-TEST
+    portal_out_n (2021-25)         +0.0586        -0.0139     reject
+
+What the run established:
+
+1. **Trailing recruiting pipeline is the strongest preseason signal found** --
+   3x the pre-registered floor, and STRONGER in the portal era (+0.2840 on
+   2021-25) rather than weaker.
+2. **Draft production is redundant, not absent.** It predicts (+0.0949) until
+   recruiting is controlled, then collapses to +0.0068. Draft output identifies
+   programs that *recruit* well, not ones that *develop*.
+3. **Regime-scoping is real** (design doc section 6.0b). Restricting the
+   recruiting window to classes signed under the current head coach scores
+   lower on its own (+0.1525 vs +0.2848) but adds +0.0955 BEYOND the flat
+   window -- the two together beat either alone. It partly encodes "new staff,
+   inherited roster", which the flat window cannot express.
+4. **The development term survives regime-scoping but still fails.**
+   `conversion` goes from -0.0007 to +0.0344 once scoped to the current staff
+   -- the right direction, less than half the floor. Draft counts are a coarse,
+   laggy proxy and season-level SP+ may not isolate development; the negative
+   result is on this measurement, not on the concept.
+5. **`draft_departures` is this gate's own justification:** raw correlation
+   +0.3474, partial +0.0088. Losing draft picks correlates with having been
+   good and says nothing about next season.
+
+Both composites in the original design failed: `pipeline_index`
+(talent_stock x conversion) scores +0.0952 against its own input's +0.2664 --
+the multiplication destroys signal -- and `talent_stock` beats plain recruiting
+by +0.002, complexity for nothing.
 
 Usage:
     python scripts/screen_preseason_features.py --check-schema
@@ -257,7 +306,40 @@ CANDIDATE_COLUMNS = [
     "draft_yield",
     "portal_net_rating",
     "draft_departures",
+    # Section 6.0b regime variant.
+    "recruiting_points_regime",
 ]
+
+# What actually cleared the 2026-07-26 run (see RESULTS in the module
+# docstring). This -- NOT CANDIDATE_COLUMNS -- is the set migration 042 should
+# add to features.team_week. CANDIDATE_COLUMNS stays comprehensive so the
+# rejections remain reproducible.
+#
+# `recruiting_points_regime` is the section 6.0b variant: the same decayed sum
+# restricted to classes signed from the current head coach's tenure start
+# onward. It is kept ALONGSIDE the flat window rather than replacing it -- it
+# scores lower alone but adds +0.0955 beyond it, so the pair carries more than
+# either does by itself.
+SHIPPED_COLUMNS = [
+    "recruiting_points_3yr",
+    "blue_chip_pipeline",
+    "recruiting_points_regime",
+]
+
+# Rejected, with the reason, so a future reader does not re-propose them
+# without new evidence. Re-test conditions noted where they exist.
+REJECTED_COLUMNS = {
+    "talent_stock": "beats plain recruiting by +0.002 -- complexity for nothing",
+    "pipeline_index": "+0.0952 vs its own input's +0.2664 -- the product destroys signal",
+    "draft_picks_3yr": "+0.0068 once recruiting is controlled -- a recruiting proxy",
+    "conversion": "-0.0007 once recruiting is controlled",
+    "conversion_regime": "+0.0344 -- regime-scoping helps but stays under the floor",
+    "draft_departures": "+0.0088 partial against +0.3474 raw -- pure confound",
+    "portal_net_rating": (
+        "+0.0731 (2021-25, n=663) -- under floor; RE-TEST as portal history accrues"
+    ),
+    "portal_out_n": "-0.0139 once recruiting is controlled",
+}
 
 # Recruiting-class decay across the four-year eligibility window: the class
 # entering season S-1 is weighted 1.0, S-2 0.8, and so on. A flat sum would
@@ -268,7 +350,28 @@ CLASS_DECAY = 0.8
 CLASS_WINDOW = 4
 
 SCREEN_FRAME_QUERY = f"""
-WITH class_points AS (
+WITH coach_year AS (
+    -- One head coach per (school, year). A school-year can list several
+    -- coaches (interim, co-HC), so take the one who actually coached the most
+    -- games. Covers 99.1% of the sp_ratings spine.
+    SELECT DISTINCT ON (c.school, c.year)
+           c.school, c.year, c._dlt_parent_id AS coach_id
+    FROM ref.coaches__seasons c
+    ORDER BY c.school, c.year, c.games DESC NULLS LAST
+),
+coach_islands AS (
+    -- Gaps-and-islands: a coach's SECOND stint at the same school must not
+    -- inherit the first stint's start year.
+    SELECT school, year, coach_id,
+           year - ROW_NUMBER() OVER (PARTITION BY school, coach_id ORDER BY year) AS grp
+    FROM coach_year
+),
+coach_tenure AS (
+    SELECT school, year, coach_id,
+           MIN(year) OVER (PARTITION BY school, coach_id, grp) AS tenure_start
+    FROM coach_islands
+),
+class_points AS (
     -- Recruiting class quality per (team, year).
     SELECT tr.team, tr.year, tr.points::double precision AS points
     FROM recruiting.team_recruiting tr
@@ -314,13 +417,19 @@ draft_out AS (
     GROUP BY 1, 2
 ),
 spine AS (
-    -- One row per (season, team) with the outcome and its control.
+    -- One row per (season, team) with the outcome, its control, and the
+    -- current staff's tenure start (for the section 6.0b regime variant).
+    -- LEFT JOIN on tenure so the ~1% of team-seasons with no coach record
+    -- still screen; tenure_start falls back to the window start, making the
+    -- regime variant equal the flat window for those rows.
     SELECT sp.year AS season, sp.team,
            sp.rating::double precision AS sp_rating,
-           sp0.rating::double precision AS prior_sp_rating
+           sp0.rating::double precision AS prior_sp_rating,
+           COALESCE(ct.tenure_start, sp.year - {CLASS_WINDOW}) AS tenure_start
     FROM ratings.sp_ratings sp
     JOIN ratings.sp_ratings sp0
       ON sp0.team = sp.team AND sp0.year = sp.year - 1
+    LEFT JOIN coach_tenure ct ON ct.school = sp.team AND ct.year = sp.year
     WHERE sp.year BETWEEN %(from_season)s AND %(to_season)s
       AND sp.rating IS NOT NULL AND sp0.rating IS NOT NULL
 )
@@ -336,6 +445,17 @@ SELECT
         WHERE cp.team = s.team
           AND cp.year BETWEEN s.season - {CLASS_WINDOW} AND s.season - 1
     ), 0) AS recruiting_points_3yr,
+    -- Section 6.0b regime variant: same decayed sum, but only classes signed
+    -- from the current staff's tenure start onward. Scores lower alone than
+    -- the flat window yet adds beyond it, because a short window is itself a
+    -- signal ("new coach, inherited roster").
+    COALESCE((
+        SELECT SUM(cp.points * POWER({CLASS_DECAY}, s.season - cp.year - 1))
+        FROM class_points cp
+        WHERE cp.team = s.team
+          AND cp.year BETWEEN GREATEST(s.season - {CLASS_WINDOW}, s.tenure_start)
+                          AND s.season - 1
+    ), 0) AS recruiting_points_regime,
     COALESCE((
         SELECT SUM(bc.blue_chips) / NULLIF(SUM(bc.signees), 0)
         FROM blue_chips bc

--- a/scripts/screen_preseason_features.py
+++ b/scripts/screen_preseason_features.py
@@ -1,0 +1,602 @@
+#!/usr/bin/env python3
+"""Screen candidate preseason features for incremental predictive value.
+
+Plan: docs/plans/2026-07-25-preseason-outlook-model-plan.md section 2.5 (the
+validation gate) and section 6.0/6.0b (the Tier A pipeline candidates this
+first screens). **No candidate column ships into migration 042 until it clears
+this screen.**
+
+WHY THIS EXISTS
+---------------
+The naive form of the trench thesis already failed a first test. Screening
+correlations against next-season SP+ *change* found roster-headcount trench
+continuity essentially uncorrelated (OL -0.015, DL +0.013) while the existing
+`returning_ppa_pct` scored +0.242, and returning the primary passer scored
++0.019. Against direct trench outcomes the same measure moved correctly but
+weakly (line yards +0.070, stuff-rate improvement +0.083).
+
+Both of those framings are the wrong instrument, and this script is the right
+one. Correlating a feature against a year-over-year delta is dominated by mean
+reversion, and the candidates correlate with prior-season quality too. The
+question that actually matters for a prediction model is narrower:
+
+    Given what last season's rating already tells us, does this feature tell
+    us anything more?
+
+That is a partial correlation -- feature vs season-S rating, controlling for
+season-(S-1) rating. A feature that merely re-expresses prior-season quality
+scores ~0 here no matter how large its raw correlation was, which is exactly
+the discrimination the raw screen could not make.
+
+MULTIPLE COMPARISONS
+--------------------
+The candidate set is large (Tier A alone contributes several terms, and
+section 6.0b's `_raw`/`_regime` variants roughly double it), so testing each at
+a fixed threshold would manufacture survivors by chance. Benjamini-Hochberg FDR
+control is applied across the whole screened set: it bounds the expected share
+of *shipped* columns that are false positives, which is the error that matters
+here -- unlike family-wise correction, which would be needlessly conservative
+for a screen whose output is a shortlist rather than a single verdict.
+
+Both the effect-size floor and the FDR level are PRE-REGISTERED (the constants
+below) and the screen is meant to be run ONCE. Re-running with adjusted
+thresholds after seeing results converts this gate into the thing it exists to
+prevent.
+
+REPORTING NULLS
+---------------
+Failures are printed, not silently dropped. A documented null on trench
+continuity is a finding: it tells us whether the ceiling is the metric or the
+data.
+
+Usage:
+    python scripts/screen_preseason_features.py --check-schema
+        Preflight only: verify every source column this script reads exists,
+        and exit. Run this first -- the candidate SQL spans six schemas.
+
+    python scripts/screen_preseason_features.py
+        Screen every candidate over the default 2015-2025 window.
+
+    python scripts/screen_preseason_features.py --from 2015 --to 2025
+
+Prints one line per candidate:
+    SCREEN_RESULT feature={f} n={n} partial_r={r} p={p} q={q} verdict={ship|reject}
+and a summary:
+    SCREEN_SUMMARY n_candidates={c} shipped={s} rejected={r} window={a}-{b}
+"""
+
+import argparse
+import logging
+import math
+import sys
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+# --- Pre-registered decision rule (plan section 2.5). Do not tune post hoc. ---
+
+# Minimum |partial correlation| for a candidate to be worth a column. Set from
+# the plan's proposal: below this the feature is real-but-negligible against an
+# 18.5-point residual SD, and not worth the contract surface.
+MIN_PARTIAL_R = 0.08
+
+# Benjamini-Hochberg false-discovery rate across the screened set.
+FDR_ALPHA = 0.10
+
+# Default screening window. Starts at 2015 to match the feature-availability
+# floor in the design doc (section 3).
+DEFAULT_FROM_SEASON = 2015
+DEFAULT_TO_SEASON = 2025
+
+# Below this many degrees of freedom the normal approximation to Student's t
+# (see partial_corr_pvalue) stops being safe and the p-value is not reported.
+MIN_DF_FOR_NORMAL_APPROX = 200
+
+
+# =============================================================================
+# Pure math -- no I/O, no DB, unit-tested directly (tests/test_screen_features.py).
+# =============================================================================
+
+
+def partial_correlation(x: list[float], y: list[float], z: list[float]) -> float:
+    """Partial correlation of `x` and `y` controlling for `z`.
+
+    Computed from the three pairwise Pearson correlations:
+
+        r_xy.z = (r_xy - r_xz * r_yz) / sqrt((1 - r_xz^2) * (1 - r_yz^2))
+
+    which is algebraically identical to correlating the residuals of x~z and
+    y~z, but needs no regression fit.
+
+    In this screen `y` is season-S rating and `z` is season-(S-1) rating, so
+    the result is "what this feature says about season S beyond what last
+    season already said". A feature that is purely a restatement of `z`
+    returns ~0 by construction.
+
+    Raises ValueError on unequal lengths. Returns 0.0 when either control
+    correlation is degenerate (|r| = 1), where the partial is undefined and
+    "no incremental signal" is the honest reading.
+    """
+    if not (len(x) == len(y) == len(z)):
+        raise ValueError(
+            f"partial_correlation needs equal-length inputs, got {len(x)}, {len(y)}, {len(z)}"
+        )
+    if len(x) < 3:
+        raise ValueError("partial_correlation needs at least 3 observations")
+
+    r_xy = _pearson(x, y)
+    r_xz = _pearson(x, z)
+    r_yz = _pearson(y, z)
+
+    denom = math.sqrt(max(0.0, (1.0 - r_xz**2) * (1.0 - r_yz**2)))
+    if denom == 0.0:
+        return 0.0
+    return (r_xy - r_xz * r_yz) / denom
+
+
+def _pearson(a: list[float], b: list[float]) -> float:
+    """Pearson correlation. Returns 0.0 for a constant input (no variance =
+    no signal), rather than raising on a divide-by-zero."""
+    n = len(a)
+    mean_a = sum(a) / n
+    mean_b = sum(b) / n
+    da = [v - mean_a for v in a]
+    db = [v - mean_b for v in b]
+    num = sum(p * q for p, q in zip(da, db, strict=True))
+    den = math.sqrt(sum(p * p for p in da) * sum(q * q for q in db))
+    if den == 0.0:
+        return 0.0
+    return num / den
+
+
+def partial_corr_pvalue(r: float, n: int, n_controls: int = 1) -> float | None:
+    """Two-sided p-value for a partial correlation.
+
+    The test statistic is ``t = r * sqrt(df / (1 - r^2))`` with
+    ``df = n - 2 - n_controls``, which follows Student's t under the null.
+
+    **Normal approximation, deliberately.** The repo carries no scipy (numpy
+    only -- see pyproject.toml's `compute` extra), and implementing a t CDF
+    means an incomplete beta function. At the sample sizes this screen runs on
+    (~1,400 team-seasons, so df ~1,400) Student's t and the standard normal
+    agree to well under 0.1%, so the approximation costs nothing real. Phi is
+    computed from stdlib ``math.erf``, the same approach
+    ``scripts/poll_scoreboard.py`` uses for its live win-probability Phi.
+
+    Returns None when df is too small for that approximation to be safe
+    (below MIN_DF_FOR_NORMAL_APPROX) -- the honest answer is "this screen
+    cannot p-value that", not a number computed the wrong way.
+    """
+    df = n - 2 - n_controls
+    if df < MIN_DF_FOR_NORMAL_APPROX:
+        return None
+    if abs(r) >= 1.0:
+        return 0.0
+
+    t = abs(r) * math.sqrt(df / (1.0 - r**2))
+    # Two-sided: 2 * (1 - Phi(|t|)).
+    return 2.0 * (1.0 - 0.5 * (1.0 + math.erf(t / math.sqrt(2.0))))
+
+
+def benjamini_hochberg(pvalues: list[float], alpha: float = FDR_ALPHA) -> list[float]:
+    """Benjamini-Hochberg adjusted p-values (q-values), input order preserved.
+
+    Sorts ascending, scales each by ``m / rank``, then enforces monotonicity by
+    taking a running minimum from the largest p downward so a q-value can never
+    exceed one belonging to a larger p. Values are capped at 1.0.
+
+    `alpha` is accepted for interface symmetry with the decision rule but does
+    not affect the returned q-values -- comparison happens in `screen_verdict`.
+    """
+    m = len(pvalues)
+    if m == 0:
+        return []
+
+    indexed = sorted(enumerate(pvalues), key=lambda pair: pair[1])
+    qvalues = [0.0] * m
+    running_min = 1.0
+    # Walk from the largest p down so the running minimum enforces monotonicity.
+    for rank in range(m, 0, -1):
+        original_index, p = indexed[rank - 1]
+        scaled = min(1.0, p * m / rank)
+        running_min = min(running_min, scaled)
+        qvalues[original_index] = running_min
+    return qvalues
+
+
+def screen_verdict(
+    partial_r: float,
+    qvalue: float | None,
+    min_partial_r: float = MIN_PARTIAL_R,
+    fdr_alpha: float = FDR_ALPHA,
+) -> str:
+    """Ship/reject for one candidate. BOTH conditions must hold:
+
+    1. ``|partial_r| >= min_partial_r`` -- the effect is big enough to matter.
+    2. ``qvalue <= fdr_alpha`` -- it survives FDR control across the set.
+
+    Requiring both is the point. Significance alone ships noise that happens to
+    clear a large-n test; effect size alone ships whatever the screen's widest
+    candidate happened to be. A missing q-value (df too small to test) rejects:
+    unverifiable is not the same as valuable.
+    """
+    if abs(partial_r) < min_partial_r:
+        return "reject"
+    if qvalue is None or qvalue > fdr_alpha:
+        return "reject"
+    return "ship"
+
+
+# =============================================================================
+# --- Candidate definitions ---
+# =============================================================================
+#
+# Each candidate is one column of the screening frame. The SQL below builds
+# them all at (season, team) grain alongside the outcome `sp_rating` (y) and
+# the control `prior_sp_rating` (z).
+#
+# LEAK RULE: every candidate must be knowable before week 1 of season S.
+# Recruiting classes for S, portal movement into S, and the April draft of year
+# S all precede the season. Draft picks PRODUCED are windowed to S-1..S-3 so a
+# season never sees its own draft outcomes.
+#
+# SIGN NOTE (plan section 2.4b): picks *produced* over a trailing window and
+# picks *lost* in year S are opposite signals and are kept as separate
+# candidates -- conflating them nets the effects toward zero.
+
+CANDIDATE_COLUMNS = [
+    # Tier A core (plan section 6.0)
+    "talent_stock",
+    "conversion",
+    "pipeline_index",
+    "blue_chip_pipeline",
+    # Component terms, screened separately so a composite that fails can be
+    # diagnosed rather than merely discarded.
+    "recruiting_points_3yr",
+    "draft_picks_3yr",
+    "draft_yield",
+    "portal_net_rating",
+    "draft_departures",
+]
+
+# Recruiting-class decay across the four-year eligibility window: the class
+# entering season S-1 is weighted 1.0, S-2 0.8, and so on. A flat sum would
+# treat a fifth-year contributor and a true freshman identically; the geometric
+# taper is the simplest defensible shape and is itself a tunable the screen can
+# be re-run against if the composite underperforms its components.
+CLASS_DECAY = 0.8
+CLASS_WINDOW = 4
+
+SCREEN_FRAME_QUERY = f"""
+WITH class_points AS (
+    -- Recruiting class quality per (team, year).
+    SELECT tr.team, tr.year, tr.points::double precision AS points
+    FROM recruiting.team_recruiting tr
+    WHERE tr.points IS NOT NULL
+),
+blue_chips AS (
+    -- 4-5 star signees per (team, year), the blue-chip-ratio numerator.
+    SELECT rc.committed_to AS team, rc.year,
+           COUNT(*) FILTER (WHERE rc.stars >= 4)::double precision AS blue_chips,
+           COUNT(*)::double precision AS signees
+    FROM recruiting.recruits rc
+    WHERE rc.committed_to IS NOT NULL
+    GROUP BY 1, 2
+),
+portal_flow AS (
+    -- Portal movement INTO season S (leak-free: happens before the season).
+    SELECT s.season, s.team,
+           SUM(s.in_rating) AS portal_in_rating,
+           SUM(s.out_rating) AS portal_out_rating
+    FROM (
+        SELECT tp.season, tp.destination AS team,
+               COALESCE(tp.rating, 0)::double precision AS in_rating,
+               0::double precision AS out_rating
+        FROM recruiting.transfer_portal tp
+        WHERE tp.destination IS NOT NULL
+        UNION ALL
+        SELECT tp.season, tp.origin,
+               0::double precision,
+               COALESCE(tp.rating, 0)::double precision
+        FROM recruiting.transfer_portal tp
+        WHERE tp.origin IS NOT NULL
+    ) s
+    GROUP BY 1, 2
+),
+draft_out AS (
+    -- Picks a program LOST in the April draft of year S, round-weighted
+    -- (a first-rounder is not one seventh-rounder).
+    SELECT dp.year AS season, dp.college_team AS team,
+           COUNT(*)::double precision AS picks,
+           SUM(8.0 - LEAST(7, COALESCE(dp.round, 7)))::double precision AS capital
+    FROM draft.draft_picks dp
+    WHERE dp.college_team IS NOT NULL
+    GROUP BY 1, 2
+),
+spine AS (
+    -- One row per (season, team) with the outcome and its control.
+    SELECT sp.year AS season, sp.team,
+           sp.rating::double precision AS sp_rating,
+           sp0.rating::double precision AS prior_sp_rating
+    FROM ratings.sp_ratings sp
+    JOIN ratings.sp_ratings sp0
+      ON sp0.team = sp.team AND sp0.year = sp.year - 1
+    WHERE sp.year BETWEEN %(from_season)s AND %(to_season)s
+      AND sp.rating IS NOT NULL AND sp0.rating IS NOT NULL
+)
+SELECT
+    s.season,
+    s.team,
+    s.sp_rating,
+    s.prior_sp_rating,
+    -- Decayed recruiting stock over the eligibility window (S-1..S-4).
+    COALESCE((
+        SELECT SUM(cp.points * POWER({CLASS_DECAY}, s.season - cp.year - 1))
+        FROM class_points cp
+        WHERE cp.team = s.team
+          AND cp.year BETWEEN s.season - {CLASS_WINDOW} AND s.season - 1
+    ), 0) AS recruiting_points_3yr,
+    COALESCE((
+        SELECT SUM(bc.blue_chips) / NULLIF(SUM(bc.signees), 0)
+        FROM blue_chips bc
+        WHERE bc.team = s.team
+          AND bc.year BETWEEN s.season - {CLASS_WINDOW} AND s.season - 1
+    ), 0) AS blue_chip_pipeline,
+    COALESCE(pf.portal_in_rating - pf.portal_out_rating, 0) AS portal_net_rating,
+    COALESCE(dout.picks, 0) AS draft_departures,
+    -- Picks PRODUCED over S-1..S-3 (never season S's own draft).
+    COALESCE((
+        SELECT SUM(d2.picks)
+        FROM draft_out d2
+        WHERE d2.team = s.team AND d2.season BETWEEN s.season - 3 AND s.season - 1
+    ), 0) AS draft_picks_3yr,
+    COALESCE((
+        SELECT SUM(d3.capital)
+        FROM draft_out d3
+        WHERE d3.team = s.team AND d3.season BETWEEN s.season - 3 AND s.season - 1
+    ), 0) AS draft_capital_3yr
+FROM spine s
+LEFT JOIN portal_flow pf ON pf.team = s.team AND pf.season = s.season
+LEFT JOIN draft_out dout ON dout.team = s.team AND dout.season = s.season
+ORDER BY s.season, s.team
+"""
+
+# Source columns the query above depends on, for --check-schema. Written out
+# explicitly because this script spans six schemas and a silent column rename
+# would surface as a confusing SQL error mid-screen rather than a clear
+# preflight failure.
+REQUIRED_COLUMNS: list[tuple[str, str, tuple[str, ...]]] = [
+    ("recruiting", "team_recruiting", ("team", "year", "points")),
+    ("recruiting", "recruits", ("committed_to", "year", "stars")),
+    ("recruiting", "transfer_portal", ("season", "origin", "destination", "rating")),
+    ("draft", "draft_picks", ("year", "college_team", "round")),
+    ("ratings", "sp_ratings", ("year", "team", "rating")),
+]
+
+
+def derive_composites(row: dict) -> dict:
+    """Add the Tier A composites that are cheaper to build in Python than SQL.
+
+    `talent_stock` is the accumulated recruiting stock adjusted for what has
+    left and arrived; `conversion` is draft output per unit of recruiting input
+    (the development term -- a rate, not a count); `pipeline_index` is their
+    product. See plan section 6.0.
+
+    `conversion` divides by the recruiting stock, so a program with no
+    recorded recruiting points yields 0.0 rather than a divide-by-zero -- and
+    0.0 is the right reading: no inputs means no demonstrated conversion.
+    """
+    stock = row["recruiting_points_3yr"] + row["portal_net_rating"] - row["draft_departures"]
+    denom = row["recruiting_points_3yr"]
+    conversion = (row["draft_picks_3yr"] / denom) if denom > 0 else 0.0
+    return {
+        **row,
+        "talent_stock": stock,
+        "conversion": conversion,
+        "pipeline_index": stock * conversion,
+        # draft_yield: picks produced relative to recruiting inputs, the
+        # development variant (plan section 2.4b). Same construction as
+        # `conversion` here; kept as a separate name because section 6.0b will
+        # give it a regime-scoped variant that `conversion` does not get.
+        "draft_yield": conversion,
+    }
+
+
+# =============================================================================
+# --- I/O layer ---
+# =============================================================================
+
+
+def get_db_url() -> str:
+    """Database URL from dlt secrets or environment (same pattern as the other
+    compute scripts -- each keeps its own copy of this one utility)."""
+    import os
+
+    import dlt
+
+    url = None
+    try:
+        creds = dlt.secrets.get("destination.postgres.credentials")
+        if creds:
+            url = str(creds)
+    except Exception:
+        pass
+
+    if not url:
+        url = os.environ.get("SUPABASE_DB_URL") or os.environ.get("DATABASE_URL")
+
+    if not url:
+        raise RuntimeError(
+            "No database URL found. Set destination.postgres.credentials in "
+            ".dlt/secrets.toml or SUPABASE_DB_URL environment variable."
+        )
+    return url
+
+
+def check_schema(conn) -> list[str]:
+    """Verify every column in REQUIRED_COLUMNS exists. Returns a list of
+    human-readable problems (empty = all present)."""
+    problems: list[str] = []
+    with conn.cursor() as cur:
+        for schema, table, columns in REQUIRED_COLUMNS:
+            cur.execute(
+                """
+                SELECT column_name FROM information_schema.columns
+                WHERE table_schema = %s AND table_name = %s
+                """,
+                (schema, table),
+            )
+            present = {r[0] for r in cur.fetchall()}
+            if not present:
+                problems.append(f"{schema}.{table}: table not found")
+                continue
+            missing = [c for c in columns if c not in present]
+            if missing:
+                problems.append(f"{schema}.{table}: missing column(s) {missing}")
+    return problems
+
+
+def fetch_frame(conn, from_season: int, to_season: int) -> list[dict]:
+    """Screening frame: one dict per (season, team) with outcome, control and
+    every candidate, composites already derived."""
+    import psycopg2.extras
+
+    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(
+            SCREEN_FRAME_QUERY,
+            {"from_season": from_season, "to_season": to_season},
+        )
+        rows = [dict(r) for r in cur.fetchall()]
+
+    return [derive_composites({k: _as_float(v) for k, v in row.items()}) for row in rows]
+
+
+def _as_float(value):
+    """Numeric columns arrive as Decimal; team/season stay as-is."""
+    from decimal import Decimal
+
+    if isinstance(value, Decimal):
+        return float(value)
+    return value
+
+
+def screen(frame: list[dict], candidates: list[str]) -> list[dict]:
+    """Run the screen over `frame`. Returns one result dict per candidate,
+    ordered by descending |partial_r| so the strongest signals read first."""
+    y = [r["sp_rating"] for r in frame]
+    z = [r["prior_sp_rating"] for r in frame]
+    n = len(frame)
+
+    raw: list[dict] = []
+    for name in candidates:
+        x = [r[name] for r in frame]
+        r_partial = partial_correlation(x, y, z)
+        p = partial_corr_pvalue(r_partial, n)
+        raw.append({"feature": name, "n": n, "partial_r": r_partial, "p": p})
+
+    # FDR across the whole set. Untestable candidates (p is None) are held out
+    # of the correction -- they cannot be false discoveries because they will
+    # be rejected regardless -- so they do not inflate m and penalize the rest.
+    testable = [c for c in raw if c["p"] is not None]
+    qvalues = benjamini_hochberg([c["p"] for c in testable])
+    for candidate, q in zip(testable, qvalues, strict=True):
+        candidate["q"] = q
+    for candidate in raw:
+        candidate.setdefault("q", None)
+        candidate["verdict"] = screen_verdict(candidate["partial_r"], candidate["q"])
+
+    return sorted(raw, key=lambda c: abs(c["partial_r"]), reverse=True)
+
+
+def report(results: list[dict], from_season: int, to_season: int) -> int:
+    """Print every result -- shipped AND rejected (plan section 2.5: nulls are
+    findings). Returns the number of candidates that cleared."""
+    shipped = 0
+    for c in results:
+        p_str = f"{c['p']:.5f}" if c["p"] is not None else "na"
+        q_str = f"{c['q']:.5f}" if c["q"] is not None else "na"
+        print(
+            f"SCREEN_RESULT feature={c['feature']} n={c['n']} "
+            f"partial_r={c['partial_r']:+.4f} p={p_str} q={q_str} "
+            f"verdict={c['verdict']}"
+        )
+        if c["verdict"] == "ship":
+            shipped += 1
+
+    print(
+        f"SCREEN_SUMMARY n_candidates={len(results)} shipped={shipped} "
+        f"rejected={len(results) - shipped} window={from_season}-{to_season} "
+        f"min_partial_r={MIN_PARTIAL_R} fdr_alpha={FDR_ALPHA}"
+    )
+    return shipped
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Screen candidate preseason features for incremental "
+        "predictive value beyond prior-season rating (plan section 2.5)"
+    )
+    parser.add_argument(
+        "--from",
+        dest="from_season",
+        type=int,
+        default=DEFAULT_FROM_SEASON,
+        help=f"First season to screen (default {DEFAULT_FROM_SEASON})",
+    )
+    parser.add_argument(
+        "--to",
+        dest="to_season",
+        type=int,
+        default=DEFAULT_TO_SEASON,
+        help=f"Last season to screen (default {DEFAULT_TO_SEASON})",
+    )
+    parser.add_argument(
+        "--check-schema",
+        action="store_true",
+        help="Verify every source column exists, then exit without screening",
+    )
+    args = parser.parse_args()
+
+    if args.from_season > args.to_season:
+        logger.error("--from %d is after --to %d", args.from_season, args.to_season)
+        sys.exit(1)
+
+    import psycopg2
+
+    conn = psycopg2.connect(get_db_url())
+    try:
+        problems = check_schema(conn)
+        if problems:
+            for p in problems:
+                logger.error("schema preflight: %s", p)
+            logger.error(
+                "%d schema problem(s); the candidate SQL would fail. Fix the "
+                "column references in SCREEN_FRAME_QUERY / REQUIRED_COLUMNS.",
+                len(problems),
+            )
+            sys.exit(1)
+        logger.info("Schema preflight passed (%d table(s))", len(REQUIRED_COLUMNS))
+        if args.check_schema:
+            return
+
+        frame = fetch_frame(conn, args.from_season, args.to_season)
+        if len(frame) < MIN_DF_FOR_NORMAL_APPROX:
+            logger.error(
+                "Only %d team-season(s) in %d-%d; too few to screen reliably",
+                len(frame),
+                args.from_season,
+                args.to_season,
+            )
+            sys.exit(1)
+        logger.info(
+            "Screening %d candidate(s) over %d team-season(s)", len(CANDIDATE_COLUMNS), len(frame)
+        )
+
+        results = screen(frame, CANDIDATE_COLUMNS)
+        report(results, args.from_season, args.to_season)
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/simulate_season.py
+++ b/scripts/simulate_season.py
@@ -1,0 +1,573 @@
+#!/usr/bin/env python3
+"""Simulate season outcomes into predictions.season_projections.
+
+Plan: docs/plans/2026-07-25-preseason-outlook-model-plan.md Phase 4. Target
+DDL: src/schemas/migrations/043_season_projections.sql.
+
+WHY THIS EXISTS
+---------------
+Everything the warehouse predicted before this was a per-game point estimate.
+Asked for a team's season outlook, the only honest answer was a list of twelve
+spreads -- which is not a win total, carries no interval, and cannot say
+"62% to reach 9 wins". This script composes the per-game predictions into the
+season-level object that question actually needs.
+
+METHOD
+------
+Monte Carlo over the team's schedule:
+
+  - Completed games contribute their ACTUAL result (so an in-season projection
+    is "record so far + simulated remainder", not a fantasy re-run of games
+    already played).
+  - Each remaining game draws ``margin ~ Normal(expected_home_margin, sigma)``
+    and the home team wins iff the drawn margin is positive.
+  - Wins accumulate per team per simulation, giving a full distribution rather
+    than a point estimate.
+
+``sigma`` is MEASURED per model from completed games -- ``stddev_pop(actual -
+predicted)`` -- never hardcoded, and is written to every row so a projection
+always carries the assumption that produced it. For fitted_v1 on 2025 this is
+about 18.5 points.
+
+Drawing the margin (rather than flipping the stored ``home_win_prob``) keeps a
+single, explicit, tunable uncertainty parameter instead of relying on per-game
+Platt-calibrated probabilities that were never jointly calibrated across a
+season.
+
+KNOWN v1 LIMITATION -- INDEPENDENT DRAWS
+----------------------------------------
+Each game is drawn independently. Real season outcomes are correlated: a team
+genuinely better than its rating beats *everyone* more often, so its wins
+cluster. Independent draws therefore understate BOTH tails -- 11-win and 2-win
+seasons are each less likely under this model than in reality. Central
+tendency (``projected_wins``, ``median_wins``) is essentially unaffected;
+``wins_p10``/``wins_p90``/``p_ten_plus`` are conservative at the edges. The
+fix (draw one per-team season-strength offset per simulation and apply it to
+all of that team's games) is a small change, deliberately deferred to v1.1 so
+the honest version ships first. The limitation is also recorded in the
+``n_sims`` column comment for downstream consumers.
+
+Usage:
+    python scripts/simulate_season.py
+        Simulate every projection season (the current season plus any later
+        season with a published schedule).
+
+    python scripts/simulate_season.py --season 2026
+    python scripts/simulate_season.py --season 2026 --model fitted_v1 --sims 10000
+
+Each season prints:
+    SIM_GATE season={s} model={m} teams={t} sims={n} sigma={g} complete={c}
+"""
+
+import argparse
+import logging
+import sys
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "fitted_v1"
+DEFAULT_SIMS = 10_000
+
+# Fixed so a re-run reproduces the same projection given the same inputs.
+# Without this, the daily snapshot would jitter by simulation noise alone and
+# the append-only history would show movement that is not a change of opinion.
+DEFAULT_SEED = 20260726
+
+# A schedule is "complete" enough for a season win total to mean what a reader
+# assumes at this many regular-season games. Below it the projection is still
+# written -- over the games that exist -- but flagged.
+COMPLETE_SCHEDULE_GAMES = 11
+
+# Bowl eligibility, and the "double-digit season" threshold the outlook surface
+# reports.
+BOWL_ELIGIBLE_WINS = 6
+TEN_PLUS_WINS = 10
+
+
+# =============================================================================
+# Pure functions -- no I/O, no DB, unit-tested directly
+# (tests/test_simulate_season.py).
+# =============================================================================
+
+
+def simulate_wins(games, n_sims, sigma, seed=DEFAULT_SEED):
+    """Simulate `n_sims` seasons; return ``{team: ndarray[n_sims] of win counts}``.
+
+    ``games`` is a list of dicts with ``home_team``, ``away_team``,
+    ``completed``, ``home_win`` (bool, only read when completed) and
+    ``expected_home_margin`` (only read when not completed).
+
+    Completed games add a deterministic win to the actual winner in every
+    simulation -- results already in the book are not re-rolled. Remaining
+    games draw a margin per simulation.
+
+    Vectorized: one ``(n_pending, n_sims)`` normal draw, then column sums per
+    team. At ~1,600 games x 10,000 sims this is ~16M doubles (~128MB) and runs
+    in about a second, where a per-simulation Python loop would take minutes.
+
+    A game whose ``expected_home_margin`` is None is SKIPPED (it contributes to
+    neither side) rather than treated as a coin flip -- silently inventing a
+    50/50 game would bias every projection toward .500 in proportion to how
+    much of the schedule is unscored.
+    """
+    import numpy as np
+
+    teams = sorted({g["home_team"] for g in games} | {g["away_team"] for g in games})
+    index = {t: i for i, t in enumerate(teams)}
+    wins = np.zeros((len(teams), n_sims), dtype=np.int32)
+
+    pending = []
+    for g in games:
+        if g["completed"]:
+            winner = g["home_team"] if g["home_win"] else g["away_team"]
+            wins[index[winner], :] += 1
+        elif g.get("expected_home_margin") is not None:
+            pending.append(g)
+
+    if pending:
+        rng = np.random.default_rng(seed)
+        mu = np.array([g["expected_home_margin"] for g in pending], dtype=np.float64)
+        draws = rng.normal(loc=mu[:, None], scale=sigma, size=(len(pending), n_sims))
+        home_won = draws > 0.0
+        for row, g in enumerate(pending):
+            h, a = index[g["home_team"]], index[g["away_team"]]
+            wins[h, :] += home_won[row]
+            wins[a, :] += ~home_won[row]
+
+    return {t: wins[index[t], :] for t in teams}
+
+
+def win_distribution(team_wins, games_scheduled):
+    """``{win_count: probability}`` over 0..games_scheduled, summing to 1.
+
+    Keys are ints covering the full range (zeros included) so consumers can
+    index without checking membership; the DDL stores it as JSONB with string
+    keys, which the writer converts.
+    """
+    import numpy as np
+
+    n_sims = len(team_wins)
+    counts = np.bincount(team_wins, minlength=games_scheduled + 1)
+    return {w: float(counts[w]) / n_sims for w in range(games_scheduled + 1)}
+
+
+def summarize(team_wins, games_scheduled):
+    """Central tendency, percentiles and threshold probabilities for one team.
+
+    Percentiles use the ``lower`` interpolation method: win totals are integers,
+    and reporting a p10 of 7.4 wins would imply a precision the quantity does
+    not have.
+    """
+    import numpy as np
+
+    return {
+        "projected_wins": float(np.mean(team_wins)),
+        "projected_losses": float(games_scheduled - np.mean(team_wins)),
+        "median_wins": float(np.percentile(team_wins, 50, method="lower")),
+        "wins_p10": float(np.percentile(team_wins, 10, method="lower")),
+        "wins_p25": float(np.percentile(team_wins, 25, method="lower")),
+        "wins_p75": float(np.percentile(team_wins, 75, method="lower")),
+        "wins_p90": float(np.percentile(team_wins, 90, method="lower")),
+        "p_bowl_eligible": float(np.mean(team_wins >= BOWL_ELIGIBLE_WINS)),
+        "p_ten_plus": float(np.mean(team_wins >= TEN_PLUS_WINS)),
+    }
+
+
+def schedule_strength(team, games, ratings):
+    """Average opponent rating over `team`'s scheduled games.
+
+    Opponents missing from `ratings` are skipped rather than scored 0 -- an
+    FCS opponent with no rating would otherwise drag a schedule's average down
+    as if it were a merely-bad FBS team. Returns None when no opponent has a
+    rating, which the writer stores as NULL.
+    """
+    opp_ratings = []
+    for g in games:
+        if g["home_team"] == team:
+            opp = g["away_team"]
+        elif g["away_team"] == team:
+            opp = g["home_team"]
+        else:
+            continue
+        if opp in ratings and ratings[opp] is not None:
+            opp_ratings.append(ratings[opp])
+    if not opp_ratings:
+        return None
+    return sum(opp_ratings) / len(opp_ratings)
+
+
+def conference_title_probs(wins_by_team, conf_by_team, games_played):
+    """P(highest conference win pct) per team, ties split evenly.
+
+    **v1 crude, deliberately.** Real conference championships turn on
+    tiebreakers, division/pod structure and a title game; none of that is
+    modeled. A team's odds here are simply the share of simulations in which
+    it holds (or shares) the best win percentage in its conference. Win
+    *percentage* rather than raw wins, because conference members can have
+    different numbers of scheduled games.
+    """
+    import numpy as np
+
+    by_conf = {}
+    for team, conf in conf_by_team.items():
+        if conf and team in wins_by_team and games_played.get(team, 0) > 0:
+            by_conf.setdefault(conf, []).append(team)
+
+    probs = {}
+    for _conf, members in by_conf.items():
+        if len(members) < 2:
+            continue
+        pct = np.vstack([wins_by_team[t] / games_played[t] for t in members])
+        best = pct.max(axis=0)
+        is_best = pct >= best  # ties included
+        share = is_best / is_best.sum(axis=0)  # split evenly among tied teams
+        for i, t in enumerate(members):
+            probs[t] = float(share[i].mean())
+    return probs
+
+
+def build_projection_row(
+    team, team_wins, games, ratings, conf, model_version, n_sims, sigma, conf_title_prob
+):
+    """One predictions.season_projections row dict for `team`."""
+    team_games = [g for g in games if team in (g["home_team"], g["away_team"])]
+    completed = [g for g in team_games if g["completed"]]
+    actual_wins = sum(
+        1
+        for g in completed
+        if (g["home_team"] == team and g["home_win"])
+        or (g["away_team"] == team and not g["home_win"])
+    )
+    games_scheduled = len(team_games)
+
+    row = {
+        "model_version": model_version,
+        "season": games[0]["season"] if games else None,
+        "team": team,
+        "conference": conf,
+        "games_scheduled": games_scheduled,
+        "games_completed": len(completed),
+        "actual_wins": actual_wins,
+        "schedule_complete": games_scheduled >= COMPLETE_SCHEDULE_GAMES,
+        "p_win_dist": {str(k): v for k, v in win_distribution(team_wins, games_scheduled).items()},
+        "sos_rating": schedule_strength(team, team_games, ratings),
+        "sos_rank": None,  # filled after all teams are summarized
+        "conf_title_prob": conf_title_prob,
+        "playoff_prob": None,  # see migration 043 -- not modeled in v1
+        "n_sims": n_sims,
+        "residual_sigma": sigma,
+    }
+    row.update(summarize(team_wins, games_scheduled))
+    return row
+
+
+def assign_sos_ranks(rows):
+    """Rank rows by descending sos_rating (1 = toughest). Rows with a NULL
+    rating keep sos_rank None. Mutates and returns `rows`."""
+    rated = [r for r in rows if r["sos_rating"] is not None]
+    for rank, row in enumerate(sorted(rated, key=lambda r: -r["sos_rating"]), start=1):
+        row["sos_rank"] = rank
+    return rows
+
+
+# =============================================================================
+# --- I/O layer ---
+# =============================================================================
+
+
+def get_db_url() -> str:
+    """Database URL from dlt secrets or environment (same pattern the other
+    compute scripts use -- each keeps its own copy of this one utility)."""
+    import os
+
+    import dlt
+
+    url = None
+    try:
+        creds = dlt.secrets.get("destination.postgres.credentials")
+        if creds:
+            url = str(creds)
+    except Exception:
+        pass
+
+    if not url:
+        url = os.environ.get("SUPABASE_DB_URL") or os.environ.get("DATABASE_URL")
+
+    if not url:
+        raise RuntimeError(
+            "No database URL found. Set destination.postgres.credentials in "
+            ".dlt/secrets.toml or SUPABASE_DB_URL environment variable."
+        )
+    return url
+
+
+# Latest snapshot per game for the chosen model. predictions.game_predictions
+# is append-only across days, so DISTINCT ON picks the most recent read rather
+# than an arbitrary historical one -- the same idiom
+# compute_predictions.MARKET_SNAPSHOTS_QUERY uses.
+SEASON_GAMES_QUERY = """
+    SELECT g.id AS game_id, g.season, g.home_team, g.away_team,
+           COALESCE(g.completed, false) AS completed,
+           g.home_points, g.away_points,
+           g.home_conference, g.away_conference,
+           p.expected_home_margin
+    FROM core.games g
+    LEFT JOIN LATERAL (
+        SELECT gp.expected_home_margin
+        FROM predictions.game_predictions gp
+        WHERE gp.game_id = g.id AND gp.model_version = %(model)s
+        ORDER BY gp.prediction_date DESC, gp.computed_at DESC
+        LIMIT 1
+    ) p ON true
+    WHERE g.season = %(season)s
+    ORDER BY g.id
+"""
+
+# Team rating for the schedule-strength calculation: the most recent pregame
+# Elo the model recorded for that team this season.
+TEAM_RATINGS_QUERY = """
+    SELECT team, rating FROM analytics.house_elo_current
+"""
+
+RESIDUAL_SIGMA_QUERY = """
+    SELECT stddev_pop(
+        (g.home_points - g.away_points)::double precision - p.expected_home_margin
+    )
+    FROM predictions.game_predictions p
+    JOIN core.games g ON g.id = p.game_id
+    WHERE p.model_version = %(model)s
+      AND COALESCE(g.completed, false)
+      AND g.home_points IS NOT NULL AND g.away_points IS NOT NULL
+      AND p.expected_home_margin IS NOT NULL
+"""
+
+
+def fetch_sigma(conn, model: str) -> float:
+    """Measured residual SD for `model`. Hard error rather than a default:
+    a wrong sigma produces confident, well-formatted, wrong win totals, and a
+    silent fallback is exactly how that ships unnoticed."""
+    with conn.cursor() as cur:
+        cur.execute(RESIDUAL_SIGMA_QUERY, {"model": model})
+        row = cur.fetchone()[0]
+    if row is None:
+        raise RuntimeError(
+            f"No completed games with {model} predictions; cannot measure residual sigma. "
+            "Backfill predictions before simulating."
+        )
+    return float(row)
+
+
+def fetch_season_games(conn, season: int, model: str) -> list[dict]:
+    import psycopg2.extras
+
+    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(SEASON_GAMES_QUERY, {"season": season, "model": model})
+        rows = [dict(r) for r in cur.fetchall()]
+
+    games = []
+    for r in rows:
+        home_win = None
+        if r["completed"] and r["home_points"] is not None and r["away_points"] is not None:
+            home_win = r["home_points"] > r["away_points"]
+        games.append(
+            {
+                "game_id": r["game_id"],
+                "season": r["season"],
+                "home_team": r["home_team"],
+                "away_team": r["away_team"],
+                # A game flagged completed but missing a score cannot contribute
+                # a result; treat it as pending so it is simulated rather than
+                # awarded to nobody.
+                "completed": home_win is not None,
+                "home_win": home_win,
+                "home_conference": r["home_conference"],
+                "away_conference": r["away_conference"],
+                "expected_home_margin": (
+                    float(r["expected_home_margin"])
+                    if r["expected_home_margin"] is not None
+                    else None
+                ),
+            }
+        )
+    return games
+
+
+def fetch_team_ratings(conn) -> dict:
+    with conn.cursor() as cur:
+        cur.execute(TEAM_RATINGS_QUERY)
+        return {team: float(rating) for team, rating in cur.fetchall() if rating is not None}
+
+
+_ROW_COLUMNS = [
+    "model_version",
+    "season",
+    "team",
+    "conference",
+    "games_scheduled",
+    "games_completed",
+    "actual_wins",
+    "schedule_complete",
+    "projected_wins",
+    "projected_losses",
+    "median_wins",
+    "wins_p10",
+    "wins_p25",
+    "wins_p75",
+    "wins_p90",
+    "p_win_dist",
+    "p_bowl_eligible",
+    "p_ten_plus",
+    "sos_rating",
+    "sos_rank",
+    "conf_title_prob",
+    "playoff_prob",
+    "n_sims",
+    "residual_sigma",
+]
+
+# The conflict-key columns are the ones NOT refreshed on a same-day re-run.
+_CONFLICT_COLUMNS = ("season", "team", "model_version")
+_UPDATE_ASSIGNMENTS = ", ".join(
+    f"{c} = EXCLUDED.{c}" for c in _ROW_COLUMNS if c not in _CONFLICT_COLUMNS
+)
+
+# Same-day convergence only -- a re-run updates today's snapshot, never a
+# prior day's (migration 043, mirroring migration 024's semantics).
+_UPSERT_SQL = f"""
+    INSERT INTO predictions.season_projections ({", ".join(_ROW_COLUMNS)})
+    VALUES %s
+    ON CONFLICT (season, team, model_version, projection_date) DO UPDATE SET
+        {_UPDATE_ASSIGNMENTS},
+        computed_at = now()
+"""
+
+
+def write_projections(conn, rows: list[dict]) -> None:
+    import json
+
+    from psycopg2.extras import execute_values
+
+    if not rows:
+        return
+    values = [
+        tuple(json.dumps(r[c]) if c == "p_win_dist" else r[c] for c in _ROW_COLUMNS) for r in rows
+    ]
+    with conn.cursor() as cur:
+        execute_values(cur, _UPSERT_SQL, values)
+    conn.commit()
+
+
+def simulate_one_season(conn, season: int, model: str, n_sims: int, seed: int) -> int:
+    """Simulate and write one season. Returns the number of team rows written."""
+    games = fetch_season_games(conn, season, model)
+    if not games:
+        logger.info("season=%d: no games in core.games, skipping", season)
+        return 0
+
+    scored = sum(1 for g in games if not g["completed"] and g["expected_home_margin"] is not None)
+    pending = sum(1 for g in games if not g["completed"])
+    if pending and not scored:
+        logger.warning(
+            "season=%d: %d pending game(s) but NONE have %s predictions -- "
+            "projections will reflect completed games only",
+            season,
+            pending,
+            model,
+        )
+
+    sigma = fetch_sigma(conn, model)
+    ratings = fetch_team_ratings(conn)
+    wins_by_team = simulate_wins(games, n_sims, sigma, seed=seed)
+
+    conf_by_team = {}
+    games_played = {}
+    for g in games:
+        for side, conf in (("home_team", "home_conference"), ("away_team", "away_conference")):
+            conf_by_team.setdefault(g[side], g[conf])
+            games_played[g[side]] = games_played.get(g[side], 0) + 1
+
+    title_probs = conference_title_probs(wins_by_team, conf_by_team, games_played)
+
+    rows = [
+        build_projection_row(
+            team,
+            team_wins,
+            games,
+            ratings,
+            conf_by_team.get(team),
+            model,
+            n_sims,
+            sigma,
+            title_probs.get(team),
+        )
+        for team, team_wins in wins_by_team.items()
+    ]
+    assign_sos_ranks(rows)
+    write_projections(conn, rows)
+
+    complete = sum(1 for r in rows if r["schedule_complete"])
+    print(
+        f"SIM_GATE season={season} model={model} teams={len(rows)} sims={n_sims} "
+        f"sigma={sigma:.2f} complete={complete}"
+    )
+    logger.info(
+        "season=%d: wrote %d team projection(s), sigma=%.2f, %d with a complete schedule",
+        season,
+        len(rows),
+        sigma,
+        complete,
+    )
+    return len(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Simulate season outcomes into predictions.season_projections"
+    )
+    parser.add_argument(
+        "--season",
+        type=int,
+        default=None,
+        help="Season to simulate (default: every projection season)",
+    )
+    parser.add_argument(
+        "--model", default=DEFAULT_MODEL, help=f"Model version (default {DEFAULT_MODEL})"
+    )
+    parser.add_argument(
+        "--sims",
+        type=int,
+        default=DEFAULT_SIMS,
+        help=f"Simulations per season (default {DEFAULT_SIMS})",
+    )
+    parser.add_argument(
+        "--seed", type=int, default=DEFAULT_SEED, help="RNG seed; fixed so re-runs reproduce"
+    )
+    args = parser.parse_args()
+
+    import psycopg2
+
+    conn = psycopg2.connect(get_db_url())
+    try:
+        if args.season is not None:
+            seasons = [args.season]
+        else:
+            from src.pipelines.config.years import get_projection_seasons
+
+            seasons = get_projection_seasons(conn)
+            logger.info("Projection seasons: %s", seasons)
+
+        total = 0
+        for season in seasons:
+            total += simulate_one_season(conn, season, args.model, args.sims, args.seed)
+        logger.info("Wrote %d projection row(s) across %d season(s)", total, len(seasons))
+    except Exception:
+        conn.rollback()
+        logger.exception("season simulation failed")
+        sys.exit(1)
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/simulate_season.py
+++ b/scripts/simulate_season.py
@@ -84,6 +84,18 @@ COMPLETE_SCHEDULE_GAMES = 11
 BOWL_ELIGIBLE_WINS = 6
 TEN_PLUS_WINS = 10
 
+# Refuse to simulate on a residual SD estimated from fewer than this many
+# completed games -- sigma drives every probability the script writes, so a
+# noisy estimate is worse than an explicit failure.
+MIN_SIGMA_GAMES = 100
+
+# Projections describe the REGULAR season. CFBD marks conference championship
+# games as season_type='regular' (they are the final regular week), so this
+# filter keeps CCGs while excluding bowls and playoff games -- which would
+# otherwise inflate games_scheduled, make p_bowl_eligible circular, and cause
+# projections to jump as the postseason bracket is published.
+PROJECTION_SEASON_TYPE = "regular"
+
 
 # =============================================================================
 # Pure functions -- no I/O, no DB, unit-tested directly
@@ -92,38 +104,68 @@ TEN_PLUS_WINS = 10
 
 
 def simulate_wins(games, n_sims, sigma, seed=DEFAULT_SEED):
-    """Simulate `n_sims` seasons; return ``{team: ndarray[n_sims] of win counts}``.
+    """Simulate `n_sims` seasons over `games`.
+
+    Returns a dict of per-team results:
+
+    ``wins``            {team: ndarray[n_sims]} -- wins over all counted games
+    ``conf_wins``       {team: ndarray[n_sims]} -- wins in conference games only
+    ``games_simulated`` {team: int}             -- games that actually counted
+    ``conf_games``      {team: int}             -- conference games that counted
 
     ``games`` is a list of dicts with ``home_team``, ``away_team``,
-    ``completed``, ``home_win`` (bool, only read when completed) and
-    ``expected_home_margin`` (only read when not completed).
+    ``completed``, ``home_win`` (read only when completed),
+    ``expected_home_margin`` (read only when pending) and ``conference_game``.
 
     Completed games add a deterministic win to the actual winner in every
-    simulation -- results already in the book are not re-rolled. Remaining
-    games draw a margin per simulation.
+    simulation -- results already in the book are not re-rolled. Remaining games
+    draw a margin per simulation.
 
-    Vectorized: one ``(n_pending, n_sims)`` normal draw, then column sums per
-    team. At ~1,600 games x 10,000 sims this is ~16M doubles (~128MB) and runs
-    in about a second, where a per-simulation Python loop would take minutes.
+    Vectorized: one ``(n_pending, n_sims)`` normal draw, then per-team
+    accumulation. At ~1,600 games x 10,000 sims this is ~16M doubles (~128MB)
+    and runs in about a second, where a per-simulation Python loop would take
+    minutes.
 
-    A game whose ``expected_home_margin`` is None is SKIPPED (it contributes to
-    neither side) rather than treated as a coin flip -- silently inventing a
-    50/50 game would bias every projection toward .500 in proportion to how
-    much of the schedule is unscored.
+    **Conference wins are accumulated from the SAME draws**, not a second
+    simulation. Re-simulating would let a game be a win in the overall tally and
+    a loss in the conference tally within one "season", making title odds
+    inconsistent with the win totals shown beside them.
+
+    A game whose ``expected_home_margin`` is None is SKIPPED entirely -- it
+    counts toward neither wins nor ``games_simulated``. Inventing a 50/50 game
+    would bias projections toward .500, and counting it in the denominator
+    without letting it produce a win would make it a guaranteed loss. Callers
+    must use ``games_simulated``, not the raw schedule length, as the
+    denominator.
     """
     import numpy as np
 
     teams = sorted({g["home_team"] for g in games} | {g["away_team"] for g in games})
     index = {t: i for i, t in enumerate(teams)}
-    wins = np.zeros((len(teams), n_sims), dtype=np.int32)
+    n_teams = len(teams)
+    wins = np.zeros((n_teams, n_sims), dtype=np.int32)
+    conf_wins = np.zeros((n_teams, n_sims), dtype=np.int32)
+    games_simulated = dict.fromkeys(teams, 0)
+    conf_games = dict.fromkeys(teams, 0)
+
+    def _count(g):
+        games_simulated[g["home_team"]] += 1
+        games_simulated[g["away_team"]] += 1
+        if g.get("conference_game"):
+            conf_games[g["home_team"]] += 1
+            conf_games[g["away_team"]] += 1
 
     pending = []
     for g in games:
         if g["completed"]:
             winner = g["home_team"] if g["home_win"] else g["away_team"]
             wins[index[winner], :] += 1
+            if g.get("conference_game"):
+                conf_wins[index[winner], :] += 1
+            _count(g)
         elif g.get("expected_home_margin") is not None:
             pending.append(g)
+            _count(g)
 
     if pending:
         rng = np.random.default_rng(seed)
@@ -134,12 +176,24 @@ def simulate_wins(games, n_sims, sigma, seed=DEFAULT_SEED):
             h, a = index[g["home_team"]], index[g["away_team"]]
             wins[h, :] += home_won[row]
             wins[a, :] += ~home_won[row]
+            if g.get("conference_game"):
+                conf_wins[h, :] += home_won[row]
+                conf_wins[a, :] += ~home_won[row]
 
-    return {t: wins[index[t], :] for t in teams}
+    return {
+        "wins": {t: wins[index[t], :] for t in teams},
+        "conf_wins": {t: conf_wins[index[t], :] for t in teams},
+        "games_simulated": games_simulated,
+        "conf_games": conf_games,
+    }
 
 
-def win_distribution(team_wins, games_scheduled):
-    """``{win_count: probability}`` over 0..games_scheduled, summing to 1.
+def win_distribution(team_wins, games_simulated):
+    """``{win_count: probability}`` over 0..games_simulated, summing to 1.
+
+    The range is the number of games actually SIMULATED, not the number
+    scheduled. Spanning the full schedule when some games were skipped would
+    reserve probability mass for win totals the simulation can never produce.
 
     Keys are ints covering the full range (zeros included) so consumers can
     index without checking membership; the DDL stores it as JSONB with string
@@ -148,12 +202,18 @@ def win_distribution(team_wins, games_scheduled):
     import numpy as np
 
     n_sims = len(team_wins)
-    counts = np.bincount(team_wins, minlength=games_scheduled + 1)
-    return {w: float(counts[w]) / n_sims for w in range(games_scheduled + 1)}
+    counts = np.bincount(team_wins, minlength=games_simulated + 1)
+    return {w: float(counts[w]) / n_sims for w in range(games_simulated + 1)}
 
 
-def summarize(team_wins, games_scheduled):
+def summarize(team_wins, games_simulated):
     """Central tendency, percentiles and threshold probabilities for one team.
+
+    ``games_simulated`` -- NOT the scheduled count -- is the denominator for
+    ``projected_losses``. Using the schedule length would turn every game the
+    simulation skipped (no prediction available) into a guaranteed loss, which
+    is a stronger and more wrong claim than the coin flip skipping was meant to
+    avoid.
 
     Percentiles use the ``lower`` interpolation method: win totals are integers,
     and reporting a p10 of 7.4 wins would imply a precision the quantity does
@@ -163,7 +223,7 @@ def summarize(team_wins, games_scheduled):
 
     return {
         "projected_wins": float(np.mean(team_wins)),
-        "projected_losses": float(games_scheduled - np.mean(team_wins)),
+        "projected_losses": float(games_simulated - np.mean(team_wins)),
         "median_wins": float(np.percentile(team_wins, 50, method="lower")),
         "wins_p10": float(np.percentile(team_wins, 10, method="lower")),
         "wins_p25": float(np.percentile(team_wins, 25, method="lower")),
@@ -197,28 +257,35 @@ def schedule_strength(team, games, ratings):
     return sum(opp_ratings) / len(opp_ratings)
 
 
-def conference_title_probs(wins_by_team, conf_by_team, games_played):
-    """P(highest conference win pct) per team, ties split evenly.
+def conference_title_probs(conf_wins_by_team, conf_by_team, conf_games_played):
+    """P(best CONFERENCE record) per team, ties split evenly.
 
-    **v1 crude, deliberately.** Real conference championships turn on
-    tiebreakers, division/pod structure and a title game; none of that is
-    modeled. A team's odds here are simply the share of simulations in which
-    it holds (or shares) the best win percentage in its conference. Win
-    *percentage* rather than raw wins, because conference members can have
-    different numbers of scheduled games.
+    Takes **conference-only** wins and game counts. Using overall record here
+    would let a team buy title odds with non-conference wins -- beating three
+    weak out-of-conference opponents would outrank a better league record,
+    which is not how any conference decides a champion.
+
+    Win *percentage* rather than raw wins, because conference members can play
+    different numbers of league games (uneven schedules are routine in
+    16-team leagues).
+
+    **v1 crude, deliberately.** Real championships turn on head-to-head and
+    divisional tiebreakers and a title game; none of that is modeled. A team's
+    odds here are the share of simulations in which it holds (or shares) the
+    best conference win percentage.
     """
     import numpy as np
 
     by_conf = {}
     for team, conf in conf_by_team.items():
-        if conf and team in wins_by_team and games_played.get(team, 0) > 0:
+        if conf and team in conf_wins_by_team and conf_games_played.get(team, 0) > 0:
             by_conf.setdefault(conf, []).append(team)
 
     probs = {}
     for _conf, members in by_conf.items():
         if len(members) < 2:
             continue
-        pct = np.vstack([wins_by_team[t] / games_played[t] for t in members])
+        pct = np.vstack([conf_wins_by_team[t] / conf_games_played[t] for t in members])
         best = pct.max(axis=0)
         is_best = pct >= best  # ties included
         share = is_best / is_best.sum(axis=0)  # split evenly among tied teams
@@ -228,9 +295,25 @@ def conference_title_probs(wins_by_team, conf_by_team, games_played):
 
 
 def build_projection_row(
-    team, team_wins, games, ratings, conf, model_version, n_sims, sigma, conf_title_prob
+    team,
+    team_wins,
+    games,
+    ratings,
+    conf,
+    model_version,
+    n_sims,
+    sigma,
+    conf_title_prob,
+    games_simulated,
 ):
-    """One predictions.season_projections row dict for `team`."""
+    """One predictions.season_projections row dict for `team`.
+
+    ``games_scheduled`` is reported for transparency, but every projected
+    quantity is computed over ``games_simulated`` -- the games that actually
+    contributed an outcome. When a pending game has no prediction the two
+    differ, and folding that gap into ``projected_losses`` would present a
+    missing game as a certain defeat.
+    """
     team_games = [g for g in games if team in (g["home_team"], g["away_team"])]
     completed = [g for g in team_games if g["completed"]]
     actual_wins = sum(
@@ -247,10 +330,11 @@ def build_projection_row(
         "team": team,
         "conference": conf,
         "games_scheduled": games_scheduled,
+        "games_simulated": games_simulated,
         "games_completed": len(completed),
         "actual_wins": actual_wins,
         "schedule_complete": games_scheduled >= COMPLETE_SCHEDULE_GAMES,
-        "p_win_dist": {str(k): v for k, v in win_distribution(team_wins, games_scheduled).items()},
+        "p_win_dist": {str(k): v for k, v in win_distribution(team_wins, games_simulated).items()},
         "sos_rating": schedule_strength(team, team_games, ratings),
         "sos_rank": None,  # filled after all teams are summarized
         "conf_title_prob": conf_title_prob,
@@ -258,7 +342,7 @@ def build_projection_row(
         "n_sims": n_sims,
         "residual_sigma": sigma,
     }
-    row.update(summarize(team_wins, games_scheduled))
+    row.update(summarize(team_wins, games_simulated))
     return row
 
 
@@ -311,6 +395,7 @@ SEASON_GAMES_QUERY = """
            COALESCE(g.completed, false) AS completed,
            g.home_points, g.away_points,
            g.home_conference, g.away_conference,
+           COALESCE(g.conference_game, false) AS conference_game,
            p.expected_home_margin
     FROM core.games g
     LEFT JOIN LATERAL (
@@ -321,6 +406,7 @@ SEASON_GAMES_QUERY = """
         LIMIT 1
     ) p ON true
     WHERE g.season = %(season)s
+      AND g.season_type = %(season_type)s
     ORDER BY g.id
 """
 
@@ -330,39 +416,64 @@ TEAM_RATINGS_QUERY = """
     SELECT team, rating FROM analytics.house_elo_current
 """
 
+# ONE snapshot per game before the aggregate. predictions.game_predictions is
+# append-only daily, so a naive join contributes a game once per day it was
+# predicted: games that sat on the board for weeks would dominate the estimate,
+# and their early, worse predictions would mix with the final pregame one. That
+# is not a per-game residual SD, and since sigma drives every simulated
+# probability, the error would propagate into every number this script writes.
+# DISTINCT ON takes the last snapshot at or before kickoff -- the pregame read
+# the simulation is actually modelling.
 RESIDUAL_SIGMA_QUERY = """
-    SELECT stddev_pop(
-        (g.home_points - g.away_points)::double precision - p.expected_home_margin
+    WITH latest AS (
+        SELECT DISTINCT ON (p.game_id)
+               p.game_id,
+               p.expected_home_margin,
+               g.home_points - g.away_points AS actual_margin
+        FROM predictions.game_predictions p
+        JOIN core.games g ON g.id = p.game_id
+        WHERE p.model_version = %(model)s
+          AND COALESCE(g.completed, false)
+          AND g.home_points IS NOT NULL AND g.away_points IS NOT NULL
+          AND p.expected_home_margin IS NOT NULL
+          AND (g.start_date IS NULL OR p.prediction_date <= g.start_date::date)
+        ORDER BY p.game_id, p.prediction_date DESC, p.computed_at DESC
     )
-    FROM predictions.game_predictions p
-    JOIN core.games g ON g.id = p.game_id
-    WHERE p.model_version = %(model)s
-      AND COALESCE(g.completed, false)
-      AND g.home_points IS NOT NULL AND g.away_points IS NOT NULL
-      AND p.expected_home_margin IS NOT NULL
+    SELECT stddev_pop(actual_margin::double precision - expected_home_margin),
+           COUNT(*)
+    FROM latest
 """
 
 
 def fetch_sigma(conn, model: str) -> float:
-    """Measured residual SD for `model`. Hard error rather than a default:
-    a wrong sigma produces confident, well-formatted, wrong win totals, and a
-    silent fallback is exactly how that ships unnoticed."""
+    """Measured residual SD for `model`, one pregame snapshot per game.
+
+    Hard error rather than a default: a wrong sigma produces confident,
+    well-formatted, wrong win totals, and a silent fallback is exactly how that
+    ships unnoticed. A tiny sample is refused for the same reason -- an SD
+    estimated from a handful of games is not a usable uncertainty parameter.
+    """
     with conn.cursor() as cur:
         cur.execute(RESIDUAL_SIGMA_QUERY, {"model": model})
-        row = cur.fetchone()[0]
-    if row is None:
+        sigma, n_games = cur.fetchone()
+    if sigma is None or n_games < MIN_SIGMA_GAMES:
         raise RuntimeError(
-            f"No completed games with {model} predictions; cannot measure residual sigma. "
+            f"Only {n_games or 0} completed game(s) with a pregame {model} prediction "
+            f"(need >= {MIN_SIGMA_GAMES}); cannot measure a trustworthy residual sigma. "
             "Backfill predictions before simulating."
         )
-    return float(row)
+    logger.info("Measured residual sigma for %s: %.2f over %d game(s)", model, sigma, n_games)
+    return float(sigma)
 
 
 def fetch_season_games(conn, season: int, model: str) -> list[dict]:
     import psycopg2.extras
 
     with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
-        cur.execute(SEASON_GAMES_QUERY, {"season": season, "model": model})
+        cur.execute(
+            SEASON_GAMES_QUERY,
+            {"season": season, "model": model, "season_type": PROJECTION_SEASON_TYPE},
+        )
         rows = [dict(r) for r in cur.fetchall()]
 
     games = []
@@ -383,6 +494,7 @@ def fetch_season_games(conn, season: int, model: str) -> list[dict]:
                 "home_win": home_win,
                 "home_conference": r["home_conference"],
                 "away_conference": r["away_conference"],
+                "conference_game": bool(r["conference_game"]),
                 "expected_home_margin": (
                     float(r["expected_home_margin"])
                     if r["expected_home_margin"] is not None
@@ -405,6 +517,7 @@ _ROW_COLUMNS = [
     "team",
     "conference",
     "games_scheduled",
+    "games_simulated",
     "games_completed",
     "actual_wins",
     "schedule_complete",
@@ -478,16 +591,16 @@ def simulate_one_season(conn, season: int, model: str, n_sims: int, seed: int) -
 
     sigma = fetch_sigma(conn, model)
     ratings = fetch_team_ratings(conn)
-    wins_by_team = simulate_wins(games, n_sims, sigma, seed=seed)
+    sim = simulate_wins(games, n_sims, sigma, seed=seed)
+    wins_by_team = sim["wins"]
 
     conf_by_team = {}
-    games_played = {}
     for g in games:
         for side, conf in (("home_team", "home_conference"), ("away_team", "away_conference")):
             conf_by_team.setdefault(g[side], g[conf])
-            games_played[g[side]] = games_played.get(g[side], 0) + 1
 
-    title_probs = conference_title_probs(wins_by_team, conf_by_team, games_played)
+    # Conference-only records, from the same draws as the overall tally.
+    title_probs = conference_title_probs(sim["conf_wins"], conf_by_team, sim["conf_games"])
 
     rows = [
         build_projection_row(
@@ -500,6 +613,7 @@ def simulate_one_season(conn, season: int, model: str, n_sims: int, seed: int) -
             n_sims,
             sigma,
             title_probs.get(team),
+            sim["games_simulated"][team],
         )
         for team, team_wins in wins_by_team.items()
     ]
@@ -507,9 +621,18 @@ def simulate_one_season(conn, season: int, model: str, n_sims: int, seed: int) -
     write_projections(conn, rows)
 
     complete = sum(1 for r in rows if r["schedule_complete"])
+    unscored = sum(r["games_scheduled"] - r["games_simulated"] for r in rows)
+    if unscored:
+        logger.warning(
+            "season=%d: %d team-game(s) had no %s prediction and were excluded from "
+            "projections (games_simulated < games_scheduled on those rows)",
+            season,
+            unscored,
+            model,
+        )
     print(
         f"SIM_GATE season={season} model={model} teams={len(rows)} sims={n_sims} "
-        f"sigma={sigma:.2f} complete={complete}"
+        f"sigma={sigma:.2f} complete={complete} unscored_team_games={unscored}"
     )
     logger.info(
         "season=%d: wrote %d team projection(s), sigma=%.2f, %d with a complete schedule",

--- a/scripts/simulate_season.py
+++ b/scripts/simulate_season.py
@@ -462,6 +462,16 @@ def fetch_sigma(conn, model: str) -> float:
             f"(need >= {MIN_SIGMA_GAMES}); cannot measure a trustworthy residual sigma. "
             "Backfill predictions before simulating."
         )
+    if sigma <= 0.0:
+        # Degenerate rather than merely small: every draw would collapse onto
+        # its mean, so every game would resolve deterministically and every
+        # win probability would be exactly 0 or 1. That is a broken input
+        # (identical residuals across hundreds of games), not a confident
+        # model, and it must not pass silently.
+        raise RuntimeError(
+            f"Residual sigma for {model} measured as {sigma} over {n_games} game(s); "
+            "a non-positive sigma would make every simulated game deterministic."
+        )
     logger.info("Measured residual sigma for %s: %.2f over %d game(s)", model, sigma, n_games)
     return float(sigma)
 
@@ -602,6 +612,22 @@ def simulate_one_season(conn, season: int, model: str, n_sims: int, seed: int) -
     # Conference-only records, from the same draws as the overall tally.
     title_probs = conference_title_probs(sim["conf_wins"], conf_by_team, sim["conf_games"])
 
+    # A team none of whose games could be scored gets NO row rather than a row
+    # of zeros. `projected_wins = 0.0` with `p_bowl_eligible = 0.0` reads as
+    # "the model expects this team to win nothing", when the truth is that the
+    # model has no opinion at all -- the same plausible-number-instead-of-an-
+    # absence failure the games_simulated split exists to prevent, reintroduced
+    # one level up.
+    unprojectable = [t for t in wins_by_team if sim["games_simulated"][t] == 0]
+    if unprojectable:
+        logger.warning(
+            "season=%d: %d team(s) had no scorable game and are omitted from "
+            "projections entirely (e.g. %s)",
+            season,
+            len(unprojectable),
+            ", ".join(sorted(unprojectable)[:5]),
+        )
+
     rows = [
         build_projection_row(
             team,
@@ -616,6 +642,7 @@ def simulate_one_season(conn, season: int, model: str, n_sims: int, seed: int) -
             sim["games_simulated"][team],
         )
         for team, team_wins in wins_by_team.items()
+        if sim["games_simulated"][team] > 0
     ]
     assign_sos_ranks(rows)
     write_projections(conn, rows)
@@ -632,7 +659,8 @@ def simulate_one_season(conn, season: int, model: str, n_sims: int, seed: int) -
         )
     print(
         f"SIM_GATE season={season} model={model} teams={len(rows)} sims={n_sims} "
-        f"sigma={sigma:.2f} complete={complete} unscored_team_games={unscored}"
+        f"sigma={sigma:.2f} complete={complete} unscored_team_games={unscored} "
+        f"omitted_teams={len(unprojectable)}"
     )
     logger.info(
         "season=%d: wrote %d team projection(s), sigma=%.2f, %d with a complete schedule",

--- a/scripts/train_model.py
+++ b/scripts/train_model.py
@@ -619,17 +619,21 @@ def train_walk_forward(conn, score_start: int, score_end: int) -> None:
 
 
 def stale_score_seasons(
-    latest_completed_season: int,
+    latest_finished_season: int,
     existing_train_through: list[int],
     default_start: int = DEFAULT_SCORE_START,
 ) -> list[int]:
     """Score seasons still needed so a fit exists at
-    ``train_through_season = latest_completed_season``.
+    ``train_through_season = latest_finished_season``.
 
     Walk-forward keying (design section 2d): score season ``S`` produces the fit
     ``train_through_season = S-1``. So covering train-through values up through
-    ``latest_completed_season`` means running score seasons up through
-    ``latest_completed_season + 1``.
+    ``latest_finished_season`` means running score seasons up through
+    ``latest_finished_season + 1``.
+
+    The caller MUST pass the last *fully finished* season (see
+    fetch_refit_state). Passing a season that is merely in progress would train
+    a fit on partial data and then score the rest of that same season in-sample.
 
     Returns ``[]`` when the newest fit is already current -- the no-op the daily
     workflow hits on 364 days a year. Pure, so the staleness rule is testable
@@ -640,7 +644,7 @@ def stale_score_seasons(
     ``train_through_season=2024`` in July, so 2026 scoring would have silently
     used a two-season-stale fit.
     """
-    target = latest_completed_season
+    target = latest_finished_season
     if not existing_train_through:
         return list(range(default_start, target + 2))
     max_existing = max(existing_train_through)
@@ -649,12 +653,52 @@ def stale_score_seasons(
     return list(range(max_existing + 2, target + 2))
 
 
+# A season counts as FINISHED once at least this share of its games are
+# complete. Not 100%: a cancelled or never-reconciled game would otherwise keep
+# a season "unfinished" forever and permanently freeze the refit. 99% clears a
+# handful of stragglers on a ~1,600-game season while still requiring the
+# season to be genuinely over.
+SEASON_COMPLETE_THRESHOLD = 0.99
+
+# Below this many games a season is too small to judge complete by ratio alone
+# (an early season with 3 of 3 games played would look 100% finished).
+MIN_GAMES_FOR_FINISHED_SEASON = 100
+
+
 def fetch_refit_state(conn) -> tuple[int | None, list[int]]:
-    """``(latest completed season, existing fitted_v1 train_through values)``."""
+    """``(latest FINISHED season, existing fitted_v1 train_through values)``.
+
+    "Finished" deliberately means *the whole season is over*, not "has at least
+    one completed game". Using ``MAX(season) WHERE completed`` would flip to the
+    new season the moment its first game ends, and the consequences compound:
+
+      1. ``stale_score_seasons`` would train a fit labelled
+         ``train_through_season = S`` on a season with a handful of games played,
+      2. ``score_fitted --upcoming`` selects ``MAX(train_through_season)`` and
+         would adopt it,
+      3. the remaining games of season S would then be scored **in-sample**, and
+      4. the staleness check would never fire again, because the S key now
+         exists.
+
+    That is a leak that inflates apparent accuracy rather than an outage, so it
+    would not announce itself. Requiring a finished season keeps every fit
+    strictly walk-forward.
+    """
     with conn.cursor() as cur:
-        cur.execute("SELECT MAX(season) FROM core.games WHERE COALESCE(completed, false)")
+        cur.execute(
+            """
+            SELECT MAX(season) FROM (
+                SELECT season
+                FROM core.games
+                GROUP BY season
+                HAVING COUNT(*) >= %s
+                   AND AVG(CASE WHEN COALESCE(completed, false) THEN 1.0 ELSE 0.0 END) >= %s
+            ) finished
+            """,
+            (MIN_GAMES_FOR_FINISHED_SEASON, SEASON_COMPLETE_THRESHOLD),
+        )
         row = cur.fetchone()[0]
-        latest_completed = int(row) if row is not None else None
+        latest_finished = int(row) if row is not None else None
 
         cur.execute(
             "SELECT DISTINCT train_through_season FROM features.model_metadata "
@@ -662,7 +706,7 @@ def fetch_refit_state(conn) -> tuple[int | None, list[int]]:
             (MODEL_VERSION,),
         )
         existing = [int(r[0]) for r in cur.fetchall()]
-    return latest_completed, existing
+    return latest_finished, existing
 
 
 def main() -> None:
@@ -698,24 +742,24 @@ def main() -> None:
     conn = psycopg2.connect(get_db_url())
     try:
         if args.refit_if_stale:
-            latest_completed, existing = fetch_refit_state(conn)
-            if latest_completed is None:
-                logger.info("No completed seasons in core.games; nothing to refit")
+            latest_finished, existing = fetch_refit_state(conn)
+            if latest_finished is None:
+                logger.info("No finished season in core.games yet; nothing to refit")
                 return
-            needed = stale_score_seasons(latest_completed, existing)
+            needed = stale_score_seasons(latest_finished, existing)
             if not needed:
                 logger.info(
                     "fitted_v1 is current: newest fit train_through=%d covers the "
-                    "latest completed season (%d); nothing to refit",
+                    "latest FINISHED season (%d); nothing to refit",
                     max(existing),
-                    latest_completed,
+                    latest_finished,
                 )
                 return
             logger.info(
-                "fitted_v1 is stale: newest fit train_through=%s vs latest completed "
+                "fitted_v1 is stale: newest fit train_through=%s vs latest FINISHED "
                 "season %d; training score season(s) %s",
                 max(existing) if existing else "none",
-                latest_completed,
+                latest_finished,
                 needed,
             )
             train_walk_forward(conn, needed[0], needed[-1])

--- a/scripts/train_model.py
+++ b/scripts/train_model.py
@@ -618,6 +618,53 @@ def train_walk_forward(conn, score_start: int, score_end: int) -> None:
         fit_one(conn, train_through, train_seasons)
 
 
+def stale_score_seasons(
+    latest_completed_season: int,
+    existing_train_through: list[int],
+    default_start: int = DEFAULT_SCORE_START,
+) -> list[int]:
+    """Score seasons still needed so a fit exists at
+    ``train_through_season = latest_completed_season``.
+
+    Walk-forward keying (design section 2d): score season ``S`` produces the fit
+    ``train_through_season = S-1``. So covering train-through values up through
+    ``latest_completed_season`` means running score seasons up through
+    ``latest_completed_season + 1``.
+
+    Returns ``[]`` when the newest fit is already current -- the no-op the daily
+    workflow hits on 364 days a year. Pure, so the staleness rule is testable
+    without a DB.
+
+    Exists because the annual refit was a manual chore and was missed: the 2025
+    season ended in January 2026 and the newest fit was still
+    ``train_through_season=2024`` in July, so 2026 scoring would have silently
+    used a two-season-stale fit.
+    """
+    target = latest_completed_season
+    if not existing_train_through:
+        return list(range(default_start, target + 2))
+    max_existing = max(existing_train_through)
+    if max_existing >= target:
+        return []
+    return list(range(max_existing + 2, target + 2))
+
+
+def fetch_refit_state(conn) -> tuple[int | None, list[int]]:
+    """``(latest completed season, existing fitted_v1 train_through values)``."""
+    with conn.cursor() as cur:
+        cur.execute("SELECT MAX(season) FROM core.games WHERE COALESCE(completed, false)")
+        row = cur.fetchone()[0]
+        latest_completed = int(row) if row is not None else None
+
+        cur.execute(
+            "SELECT DISTINCT train_through_season FROM features.model_metadata "
+            "WHERE model_version = %s",
+            (MODEL_VERSION,),
+        )
+        existing = [int(r[0]) for r in cur.fetchall()]
+    return latest_completed, existing
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Train fitted_v1 walk-forward ridge-margin + IRLS/Platt win-prob "
@@ -633,6 +680,13 @@ def main() -> None:
         f"through S-1 on {TRAIN_START_SEASON}..S-1. Default: "
         f"{DEFAULT_SCORE_START} {DEFAULT_SCORE_END}.",
     )
+    parser.add_argument(
+        "--refit-if-stale",
+        action="store_true",
+        help="Train only the fits missing relative to the latest completed season, "
+        "then exit. A clean no-op when the newest fit is already current -- safe "
+        "to run daily. What the daily workflow runs.",
+    )
     args = parser.parse_args()
     start, end = args.seasons
     if start > end:
@@ -643,6 +697,30 @@ def main() -> None:
 
     conn = psycopg2.connect(get_db_url())
     try:
+        if args.refit_if_stale:
+            latest_completed, existing = fetch_refit_state(conn)
+            if latest_completed is None:
+                logger.info("No completed seasons in core.games; nothing to refit")
+                return
+            needed = stale_score_seasons(latest_completed, existing)
+            if not needed:
+                logger.info(
+                    "fitted_v1 is current: newest fit train_through=%d covers the "
+                    "latest completed season (%d); nothing to refit",
+                    max(existing),
+                    latest_completed,
+                )
+                return
+            logger.info(
+                "fitted_v1 is stale: newest fit train_through=%s vs latest completed "
+                "season %d; training score season(s) %s",
+                max(existing) if existing else "none",
+                latest_completed,
+                needed,
+            )
+            train_walk_forward(conn, needed[0], needed[-1])
+            return
+
         train_walk_forward(conn, start, end)
     except Exception:
         conn.rollback()

--- a/scripts/verify_load.py
+++ b/scripts/verify_load.py
@@ -283,6 +283,51 @@ def check_availability_archive(cur, season: int, report: Report) -> None:
     )
 
 
+def check_fitted_coverage(cur, report: Report) -> None:
+    """fitted_v1 must have a prediction for (nearly) every pending game.
+
+    Independent of score_fitted.py's own gate on purpose: that gate only fires
+    when the scoring step actually runs, and the failure this guards against --
+    features.team_week never built for the upcoming season -- produced a clean
+    exit-0 there for six months. Checking it from the post-load verifier means
+    the shortfall surfaces even if the scoring step is skipped, reordered, or
+    silently no-ops again.
+
+    Season-independent (the pending window spans whatever seasons have
+    schedules), so it takes no season argument.
+    """
+    from scripts.score_fitted import MIN_UPCOMING_COVERAGE, coverage_verdict
+
+    cur.execute(
+        """
+        WITH pending AS (
+            SELECT g.id
+            FROM core.games g
+            WHERE NOT COALESCE(g.completed, false)
+              AND g.season >= (
+                  SELECT COALESCE(MAX(season), 0) FROM core.games WHERE completed
+              )
+        )
+        SELECT
+            (SELECT COUNT(*) FROM pending),
+            (SELECT COUNT(*) FROM pending p
+             WHERE EXISTS (
+                 SELECT 1 FROM predictions.game_predictions gp
+                 WHERE gp.game_id = p.id AND gp.model_version = 'fitted_v1'
+             ))
+        """
+    )
+    n_pending, n_scored = cur.fetchone()
+    n_pending, n_scored = int(n_pending), int(n_scored)
+    ok, coverage = coverage_verdict(n_pending, n_scored)
+    report.record(
+        PASS if ok else FAIL,
+        "fitted_coverage",
+        f"fitted_v1 covers {n_scored}/{n_pending} pending game(s) "
+        f"({coverage:.1%}, threshold {MIN_UPCOMING_COVERAGE:.0%})",
+    )
+
+
 def check_freshness(cur, in_season: bool, strict: bool, report: Report) -> None:
     cur.execute(
         """
@@ -323,6 +368,7 @@ def verify(season: int, strict: bool) -> int:
             check_game_counts(cur, season, report)
             check_completed_have_team_stats(cur, season, report)
             check_completed_have_plays(cur, season, report)
+            check_fitted_coverage(cur, report)
             check_freshness(cur, in_season, strict, report)
             check_massey_composite(cur, season, report)
             check_availability_archive(cur, season, report)

--- a/src/pipelines/config/years.py
+++ b/src/pipelines/config/years.py
@@ -60,3 +60,48 @@ def get_current_season() -> int:
     if now.month < 8:  # Before August
         return now.year - 1
     return now.year
+
+
+def get_projection_seasons(conn) -> list[int]:
+    """Seasons the compute chain must maintain, resolved from the data itself.
+
+    `get_current_season()` is a *calendar* rule and is correct for ingest year
+    windows, but it is wrong for the compute chain: it returns `year - 1` until
+    August, so between January and July the "current season" is the one that
+    already finished. Every `--incremental` step keyed on it spends the whole
+    offseason rebuilding last season while the upcoming season -- which already
+    has a published schedule and is exactly what predictions are wanted for --
+    is never built at all.
+
+    This resolves the target seasons from `core.games` instead: the most recent
+    season with completed games, plus every later season that has scheduled
+    games. In July 2026 that is `[2025, 2026]`; in October 2026 it is `[2026]`.
+    Calendar-independent and self-healing at the season rollover.
+
+    Mirrors the selection `scripts/compute_predictions.py`'s
+    `TARGET_GAMES_QUERY` already uses (`season >= (SELECT MAX(season) FROM
+    core.games WHERE completed)`) -- that script was unaffected by the blackout
+    precisely because it never consulted the calendar.
+
+    Takes an open psycopg2 connection so this module keeps no DB dependency of
+    its own. Returns seasons in ascending order.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT COALESCE(MAX(season), 0) FROM core.games WHERE COALESCE(completed, false)"
+        )
+        latest_completed = int(cur.fetchone()[0])
+
+        # No completed games anywhere (fresh/partial DB): there is no "since
+        # the last completed season" window to open, and `season >= 0` would
+        # match all of 1869+. Fall back to the single latest season present.
+        if latest_completed == 0:
+            cur.execute("SELECT COALESCE(MAX(season), 0) FROM core.games")
+            latest_any = int(cur.fetchone()[0])
+            return [latest_any] if latest_any else []
+
+        cur.execute(
+            "SELECT DISTINCT season FROM core.games WHERE season >= %s ORDER BY season",
+            (latest_completed,),
+        )
+        return [int(row[0]) for row in cur.fetchall()]

--- a/src/schemas/migrations/043_season_projections.sql
+++ b/src/schemas/migrations/043_season_projections.sql
@@ -47,6 +47,11 @@ CREATE TABLE IF NOT EXISTS predictions.season_projections (
     -- slate is whole enough for the win total to mean what a reader assumes
     -- (>= 11 regular-season games).
     games_scheduled BIGINT NOT NULL,
+    -- Games that actually contributed a simulated or actual outcome. Differs
+    -- from games_scheduled when a pending game has no prediction; every
+    -- projected quantity below is computed over THIS count, so a game the
+    -- simulation could not score is never presented as a certain loss.
+    games_simulated BIGINT NOT NULL,
     games_completed BIGINT NOT NULL,
     actual_wins BIGINT,
     schedule_complete BOOLEAN NOT NULL,
@@ -112,7 +117,10 @@ COMMENT ON COLUMN predictions.season_projections.p_win_dist IS
     'Full win-total distribution as {"0": p, "1": p, ...} over 0..games_scheduled; sums to 1.';
 
 COMMENT ON COLUMN predictions.season_projections.games_scheduled IS
-    'Games actually on the schedule. Projections are never extrapolated to a hypothetical full slate -- see schedule_complete.';
+    'Regular-season games on the schedule (season_type = ''regular'', which includes conference championship games; bowls and playoff games are excluded). Projections are never extrapolated to a hypothetical full slate -- see schedule_complete.';
+
+COMMENT ON COLUMN predictions.season_projections.games_simulated IS
+    'Games that contributed an outcome. Lower than games_scheduled when a pending game has no prediction for this model_version; projected_wins/losses, the percentiles and p_win_dist are all computed over this count so an unscored game is never counted as a loss.';
 
 COMMENT ON COLUMN predictions.season_projections.n_sims IS
     'Simulation count. v1 draws each game INDEPENDENTLY, which understates both tails: real season outcomes are correlated (a team better than its rating beats everyone more often), so extreme records are underpredicted. Treat p10/p90 and p_ten_plus as conservative at the edges.';

--- a/src/schemas/migrations/043_season_projections.sql
+++ b/src/schemas/migrations/043_season_projections.sql
@@ -1,0 +1,129 @@
+-- Season projections: append-only Monte Carlo season-outcome snapshots
+-- =============================================================================
+-- Preseason outlook plan (docs/plans/2026-07-25-preseason-outlook-model-plan.md),
+-- Phase 4.
+--
+-- predictions.season_projections holds one immutable snapshot row per
+-- (season, team, model_version, UTC projection_date): the distribution of
+-- season win totals implied by simulating every game on that team's schedule
+-- with the per-game predictions in predictions.game_predictions.
+--
+-- WHY THIS TABLE EXISTS. Everything the warehouse predicted until now was a
+-- per-game point estimate. Nothing represented a *season* as an object, so a
+-- question like "what is this team's 2026 outlook" had no surface to read and
+-- degraded to prose. Twelve independent game predictions do not compose into a
+-- win total with an interval; this table is that composition, materialized.
+--
+-- Append-only across days, exactly like predictions.game_predictions
+-- (migration 024): the same-day ON CONFLICT DO UPDATE only lets a re-run
+-- *converge* today's snapshot, never overwrite a prior day's. The snapshot
+-- history is the point -- it shows how the model's read on a season moved as
+-- games resolved, which is what makes a preseason projection auditable after
+-- the fact rather than quietly revised.
+--
+-- Writer: scripts/simulate_season.py. Created empty here so schema and grants
+-- are in place before the compute script and the Phase 5 marts/api views land.
+--
+-- Not in MIGRATION_ORDER: applied via run_migrations.py --file (deploy
+-- manifest), like 019-028 and 041. Idempotent (IF NOT EXISTS throughout).
+
+CREATE SCHEMA IF NOT EXISTS predictions;
+
+CREATE TABLE IF NOT EXISTS predictions.season_projections (
+    projection_id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    computed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    projection_date DATE NOT NULL DEFAULT ((now() AT TIME ZONE 'utc')::date),
+    model_version TEXT NOT NULL,
+
+    -- Identity
+    season BIGINT NOT NULL,
+    team VARCHAR NOT NULL,
+    conference VARCHAR,
+
+    -- Schedule state. games_scheduled counts games actually ON the schedule,
+    -- never a hypothetical full slate: as of 2026-07-25 the 2026 schedule had
+    -- 68 of 337 teams with fewer than 8 games published, and projecting those
+    -- over 12 games would invent results. schedule_complete flags whether the
+    -- slate is whole enough for the win total to mean what a reader assumes
+    -- (>= 11 regular-season games).
+    games_scheduled BIGINT NOT NULL,
+    games_completed BIGINT NOT NULL,
+    actual_wins BIGINT,
+    schedule_complete BOOLEAN NOT NULL,
+
+    -- Central tendency
+    projected_wins NUMERIC(5, 2),
+    projected_losses NUMERIC(5, 2),
+    median_wins NUMERIC(5, 2),
+
+    -- Distribution. The percentiles and p_win_dist are the reason this table
+    -- exists rather than a single projected_wins column: a 9-3 projection with
+    -- a [7, 11] interval and one with a [8.5, 9.5] interval are different
+    -- claims, and only the distribution distinguishes them.
+    wins_p10 NUMERIC(5, 2),
+    wins_p25 NUMERIC(5, 2),
+    wins_p75 NUMERIC(5, 2),
+    wins_p90 NUMERIC(5, 2),
+    p_win_dist JSONB,
+    p_bowl_eligible NUMERIC(5, 4),
+    p_ten_plus NUMERIC(5, 4),
+
+    -- Schedule strength (average opponent rating over the team's slate).
+    sos_rating NUMERIC(8, 3),
+    sos_rank BIGINT,
+
+    -- Conference title odds are v1-crude: highest conference win percentage
+    -- per simulation with ties split evenly. Real tiebreakers and
+    -- championship-game formats are not modeled.
+    conf_title_prob NUMERIC(5, 4),
+
+    -- playoff_prob ships NULL deliberately. The 12-team format's automatic
+    -- bids and seeding are a rules-modeling project of their own, and a number
+    -- nobody can defend is worse than an honest absence. The column exists now
+    -- so adding it later needs no migration.
+    playoff_prob NUMERIC(5, 4),
+
+    -- Simulation provenance. residual_sigma is the per-model standard
+    -- deviation of (actual - predicted) margin the draws used; it is stored
+    -- per row rather than assumed, so a projection always carries the
+    -- assumption that produced it.
+    n_sims BIGINT NOT NULL,
+    residual_sigma NUMERIC(6, 3)
+);
+
+-- One snapshot per team per model per UTC day (mirrors
+-- game_predictions_daily_key in migration 024).
+CREATE UNIQUE INDEX IF NOT EXISTS season_projections_daily_key
+    ON predictions.season_projections (season, team, model_version, projection_date);
+
+CREATE INDEX IF NOT EXISTS season_projections_season_idx
+    ON predictions.season_projections (season);
+
+CREATE INDEX IF NOT EXISTS season_projections_team_season_idx
+    ON predictions.season_projections (team, season);
+
+CREATE INDEX IF NOT EXISTS season_projections_computed_at_idx
+    ON predictions.season_projections (computed_at);
+
+COMMENT ON TABLE predictions.season_projections IS
+    'Append-only Monte Carlo season-outcome snapshots: one immutable row per (season, team, model_version, UTC projection_date), same-day ON CONFLICT DO UPDATE for intra-day convergence only. Completed games contribute their actual result; remaining games are drawn from Normal(expected_home_margin, residual_sigma). Written by scripts/simulate_season.py.';
+
+COMMENT ON COLUMN predictions.season_projections.p_win_dist IS
+    'Full win-total distribution as {"0": p, "1": p, ...} over 0..games_scheduled; sums to 1.';
+
+COMMENT ON COLUMN predictions.season_projections.games_scheduled IS
+    'Games actually on the schedule. Projections are never extrapolated to a hypothetical full slate -- see schedule_complete.';
+
+COMMENT ON COLUMN predictions.season_projections.n_sims IS
+    'Simulation count. v1 draws each game INDEPENDENTLY, which understates both tails: real season outcomes are correlated (a team better than its rating beats everyone more often), so extreme records are underpredicted. Treat p10/p90 and p_ten_plus as conservative at the edges.';
+
+COMMENT ON COLUMN predictions.season_projections.playoff_prob IS
+    'NULL in v1 -- the 12-team format''s automatic bids and seeding are not modeled.';
+
+-- Grant USAGE + read-only SELECT per the repo's read-access pattern
+-- (see grant_read_access_for_security_invoker.sql), matching 024/028 -- no
+-- write grants to anon/authenticated; writes come only from the compute
+-- scripts via the direct connection owner.
+GRANT USAGE ON SCHEMA predictions TO anon, authenticated;
+GRANT SELECT ON ALL TABLES IN SCHEMA predictions TO anon, authenticated;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON ALL TABLES IN SCHEMA predictions FROM anon, authenticated;

--- a/tests/test_fitted_model.py
+++ b/tests/test_fitted_model.py
@@ -13,7 +13,11 @@ pytest.importorskip("numpy")
 
 import numpy as np  # noqa: E402
 
-from scripts.score_fitted import select_train_through  # noqa: E402
+from scripts.score_fitted import (  # noqa: E402
+    MIN_UPCOMING_COVERAGE,
+    coverage_verdict,
+    select_train_through,
+)
 from scripts.train_model import (  # noqa: E402
     FEATURE_NAMES,
     INTERCEPT_IDX,
@@ -32,6 +36,7 @@ from scripts.train_model import (  # noqa: E402
     platt_transform,
     ridge_fit,
     sigmoid,
+    stale_score_seasons,
     standardize,
 )
 
@@ -319,3 +324,62 @@ class TestEndToEndWalkForward:
         probs = np.array([platt_transform(float(z), platt_a, platt_b) for z in logits4])
         assert np.all(probs > 0.0)
         assert np.all(probs < 1.0)
+
+
+class TestCoverageVerdict:
+    """The silent-failure regression: score_fitted.run_upcoming used to log
+    'nothing to write' and return normally when features.team_week had no rows
+    for the upcoming season, so the workflow went green for six months while
+    fitted_v1 produced nothing for 2026."""
+
+    def test_no_pending_games_is_success(self):
+        # Legitimately nothing to do (e.g. mid-January, post-bowls).
+        ok, coverage = coverage_verdict(0, 0)
+        assert ok is True
+        assert coverage == 1.0
+
+    def test_pending_games_but_none_scored_fails(self):
+        # The exact 2026 blackout shape: 1,638 pending, zero feature rows.
+        ok, coverage = coverage_verdict(1638, 0)
+        assert ok is False
+        assert coverage == 0.0
+
+    def test_full_coverage_passes(self):
+        ok, coverage = coverage_verdict(1638, 1638)
+        assert ok is True
+        assert coverage == 1.0
+
+    def test_just_below_threshold_fails(self):
+        ok, _ = coverage_verdict(1000, 899, min_coverage=0.90)
+        assert ok is False
+
+    def test_at_threshold_passes(self):
+        ok, coverage = coverage_verdict(1000, 900, min_coverage=0.90)
+        assert ok is True
+        assert coverage == pytest.approx(0.90)
+
+    def test_default_threshold_is_ninety_percent(self):
+        assert MIN_UPCOMING_COVERAGE == 0.90
+
+
+class TestStaleScoreSeasons:
+    """Walk-forward keying: score season S produces train_through = S-1."""
+
+    def test_stale_by_one_season_trains_the_gap(self):
+        # The real July-2026 state: newest fit train_through=2024, 2025 done.
+        assert stale_score_seasons(2025, [2018, 2020, 2024]) == [2026]
+
+    def test_current_fit_is_a_no_op(self):
+        assert stale_score_seasons(2025, [2024, 2025]) == []
+
+    def test_fit_ahead_of_completed_season_is_a_no_op(self):
+        assert stale_score_seasons(2024, [2025]) == []
+
+    def test_no_existing_fits_trains_from_default_start(self):
+        seasons = stale_score_seasons(2025, [], default_start=2018)
+        assert seasons[0] == 2018
+        assert seasons[-1] == 2026
+
+    def test_multi_season_gap(self):
+        # train_through 2023 present, 2025 complete -> need 2024 and 2025.
+        assert stale_score_seasons(2025, [2023]) == [2025, 2026]

--- a/tests/test_fitted_model.py
+++ b/tests/test_fitted_model.py
@@ -383,3 +383,23 @@ class TestStaleScoreSeasons:
     def test_multi_season_gap(self):
         # train_through 2023 present, 2025 complete -> need 2024 and 2025.
         assert stale_score_seasons(2025, [2023]) == [2025, 2026]
+
+
+class TestRefitLeakRegression:
+    """PR #48 P1-A. `stale_score_seasons` must be fed the last FULLY FINISHED
+    season. Feeding it a season that has merely started trains a fit on partial
+    data, which `score_fitted --upcoming` then adopts as MAX(train_through) and
+    uses to score the remainder of that same season -- in-sample, and never
+    refreshed again because the key now exists."""
+
+    def test_in_progress_season_would_produce_an_in_sample_fit(self):
+        # 2025 finished; 2026 has kicked off. Passing 2026 (the WRONG input)
+        # asks for a fit trained through 2026 while 2026 is still being played.
+        wrong = stale_score_seasons(2026, [2024, 2025])
+        assert wrong == [2027], "documents the bad behavior the fix avoids"
+        # Passing the last FINISHED season is a correct no-op.
+        assert stale_score_seasons(2025, [2024, 2025]) == []
+
+    def test_finished_season_still_triggers_the_annual_refit(self):
+        # The real July-2026 state: 2025 finished, newest fit train_through=2024.
+        assert stale_score_seasons(2025, [2024]) == [2026]

--- a/tests/test_screen_features.py
+++ b/tests/test_screen_features.py
@@ -20,11 +20,14 @@ import pytest
 from scripts.screen_preseason_features import (
     FDR_ALPHA,
     MIN_PARTIAL_R,
+    PRIMARY_CONTROL,
     benjamini_hochberg,
     derive_composites,
     partial_corr_pvalue,
     partial_correlation,
+    screen,
     screen_verdict,
+    second_order_partial_correlation,
 )
 
 
@@ -237,3 +240,90 @@ def _residualize(v, control):
     dc = [c - mc for c in control]
     slope = sum(c * (x - mv) for c, x in zip(dc, v, strict=True)) / sum(c * c for c in dc)
     return [x - (mv + slope * c) for x, c in zip(v, dc, strict=True)]
+
+
+class TestSecondOrderPartialCorrelation:
+    """P2-F regression. The recorded verdicts control for prior-season rating
+    AND recruiting; screening on prior rating alone would ship a candidate that
+    merely restates recruiting."""
+
+    def _frame(self, n=1200, seed=13):
+        """`w` (recruiting) genuinely predicts `y` beyond `z`. `redundant` is a
+        noisy copy of `w` carrying NO information `w` lacks -- the shape of
+        `draft_picks_3yr`."""
+        rng = random.Random(seed)
+        z, y, w, redundant, extra = [], [], [], [], []
+        for _ in range(n):
+            z_i = rng.gauss(0.0, 1.0)
+            w_i = rng.gauss(0.0, 1.0)
+            extra_i = rng.gauss(0.0, 1.0)
+            y_i = 0.6 * z_i + 0.45 * w_i + 0.35 * extra_i + rng.gauss(0.0, 0.3)
+            z.append(z_i)
+            y.append(y_i)
+            w.append(w_i)
+            redundant.append(w_i + rng.gauss(0.0, 0.2))
+            extra.append(extra_i)
+        return {"z": z, "y": y, "w": w, "redundant": redundant, "extra": extra}
+
+    def test_redundant_candidate_survives_one_control_but_not_two(self):
+        f = self._frame()
+        first = partial_correlation(f["redundant"], f["y"], f["z"])
+        second = second_order_partial_correlation(f["redundant"], f["y"], f["z"], f["w"])
+        assert abs(first) > MIN_PARTIAL_R, "fixture should clear the floor on one control"
+        assert abs(second) < MIN_PARTIAL_R, (
+            f"redundant candidate must fail the second control (got {second:.4f})"
+        )
+
+    def test_genuinely_incremental_candidate_survives_both_controls(self):
+        f = self._frame()
+        second = second_order_partial_correlation(f["extra"], f["y"], f["z"], f["w"])
+        assert second > MIN_PARTIAL_R
+
+    def test_reduces_to_first_order_when_second_control_is_noise(self):
+        f = self._frame(n=600, seed=21)
+        rng = random.Random(99)
+        noise = [rng.gauss(0.0, 1.0) for _ in f["y"]]
+        first = partial_correlation(f["extra"], f["y"], f["z"])
+        second = second_order_partial_correlation(f["extra"], f["y"], f["z"], noise)
+        assert second == pytest.approx(first, abs=0.05)
+
+
+class TestScreenUsesBothControls:
+    """The executable gate must reproduce the recorded decisions."""
+
+    def _frame(self, n=1000, seed=17):
+        rng = random.Random(seed)
+        rows = []
+        for _ in range(n):
+            z = rng.gauss(0.0, 1.0)
+            w = rng.gauss(0.0, 1.0)
+            y = 0.6 * z + 0.45 * w + rng.gauss(0.0, 0.3)
+            rows.append(
+                {
+                    "sp_rating": y,
+                    "prior_sp_rating": z,
+                    PRIMARY_CONTROL: w,
+                    # A noisy restatement of the control: no independent signal.
+                    "redundant_candidate": w + rng.gauss(0.0, 0.2),
+                }
+            )
+        return rows
+
+    def test_redundant_candidate_is_rejected_by_the_screen(self):
+        results = screen(self._frame(), [PRIMARY_CONTROL, "redundant_candidate"])
+        by_name = {r["feature"]: r for r in results}
+        red = by_name["redundant_candidate"]
+        assert abs(red["partial_r_vs_prior"]) > MIN_PARTIAL_R, "would ship on one control"
+        assert red["verdict"] == "reject", "must reject once recruiting is controlled"
+
+    def test_primary_control_is_judged_on_the_first_order_partial(self):
+        results = screen(self._frame(), [PRIMARY_CONTROL, "redundant_candidate"])
+        control = next(r for r in results if r["feature"] == PRIMARY_CONTROL)
+        # It cannot be screened against itself, so both figures agree.
+        assert control["partial_r"] == pytest.approx(control["partial_r_vs_prior"])
+        assert control["verdict"] == "ship"
+
+    def test_both_columns_are_reported(self):
+        for r in screen(self._frame(), [PRIMARY_CONTROL, "redundant_candidate"]):
+            assert "partial_r_vs_prior" in r
+            assert "partial_r" in r

--- a/tests/test_screen_features.py
+++ b/tests/test_screen_features.py
@@ -1,0 +1,239 @@
+"""Unit tests for the preseason-feature screen math (no DB, no I/O).
+
+Covers scripts/screen_preseason_features.py's pure core: partial correlation,
+the normal-approximation p-value, Benjamini-Hochberg FDR adjustment, the
+ship/reject rule, and the Tier A composite derivation. Everything here runs on
+plain Python lists and stdlib `random`; nothing touches Postgres or numpy.
+
+The load-bearing test is TestPartialCorrelation.test_pure_proxy_of_control_
+scores_near_zero: a candidate that merely restates prior-season quality must
+screen out even though its RAW correlation with the outcome is large. That
+discrimination is the entire reason the screen replaced raw-correlation
+screening (plan section 2.5).
+"""
+
+import math
+import random
+
+import pytest
+
+from scripts.screen_preseason_features import (
+    FDR_ALPHA,
+    MIN_PARTIAL_R,
+    benjamini_hochberg,
+    derive_composites,
+    partial_corr_pvalue,
+    partial_correlation,
+    screen_verdict,
+)
+
+
+def _correlated_frame(n=1400, seed=7):
+    """Synthetic team-seasons.
+
+    `z` is prior-season rating. `y` is season-S rating: mostly persistence of
+    `z` plus a genuine `signal` component plus noise. `proxy` is a noisy
+    restatement of `z` with NO independent information about `y`; `signal` is
+    the honest predictor. A correct screen ranks signal high and proxy ~0.
+    """
+    rng = random.Random(seed)
+    z, y, proxy, signal = [], [], [], []
+    for _ in range(n):
+        z_i = rng.gauss(0.0, 1.0)
+        signal_i = rng.gauss(0.0, 1.0)
+        y_i = 0.75 * z_i + 0.40 * signal_i + rng.gauss(0.0, 0.35)
+        z.append(z_i)
+        y.append(y_i)
+        proxy.append(z_i + rng.gauss(0.0, 0.15))
+        signal.append(signal_i)
+    return {"z": z, "y": y, "proxy": proxy, "signal": signal}
+
+
+class TestPartialCorrelation:
+    def test_pure_proxy_of_control_scores_near_zero(self):
+        """A feature that only re-expresses the control adds nothing.
+
+        This is the failure mode raw-correlation screening could not detect:
+        `proxy` correlates strongly with the outcome, but every bit of that is
+        already carried by prior-season rating.
+        """
+        f = _correlated_frame()
+        raw = abs(_raw_corr(f["proxy"], f["y"]))
+        partial = partial_correlation(f["proxy"], f["y"], f["z"])
+
+        assert raw > 0.5, "fixture should give the proxy a large raw correlation"
+        assert abs(partial) < 0.1, (
+            f"proxy should screen out (partial={partial:.4f}) despite raw={raw:.4f}"
+        )
+
+    def test_genuine_signal_survives_the_control(self):
+        f = _correlated_frame()
+        partial = partial_correlation(f["signal"], f["y"], f["z"])
+        assert partial > 0.5
+
+    def test_matches_residual_correlation_definition(self):
+        """Partial correlation == correlation of the two residuals after
+        regressing each on the control. The formula is a shortcut for that."""
+        f = _correlated_frame(n=400, seed=11)
+        via_formula = partial_correlation(f["signal"], f["y"], f["z"])
+        via_residuals = _raw_corr(_residualize(f["signal"], f["z"]), _residualize(f["y"], f["z"]))
+        assert via_formula == pytest.approx(via_residuals, abs=1e-9)
+
+    def test_constant_feature_has_no_signal(self):
+        f = _correlated_frame(n=300, seed=3)
+        constant = [1.0] * 300
+        assert partial_correlation(constant, f["y"], f["z"]) == pytest.approx(0.0)
+
+    def test_unequal_lengths_raise(self):
+        with pytest.raises(ValueError, match="equal-length"):
+            partial_correlation([1.0, 2.0], [1.0, 2.0, 3.0], [1.0, 2.0, 3.0])
+
+    def test_too_few_observations_raise(self):
+        with pytest.raises(ValueError, match="at least 3"):
+            partial_correlation([1.0], [1.0], [1.0])
+
+
+class TestPartialCorrPvalue:
+    def test_small_sample_returns_none_rather_than_a_bad_number(self):
+        # Below the df floor the normal approximation is unsafe, so the honest
+        # answer is "cannot test", not a plausible-looking p-value.
+        assert partial_corr_pvalue(0.5, n=50) is None
+
+    def test_zero_correlation_gives_p_near_one(self):
+        assert partial_corr_pvalue(0.0, n=1400) == pytest.approx(1.0, abs=1e-9)
+
+    def test_strong_correlation_gives_tiny_p(self):
+        p = partial_corr_pvalue(0.5, n=1400)
+        assert p is not None
+        assert p < 1e-10
+
+    def test_threshold_effect_is_significant_at_screen_sample_size(self):
+        # An effect exactly at the pre-registered floor should be detectable
+        # with ~1,400 team-seasons -- otherwise the floor and the sample are
+        # mismatched and the screen could never ship anything.
+        p = partial_corr_pvalue(MIN_PARTIAL_R, n=1400)
+        assert p is not None
+        assert p < 0.01
+
+    def test_two_sided_is_sign_symmetric(self):
+        assert partial_corr_pvalue(0.2, n=1400) == pytest.approx(partial_corr_pvalue(-0.2, n=1400))
+
+
+class TestBenjaminiHochberg:
+    def test_empty_input(self):
+        assert benjamini_hochberg([]) == []
+
+    def test_preserves_input_order(self):
+        # Largest p is last in input; its q must also be the largest.
+        q = benjamini_hochberg([0.01, 0.001, 0.5])
+        assert q[2] == max(q)
+        assert q[1] == min(q)
+
+    def test_monotone_in_p(self):
+        pvalues = [0.001, 0.008, 0.02, 0.04, 0.3, 0.7]
+        q = benjamini_hochberg(pvalues)
+        # Deliberately not strict: this is a pairwise (offset) zip.
+        assert all(a <= b for a, b in zip(q, q[1:]))  # noqa: B905
+
+    def test_q_never_below_p(self):
+        pvalues = [0.001, 0.01, 0.02, 0.2]
+        for p, q in zip(pvalues, benjamini_hochberg(pvalues), strict=True):
+            assert q >= p - 1e-12
+
+    def test_capped_at_one(self):
+        assert all(q <= 1.0 for q in benjamini_hochberg([0.9, 0.95, 0.99]))
+
+    def test_single_value_is_unchanged(self):
+        assert benjamini_hochberg([0.03]) == pytest.approx([0.03])
+
+    def test_penalizes_a_lone_marginal_result_among_many_nulls(self):
+        # One p just under 0.05 among 19 nulls is what an uncorrected screen
+        # would ship; FDR should pull it well above alpha.
+        pvalues = [0.045] + [0.6] * 19
+        assert benjamini_hochberg(pvalues)[0] > FDR_ALPHA
+
+
+class TestScreenVerdict:
+    def test_ships_when_both_conditions_hold(self):
+        assert screen_verdict(0.15, 0.01) == "ship"
+
+    def test_rejects_small_effect_even_when_significant(self):
+        # Large n makes tiny effects significant; the effect floor is what
+        # stops the screen shipping statistically-real irrelevance.
+        assert screen_verdict(0.02, 1e-12) == "reject"
+
+    def test_rejects_large_effect_that_fails_fdr(self):
+        assert screen_verdict(0.30, 0.5) == "reject"
+
+    def test_rejects_untestable_candidate(self):
+        # q is None when df was too small -- unverifiable is not valuable.
+        assert screen_verdict(0.30, None) == "reject"
+
+    def test_negative_effects_are_judged_on_magnitude(self):
+        assert screen_verdict(-0.15, 0.01) == "ship"
+
+    def test_exactly_at_both_thresholds_ships(self):
+        assert screen_verdict(MIN_PARTIAL_R, FDR_ALPHA) == "ship"
+
+
+class TestDeriveComposites:
+    def _row(self, **overrides):
+        row = {
+            "recruiting_points_3yr": 500.0,
+            "portal_net_rating": 20.0,
+            "draft_departures": 5.0,
+            "draft_picks_3yr": 10.0,
+        }
+        row.update(overrides)
+        return row
+
+    def test_talent_stock_nets_arrivals_against_departures(self):
+        out = derive_composites(self._row())
+        assert out["talent_stock"] == pytest.approx(500.0 + 20.0 - 5.0)
+
+    def test_conversion_is_a_rate_not_a_count(self):
+        out = derive_composites(self._row())
+        assert out["conversion"] == pytest.approx(10.0 / 500.0)
+
+    def test_pipeline_index_is_the_product(self):
+        out = derive_composites(self._row())
+        assert out["pipeline_index"] == pytest.approx(out["talent_stock"] * out["conversion"])
+
+    def test_no_recruiting_inputs_yields_zero_conversion_not_a_crash(self):
+        out = derive_composites(self._row(recruiting_points_3yr=0.0))
+        assert out["conversion"] == 0.0
+        assert out["pipeline_index"] == 0.0
+
+    def test_draft_yield_tracks_conversion(self):
+        out = derive_composites(self._row())
+        assert out["draft_yield"] == pytest.approx(out["conversion"])
+
+    def test_two_programs_same_stock_different_development(self):
+        """The distinction the composite exists to make: equal raw material,
+        different ability to turn it into NFL players."""
+        developer = derive_composites(self._row(draft_picks_3yr=15.0))
+        squanderer = derive_composites(self._row(draft_picks_3yr=2.0))
+        assert developer["talent_stock"] == squanderer["talent_stock"]
+        assert developer["pipeline_index"] > squanderer["pipeline_index"]
+
+
+# --- helpers -----------------------------------------------------------------
+
+
+def _raw_corr(a, b):
+    n = len(a)
+    ma, mb = sum(a) / n, sum(b) / n
+    da = [v - ma for v in a]
+    db = [v - mb for v in b]
+    den = math.sqrt(sum(p * p for p in da) * sum(q * q for q in db))
+    return sum(p * q for p, q in zip(da, db, strict=True)) / den
+
+
+def _residualize(v, control):
+    """Residuals of v after an OLS fit on control (with intercept)."""
+    n = len(v)
+    mc = sum(control) / n
+    mv = sum(v) / n
+    dc = [c - mc for c in control]
+    slope = sum(c * (x - mv) for c, x in zip(dc, v, strict=True)) / sum(c * c for c in dc)
+    return [x - (mv + slope * c) for x, c in zip(v, dc, strict=True)]

--- a/tests/test_simulate_season.py
+++ b/tests/test_simulate_season.py
@@ -1,0 +1,267 @@
+"""Unit tests for the season-simulation math (no DB, no I/O).
+
+Covers scripts/simulate_season.py's pure core: the Monte Carlo win draw,
+distribution/percentile summaries, schedule strength, conference title odds,
+SOS ranking and the row builder. Everything runs on plain dicts and numpy;
+nothing touches Postgres.
+
+Two tests are load-bearing:
+
+- ``test_completed_games_are_not_re_rolled`` -- an in-season projection must be
+  "record so far + simulated remainder". Re-simulating games already played
+  would let a 6-0 team project to 3-3.
+- ``test_unscored_pending_games_are_skipped_not_coin_flipped`` -- treating a
+  game with no prediction as 50/50 would bias every projection toward .500 in
+  proportion to how much of the schedule is unscored, which is exactly the
+  silent-degradation failure this project already hit once.
+"""
+
+import pytest
+
+pytest.importorskip("numpy")
+
+import numpy as np  # noqa: E402
+
+from scripts.simulate_season import (  # noqa: E402
+    BOWL_ELIGIBLE_WINS,
+    COMPLETE_SCHEDULE_GAMES,
+    assign_sos_ranks,
+    build_projection_row,
+    conference_title_probs,
+    schedule_strength,
+    simulate_wins,
+    summarize,
+    win_distribution,
+)
+
+
+def _game(home, away, completed=False, home_win=None, margin=None, season=2026):
+    return {
+        "season": season,
+        "home_team": home,
+        "away_team": away,
+        "completed": completed,
+        "home_win": home_win,
+        "expected_home_margin": margin,
+        "home_conference": "TestConf",
+        "away_conference": "TestConf",
+    }
+
+
+class TestSimulateWins:
+    def test_deterministic_under_fixed_seed(self):
+        games = [_game("A", "B", margin=3.0), _game("C", "A", margin=-7.0)]
+        a = simulate_wins(games, 500, 18.5, seed=42)
+        b = simulate_wins(games, 500, 18.5, seed=42)
+        for team in a:
+            np.testing.assert_array_equal(a[team], b[team])
+
+    def test_different_seeds_differ(self):
+        games = [_game("A", "B", margin=0.0)]
+        a = simulate_wins(games, 500, 18.5, seed=1)
+        b = simulate_wins(games, 500, 18.5, seed=2)
+        assert not np.array_equal(a["A"], b["A"])
+
+    def test_completed_games_are_not_re_rolled(self):
+        # A won all three completed games; every simulation must show 3 wins.
+        games = [
+            _game("A", "B", completed=True, home_win=True),
+            _game("A", "C", completed=True, home_win=True),
+            _game("D", "A", completed=True, home_win=False),
+        ]
+        wins = simulate_wins(games, 200, 18.5)
+        assert np.all(wins["A"] == 3)
+        assert np.all(wins["B"] == 0)
+
+    def test_unscored_pending_games_are_skipped_not_coin_flipped(self):
+        # One completed win plus a pending game with NO prediction. The
+        # unscored game must contribute nothing rather than a 50/50 draw.
+        games = [
+            _game("A", "B", completed=True, home_win=True),
+            _game("A", "C", margin=None),
+        ]
+        wins = simulate_wins(games, 500, 18.5)
+        assert np.all(wins["A"] == 1)
+        assert np.all(wins["C"] == 0)
+
+    def test_huge_favorite_wins_nearly_always(self):
+        games = [_game("A", "B", margin=100.0)]
+        wins = simulate_wins(games, 2000, 18.5)
+        assert wins["A"].mean() > 0.99
+        assert wins["B"].mean() < 0.01
+
+    def test_pickem_is_about_even(self):
+        games = [_game("A", "B", margin=0.0)]
+        wins = simulate_wins(games, 20000, 18.5)
+        assert wins["A"].mean() == pytest.approx(0.5, abs=0.02)
+
+    def test_every_game_produces_exactly_one_winner(self):
+        games = [_game("A", "B", margin=5.0), _game("B", "C", margin=-2.0)]
+        wins = simulate_wins(games, 300, 18.5)
+        total = wins["A"] + wins["B"] + wins["C"]
+        assert np.all(total == len(games))
+
+    def test_larger_sigma_widens_the_outcome_spread(self):
+        games = [_game("A", "B", margin=14.0)]
+        tight = simulate_wins(games, 5000, 5.0, seed=3)["A"].mean()
+        loose = simulate_wins(games, 5000, 30.0, seed=3)["A"].mean()
+        # A 14-point favorite is less certain under a wider error distribution.
+        assert tight > loose
+
+
+class TestWinDistribution:
+    def test_sums_to_one(self):
+        wins = np.array([3, 4, 4, 5, 6, 6, 6, 7])
+        dist = win_distribution(wins, 12)
+        assert sum(dist.values()) == pytest.approx(1.0)
+
+    def test_covers_full_range_including_zeros(self):
+        dist = win_distribution(np.array([2, 2, 3]), 5)
+        assert set(dist.keys()) == set(range(6))
+        assert dist[0] == 0.0
+        assert dist[2] == pytest.approx(2 / 3)
+
+    def test_probabilities_are_non_negative(self):
+        dist = win_distribution(np.array([0, 12, 6]), 12)
+        assert all(p >= 0 for p in dist.values())
+
+
+class TestSummarize:
+    def test_median_lies_within_p10_p90(self):
+        rng = np.random.default_rng(5)
+        wins = rng.integers(0, 13, size=5000)
+        s = summarize(wins, 12)
+        assert s["wins_p10"] <= s["median_wins"] <= s["wins_p90"]
+        assert s["wins_p25"] <= s["median_wins"] <= s["wins_p75"]
+
+    def test_wins_plus_losses_equals_schedule(self):
+        s = summarize(np.array([6, 7, 8]), 12)
+        assert s["projected_wins"] + s["projected_losses"] == pytest.approx(12)
+
+    def test_perfect_team_projects_full_schedule(self):
+        s = summarize(np.full(100, 12), 12)
+        assert s["projected_wins"] == pytest.approx(12.0)
+        assert s["projected_losses"] == pytest.approx(0.0)
+        assert s["p_ten_plus"] == pytest.approx(1.0)
+
+    def test_bowl_eligibility_threshold(self):
+        wins = np.array([5, 5, 6, 7])  # half at or above 6
+        s = summarize(wins, 12)
+        assert s["p_bowl_eligible"] == pytest.approx(0.5)
+        assert BOWL_ELIGIBLE_WINS == 6
+
+    def test_probabilities_are_monotone_in_strength(self):
+        weak = summarize(np.full(1000, 4), 12)
+        strong = summarize(np.full(1000, 9), 12)
+        assert strong["p_bowl_eligible"] > weak["p_bowl_eligible"]
+
+
+class TestScheduleStrength:
+    def test_averages_opponent_ratings_both_sides(self):
+        games = [_game("A", "B"), _game("C", "A")]
+        sos = schedule_strength("A", games, {"B": 1600.0, "C": 1400.0})
+        assert sos == pytest.approx(1500.0)
+
+    def test_unrated_opponents_are_skipped_not_zeroed(self):
+        # An FCS opponent with no rating must not drag the average toward 0.
+        games = [_game("A", "B"), _game("A", "FCS Team")]
+        sos = schedule_strength("A", games, {"B": 1600.0})
+        assert sos == pytest.approx(1600.0)
+
+    def test_returns_none_when_no_opponent_is_rated(self):
+        assert schedule_strength("A", [_game("A", "B")], {}) is None
+
+
+class TestConferenceTitleProbs:
+    def test_probabilities_sum_to_one_within_a_conference(self):
+        wins = {"A": np.array([8, 9]), "B": np.array([7, 6]), "C": np.array([5, 10])}
+        conf = dict.fromkeys(("A", "B", "C"), "Big Test")
+        played = dict.fromkeys(("A", "B", "C"), 12)
+        probs = conference_title_probs(wins, conf, played)
+        assert sum(probs.values()) == pytest.approx(1.0)
+
+    def test_ties_split_evenly(self):
+        wins = {"A": np.array([9, 9]), "B": np.array([9, 9])}
+        conf = {"A": "C1", "B": "C1"}
+        played = {"A": 12, "B": 12}
+        probs = conference_title_probs(wins, conf, played)
+        assert probs["A"] == pytest.approx(0.5)
+        assert probs["B"] == pytest.approx(0.5)
+
+    def test_dominant_team_takes_the_title(self):
+        wins = {"A": np.array([12, 12]), "B": np.array([3, 2])}
+        conf = {"A": "C1", "B": "C1"}
+        played = {"A": 12, "B": 12}
+        probs = conference_title_probs(wins, conf, played)
+        assert probs["A"] == pytest.approx(1.0)
+
+    def test_uses_win_pct_so_uneven_schedules_compare_fairly(self):
+        # B wins fewer games but plays fewer, at a better rate.
+        wins = {"A": np.array([6, 6]), "B": np.array([5, 5])}
+        conf = {"A": "C1", "B": "C1"}
+        played = {"A": 12, "B": 8}
+        probs = conference_title_probs(wins, conf, played)
+        assert probs["B"] > probs["A"]
+
+    def test_single_team_conference_is_skipped(self):
+        wins = {"Independent": np.array([6, 6])}
+        probs = conference_title_probs(wins, {"Independent": "FBS Ind"}, {"Independent": 12})
+        assert probs == {}
+
+
+class TestSosRanks:
+    def test_toughest_schedule_ranks_first(self):
+        rows = [
+            {"team": "A", "sos_rating": 1500.0, "sos_rank": None},
+            {"team": "B", "sos_rating": 1700.0, "sos_rank": None},
+            {"team": "C", "sos_rating": 1600.0, "sos_rank": None},
+        ]
+        ranked = {r["team"]: r["sos_rank"] for r in assign_sos_ranks(rows)}
+        assert ranked == {"B": 1, "C": 2, "A": 3}
+
+    def test_unrated_rows_keep_none(self):
+        rows = [
+            {"team": "A", "sos_rating": 1500.0, "sos_rank": None},
+            {"team": "B", "sos_rating": None, "sos_rank": None},
+        ]
+        ranked = {r["team"]: r["sos_rank"] for r in assign_sos_ranks(rows)}
+        assert ranked["A"] == 1
+        assert ranked["B"] is None
+
+
+class TestBuildProjectionRow:
+    def _row(self):
+        games = [
+            _game("A", "B", completed=True, home_win=True),
+            _game("C", "A", completed=True, home_win=False),
+            _game("A", "D", margin=7.0),
+        ]
+        wins = simulate_wins(games, 500, 18.5)
+        return build_projection_row(
+            "A", wins["A"], games, {"B": 1500.0}, "TestConf", "fitted_v1", 500, 18.5, 0.25
+        )
+
+    def test_counts_actual_wins_from_both_sides(self):
+        row = self._row()
+        assert row["actual_wins"] == 2  # home win vs B, away win at C
+        assert row["games_completed"] == 2
+        assert row["games_scheduled"] == 3
+
+    def test_short_schedule_is_flagged_incomplete(self):
+        row = self._row()
+        assert row["schedule_complete"] is False
+        assert COMPLETE_SCHEDULE_GAMES == 11
+
+    def test_win_distribution_keys_are_strings_for_jsonb(self):
+        row = self._row()
+        assert all(isinstance(k, str) for k in row["p_win_dist"])
+        assert sum(row["p_win_dist"].values()) == pytest.approx(1.0)
+
+    def test_playoff_prob_is_null_in_v1(self):
+        assert self._row()["playoff_prob"] is None
+
+    def test_carries_simulation_provenance(self):
+        row = self._row()
+        assert row["n_sims"] == 500
+        assert row["residual_sigma"] == 18.5
+        assert row["model_version"] == "fitted_v1"

--- a/tests/test_simulate_season.py
+++ b/tests/test_simulate_season.py
@@ -375,3 +375,40 @@ class TestCodexRegressions:
         sim = simulate_wins(games, 100, 18.5)
         assert sim["games_simulated"]["A"] == 2
         assert sim["conf_games"]["A"] == 1
+
+
+class TestSelfReviewRegressions:
+    """Defects found in the fixes for the PR #48 review, before merge.
+
+    Both are the same shape as the originals: a plausible number where an
+    absence or an error belongs."""
+
+    def test_team_with_no_scorable_game_gets_no_projection(self):
+        """The `games_simulated` split (fix for P2-C) reintroduced the problem
+        one level up: a team whose entire slate is unscored produced
+        `projected_wins=0.0`, `p_bowl_eligible=0.0` and `p_win_dist={"0": 1.0}`
+        -- indistinguishable from a team the model expects to go winless.
+        Such teams must be omitted entirely."""
+        games = [_game("A", "B", margin=None), _game("A", "C", margin=None)]
+        sim = simulate_wins(games, 100, 18.5)
+        assert sim["games_simulated"]["A"] == 0
+
+        # The row builder still produces the degenerate shape if called...
+        row = build_projection_row(
+            "A", sim["wins"]["A"], games, {}, "C", "fitted_v1", 100, 18.5, None, 0
+        )
+        assert row["projected_wins"] == 0.0
+        assert row["p_bowl_eligible"] == 0.0
+        # ...which is precisely why simulate_one_season filters on
+        # games_simulated > 0 before building rows. Guard the invariant here so
+        # the filter cannot be dropped without a failing test.
+        assert [t for t in sim["wins"] if sim["games_simulated"][t] > 0] == []
+
+    def test_zero_sigma_would_make_every_game_deterministic(self):
+        """A non-positive sigma collapses every draw onto its mean, so every
+        win probability becomes exactly 0 or 1. `fetch_sigma` rejects it; this
+        pins why."""
+        games = [_game("A", "B", margin=3.0)]
+        wins = simulate_wins(games, 200, 0.0)["wins"]
+        assert np.all(wins["A"] == 1)
+        assert np.all(wins["B"] == 0)

--- a/tests/test_simulate_season.py
+++ b/tests/test_simulate_season.py
@@ -35,7 +35,9 @@ from scripts.simulate_season import (  # noqa: E402
 )
 
 
-def _game(home, away, completed=False, home_win=None, margin=None, season=2026):
+def _game(
+    home, away, completed=False, home_win=None, margin=None, season=2026, conference_game=True
+):
     return {
         "season": season,
         "home_team": home,
@@ -45,21 +47,28 @@ def _game(home, away, completed=False, home_win=None, margin=None, season=2026):
         "expected_home_margin": margin,
         "home_conference": "TestConf",
         "away_conference": "TestConf",
+        "conference_game": conference_game,
     }
+
+
+def _wins(games, n_sims, sigma, seed=None):
+    """simulate_wins()['wins'] -- most tests only care about the overall tally."""
+    kwargs = {"seed": seed} if seed is not None else {}
+    return simulate_wins(games, n_sims, sigma, **kwargs)["wins"]
 
 
 class TestSimulateWins:
     def test_deterministic_under_fixed_seed(self):
         games = [_game("A", "B", margin=3.0), _game("C", "A", margin=-7.0)]
-        a = simulate_wins(games, 500, 18.5, seed=42)
-        b = simulate_wins(games, 500, 18.5, seed=42)
+        a = _wins(games, 500, 18.5, seed=42)
+        b = _wins(games, 500, 18.5, seed=42)
         for team in a:
             np.testing.assert_array_equal(a[team], b[team])
 
     def test_different_seeds_differ(self):
         games = [_game("A", "B", margin=0.0)]
-        a = simulate_wins(games, 500, 18.5, seed=1)
-        b = simulate_wins(games, 500, 18.5, seed=2)
+        a = _wins(games, 500, 18.5, seed=1)
+        b = _wins(games, 500, 18.5, seed=2)
         assert not np.array_equal(a["A"], b["A"])
 
     def test_completed_games_are_not_re_rolled(self):
@@ -69,7 +78,7 @@ class TestSimulateWins:
             _game("A", "C", completed=True, home_win=True),
             _game("D", "A", completed=True, home_win=False),
         ]
-        wins = simulate_wins(games, 200, 18.5)
+        wins = _wins(games, 200, 18.5)
         assert np.all(wins["A"] == 3)
         assert np.all(wins["B"] == 0)
 
@@ -80,31 +89,31 @@ class TestSimulateWins:
             _game("A", "B", completed=True, home_win=True),
             _game("A", "C", margin=None),
         ]
-        wins = simulate_wins(games, 500, 18.5)
+        wins = _wins(games, 500, 18.5)
         assert np.all(wins["A"] == 1)
         assert np.all(wins["C"] == 0)
 
     def test_huge_favorite_wins_nearly_always(self):
         games = [_game("A", "B", margin=100.0)]
-        wins = simulate_wins(games, 2000, 18.5)
+        wins = _wins(games, 2000, 18.5)
         assert wins["A"].mean() > 0.99
         assert wins["B"].mean() < 0.01
 
     def test_pickem_is_about_even(self):
         games = [_game("A", "B", margin=0.0)]
-        wins = simulate_wins(games, 20000, 18.5)
+        wins = _wins(games, 20000, 18.5)
         assert wins["A"].mean() == pytest.approx(0.5, abs=0.02)
 
     def test_every_game_produces_exactly_one_winner(self):
         games = [_game("A", "B", margin=5.0), _game("B", "C", margin=-2.0)]
-        wins = simulate_wins(games, 300, 18.5)
+        wins = _wins(games, 300, 18.5)
         total = wins["A"] + wins["B"] + wins["C"]
         assert np.all(total == len(games))
 
     def test_larger_sigma_widens_the_outcome_spread(self):
         games = [_game("A", "B", margin=14.0)]
-        tight = simulate_wins(games, 5000, 5.0, seed=3)["A"].mean()
-        loose = simulate_wins(games, 5000, 30.0, seed=3)["A"].mean()
+        tight = _wins(games, 5000, 5.0, seed=3)["A"].mean()
+        loose = _wins(games, 5000, 30.0, seed=3)["A"].mean()
         # A 14-point favorite is less certain under a wider error distribution.
         assert tight > loose
 
@@ -236,9 +245,18 @@ class TestBuildProjectionRow:
             _game("C", "A", completed=True, home_win=False),
             _game("A", "D", margin=7.0),
         ]
-        wins = simulate_wins(games, 500, 18.5)
+        sim = simulate_wins(games, 500, 18.5)
         return build_projection_row(
-            "A", wins["A"], games, {"B": 1500.0}, "TestConf", "fitted_v1", 500, 18.5, 0.25
+            "A",
+            sim["wins"]["A"],
+            games,
+            {"B": 1500.0},
+            "TestConf",
+            "fitted_v1",
+            500,
+            18.5,
+            0.25,
+            sim["games_simulated"]["A"],
         )
 
     def test_counts_actual_wins_from_both_sides(self):
@@ -265,3 +283,95 @@ class TestBuildProjectionRow:
         assert row["n_sims"] == 500
         assert row["residual_sigma"] == 18.5
         assert row["model_version"] == "fitted_v1"
+
+
+class TestCodexRegressions:
+    """One test per PR #48 review finding, each failing before its fix."""
+
+    def test_unscored_game_is_not_counted_as_a_loss(self):
+        """P2-C. `simulate_wins` skips a game with no prediction, so the
+        projection denominator must skip it too. Counting it in
+        `games_scheduled` while it can never produce a win turns a missing
+        prediction into a certain defeat -- a stronger claim than the coin flip
+        skipping was meant to avoid."""
+        games = [
+            _game("A", "B", margin=100.0),  # A wins ~always
+            _game("A", "C", margin=None),  # unscored
+        ]
+        sim = simulate_wins(games, 1000, 18.5)
+        row = build_projection_row(
+            "A",
+            sim["wins"]["A"],
+            games,
+            {},
+            "TestConf",
+            "fitted_v1",
+            1000,
+            18.5,
+            None,
+            sim["games_simulated"]["A"],
+        )
+        assert row["games_scheduled"] == 2
+        assert row["games_simulated"] == 1
+        # Over the one simulated game A wins ~1.0 and loses ~0.0. If the
+        # unscored game were folded in, losses would be ~1.0.
+        assert row["projected_losses"] < 0.1
+        assert row["projected_wins"] + row["projected_losses"] == pytest.approx(1.0)
+
+    def test_win_distribution_spans_simulated_not_scheduled_games(self):
+        """P2-C. Probability mass must not be reserved for win totals the
+        simulation cannot produce."""
+        games = [_game("A", "B", margin=10.0), _game("A", "C", margin=None)]
+        sim = simulate_wins(games, 500, 18.5)
+        row = build_projection_row(
+            "A",
+            sim["wins"]["A"],
+            games,
+            {},
+            "TestConf",
+            "fitted_v1",
+            500,
+            18.5,
+            None,
+            sim["games_simulated"]["A"],
+        )
+        assert set(row["p_win_dist"]) == {"0", "1"}
+        assert sum(row["p_win_dist"].values()) == pytest.approx(1.0)
+
+    def test_non_conference_wins_do_not_buy_title_odds(self):
+        """P1-B. A team that sweeps weak non-conference opponents but loses in
+        the league must not out-rank a better conference record."""
+        games = [
+            # A: 1-1 in conference, plus two non-conference wins.
+            _game("A", "B", completed=True, home_win=True, conference_game=True),
+            _game("C", "A", completed=True, home_win=True, conference_game=True),
+            _game("A", "Cupcake1", completed=True, home_win=True, conference_game=False),
+            _game("A", "Cupcake2", completed=True, home_win=True, conference_game=False),
+            # C: 2-0 in conference.
+            _game("C", "B", completed=True, home_win=True, conference_game=True),
+        ]
+        sim = simulate_wins(games, 200, 18.5)
+        conf = {"A": "C1", "B": "C1", "C": "C1", "Cupcake1": None, "Cupcake2": None}
+        probs = conference_title_probs(sim["conf_wins"], conf, sim["conf_games"])
+
+        # Overall records: A is 3-1, C is 2-0. Conference records: A 1-1, C 2-0.
+        assert sim["wins"]["A"][0] > sim["wins"]["C"][0]  # A leads overall
+        assert probs["C"] == pytest.approx(1.0)  # C still wins the league
+        assert probs["A"] == pytest.approx(0.0)
+
+    def test_conference_wins_come_from_the_same_draws_as_overall(self):
+        """P1-B. Conference tallies must be a filtered view of the same
+        simulated season, not an independent re-simulation -- otherwise a game
+        could be a win overall and a loss in the league within one 'season'."""
+        games = [_game("A", "B", margin=3.0, conference_game=True)]
+        sim = simulate_wins(games, 1000, 18.5)
+        np.testing.assert_array_equal(sim["wins"]["A"], sim["conf_wins"]["A"])
+
+    def test_non_conference_games_excluded_from_conference_counts(self):
+        games = [
+            _game("A", "B", margin=3.0, conference_game=True),
+            _game("A", "Cupcake", margin=40.0, conference_game=False),
+        ]
+        sim = simulate_wins(games, 100, 18.5)
+        assert sim["games_simulated"]["A"] == 2
+        assert sim["conf_games"]["A"] == 1

--- a/tests/test_years.py
+++ b/tests/test_years.py
@@ -2,7 +2,44 @@
 
 from unittest.mock import patch
 
-from src.pipelines.config.years import YEAR_RANGES, YearRange, get_current_season
+from src.pipelines.config.years import (
+    YEAR_RANGES,
+    YearRange,
+    get_current_season,
+    get_projection_seasons,
+)
+
+
+class FakeCursor:
+    """Minimal psycopg2-cursor stand-in: replays a queued list of results in
+    execute order, so get_projection_seasons can be tested without a DB."""
+
+    def __init__(self, results):
+        self._results = list(results)
+        self._current = None
+
+    def execute(self, sql, params=None):
+        self._current = self._results.pop(0)
+
+    def fetchone(self):
+        return self._current[0]
+
+    def fetchall(self):
+        return self._current
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+class FakeConn:
+    def __init__(self, results):
+        self._cursor = FakeCursor(results)
+
+    def cursor(self):
+        return self._cursor
 
 
 class TestYearRange:
@@ -86,3 +123,33 @@ class TestGetCurrentSeason:
         with patch("datetime.datetime") as mock_dt:
             mock_dt.now.return_value = datetime(2026, 1, 27)
             assert get_current_season() == 2025
+
+
+class TestGetProjectionSeasons:
+    """The offseason-blackout regression: between January and July,
+    get_current_season() returns the season that already finished, so a
+    calendar-keyed --incremental never builds the upcoming season."""
+
+    def test_offseason_includes_upcoming_season(self):
+        # July 2026: 2025 complete, 2026 scheduled. The calendar rule would
+        # say 2025 alone; the data says both.
+        conn = FakeConn([[(2025,)], [(2025,), (2026,)]])
+        assert get_projection_seasons(conn) == [2025, 2026]
+
+    def test_in_season_is_just_the_current_season(self):
+        # October 2026: 2026 has completed games, no later season scheduled.
+        conn = FakeConn([[(2026,)], [(2026,)]])
+        assert get_projection_seasons(conn) == [2026]
+
+    def test_seasons_are_ascending(self):
+        conn = FakeConn([[(2024,)], [(2024,), (2025,), (2026,)]])
+        assert get_projection_seasons(conn) == [2024, 2025, 2026]
+
+    def test_no_completed_games_falls_back_to_latest_present(self):
+        # Guard against `season >= 0` matching all of 1869+ on a fresh DB.
+        conn = FakeConn([[(0,)], [(2026,)]])
+        assert get_projection_seasons(conn) == [2026]
+
+    def test_empty_database_returns_empty(self):
+        conn = FakeConn([[(0,)], [(0,)]])
+        assert get_projection_seasons(conn) == []


### PR DESCRIPTION
## Why

A downstream agent asked for a 2026 Oklahoma outlook and answered, in substance, "zero 2026 games completed means zero EPA, zero Elo trajectory, zero predictive edges" — then offered "9-3ish on vibes."

That framing was wrong in a correctable way. `fitted_v1` was built to score a week-1 game with no games played (design doc §1f defines the preseason-known constants, §1i fixes the week-1 NULL semantics). The model is supposed to have a July opinion. It had none, for two reasons this PR addresses.

## What was broken (verified against prod)

| # | Finding |
|---|---|
| 1 | `get_current_season()` returns `year - 1` before August, so every `--incremental` step spent the offseason rebuilding **2025**. `features.team_week` had **0 rows for 2026** against a published 1,638-game schedule. |
| 2 | `score_fitted.py` INNER JOINs `team_week`; zero matches logged "nothing to write" and **exited 0**. Six months of green daily-load runs, no output. |
| 3 | `features.model_metadata` maxed at `train_through_season=2024`. The 2025 season ended in January; the annual refit was manual and was missed. |
| 4 | The dark model was the best one — 2025, 3,829 games: `fitted_v1` MAE **14.69** vs `elo_epa_blend_v1` 15.69. The two models that survived have no preseason signal. |

`compute_predictions.py` was unaffected because its `TARGET_GAMES_QUERY` already selects `season >= (SELECT MAX(season) FROM core.games WHERE completed)`. This PR adopts that idiom everywhere.

## Changes

**Phase 1 — unbreak the offseason.** Adds `get_projection_seasons(conn)`, which resolves target seasons from `core.games` rather than the calendar, and rewires `--incremental` in `build_features.py`, `compute_adjusted_epa.py`, and `compute_adjusted_epa_week.py`. `get_current_season()` is left alone — it remains correct for ingest year windows.

Converts the silent-zero path into a gate: `run_upcoming` now counts pending games from `core.games` **before** the feature join (joining `team_week` there would make numerator and denominator agree by construction and the gate could never fire) and fails below 90% coverage, while still treating a genuinely empty slate as success. Rows that do score are written before the failure. `verify_load.py` asserts the same invariant independently, so a shortfall surfaces even if the scoring step is skipped or reordered.

Adds `train_model.py --refit-if-stale`, a no-op on all but one day a year, removing a manual chore that was already missed once.

Adds `probe_offseason_availability.py`: several 2026 offseason inputs are still missing, and the calendar bug and genuine non-publication look identical from the warehouse side. Unpublished is treated as a reportable state, not a failure.

**Feature screen.** Adds `screen_preseason_features.py`, a partial-correlation gate — does a candidate add signal *beyond prior-season rating* — with a pre-registered effect floor and Benjamini-Hochberg FDR control. Run against prod (n=1,439, 2015–2025); results recorded in the plan appendix and the script docstring. Rejected candidates are retained so the nulls stay reproducible.

**Phase 4 — season simulation.** Migration 043 adds `predictions.season_projections`, append-only daily snapshots mirroring `game_predictions` semantics. `simulate_season.py` runs the Monte Carlo: completed games contribute actual results, remaining games draw `margin ~ Normal(expected_home_margin, sigma)` with sigma measured per model and stored on every row.

## Screen results worth knowing

| candidate | vs prior SP+ | + recruiting | verdict |
|---|---|---|---|
| `recruiting_points_3yr` | **+0.2642** | (control) | ship |
| `blue_chip_pipeline` | +0.2532 | **+0.0931** | ship |
| `recruiting_points_regime` | +0.1525 | **+0.0955** | ship |
| `draft_picks_3yr` | +0.0949 | **+0.0068** | reject |
| `draft_departures` | +0.0088 | — | reject |

Trailing recruiting pipeline is the strongest preseason signal found, at 3× the floor, and *stronger* in the portal era (+0.2840). Prior-year draft output is redundant rather than absent — it predicts until recruiting is controlled, then collapses. `draft_departures` is the clearest case for having built the gate: raw correlation **+0.3474**, partial **+0.0088**.

Scope note: this covers only backward-looking draft output. Current-roster draft *potential* is a different construct and remains untested.

## Deliberate limitations

- **Simulation draws games independently.** Real outcomes are correlated, so both tails are understated — 11-win and 2-win seasons are each less likely here than in reality. Central tendency is unaffected; `p10`/`p90`/`p_ten_plus` are conservative. Recorded in the `n_sims` column comment. Correlated variant queued as v1.1.
- **`playoff_prob` ships NULL.** The 12-team format's autobids and seeding are their own project; a number nobody can defend is worse than an absence.
- Projections cover **listed** games only — 68 of 337 teams have fewer than 8 games on the 2026 schedule, flagged per row via `schedule_complete`.
- A pending game with no prediction is skipped, not treated as a coin flip, which would bias projections toward .500.

## Verification

`ruff check`, `ruff format --check` clean; **1,005 passed / 380 skipped**. New tests cover both regressions explicitly — `coverage_verdict(1638, 0)` fails, `coverage_verdict(0, 0)` passes — plus simulator determinism under a fixed seed and the "completed games are not re-rolled" invariant.

**Not yet validated against prod.** The sandbox blocks outbound TCP on 5432/6543 (only 443 gets out), so no compute script in this PR has run against real data. Two follow-ups after merge:

1. Apply migration 043: `run_migrations.py --file src/schemas/migrations/043_season_projections.sql` — required before the new simulate step can run.
2. Trigger `daily-load.yml`. Expect ~3,276 `features.team_week` rows for 2026, `train_through_season=2025` present, and `fitted_v1` covering ≥90% of pending 2026 games. The `fitted_coverage` gate will fail loudly if not.

One unverified assumption worth a reviewer's eye: `simulate_season.py`'s schedule-strength calculation joins `analytics.house_elo_current.team` to `core.games` team names. Unrated opponents are skipped rather than scored 0, so a mismatch degrades SOS quietly rather than catastrophically — but it would degrade it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVhu1FqpWFakBHAYQShbMq

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVhu1FqpWFakBHAYQShbMq)_