### PR TITLE
Fail loudly on rate limits instead of returning empty results

### DIFF
--- a/scripts/deploy_schema.py
+++ b/scripts/deploy_schema.py
@@ -79,6 +79,11 @@ COMPUTE_SCRIPTS = {
     "tune_params",
     "calibrate_live_wp",
     "poll_scoreboard",
+    # Phase 4 of the preseason-outlook plan. Needed here, not just in
+    # daily-load.yml, because the compute chain must be runnable independently
+    # of ingest -- a rate-limited season load should not be able to block
+    # season projections, which touch no API at all.
+    "simulate_season",
 }
 
 # Marts refreshed after a compute run when plan.refresh is set. One home for

--- a/src/pipelines/sources/game_stats.py
+++ b/src/pipelines/sources/game_stats.py
@@ -12,7 +12,7 @@ import dlt
 from dlt.sources import DltSource
 
 from ..config.years import YEAR_RANGES, get_current_season
-from ..utils.api_client import get_client
+from ..utils.api_client import RATE_LIMIT_ERRORS, get_client
 from .base import make_request
 
 logger = logging.getLogger(__name__)
@@ -97,6 +97,12 @@ def game_team_stats_resource(
                                 },
                             )
                             yield from data
+                        except RATE_LIMIT_ERRORS:
+                            # A 429 is not "this week has no games". Swallowing
+                            # it here would complete the resource with silently
+                            # missing weeks -- the exact failure the rate-limit
+                            # exceptions exist to make loud.
+                            raise
                         except Exception:
                             # Some weeks may not have games (esp postseason)
                             continue
@@ -151,6 +157,12 @@ def game_player_stats_resource(
                                 },
                             )
                             yield from data
+                        except RATE_LIMIT_ERRORS:
+                            # A 429 is not "this week has no games". Swallowing
+                            # it here would complete the resource with silently
+                            # missing weeks -- the exact failure the rate-limit
+                            # exceptions exist to make loud.
+                            raise
                         except Exception:
                             # Some weeks may not have games (esp postseason)
                             continue

--- a/src/pipelines/sources/rosters.py
+++ b/src/pipelines/sources/rosters.py
@@ -10,7 +10,7 @@ import dlt
 from dlt.sources import DltSource
 
 from ..config.years import YEAR_RANGES, get_current_season
-from ..utils.api_client import get_client
+from ..utils.api_client import RATE_LIMIT_ERRORS, get_client
 from .base import make_request
 
 logger = logging.getLogger(__name__)
@@ -79,6 +79,12 @@ def rosters_resource(
                         player["year"] = year
                         yield player
 
+                except RATE_LIMIT_ERRORS:
+                    # Demoting a 429 to a warning here yields a roster that is
+                    # quietly missing teams, which poisons every roster-derived
+                    # feature (continuity, trench counts) without any signal
+                    # that it happened. Fail the load instead.
+                    raise
                 except Exception as e:
                     logger.warning(f"Error fetching roster for {team} {year}: {e}")
                     continue

--- a/src/pipelines/utils/api_client.py
+++ b/src/pipelines/utils/api_client.py
@@ -1,13 +1,24 @@
 """HTTP client for CFBD API with retry and rate limiting."""
 
 import logging
+import threading
 import time
+from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
 from typing import Any
 
 import dlt
 import httpx
 
 logger = logging.getLogger(__name__)
+
+# Consecutive fully-rate-limited requests before the circuit opens.
+# Burst throttling clears in ~10 minutes and affects a handful of calls; an
+# exhausted monthly quota 429s everything until the quota resets. After this
+# many requests have each burned their full retry budget without one success,
+# the second explanation is the only one left, and every further minute of
+# waiting is wasted CI time.
+RATE_LIMIT_CIRCUIT_THRESHOLD = 5
 
 
 class RateLimitExhausted(Exception):
@@ -30,13 +41,87 @@ class RateLimitCircuitOpen(Exception):
     useful response is to stop immediately rather than grind at one request
     per minute until the CI job is killed.
 
-    **Terminal for the client instance, by design.** Once open the breaker
-    never reopens on its own: every subsequent ``get`` raises without issuing a
-    request, so the failure cannot be reset by a request that is never made.
-    That is the intent -- the point is to end a doomed sweep, and the pipeline
-    builds a fresh client per run. Call ``reset_rate_limit_circuit()`` to clear
-    it deliberately if a caller genuinely wants to retry within one process.
+    **Terminal once open, by design.** The breaker never reopens on its own:
+    every subsequent ``get`` raises without issuing a request, so the failure
+    cannot be reset by a request that is never made. That is the intent -- the
+    point is to end a doomed sweep. Call ``reset_rate_limit_circuit()`` to
+    clear it deliberately if a caller genuinely wants to retry in-process.
     """
+
+
+class RateLimitBreaker:
+    """Consecutive-429 counter shared by every client in a pipeline run.
+
+    Process-wide rather than per-client, and that distinction is the whole
+    point. Sources call ``get_client()`` per resource function -- 60+ call
+    sites -- and ``load_season.py`` moves to the next source when one fails.
+    Nothing catches RateLimitExhausted while keeping its client alive:
+    ``play_stats_resource`` catches only ``httpx.HTTPStatusError`` (to skip
+    400s), so the first exhaustion unwinds the loop and its ``finally`` closes
+    the client.
+
+    Held on the instance, the counter therefore tops out at **1** and a
+    threshold of 5 can never be reached -- the breaker would be unreachable
+    code. Sharing one counter across the run is what makes it fire at all: N
+    sources each burning a full retry budget against a spent quota is exactly
+    the wasted-CI case it exists to stop.
+
+    Locked because dlt runs sources on a worker pool, so increments and resets
+    genuinely race.
+    """
+
+    def __init__(self, threshold: int = RATE_LIMIT_CIRCUIT_THRESHOLD):
+        self._threshold = threshold
+        self._consecutive = 0
+        self._lock = threading.Lock()
+
+    @property
+    def consecutive(self) -> int:
+        with self._lock:
+            return self._consecutive
+
+    @property
+    def threshold(self) -> int:
+        return self._threshold
+
+    def record_success(self) -> None:
+        """Clear the count. Any success anywhere means the API is answering."""
+        with self._lock:
+            self._consecutive = 0
+
+    def record_exhausted(self) -> int:
+        """Count one request that burned its whole retry budget on 429s."""
+        with self._lock:
+            self._consecutive += 1
+            return self._consecutive
+
+    def is_open(self) -> bool:
+        with self._lock:
+            return self._consecutive >= self._threshold
+
+    def reset(self) -> None:
+        with self._lock:
+            self._consecutive = 0
+
+
+# Both rate-limit failures, for callers with a broad ``except Exception`` that
+# must not swallow them. A source that treats a 429 like "this week has no
+# games" reproduces exactly the silent-partial-data bug these exceptions were
+# added to prevent, so such handlers re-raise on this tuple first.
+RATE_LIMIT_ERRORS = (RateLimitExhausted, RateLimitCircuitOpen)
+
+# The run-wide breaker. Every CFBDClient shares it unless one is injected.
+_SHARED_BREAKER = RateLimitBreaker()
+
+
+def reset_rate_limit_circuit() -> None:
+    """Clear the run-wide breaker so new requests are issued again.
+
+    The breaker is deliberately terminal (see RateLimitCircuitOpen): it ends a
+    doomed sweep. This is the explicit escape hatch -- e.g. a caller that has
+    waited out a quota reset, or a test isolating itself from a prior run.
+    """
+    _SHARED_BREAKER.reset()
 
 
 class CFBDClient:
@@ -50,23 +135,21 @@ class CFBDClient:
     MAX_RETRIES = 3
     RETRY_DELAY = 1.0
 
-    # Consecutive fully-rate-limited requests before the circuit opens.
-    # Burst throttling clears in ~10 minutes and affects a handful of calls;
-    # an exhausted monthly quota 429s everything until the quota resets. After
-    # this many requests have each burned their full retry budget without one
-    # success, the second explanation is the only one left, and every further
-    # minute of waiting is wasted CI time.
-    RATE_LIMIT_CIRCUIT_THRESHOLD = 5
+    RATE_LIMIT_CIRCUIT_THRESHOLD = RATE_LIMIT_CIRCUIT_THRESHOLD
 
     # Upper bound on a server-supplied Retry-After. Without it a hostile or
     # mistaken header could park the pipeline for hours inside one sleep.
     MAX_RETRY_AFTER_SECONDS = 120
 
-    def __init__(self, api_key: str | None = None):
+    def __init__(self, api_key: str | None = None, breaker: RateLimitBreaker | None = None):
         """Initialize the client.
 
         Args:
             api_key: CFBD API key. If not provided, reads from dlt secrets.
+            breaker: Rate-limit circuit breaker. Defaults to the run-wide one
+                shared by every client, which is what makes the threshold
+                reachable (see RateLimitBreaker). Inject a private instance to
+                isolate a caller -- or a test -- from the rest of the run.
         """
         if api_key is None:
             api_key = dlt.secrets.get("sources.cfbd.api_key")
@@ -76,10 +159,7 @@ class CFBDClient:
                 )
 
         self._api_key = api_key
-        # Consecutive requests that exhausted their retry budget entirely on
-        # 429s. Reset by any successful response, so a burst block that clears
-        # never trips the breaker.
-        self._consecutive_rate_limited = 0
+        self._breaker = breaker if breaker is not None else _SHARED_BREAKER
         self._client = httpx.Client(
             base_url=self.BASE_URL,
             headers={
@@ -89,37 +169,66 @@ class CFBDClient:
             timeout=self.DEFAULT_TIMEOUT,
         )
 
-    def reset_rate_limit_circuit(self) -> None:
-        """Clear the rate-limit breaker so this client can issue requests again.
+    @property
+    def _consecutive_rate_limited(self) -> int:
+        """Read-through to the breaker this client uses."""
+        return self._breaker.consecutive
 
-        The breaker is deliberately terminal (see RateLimitCircuitOpen): it
-        ends a doomed sweep and the pipeline builds a fresh client per run.
-        This is the explicit escape hatch for a caller that wants to retry
-        within one process -- e.g. after waiting out a quota reset.
+    def reset_rate_limit_circuit(self) -> None:
+        """Clear this client's breaker so it can issue requests again.
+
+        Resets the run-wide breaker unless a private one was injected, since
+        that is the one blocking every client in the run.
         """
-        self._consecutive_rate_limited = 0
+        self._breaker.reset()
+
+    @staticmethod
+    def _http_date_delay(text: str, now: datetime | None = None) -> int | None:
+        """Seconds until an HTTP-date ``Retry-After``, or None if not a date.
+
+        Never negative: a date already in the past means "retry now".
+        """
+        try:
+            when = parsedate_to_datetime(text)
+        except (TypeError, ValueError):
+            return None
+        if when is None:
+            return None
+        if when.tzinfo is None:
+            # RFC 9110 fixes HTTP-dates to GMT; a missing offset is not local time.
+            when = when.replace(tzinfo=UTC)
+        reference = now if now is not None else datetime.now(UTC)
+        return max(0, int((when - reference).total_seconds()))
 
     @classmethod
-    def _parse_retry_after(cls, raw: str | None) -> int:
+    def _parse_retry_after(cls, raw: str | None, now: datetime | None = None) -> int:
         """Seconds to wait from a ``Retry-After`` header, clamped and defensive.
 
         RFC 9110 permits either a delay in seconds or an HTTP-date, and servers
         do send both -- plus, in practice, occasional nonsense. A bare
         ``int(raw)`` raises ValueError from inside the 429 handler, which
         escapes as an unrelated crash and loses the rate-limit context
-        entirely. Anything unparseable falls back to the default delay.
+        entirely, and treating a valid HTTP-date as the 60s default retries
+        before the server said to -- which can exhaust a small retry budget on
+        a request that waiting would have satisfied. So: seconds first, then
+        HTTP-date relative to now, then the default.
 
-        Also clamped to MAX_RETRY_AFTER_SECONDS so a large or hostile value
-        cannot park the pipeline inside a single sleep.
+        Clamped to MAX_RETRY_AFTER_SECONDS either way, so a distant date or a
+        hostile value cannot park the pipeline inside a single sleep.
         """
         default = 60
         if raw is None:
             return default
-        try:
-            seconds = int(str(raw).strip())
-        except (TypeError, ValueError):
-            logger.warning("Unparseable Retry-After header %r; using %ds", raw, default)
+        text = str(raw).strip()
+        if not text:
             return default
+        try:
+            seconds = int(text)
+        except (TypeError, ValueError):
+            seconds = cls._http_date_delay(text, now)
+            if seconds is None:
+                logger.warning("Unparseable Retry-After header %r; using %ds", raw, default)
+                return default
         if seconds < 0:
             return default
         return min(seconds, cls.MAX_RETRY_AFTER_SECONDS)
@@ -148,9 +257,9 @@ class CFBDClient:
                 Deliberately raised rather than returning ``[]``, which the
                 caller cannot distinguish from a genuinely empty result.
         """
-        if self._consecutive_rate_limited >= self.RATE_LIMIT_CIRCUIT_THRESHOLD:
+        if self._breaker.is_open():
             raise RateLimitCircuitOpen(
-                f"{self._consecutive_rate_limited} consecutive request(s) exhausted their "
+                f"{self._breaker.consecutive} consecutive request(s) exhausted their "
                 f"retries on HTTP 429 before {endpoint}. The API is refusing everything -- "
                 "most likely the monthly quota is spent. Stopping instead of retrying; "
                 "further requests cannot succeed until the quota resets."
@@ -162,7 +271,7 @@ class CFBDClient:
                 response.raise_for_status()
                 # Any success clears the breaker: a transient burst block that
                 # resolves must not accumulate toward the quota threshold.
-                self._consecutive_rate_limited = 0
+                self._breaker.record_success()
                 return response.json()
             except httpx.HTTPStatusError as e:
                 if e.response.status_code == 429:  # Rate limited
@@ -171,11 +280,11 @@ class CFBDClient:
                         # Out of attempts. Count it and fail loudly -- falling
                         # through to an empty list here would tell the caller
                         # this endpoint has no data.
-                        self._consecutive_rate_limited += 1
+                        consecutive = self._breaker.record_exhausted()
                         raise RateLimitExhausted(
                             f"Rate limited on all {retries + 1} attempt(s) for {endpoint} "
                             f"(params={params}). Consecutive rate-limited requests: "
-                            f"{self._consecutive_rate_limited}."
+                            f"{consecutive}."
                         ) from e
                     logger.warning(
                         f"Rate limited on {endpoint}. Waiting {retry_after}s "

--- a/src/pipelines/utils/api_client.py
+++ b/src/pipelines/utils/api_client.py
@@ -10,6 +10,35 @@ import httpx
 logger = logging.getLogger(__name__)
 
 
+class RateLimitExhausted(Exception):
+    """A request was rate-limited on every attempt.
+
+    Raised instead of returning an empty result, because to a dlt resource
+    ``[]`` is indistinguishable from "this game genuinely has no rows" -- the
+    pipeline would record the absence as fact and move on. A 2026-07-25 daily
+    load spent three hours doing exactly that against ``/plays/stats`` before
+    the job timed out.
+    """
+
+
+class RateLimitCircuitOpen(Exception):
+    """Too many consecutive requests were rate-limited; the sweep gave up.
+
+    Distinct from RateLimitExhausted: that one means a single request failed,
+    this means the API is refusing everything and continuing cannot help. A
+    monthly-quota exhaustion produces an unbroken run of 429s, and the only
+    useful response is to stop immediately rather than grind at one request
+    per minute until the CI job is killed.
+
+    **Terminal for the client instance, by design.** Once open the breaker
+    never reopens on its own: every subsequent ``get`` raises without issuing a
+    request, so the failure cannot be reset by a request that is never made.
+    That is the intent -- the point is to end a doomed sweep, and the pipeline
+    builds a fresh client per run. Call ``reset_rate_limit_circuit()`` to clear
+    it deliberately if a caller genuinely wants to retry within one process.
+    """
+
+
 class CFBDClient:
     """HTTP client for College Football Data API.
 
@@ -20,6 +49,18 @@ class CFBDClient:
     DEFAULT_TIMEOUT = 30.0
     MAX_RETRIES = 3
     RETRY_DELAY = 1.0
+
+    # Consecutive fully-rate-limited requests before the circuit opens.
+    # Burst throttling clears in ~10 minutes and affects a handful of calls;
+    # an exhausted monthly quota 429s everything until the quota resets. After
+    # this many requests have each burned their full retry budget without one
+    # success, the second explanation is the only one left, and every further
+    # minute of waiting is wasted CI time.
+    RATE_LIMIT_CIRCUIT_THRESHOLD = 5
+
+    # Upper bound on a server-supplied Retry-After. Without it a hostile or
+    # mistaken header could park the pipeline for hours inside one sleep.
+    MAX_RETRY_AFTER_SECONDS = 120
 
     def __init__(self, api_key: str | None = None):
         """Initialize the client.
@@ -35,6 +76,10 @@ class CFBDClient:
                 )
 
         self._api_key = api_key
+        # Consecutive requests that exhausted their retry budget entirely on
+        # 429s. Reset by any successful response, so a burst block that clears
+        # never trips the breaker.
+        self._consecutive_rate_limited = 0
         self._client = httpx.Client(
             base_url=self.BASE_URL,
             headers={
@@ -43,6 +88,41 @@ class CFBDClient:
             },
             timeout=self.DEFAULT_TIMEOUT,
         )
+
+    def reset_rate_limit_circuit(self) -> None:
+        """Clear the rate-limit breaker so this client can issue requests again.
+
+        The breaker is deliberately terminal (see RateLimitCircuitOpen): it
+        ends a doomed sweep and the pipeline builds a fresh client per run.
+        This is the explicit escape hatch for a caller that wants to retry
+        within one process -- e.g. after waiting out a quota reset.
+        """
+        self._consecutive_rate_limited = 0
+
+    @classmethod
+    def _parse_retry_after(cls, raw: str | None) -> int:
+        """Seconds to wait from a ``Retry-After`` header, clamped and defensive.
+
+        RFC 9110 permits either a delay in seconds or an HTTP-date, and servers
+        do send both -- plus, in practice, occasional nonsense. A bare
+        ``int(raw)`` raises ValueError from inside the 429 handler, which
+        escapes as an unrelated crash and loses the rate-limit context
+        entirely. Anything unparseable falls back to the default delay.
+
+        Also clamped to MAX_RETRY_AFTER_SECONDS so a large or hostile value
+        cannot park the pipeline inside a single sleep.
+        """
+        default = 60
+        if raw is None:
+            return default
+        try:
+            seconds = int(str(raw).strip())
+        except (TypeError, ValueError):
+            logger.warning("Unparseable Retry-After header %r; using %ds", raw, default)
+            return default
+        if seconds < 0:
+            return default
+        return min(seconds, cls.MAX_RETRY_AFTER_SECONDS)
 
     def get(
         self,
@@ -59,16 +139,48 @@ class CFBDClient:
 
         Returns:
             JSON response as a list of dicts
+
+        Raises:
+            RateLimitCircuitOpen: too many consecutive requests were fully
+                rate-limited -- the quota is almost certainly exhausted and
+                the sweep stops immediately.
+            RateLimitExhausted: this request was rate-limited on every attempt.
+                Deliberately raised rather than returning ``[]``, which the
+                caller cannot distinguish from a genuinely empty result.
         """
+        if self._consecutive_rate_limited >= self.RATE_LIMIT_CIRCUIT_THRESHOLD:
+            raise RateLimitCircuitOpen(
+                f"{self._consecutive_rate_limited} consecutive request(s) exhausted their "
+                f"retries on HTTP 429 before {endpoint}. The API is refusing everything -- "
+                "most likely the monthly quota is spent. Stopping instead of retrying; "
+                "further requests cannot succeed until the quota resets."
+            )
+
         for attempt in range(retries + 1):
             try:
                 response = self._client.get(endpoint, params=params)
                 response.raise_for_status()
+                # Any success clears the breaker: a transient burst block that
+                # resolves must not accumulate toward the quota threshold.
+                self._consecutive_rate_limited = 0
                 return response.json()
             except httpx.HTTPStatusError as e:
                 if e.response.status_code == 429:  # Rate limited
-                    retry_after = int(e.response.headers.get("Retry-After", 60))
-                    logger.warning(f"Rate limited. Waiting {retry_after}s...")
+                    retry_after = self._parse_retry_after(e.response.headers.get("Retry-After"))
+                    if attempt >= retries:
+                        # Out of attempts. Count it and fail loudly -- falling
+                        # through to an empty list here would tell the caller
+                        # this endpoint has no data.
+                        self._consecutive_rate_limited += 1
+                        raise RateLimitExhausted(
+                            f"Rate limited on all {retries + 1} attempt(s) for {endpoint} "
+                            f"(params={params}). Consecutive rate-limited requests: "
+                            f"{self._consecutive_rate_limited}."
+                        ) from e
+                    logger.warning(
+                        f"Rate limited on {endpoint}. Waiting {retry_after}s "
+                        f"(attempt {attempt + 1}/{retries + 1})..."
+                    )
                     time.sleep(retry_after)
                     continue
                 elif e.response.status_code >= 500 and attempt < retries:
@@ -85,7 +197,10 @@ class CFBDClient:
                     continue
                 raise
 
-        return []
+        # Unreachable: every path above returns or raises. Kept as a guard so a
+        # future edit that adds a `continue` cannot silently reintroduce the
+        # empty-result bug this method was rewritten to remove.
+        raise AssertionError(f"retry loop for {endpoint} exited without returning or raising")
 
     def close(self):
         """Close the HTTP client."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,22 @@ import pytest
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
 
+@pytest.fixture(autouse=True)
+def _reset_rate_limit_breaker():
+    """Clear the run-wide CFBD rate-limit breaker around every test.
+
+    The breaker is deliberately process-wide (that is what makes its threshold
+    reachable in production), so without this any test that trips it would
+    leave every later CFBDClient raising RateLimitCircuitOpen -- an
+    order-dependent failure in unrelated suites.
+    """
+    from src.pipelines.utils.api_client import reset_rate_limit_circuit
+
+    reset_rate_limit_circuit()
+    yield
+    reset_rate_limit_circuit()
+
+
 def _load_postgres_dsn() -> str:
     """Read the Postgres connection string from env var or .dlt/secrets.toml."""
     import os

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -5,7 +5,11 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
-from src.pipelines.utils.api_client import CFBDClient
+from src.pipelines.utils.api_client import (
+    CFBDClient,
+    RateLimitCircuitOpen,
+    RateLimitExhausted,
+)
 
 
 class TestCFBDClient:
@@ -106,4 +110,206 @@ class TestCFBDClient:
                 client.get("/teams")
                 mock_sleep.assert_called_with(2)
 
+        client.close()
+
+
+def _rate_limited_response(retry_after="1"):
+    r = MagicMock()
+    r.status_code = 429
+    r.headers = {"Retry-After": retry_after}
+    return r
+
+
+def _rate_limit_error():
+    return httpx.HTTPStatusError("429", request=MagicMock(), response=_rate_limited_response())
+
+
+class TestRateLimitExhaustion:
+    """A 2026-07-25 daily load spent 3 hours here: every /plays/stats request
+    was 429'd, each burned its retry budget, and `get` then returned an empty
+    list -- which dlt recorded as "this game has no play stats". Silent data
+    loss dressed as success, and the job was killed at the 3-hour mark with
+    every downstream step skipped."""
+
+    def test_exhausted_retries_raise_instead_of_returning_empty(self):
+        client = CFBDClient(api_key="test-key")
+        with patch.object(client._client, "get", side_effect=_rate_limit_error()):
+            with patch("src.pipelines.utils.api_client.time.sleep"):
+                with pytest.raises(RateLimitExhausted, match="Rate limited on all"):
+                    client.get("/plays/stats", params={"gameId": 401767542})
+        client.close()
+
+    def test_empty_list_is_never_returned_for_a_rate_limited_request(self):
+        """The specific regression: `[]` and "no data" are indistinguishable
+        to the caller, so the failure must not be expressible as a value."""
+        client = CFBDClient(api_key="test-key")
+        with patch.object(client._client, "get", side_effect=_rate_limit_error()):
+            with patch("src.pipelines.utils.api_client.time.sleep"):
+                result = None
+                try:
+                    result = client.get("/plays/stats")
+                except RateLimitExhausted:
+                    pass
+                assert result is None, "a rate-limited request must not produce a value"
+        client.close()
+
+    def test_a_success_still_returns_normally(self):
+        client = CFBDClient(api_key="test-key")
+        ok = MagicMock()
+        ok.json.return_value = [{"id": 1}]
+        ok.raise_for_status = MagicMock()
+        with patch.object(client._client, "get", side_effect=[_rate_limit_error(), ok]):
+            with patch("src.pipelines.utils.api_client.time.sleep"):
+                assert client.get("/teams") == [{"id": 1}]
+        client.close()
+
+    def test_retry_after_is_capped(self):
+        """A server-supplied Retry-After must not park the pipeline for hours."""
+        client = CFBDClient(api_key="test-key")
+        huge = MagicMock()
+        huge.status_code = 429
+        huge.headers = {"Retry-After": "86400"}
+        err = httpx.HTTPStatusError("429", request=MagicMock(), response=huge)
+        ok = MagicMock()
+        ok.json.return_value = []
+        ok.raise_for_status = MagicMock()
+        with patch.object(client._client, "get", side_effect=[err, ok]):
+            with patch("src.pipelines.utils.api_client.time.sleep") as mock_sleep:
+                client.get("/teams")
+                mock_sleep.assert_called_with(CFBDClient.MAX_RETRY_AFTER_SECONDS)
+        client.close()
+
+
+class TestRateLimitCircuitBreaker:
+    """Quota exhaustion 429s everything. Grinding at one request per minute
+    for three hours cannot succeed; the sweep must abort in seconds."""
+
+    def _exhaust(self, client, n):
+        with patch.object(client._client, "get", side_effect=_rate_limit_error()):
+            with patch("src.pipelines.utils.api_client.time.sleep"):
+                for _ in range(n):
+                    with pytest.raises(RateLimitExhausted):
+                        client.get("/plays/stats")
+
+    def test_circuit_opens_after_threshold(self):
+        client = CFBDClient(api_key="test-key")
+        self._exhaust(client, CFBDClient.RATE_LIMIT_CIRCUIT_THRESHOLD)
+        # The next call must fail immediately, without sleeping at all.
+        with patch("src.pipelines.utils.api_client.time.sleep") as mock_sleep:
+            with pytest.raises(RateLimitCircuitOpen, match="quota is spent"):
+                client.get("/plays/stats")
+            mock_sleep.assert_not_called()
+        client.close()
+
+    def test_circuit_stays_closed_below_threshold(self):
+        client = CFBDClient(api_key="test-key")
+        self._exhaust(client, CFBDClient.RATE_LIMIT_CIRCUIT_THRESHOLD - 1)
+        ok = MagicMock()
+        ok.json.return_value = [{"ok": True}]
+        ok.raise_for_status = MagicMock()
+        with patch.object(client._client, "get", return_value=ok):
+            assert client.get("/teams") == [{"ok": True}]
+        client.close()
+
+    def test_a_success_resets_the_breaker(self):
+        """A burst block that clears must not accumulate toward the quota
+        threshold -- otherwise transient throttling eventually halts a healthy
+        pipeline."""
+        client = CFBDClient(api_key="test-key")
+        self._exhaust(client, CFBDClient.RATE_LIMIT_CIRCUIT_THRESHOLD - 1)
+        ok = MagicMock()
+        ok.json.return_value = []
+        ok.raise_for_status = MagicMock()
+        with patch.object(client._client, "get", return_value=ok):
+            client.get("/teams")
+        assert client._consecutive_rate_limited == 0
+        # Full budget available again.
+        self._exhaust(client, CFBDClient.RATE_LIMIT_CIRCUIT_THRESHOLD - 1)
+        with patch.object(client._client, "get", return_value=ok):
+            assert client.get("/teams") == []
+        client.close()
+
+    def test_non_rate_limit_errors_do_not_trip_the_breaker(self):
+        client = CFBDClient(api_key="test-key")
+        boom = MagicMock()
+        boom.status_code = 404
+        err = httpx.HTTPStatusError("404", request=MagicMock(), response=boom)
+        with patch.object(client._client, "get", side_effect=err):
+            with pytest.raises(httpx.HTTPStatusError):
+                client.get("/nope")
+        assert client._consecutive_rate_limited == 0
+        client.close()
+
+
+class TestRetryAfterParsing:
+    """Found by the pre-PR adversarial pass: `int(header)` raised ValueError
+    from inside the 429 handler, escaping as an unrelated crash that lost the
+    rate-limit context. RFC 9110 allows an HTTP-date as well as seconds."""
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("30", 30),
+            (" 45 ", 45),
+            (None, 60),
+            ("soon", 60),
+            ("Wed, 21 Oct 2026 07:28:00 GMT", 60),
+            ("", 60),
+            ("-5", 60),
+            ("86400", CFBDClient.MAX_RETRY_AFTER_SECONDS),
+        ],
+    )
+    def test_parse_retry_after(self, raw, expected):
+        assert CFBDClient._parse_retry_after(raw) == expected
+
+    def test_malformed_header_does_not_crash_the_request(self):
+        client = CFBDClient(api_key="test-key")
+        bad = MagicMock()
+        bad.status_code = 429
+        bad.headers = {"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"}
+        err = httpx.HTTPStatusError("429", request=MagicMock(), response=bad)
+        ok = MagicMock()
+        ok.json.return_value = [{"ok": True}]
+        ok.raise_for_status = MagicMock()
+        with patch.object(client._client, "get", side_effect=[err, ok]):
+            with patch("src.pipelines.utils.api_client.time.sleep") as mock_sleep:
+                assert client.get("/teams") == [{"ok": True}]
+                mock_sleep.assert_called_with(60)
+        client.close()
+
+
+class TestCircuitIsTerminalButResettable:
+    """Also from the adversarial pass: once open, the breaker raises before
+    issuing any request, so a success can never reset it -- the client is dead
+    for its lifetime. That is the intended abort semantics, but it must be
+    documented and deliberately escapable rather than a surprise."""
+
+    def _open_circuit(self, client):
+        err = httpx.HTTPStatusError("429", request=MagicMock(), response=_rate_limited_response())
+        with patch.object(client._client, "get", side_effect=err):
+            with patch("src.pipelines.utils.api_client.time.sleep"):
+                for _ in range(CFBDClient.RATE_LIMIT_CIRCUIT_THRESHOLD):
+                    with pytest.raises(RateLimitExhausted):
+                        client.get("/plays/stats")
+
+    def test_open_circuit_does_not_self_heal_even_if_the_api_recovers(self):
+        client = CFBDClient(api_key="test-key")
+        self._open_circuit(client)
+        ok = MagicMock()
+        ok.json.return_value = [{"ok": True}]
+        ok.raise_for_status = MagicMock()
+        with patch.object(client._client, "get", return_value=ok):
+            with pytest.raises(RateLimitCircuitOpen):
+                client.get("/teams")
+        client.close()
+
+    def test_explicit_reset_restores_the_client(self):
+        client = CFBDClient(api_key="test-key")
+        self._open_circuit(client)
+        client.reset_rate_limit_circuit()
+        ok = MagicMock()
+        ok.json.return_value = [{"ok": True}]
+        ok.raise_for_status = MagicMock()
+        with patch.object(client._client, "get", return_value=ok):
+            assert client.get("/teams") == [{"ok": True}]
         client.close()

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,14 +1,19 @@
 """Tests for CFBD API client."""
 
+from datetime import UTC, datetime, timedelta
+from email.utils import format_datetime
 from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
 
 from src.pipelines.utils.api_client import (
+    RATE_LIMIT_ERRORS,
     CFBDClient,
+    RateLimitBreaker,
     RateLimitCircuitOpen,
     RateLimitExhausted,
+    reset_rate_limit_circuit,
 )
 
 
@@ -253,7 +258,6 @@ class TestRetryAfterParsing:
             (" 45 ", 45),
             (None, 60),
             ("soon", 60),
-            ("Wed, 21 Oct 2026 07:28:00 GMT", 60),
             ("", 60),
             ("-5", 60),
             ("86400", CFBDClient.MAX_RETRY_AFTER_SECONDS),
@@ -262,11 +266,11 @@ class TestRetryAfterParsing:
     def test_parse_retry_after(self, raw, expected):
         assert CFBDClient._parse_retry_after(raw) == expected
 
-    def test_malformed_header_does_not_crash_the_request(self):
+    def test_unparseable_header_does_not_crash_the_request(self):
         client = CFBDClient(api_key="test-key")
         bad = MagicMock()
         bad.status_code = 429
-        bad.headers = {"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"}
+        bad.headers = {"Retry-After": "whenever"}
         err = httpx.HTTPStatusError("429", request=MagicMock(), response=bad)
         ok = MagicMock()
         ok.json.return_value = [{"ok": True}]
@@ -276,6 +280,132 @@ class TestRetryAfterParsing:
                 assert client.get("/teams") == [{"ok": True}]
                 mock_sleep.assert_called_with(60)
         client.close()
+
+
+class TestRetryAfterHttpDate:
+    """Codex review on PR #49: a valid HTTP-date fell through to the flat 60s
+    default. When the date is further out than that, the client retries before
+    the server said to and can burn its whole budget -- raising
+    RateLimitExhausted on a request that simply waiting would have satisfied.
+    """
+
+    NOW = datetime(2026, 10, 21, 7, 28, 0, tzinfo=UTC)
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            # 90s out: honored exactly, not collapsed to the 60s default.
+            ("Wed, 21 Oct 2026 07:29:30 GMT", 90),
+            # Already past: retry now rather than sleeping a default minute.
+            ("Wed, 21 Oct 2026 07:00:00 GMT", 0),
+            # Distant date still cannot park the pipeline.
+            ("Fri, 25 Dec 2026 00:00:00 GMT", CFBDClient.MAX_RETRY_AFTER_SECONDS),
+            # RFC 9110 fixes HTTP-dates to GMT; a missing offset is not local time.
+            ("Wed, 21 Oct 2026 07:29:00", 60),
+        ],
+    )
+    def test_http_date_is_honored_relative_to_now(self, raw, expected):
+        assert CFBDClient._parse_retry_after(raw, now=self.NOW) == expected
+
+    def test_a_date_beyond_the_default_is_actually_slept(self):
+        """The regression in effect: 90s away must sleep 90, not 60."""
+        client = CFBDClient(api_key="test-key")
+        far = MagicMock()
+        far.status_code = 429
+        far.headers = {"Retry-After": format_datetime(self.NOW + timedelta(seconds=90))}
+        err = httpx.HTTPStatusError("429", request=MagicMock(), response=far)
+        ok = MagicMock()
+        ok.json.return_value = []
+        ok.raise_for_status = MagicMock()
+        with patch.object(client._client, "get", side_effect=[err, ok]):
+            with patch("src.pipelines.utils.api_client.time.sleep") as mock_sleep:
+                with patch("src.pipelines.utils.api_client.datetime") as mock_dt:
+                    mock_dt.now.return_value = self.NOW
+                    client.get("/teams")
+                slept = mock_sleep.call_args[0][0]
+                assert 85 <= slept <= 95, f"expected ~90s from the header, slept {slept}"
+        client.close()
+
+
+class TestBreakerIsSharedAcrossClients:
+    """Codex review on PR #49: the breaker lived on the client instance, but
+    every source calls `get_client()` fresh and nothing catches
+    RateLimitExhausted while keeping its client alive -- `play_stats_resource`
+    catches only httpx.HTTPStatusError, so the first exhaustion unwinds the
+    loop and `finally` closes the client.
+
+    The per-instance counter therefore topped out at 1, the threshold of 5 was
+    unreachable, and the breaker was dead code: a spent quota still burned a
+    full retry budget separately for every one of the ~60 resources."""
+
+    def _exhaust_on_a_fresh_client(self, n):
+        """Mimic the real call graph: one new client per rate-limited source."""
+        for _ in range(n):
+            client = CFBDClient(api_key="test-key")
+            try:
+                with patch.object(client._client, "get", side_effect=_rate_limit_error()):
+                    with patch("src.pipelines.utils.api_client.time.sleep"):
+                        with pytest.raises(RateLimitExhausted):
+                            client.get("/plays/stats")
+            finally:
+                client.close()
+
+    def test_threshold_is_reachable_across_separate_clients(self):
+        self._exhaust_on_a_fresh_client(CFBDClient.RATE_LIMIT_CIRCUIT_THRESHOLD)
+        later = CFBDClient(api_key="test-key")
+        with patch("src.pipelines.utils.api_client.time.sleep") as mock_sleep:
+            with pytest.raises(RateLimitCircuitOpen, match="quota is spent"):
+                later.get("/games")
+            mock_sleep.assert_not_called()
+        later.close()
+
+    def test_below_threshold_a_new_client_still_works(self):
+        self._exhaust_on_a_fresh_client(CFBDClient.RATE_LIMIT_CIRCUIT_THRESHOLD - 1)
+        later = CFBDClient(api_key="test-key")
+        ok = MagicMock()
+        ok.json.return_value = [{"ok": True}]
+        ok.raise_for_status = MagicMock()
+        with patch.object(later._client, "get", return_value=ok):
+            assert later.get("/games") == [{"ok": True}]
+        later.close()
+
+    def test_a_success_on_any_client_clears_the_shared_count(self):
+        self._exhaust_on_a_fresh_client(CFBDClient.RATE_LIMIT_CIRCUIT_THRESHOLD - 1)
+        healthy = CFBDClient(api_key="test-key")
+        ok = MagicMock()
+        ok.json.return_value = []
+        ok.raise_for_status = MagicMock()
+        with patch.object(healthy._client, "get", return_value=ok):
+            healthy.get("/teams")
+        healthy.close()
+        # Budget restored for everyone, so the breaker must still be closed.
+        self._exhaust_on_a_fresh_client(CFBDClient.RATE_LIMIT_CIRCUIT_THRESHOLD - 1)
+        later = CFBDClient(api_key="test-key")
+        with patch.object(later._client, "get", return_value=ok):
+            assert later.get("/games") == []
+        later.close()
+
+    def test_an_injected_breaker_isolates_a_client(self):
+        """The escape hatch: a caller that must not be halted by the run."""
+        self._exhaust_on_a_fresh_client(CFBDClient.RATE_LIMIT_CIRCUIT_THRESHOLD)
+        private = CFBDClient(api_key="test-key", breaker=RateLimitBreaker())
+        ok = MagicMock()
+        ok.json.return_value = [{"ok": True}]
+        ok.raise_for_status = MagicMock()
+        with patch.object(private._client, "get", return_value=ok):
+            assert private.get("/teams") == [{"ok": True}]
+        private.close()
+
+    def test_module_level_reset_clears_the_run(self):
+        self._exhaust_on_a_fresh_client(CFBDClient.RATE_LIMIT_CIRCUIT_THRESHOLD)
+        reset_rate_limit_circuit()
+        later = CFBDClient(api_key="test-key")
+        ok = MagicMock()
+        ok.json.return_value = []
+        ok.raise_for_status = MagicMock()
+        with patch.object(later._client, "get", return_value=ok):
+            assert later.get("/teams") == []
+        later.close()
 
 
 class TestCircuitIsTerminalButResettable:
@@ -313,3 +443,101 @@ class TestCircuitIsTerminalButResettable:
         with patch.object(client._client, "get", return_value=ok):
             assert client.get("/teams") == [{"ok": True}]
         client.close()
+
+
+class TestBroadExceptHandlersDoNotSwallowRateLimits:
+    """Found by the pre-PR adversarial pass on the Codex fixes.
+
+    Three source loops caught bare `Exception` and continued -- game_stats'
+    two week loops (to skip weeks with no games) and rosters' per-team loop.
+    Those handlers swallowed RateLimitExhausted and RateLimitCircuitOpen too,
+    so a quota-exhausted load would spin through every remaining week/team and
+    complete "successfully" with silently missing data: the exact bug raising
+    instead of returning `[]` was meant to eliminate, reintroduced one layer
+    up. For rosters it is worse than lost rows -- a partial roster poisons
+    every roster-derived feature with no signal that it happened.
+    """
+
+    @staticmethod
+    def _rate_limited_client():
+        client = CFBDClient(api_key="test-key")
+        patcher = patch.object(client._client, "get", side_effect=_rate_limit_error())
+        patcher.start()
+        return client, patcher
+
+    @staticmethod
+    def _assert_rate_limit_escapes(resource):
+        """dlt wraps a generator exception in ResourceExtractionError, so assert
+        on the chained cause -- the point is that it escaped the loop at all."""
+        from dlt.extract.exceptions import ResourceExtractionError
+
+        with pytest.raises(ResourceExtractionError) as exc_info:
+            list(resource)
+        causes = []
+        err = exc_info.value
+        while err is not None:
+            causes.append(type(err))
+            err = err.__cause__ or err.__context__
+        assert any(c in RATE_LIMIT_ERRORS for c in causes), (
+            f"rate limit was swallowed; chain was {causes}"
+        )
+
+    @pytest.mark.parametrize("exc", [RateLimitExhausted, RateLimitCircuitOpen])
+    def test_rate_limit_errors_tuple_covers_both(self, exc):
+        assert exc in RATE_LIMIT_ERRORS
+
+    def test_game_team_stats_propagates_rate_limit(self):
+        from src.pipelines.sources.game_stats import game_team_stats_resource
+
+        client, patcher = self._rate_limited_client()
+        try:
+            with patch("src.pipelines.sources.game_stats.get_client", return_value=client):
+                with patch("src.pipelines.utils.api_client.time.sleep"):
+                    res = game_team_stats_resource([2026], season_type="regular", weeks=[1, 2, 3])
+                    self._assert_rate_limit_escapes(res)
+        finally:
+            patcher.stop()
+            client.close()
+
+    def test_game_player_stats_propagates_rate_limit(self):
+        from src.pipelines.sources.game_stats import game_player_stats_resource
+
+        client, patcher = self._rate_limited_client()
+        try:
+            with patch("src.pipelines.sources.game_stats.get_client", return_value=client):
+                with patch("src.pipelines.utils.api_client.time.sleep"):
+                    res = game_player_stats_resource([2026], season_type="regular", weeks=[1, 2, 3])
+                    self._assert_rate_limit_escapes(res)
+        finally:
+            patcher.stop()
+            client.close()
+
+    def test_roster_propagates_rate_limit_instead_of_warning(self):
+        from src.pipelines.sources.rosters import rosters_resource
+
+        client, patcher = self._rate_limited_client()
+        try:
+            with patch("src.pipelines.sources.rosters.get_client", return_value=client):
+                with patch("src.pipelines.utils.api_client.time.sleep"):
+                    res = rosters_resource(teams=["Oklahoma", "Texas"], years=[2026])
+                    self._assert_rate_limit_escapes(res)
+        finally:
+            patcher.stop()
+            client.close()
+
+    def test_non_rate_limit_errors_are_still_skipped(self):
+        """The skip behaviour these handlers exist for must survive: a week
+        with no games still yields nothing rather than failing the load."""
+        from src.pipelines.sources.game_stats import game_team_stats_resource
+
+        client = CFBDClient(api_key="test-key")
+        boom = MagicMock()
+        boom.status_code = 400
+        err = httpx.HTTPStatusError("400", request=MagicMock(), response=boom)
+        try:
+            with patch.object(client._client, "get", side_effect=err):
+                with patch("src.pipelines.sources.game_stats.get_client", return_value=client):
+                    res = game_team_stats_resource([2026], season_type="regular", weeks=[1, 2])
+                    assert list(res) == []
+        finally:
+            client.close()

--- a/tests/test_deploy_schema.py
+++ b/tests/test_deploy_schema.py
@@ -38,6 +38,9 @@ class TestComputeScripts:
             "tune_params",
             "calibrate_live_wp",
             "poll_scoreboard",
+            # Phase 4 season projections. Runnable through the deploy path so
+            # the compute chain does not depend on a healthy ingest run.
+            "simulate_season",
         }
 
 


### PR DESCRIPTION
## What happened

The 2026-07-25 daily load ran for **three hours** and then was killed, having "skipped" its work. The cause is in `src/pipelines/utils/api_client.py`.

`CFBDClient.get()` retried a 429 three times, sleeping on `Retry-After` between attempts, and then fell out of the loop and returned `[]`. To a dlt resource, `[]` is indistinguishable from "this game genuinely has no rows" — so the pipeline recorded absence as fact and moved on to the next request. Against `/plays/stats`, with a per-game fan-out, that is thousands of requests each burning ~3 minutes of sleep and writing nothing.

## Changes

**`src/pipelines/utils/api_client.py`**

- `RateLimitExhausted` — raised when a single request is rate-limited on every attempt, replacing the `return []`.
- `RateLimitCircuitOpen` — raised up front once `RATE_LIMIT_CIRCUIT_THRESHOLD` (5) consecutive requests have each burned their full retry budget on 429s. A burst block clears in ~10 minutes; an exhausted monthly quota 429s *everything* until it resets, and nothing told the two apart.
- `RateLimitBreaker` — the consecutive-429 counter, held **run-wide** and shared by every client rather than per-instance (see the Codex thread below for why that distinction is the whole feature). Locked, since dlt runs sources on a worker pool. Injectable so a caller or test can isolate itself; `reset_rate_limit_circuit()` clears the run.
- Any successful response anywhere resets the count, so a transient burst block that resolves never trips the breaker.
- `_parse_retry_after()` — integer delay first, then an RFC 9110 HTTP-date parsed relative to now, then a 60s default, with `MAX_RETRY_AFTER_SECONDS` (120) clamping every path. A date in the past yields 0 ("retry now"); a date with no offset is read as GMT, not runner-local.
- `RATE_LIMIT_ERRORS` — both exceptions as a tuple, for the loops below.
- The unreachable tail of the retry loop now `raise AssertionError` rather than `return []`, so a future edit adding a `continue` cannot silently reintroduce the original bug.

**`src/pipelines/sources/game_stats.py`, `src/pipelines/sources/rosters.py`**

Three per-item loops caught bare `Exception` and continued — game_stats' two week loops (to skip weeks with no games) and rosters' per-team loop. They swallowed both rate-limit exceptions, so a quota-exhausted load would spin through every remaining week or team and complete "successfully" with silently missing data: the original bug reintroduced one layer up. For rosters that is worse than lost rows, since a partial roster poisons every roster-derived feature with no signal. These now re-raise on `RATE_LIMIT_ERRORS` before the broad catch, and a test pins that the no-games skip they exist for still works.

**`scripts/deploy_schema.py` / `tests/test_deploy_schema.py`**

`simulate_season` added to `COMPUTE_SCRIPTS`. Phase 4's projection step merged in #48 but was not runnable through the deploy path, so the compute chain depended on a healthy ingest run — exactly what the failure above took out.

## Review history

Two rounds of defects were found *after* the first commit, both worth recording because they are the same failure mode as the bug being fixed:

- **Codex** caught that the breaker was per-client and therefore unreachable — the counter could only ever reach 1, so the threshold of 5 never fired and the PR body described a feature that could not work. Also that a valid HTTP-date `Retry-After` fell through to the flat 60s default, retrying before the server said to.
- The **adversarial pass on those fixes** caught the three swallow sites above.

An earlier pass had already caught a permanently stuck-open circuit and an `int("soon")` `ValueError`. What the first pass missed, and Codex did not, is that it exercised the breaker only by manipulating a single client directly — never against the real call graph.

## Tests

`tests/test_api_client.py`: `TestRateLimitExhaustion`, `TestRateLimitCircuitBreaker`, `TestRetryAfterParsing`, `TestRetryAfterHttpDate`, `TestCircuitIsTerminalButResettable`, `TestBreakerIsSharedAcrossClients`, `TestBroadExceptHandlersDoNotSwallowRateLimits`.

`tests/conftest.py` resets the shared breaker around every test, so a tripped circuit cannot leak an order-dependent failure into unrelated suites.

Verified separately: no deadlock and no lost increments under 8 concurrent threads.

`ruff check` clean, `ruff format --check` clean, **1,054 passed / 380 skipped**.

## Risk

The behaviour change is deliberate and is the point: a rate-limited sweep now **fails** where it previously returned empty and exited 0. `load_season.py` already exits 1 when any source errors, so these runs go red instead of green-but-empty. Expect loud failures on runs that were previously silently incomplete — the three-hour run this fixes reported success.

`RATE_LIMIT_CIRCUIT_THRESHOLD = 5` is a judgment call, not derived. Five consecutive exhaustions is roughly 20 minutes of unbroken 429s with no success anywhere, which is quota exhaustion rather than burst throttling — but it is the one number here worth a reviewer's eye.