### PR TITLE
Add walk-forward preseason backtest (outlook 4.3/4.5)

### DIFF
--- a/docs/plans/2026-07-25-preseason-outlook-model-plan.md
+++ b/docs/plans/2026-07-25-preseason-outlook-model-plan.md
@@ -1263,62 +1263,89 @@ continuity, cost no new ingest, and have no roster dependency.
 
 ---
 
-### A6 — Preseason backtest results (run 2026-07-26 against prod)
+### A6 — Preseason backtest results (re-run 2026-07-26 after Codex PR #51 fixes)
 
-The section 4.5 gate, finally run. `scripts/backtest_preseason.py`, walk-forward:
-season S scored from each team's **week-1** `features.team_week` vector with the
-frozen S-1 fit, sigma from preseason residuals of seasons **before** S, all games
-simulated as pending. FBS teams only, 10,000 sims, **n = 921 team-seasons**.
+The section 4.5 gate. `scripts/backtest_preseason.py`, walk-forward: season S
+scored from each team's **week-1** `features.team_week` vector with the frozen
+S-1 fit, sigma from preseason residuals of seasons **before** S, all games
+simulated as pending. FBS only, 10,000 sims, **n = 921 team-seasons**.
 
-`maxGP = 0` for every season — the selected vectors carried zero games played, so
-they are genuinely as-of-season-start. 2016-2017 excluded (no frozen S-1 fit);
-2018 scored but not simulated (it seeds sigma for 2019).
+`maxGP = 0` every season — the selected vectors carried zero games played, so
+they are genuinely as-of-season-start. 2018 is scored as a sigma seed and not
+reported.
 
-| season | fit | teams | sigma | margin MAE | **win MAE** | RMSE | bias | p10-p90 | prior-yr base | flat base |
-|---|---|---|---|---|---|---|---|---|---|---|
-| 2019 | 2018 | 130 | 19.62 | 15.08 | 1.78 | 2.20 | -0.24 | 78.5% | 2.06 | 2.25 |
-| 2020 | 2019 | 127 | 19.34 | 15.17 | 1.43 | 1.84 | -0.06 | 74.8% | 1.71 | 1.77 |
-| 2021 | 2020 | 130 | 19.29 | 17.58 | 1.80 | 2.29 | -0.22 | 75.4% | 2.46 | 2.24 |
-| 2022 | 2021 | 131 | 20.58 | 18.17 | 1.80 | 2.25 | -0.25 | 71.8% | 2.11 | 2.05 |
-| 2023 | 2022 | 133 | 21.60 | 16.04 | 1.76 | 2.17 | -0.26 | 72.9% | 1.95 | 2.18 |
-| 2024 | 2023 | 134 | 21.29 | 15.79 | 1.96 | 2.42 | -0.27 | 70.1% | 2.25 | 2.17 |
-| 2025 | 2024 | 136 | 20.99 | 15.95 | 1.98 | 2.47 | -0.26 | 64.7% | 2.23 | 2.33 |
+**Outcome-dependent games are excluded** (`drop_outcome_dependent`). CFBD files
+conference championship games as `season_type='regular'`, and below FBS the
+whole FCS/D2 playoff bracket too. Nobody could know in August that Georgia
+would play Texas for the SEC, so each team's slate is capped at its first 12
+chronological games; the `drop` column is what that removed.
 
-**Overall: win MAE 1.791, RMSE 2.248, bias -0.226, p10-p90 coverage 72.5%.**
-Baselines: prior-season win rate 2.114, flat .500 2.144. **The model beats both.**
+| season | fit | teams | games | drop | sigma | mgn MAE | **win MAE** | RMSE | bias | p10-p90 | prior-yr | flat |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| 2019 | 2018 | 130 | 1544 | 33 | 19.69 | 15.07 | 1.76 | 2.15 | -0.24 | 76.9% | 2.03 | 2.24 |
+| 2020 | 2019 | 127 | 563 | 0 | 19.37 | 15.17 | 1.43 | 1.84 | -0.06 | 74.8% | 1.72 | 1.77 |
+| 2021 | 2020 | 130 | 2376 | 32 | 19.32 | 17.59 | 1.79 | 2.26 | -0.22 | 73.1% | 2.47 | 2.25 |
+| 2022 | 2021 | 131 | 3614 | 43 | 20.60 | 18.22 | 1.80 | 2.24 | -0.25 | 73.3% | 2.14 | 2.03 |
+| 2023 | 2022 | 133 | 3573 | 12 | 21.64 | 16.05 | 1.77 | 2.16 | -0.26 | 71.4% | 1.98 | 2.18 |
+| 2024 | 2023 | 134 | 3695 | 50 | 21.32 | 15.81 | 1.95 | 2.41 | -0.27 | 68.7% | 2.27 | 2.16 |
+| 2025 | 2024 | 136 | 3704 | 39 | 21.01 | 15.95 | 1.96 | 2.44 | -0.27 | 64.0% | 2.26 | 2.33 |
+
+**Overall: win MAE 1.784, RMSE 2.225, bias -0.226, p10-p90 coverage 71.7%.**
+Baselines: prior-season win rate 2.128, flat .500 2.140. **The model beats both.**
+
+**Empirical residual quantiles of (actual - projected), n=921 — use these for an
+interval, NOT +/- MAE:**
+
+| p05 | p10 | p25 | p50 | p75 | p90 | p95 |
+|---|---|---|---|---|---|---|
+| -3.38 | **-2.61** | -1.21 | +0.11 | +1.81 | **+3.19** | +4.02 |
+
+An 80% empirical interval around a projection is **[proj -2.61, proj +3.19]**.
 
 **Findings:**
 
-1. **The model is real but modest.** 1.791 vs 2.114 for "last year's record" is a
-   0.32-win edge (~15%). Worth having; not a large edge. It misses the plan's
-   ~1.5 aspiration (`verdict=above_1.5`) — recorded as measured, not adjusted.
+1. **The model is real but modest.** 1.784 vs 2.128 for "last year's record" is
+   a 0.34-win edge (~16%). Worth having; not large. It misses the plan's ~1.5
+   aspiration (`verdict=above_1.5`), recorded as measured.
 
-2. **The distribution is too narrow, exactly as the v1 independent-draw
-   limitation predicts.** Coverage is 72.5% against a nominal 80%, and both
-   calibration tables show the same signature from opposite ends: strong teams'
-   downside is underweighted (`p_bowl_eligible` 0.8-0.9 bucket predicted 0.850,
-   observed **0.724**; 0.9-1.0 predicted 0.958, observed **0.896**) while the
-   upper tail is underweighted too (`p_ten_plus` 0.4-0.5 predicted 0.440,
-   observed **0.706**). Too little mass in *both* tails is one phenomenon, not
-   two. **This is the strongest evidence yet for promoting the correlated-draw
-   variant (section 4.2's v1.1) from nice-to-have to next.**
+2. **Removing the outcome-dependent games barely moved the headline** (MAE
+   1.791 -> 1.784, coverage 72.5% -> 71.7%). The leak was real and had to go,
+   but it was not what made the model look good — worth recording so the fix is
+   not credited with more than it did.
 
-3. **Coverage decays over time: 78.5% (2019) -> 64.7% (2025).** Sigma rose only
-   19.6 -> 21.0 over the same span. Real season-outcome variance appears to be
-   growing faster than the model's spread — plausibly the portal/NIL era, which
-   is precisely the structural break section 6.0b flags. Worth a dedicated look;
-   it means recent projections are more overconfident than the pooled 72.5%
-   suggests.
+3. **The distribution is too narrow**, and both calibration tables show it from
+   opposite ends: `p_bowl_eligible` 0.8-0.9 predicted 0.848, observed **0.720**;
+   `p_ten_plus` 0.2-0.3 predicted 0.246, observed **0.426**. Too little mass in
+   *both* tails is one phenomenon — the v1 independent-draw limitation, now
+   measured. **This is the case for promoting the correlated-draw variant
+   (section 4.2's v1.1) to next.**
 
-4. **A consistent -0.23 win bias.** Every season but 2020 under-projects FBS win
-   totals by about a quarter of a win. Small, stable, and correctable — a
-   candidate for a calibration term rather than a modelling change.
+4. **Coverage decays 76.9% (2019) -> 64.0% (2025)** while sigma rose only
+   19.7 -> 21.0. Real season variance is outgrowing the model's spread,
+   plausibly the portal/NIL structural break section 6.0b flags. Recent
+   projections are more overconfident than the pooled 71.7% suggests.
+
+5. **A stable -0.23 win bias** in every season but 2020 — small, consistent, and
+   a candidate for a calibration term rather than a modelling change.
+
+6. **The error distribution is right-skewed** (p10 -2.61 vs p90 +3.19, median
+   +0.11). Teams overperform a projection by more than they underperform it,
+   which is what a win-total floor at zero and a breakout ceiling well above the
+   projection would produce.
 
 **Consequence for the 2026 numbers already published.** Oklahoma's 7.08 carries
-+/-1.79 MAE, so the honest range is roughly 5.3-8.9. Its stated `p_bowl_eligible`
-of 84.1% sits in a bucket that historically delivered **72.4%**; its
-`p_ten_plus` of 5.9% sits in one that delivered **6.9%**. Applying the -0.23 bias
-gives ~7.3 wins. **Against a market number of 7.5, the model and the market are
-statistically indistinguishable** — the disagreement is far inside the model's
-own error. Any claim that the market misprices Oklahoma is not supported by this
-model at this accuracy.
+an 80% empirical interval of **[4.5, 10.3]** — not the "5.3-8.9" an earlier
+draft of this appendix derived by treating MAE as a half-width. That was wrong:
+MAE is an average loss, and for a roughly normal error with MAE 1.78 the SD is
+about 2.23, so +/- MAE spans only ~58%. Oklahoma's stated `p_bowl_eligible` of
+84.1% sits in a bucket that historically delivered **72.0%**; its `p_ten_plus`
+of 5.9% sits in one that delivered **7.3%**.
+
+**Against a market number of 7.5:** the 0.42-win gap is a small fraction of an
+80% interval spanning ~5.8 wins, so this backtest gives no basis for preferring
+the model's number to the market's. That is a statement about resolution, not a
+significance test — the earlier claim that the two are "statistically
+indistinguishable" asserted more than was tested. Any 2026 claim needs to be
+worth more than this interval before it means anything, which is also the bar
+Phase 2 has to clear: new features must **reduce** this error, not merely move
+the number.

--- a/docs/plans/2026-07-25-preseason-outlook-model-plan.md
+++ b/docs/plans/2026-07-25-preseason-outlook-model-plan.md
@@ -1260,3 +1260,65 @@ columns (`prior_line_yards`, `prior_stuff_rate_allowed`,
 `prior_def_line_yards`, `prior_front_seven_havoc`) are also low-risk
 independent of the screen: they are measured performance rather than inferred
 continuity, cost no new ingest, and have no roster dependency.
+
+---
+
+### A6 — Preseason backtest results (run 2026-07-26 against prod)
+
+The section 4.5 gate, finally run. `scripts/backtest_preseason.py`, walk-forward:
+season S scored from each team's **week-1** `features.team_week` vector with the
+frozen S-1 fit, sigma from preseason residuals of seasons **before** S, all games
+simulated as pending. FBS teams only, 10,000 sims, **n = 921 team-seasons**.
+
+`maxGP = 0` for every season — the selected vectors carried zero games played, so
+they are genuinely as-of-season-start. 2016-2017 excluded (no frozen S-1 fit);
+2018 scored but not simulated (it seeds sigma for 2019).
+
+| season | fit | teams | sigma | margin MAE | **win MAE** | RMSE | bias | p10-p90 | prior-yr base | flat base |
+|---|---|---|---|---|---|---|---|---|---|---|
+| 2019 | 2018 | 130 | 19.62 | 15.08 | 1.78 | 2.20 | -0.24 | 78.5% | 2.06 | 2.25 |
+| 2020 | 2019 | 127 | 19.34 | 15.17 | 1.43 | 1.84 | -0.06 | 74.8% | 1.71 | 1.77 |
+| 2021 | 2020 | 130 | 19.29 | 17.58 | 1.80 | 2.29 | -0.22 | 75.4% | 2.46 | 2.24 |
+| 2022 | 2021 | 131 | 20.58 | 18.17 | 1.80 | 2.25 | -0.25 | 71.8% | 2.11 | 2.05 |
+| 2023 | 2022 | 133 | 21.60 | 16.04 | 1.76 | 2.17 | -0.26 | 72.9% | 1.95 | 2.18 |
+| 2024 | 2023 | 134 | 21.29 | 15.79 | 1.96 | 2.42 | -0.27 | 70.1% | 2.25 | 2.17 |
+| 2025 | 2024 | 136 | 20.99 | 15.95 | 1.98 | 2.47 | -0.26 | 64.7% | 2.23 | 2.33 |
+
+**Overall: win MAE 1.791, RMSE 2.248, bias -0.226, p10-p90 coverage 72.5%.**
+Baselines: prior-season win rate 2.114, flat .500 2.144. **The model beats both.**
+
+**Findings:**
+
+1. **The model is real but modest.** 1.791 vs 2.114 for "last year's record" is a
+   0.32-win edge (~15%). Worth having; not a large edge. It misses the plan's
+   ~1.5 aspiration (`verdict=above_1.5`) — recorded as measured, not adjusted.
+
+2. **The distribution is too narrow, exactly as the v1 independent-draw
+   limitation predicts.** Coverage is 72.5% against a nominal 80%, and both
+   calibration tables show the same signature from opposite ends: strong teams'
+   downside is underweighted (`p_bowl_eligible` 0.8-0.9 bucket predicted 0.850,
+   observed **0.724**; 0.9-1.0 predicted 0.958, observed **0.896**) while the
+   upper tail is underweighted too (`p_ten_plus` 0.4-0.5 predicted 0.440,
+   observed **0.706**). Too little mass in *both* tails is one phenomenon, not
+   two. **This is the strongest evidence yet for promoting the correlated-draw
+   variant (section 4.2's v1.1) from nice-to-have to next.**
+
+3. **Coverage decays over time: 78.5% (2019) -> 64.7% (2025).** Sigma rose only
+   19.6 -> 21.0 over the same span. Real season-outcome variance appears to be
+   growing faster than the model's spread — plausibly the portal/NIL era, which
+   is precisely the structural break section 6.0b flags. Worth a dedicated look;
+   it means recent projections are more overconfident than the pooled 72.5%
+   suggests.
+
+4. **A consistent -0.23 win bias.** Every season but 2020 under-projects FBS win
+   totals by about a quarter of a win. Small, stable, and correctable — a
+   candidate for a calibration term rather than a modelling change.
+
+**Consequence for the 2026 numbers already published.** Oklahoma's 7.08 carries
++/-1.79 MAE, so the honest range is roughly 5.3-8.9. Its stated `p_bowl_eligible`
+of 84.1% sits in a bucket that historically delivered **72.4%**; its
+`p_ten_plus` of 5.9% sits in one that delivered **6.9%**. Applying the -0.23 bias
+gives ~7.3 wins. **Against a market number of 7.5, the model and the market are
+statistically indistinguishable** — the disagreement is far inside the model's
+own error. Any claim that the market misprices Oklahoma is not supported by this
+model at this accuracy.

--- a/scripts/backtest_preseason.py
+++ b/scripts/backtest_preseason.py
@@ -1,0 +1,633 @@
+"""Walk-forward PRESEASON backtest of fitted_v1 season projections.
+
+Preseason outlook plan (docs/plans/2026-07-25-preseason-outlook-model-plan.md),
+section 4.3/4.5 -- the gate that must run before a 2026 win total means
+anything.
+
+WHY THIS IS A SEPARATE SCORING PASS, NOT A QUERY
+================================================
+``score_fitted.py --backfill`` stamps each historical prediction with the
+game's own ``start_date``, so ``predictions.game_predictions`` holds
+**as-of-game-day** rows: a week-12 game was scored with eleven games of that
+season's form already in the feature vector. Simulating a season from those
+rows and calling the result a preseason backtest would measure in-season
+accuracy, report a flatteringly low error, and be wrong in the one direction
+nobody would notice.
+
+A genuine preseason backtest re-scores every game of season S from each team's
+**week-1** ``features.team_week`` vector -- the as-of-season-start state, all
+that is knowable in August -- using the frozen fit trained through S-1. That is
+what this script does.
+
+The scoring itself reuses ``score_fitted.score_game`` unchanged, so the design
+matrix, imputation, standardization and Platt calibration are byte-identical to
+production. The ONLY difference is which ``team_week`` row is joined.
+``build_feature_vector`` reads just ``neutral_site`` off the game plus the two
+team-week dicts, so there is no hidden week dependence for that swap to break.
+
+LEAK CONTROL
+============
+Three places a backtest like this leaks, all handled explicitly:
+
+1. **The fit.** Season S is scored with ``train_through = S-1``
+   (``select_train_through('backfill', S)``), the same walk-forward rule
+   production uses. S is never in its own fit's train window.
+
+2. **Sigma.** The simulation's residual SD is measured from PRESEASON
+   residuals of seasons **strictly before S**, accumulated as this script
+   walks forward. Using season S's own residuals -- or the production
+   ``fetch_sigma``, which reads as-of-game-day snapshots -- would hand the
+   simulation the answer's spread. A season with no prior residuals is scored
+   but cannot be simulated, and is reported as excluded rather than dropped
+   silently.
+
+3. **Actual results.** Every game is simulated as PENDING even though it is
+   complete. ``simulate_wins`` gives completed games a deterministic win, so
+   passing them through as completed would return the actual record and score
+   a perfect backtest.
+
+WHAT IS COMPARED
+================
+Projected wins are compared to actual wins **over exactly the games that were
+simulated**, never the full schedule. A game is droppable here (an opponent
+with no week-1 vector fails the join), and comparing a short simulated slate
+against a full actual record would manufacture error that is really missing
+data. ``games_simulated`` is reported per season so the coverage is visible.
+
+Metrics are reported for FBS teams by default -- that is the audience -- but a
+team's slate keeps its FCS opponents, because dropping those games would
+shorten real schedules.
+
+BASELINES
+=========
+An MAE means nothing alone. Two denominator-consistent baselines run beside the
+model: prior-season win RATE scaled to the simulated slate, and a flat .500. A
+preseason model that cannot beat "last year's record" has earned nothing.
+
+Read-only: reports to stdout, writes no rows.
+
+Usage:
+    python scripts/backtest_preseason.py                    # default range
+    python scripts/backtest_preseason.py --start 2018 --end 2025
+    python scripts/backtest_preseason.py --all-divisions
+"""
+
+import argparse
+import logging
+import sys
+
+import numpy as np
+
+from scripts.compute_predictions import get_db_url
+from scripts.score_fitted import (
+    fetch_available_train_through,
+    load_fit,
+    score_game,
+    select_train_through,
+)
+from scripts.simulate_season import (
+    BOWL_ELIGIBLE_WINS,
+    DEFAULT_SEED,
+    DEFAULT_SIMS,
+    TEN_PLUS_WINS,
+    simulate_wins,
+    summarize,
+)
+from scripts.train_model import MODEL_VERSION, TEAM_WEEK_SOURCE_COLUMNS
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+DEFAULT_START = 2018
+DEFAULT_END = 2025
+
+# Regular season only, matching simulate_season.PROJECTION_SEASON_TYPE. Note
+# CFBD labels FCS/D2 playoff bracket games 'regular', which is why the default
+# reporting scope is FBS.
+BACKTEST_SEASON_TYPE = "regular"
+
+# Minimum preseason residuals before a sigma estimate is trusted. Mirrors
+# simulate_season.MIN_SIGMA_GAMES.
+MIN_SIGMA_GAMES = 100
+
+# Calibration buckets for p_bowl_eligible / p_ten_plus reliability.
+CALIBRATION_EDGES = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
+
+# A preseason win-total model landing inside this is respectable (plan 4.5).
+# Advisory only -- this script reports what it measures and does not gate.
+RESPECTABLE_WIN_MAE = 1.5
+
+
+# =============================================================================
+# --- Pure metrics --- (no DB, unit-tested directly)
+# =============================================================================
+
+
+def win_error_metrics(projected: list[float], actual: list[float]) -> dict:
+    """MAE, RMSE and signed bias of projected vs actual wins.
+
+    Bias is ``mean(projected - actual)``: a preseason model can be accurate on
+    average and still systematically optimistic, and only the signed term shows
+    that.
+    """
+    if not projected:
+        return {"n": 0, "mae": None, "rmse": None, "bias": None}
+    p = np.asarray(projected, dtype=np.float64)
+    a = np.asarray(actual, dtype=np.float64)
+    err = p - a
+    return {
+        "n": len(projected),
+        "mae": float(np.mean(np.abs(err))),
+        "rmse": float(np.sqrt(np.mean(err**2))),
+        "bias": float(np.mean(err)),
+    }
+
+
+def interval_coverage(actual: list[float], p10: list[float], p90: list[float]) -> float | None:
+    """Fraction of teams whose actual wins fell inside [p10, p90].
+
+    Nominal is 0.80. Materially below means the distribution is too narrow --
+    the projection claims more confidence than it has. Materially above means
+    it is too wide to be useful. v1 draws games independently, which understates
+    both tails, so a reading under 0.80 is the expected direction of miss.
+    """
+    if not actual:
+        return None
+    inside = sum(1 for a, lo, hi in zip(actual, p10, p90, strict=True) if lo <= a <= hi)
+    return inside / len(actual)
+
+
+def calibration_table(probs: list[float], outcomes: list[bool]) -> list[dict]:
+    """Reliability buckets: predicted probability vs observed frequency.
+
+    A projection saying "70% bowl eligible" is only meaningful if teams given
+    70% actually reach six wins about 70% of the time. Empty buckets are
+    omitted rather than reported as 0/0.
+    """
+    if not probs:
+        return []
+    rows = []
+    # Slice both sides so the lengths match and strict= stays meaningful.
+    for lo, hi in zip(CALIBRATION_EDGES[:-1], CALIBRATION_EDGES[1:], strict=True):
+        # Final bucket is closed on the right so p == 1.0 is counted.
+        idx = [
+            i
+            for i, p in enumerate(probs)
+            if (lo <= p < hi) or (hi == CALIBRATION_EDGES[-1] and p == 1.0)
+        ]
+        if not idx:
+            continue
+        rows.append(
+            {
+                "bucket": f"{lo:.1f}-{hi:.1f}",
+                "n": len(idx),
+                "mean_predicted": float(np.mean([probs[i] for i in idx])),
+                "observed": float(np.mean([1.0 if outcomes[i] else 0.0 for i in idx])),
+            }
+        )
+    return rows
+
+
+def baseline_prior_rate(prior_wins: float | None, prior_games: int | None, games: int) -> float:
+    """Prior-season win RATE scaled to this season's simulated slate.
+
+    Rate rather than raw count so the baseline shares the model's denominator;
+    comparing a 12-game record against a 9-game simulated slate would make the
+    baseline look bad for a reason that has nothing to do with prediction. A
+    team with no prior season falls back to .500.
+    """
+    if not prior_games or prior_wins is None:
+        return 0.5 * games
+    return (prior_wins / prior_games) * games
+
+
+def brier(probs: list[float], outcomes: list[bool]) -> float | None:
+    """Mean squared error of a probability forecast. Lower is better."""
+    if not probs:
+        return None
+    p = np.asarray(probs, dtype=np.float64)
+    o = np.asarray([1.0 if x else 0.0 for x in outcomes], dtype=np.float64)
+    return float(np.mean((p - o) ** 2))
+
+
+# =============================================================================
+# --- I/O layer ---
+# =============================================================================
+
+
+def _week1_games_query() -> str:
+    """Season-S games joined to each side's WEEK-1 team_week vector.
+
+    ``DISTINCT ON (team) ORDER BY week_index, game_id`` inside the CTE takes
+    each team's earliest row of the season -- the as-of-season-start state.
+    The column list is built from TEAM_WEEK_SOURCE_COLUMNS so it tracks the
+    feature contract rather than drifting from it.
+    """
+    tw_cols = ", ".join(TEAM_WEEK_SOURCE_COLUMNS)
+    home_cols = ",\n           ".join(f"h.{c} AS home_{c}" for c in TEAM_WEEK_SOURCE_COLUMNS)
+    away_cols = ",\n           ".join(f"a.{c} AS away_{c}" for c in TEAM_WEEK_SOURCE_COLUMNS)
+    return f"""
+        WITH week1 AS (
+            SELECT DISTINCT ON (team)
+                   team, week_index, games_played_to_date, {tw_cols}
+            FROM features.team_week
+            WHERE season = %(season)s
+            ORDER BY team, week_index, game_id
+        )
+        SELECT g.id AS game_id, g.season, g.season_type, g.week,
+               g.neutral_site, g.home_team, g.away_team,
+               g.home_points, g.away_points,
+               COALESCE(g.conference_game, false) AS conference_game,
+               g.home_classification, g.away_classification,
+               h.games_played_to_date AS home_gp, a.games_played_to_date AS away_gp,
+           {home_cols},
+           {away_cols}
+        FROM core.games g
+        JOIN week1 h ON h.team = g.home_team
+        JOIN week1 a ON a.team = g.away_team
+        WHERE g.season = %(season)s
+          AND g.season_type = %(season_type)s
+          AND COALESCE(g.completed, false)
+          AND g.home_points IS NOT NULL
+          AND g.away_points IS NOT NULL
+        ORDER BY g.id
+    """
+
+
+def fetch_preseason_games(conn, season: int) -> list[dict]:
+    import psycopg2.extras
+
+    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(
+            _week1_games_query(),
+            {"season": season, "season_type": BACKTEST_SEASON_TYPE},
+        )
+        raw = [dict(r) for r in cur.fetchall()]
+    games = []
+    for r in raw:
+        games.append(
+            {
+                "game_id": r["game_id"],
+                "season": r["season"],
+                "week": r["week"],
+                "neutral_site": r["neutral_site"],
+                "home_team": r["home_team"],
+                "away_team": r["away_team"],
+                "home_points": r["home_points"],
+                "away_points": r["away_points"],
+                "conference_game": r["conference_game"],
+                "home_classification": r["home_classification"],
+                "away_classification": r["away_classification"],
+                "home_gp": r["home_gp"],
+                "away_gp": r["away_gp"],
+                "home_tw": {c: r[f"home_{c}"] for c in TEAM_WEEK_SOURCE_COLUMNS},
+                "away_tw": {c: r[f"away_{c}"] for c in TEAM_WEEK_SOURCE_COLUMNS},
+            }
+        )
+    return games
+
+
+def fetch_scheduled_counts(conn, season: int) -> dict:
+    """Regular-season games on each team's schedule, for coverage reporting."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT team, COUNT(*) FROM (
+                SELECT home_team AS team FROM core.games
+                WHERE season = %(season)s AND season_type = %(season_type)s
+                UNION ALL
+                SELECT away_team FROM core.games
+                WHERE season = %(season)s AND season_type = %(season_type)s
+            ) t GROUP BY team
+            """,
+            {"season": season, "season_type": BACKTEST_SEASON_TYPE},
+        )
+        return {row[0]: int(row[1]) for row in cur.fetchall()}
+
+
+def fetch_fbs_teams(conn, season: int) -> set:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT DISTINCT team FROM (
+                SELECT home_team AS team, home_classification AS c FROM core.games
+                WHERE season = %(season)s
+                UNION ALL
+                SELECT away_team, away_classification FROM core.games
+                WHERE season = %(season)s
+            ) t WHERE c = 'fbs'
+            """,
+            {"season": season},
+        )
+        return {row[0] for row in cur.fetchall()}
+
+
+# =============================================================================
+# --- Backtest ---
+# =============================================================================
+
+
+def score_season_preseason(conn, season: int, fit: dict) -> list[dict]:
+    """Every completed regular-season game of `season`, scored from week-1
+    vectors. Returns game dicts carrying ``expected_home_margin`` and the
+    realized ``actual_margin``."""
+    games = fetch_preseason_games(conn, season)
+    for g in games:
+        expected_margin, win_prob = score_game(g, fit)
+        g["expected_home_margin"] = expected_margin
+        g["home_win_prob"] = win_prob
+        g["actual_margin"] = float(g["home_points"] - g["away_points"])
+        # Simulated as PENDING: simulate_wins would otherwise hand the actual
+        # winner a deterministic win and score a perfect backtest.
+        g["completed"] = False
+    return games
+
+
+def actual_wins_over(games: list[dict]) -> dict:
+    """Actual wins per team over exactly `games` -- the simulated subset."""
+    wins: dict = {}
+    played: dict = {}
+    for g in games:
+        h, a = g["home_team"], g["away_team"]
+        played[h] = played.get(h, 0) + 1
+        played[a] = played.get(a, 0) + 1
+        winner = h if g["actual_margin"] > 0 else a if g["actual_margin"] < 0 else None
+        for t in (h, a):
+            wins.setdefault(t, 0)
+        if winner is not None:
+            wins[winner] += 1
+    return {"wins": wins, "played": played}
+
+
+def preseason_sigma(residuals: list[float]) -> float | None:
+    """Residual SD from PRESEASON residuals of earlier seasons only."""
+    if len(residuals) < MIN_SIGMA_GAMES:
+        return None
+    sd = float(np.std(np.asarray(residuals, dtype=np.float64)))
+    return sd if sd > 0 else None
+
+
+def run_backtest(conn, start: int, end: int, n_sims: int, seed: int, fbs_only: bool) -> int:
+    available = fetch_available_train_through(conn)
+    logger.info("frozen fits available for train_through: %s", sorted(available))
+
+    seasons = [s for s in range(start, end + 1)]
+    usable = [s for s in seasons if (s - 1) in available]
+    skipped_no_fit = [s for s in seasons if s not in usable]
+    if skipped_no_fit:
+        logger.warning(
+            "no frozen S-1 fit for season(s) %s -- excluded from the backtest", skipped_no_fit
+        )
+    if not usable:
+        logger.error("no season in %d-%d has a frozen S-1 fit; nothing to backtest", start, end)
+        return 1
+
+    # Walk forward. Residuals accumulate from earlier seasons ONLY, so the
+    # sigma used to simulate season S never sees season S.
+    prior_residuals: list[float] = []
+    prior_actuals: dict = {}
+    per_season = []
+    all_proj, all_act = [], []
+    all_p10, all_p90 = [], []
+    bowl_probs, bowl_out, ten_probs, ten_out = [], [], [], []
+    base_prior, base_flat = [], []
+
+    for season in usable:
+        train_through = select_train_through("backfill", season)
+        fit = load_fit(conn, train_through)
+        games = score_season_preseason(conn, season, fit)
+        if not games:
+            logger.warning("season %d: no scorable games, skipping", season)
+            continue
+
+        gp_max = max(max(g["home_gp"] or 0, g["away_gp"] or 0) for g in games)
+        margin_mae = float(
+            np.mean([abs(g["expected_home_margin"] - g["actual_margin"]) for g in games])
+        )
+
+        sigma = preseason_sigma(prior_residuals)
+        if sigma is None:
+            logger.warning(
+                "season %d: only %d prior preseason residuals (need %d) -- scored but not "
+                "simulated; it still seeds sigma for later seasons",
+                season,
+                len(prior_residuals),
+                MIN_SIGMA_GAMES,
+            )
+            prior_residuals.extend(g["actual_margin"] - g["expected_home_margin"] for g in games)
+            prior_actuals[season] = actual_wins_over(games)
+            continue
+
+        sim = simulate_wins(games, n_sims=n_sims, sigma=sigma, seed=seed)
+        truth = actual_wins_over(games)
+        scheduled = fetch_scheduled_counts(conn, season)
+        fbs = fetch_fbs_teams(conn, season) if fbs_only else None
+
+        rows = []
+        for team, team_wins in sim["wins"].items():
+            gs = sim["games_simulated"][team]
+            if gs == 0:
+                continue
+            if fbs is not None and team not in fbs:
+                continue
+            s = summarize(team_wins, gs)
+            actual = truth["wins"].get(team, 0)
+            prior = prior_actuals.get(season - 1, {})
+            rows.append(
+                {
+                    "team": team,
+                    "games_simulated": gs,
+                    "games_scheduled": scheduled.get(team, gs),
+                    "projected_wins": s["projected_wins"],
+                    "actual_wins": actual,
+                    "p10": s["wins_p10"],
+                    "p90": s["wins_p90"],
+                    "p_bowl": s["p_bowl_eligible"],
+                    "p_ten": s["p_ten_plus"],
+                    "baseline_prior": baseline_prior_rate(
+                        prior.get("wins", {}).get(team),
+                        prior.get("played", {}).get(team),
+                        gs,
+                    ),
+                    "baseline_flat": 0.5 * gs,
+                }
+            )
+
+        m = win_error_metrics([r["projected_wins"] for r in rows], [r["actual_wins"] for r in rows])
+        cov = interval_coverage(
+            [r["actual_wins"] for r in rows], [r["p10"] for r in rows], [r["p90"] for r in rows]
+        )
+        bp = win_error_metrics(
+            [r["baseline_prior"] for r in rows], [r["actual_wins"] for r in rows]
+        )
+        bf = win_error_metrics([r["baseline_flat"] for r in rows], [r["actual_wins"] for r in rows])
+
+        per_season.append(
+            {
+                "season": season,
+                "train_through": train_through,
+                "teams": len(rows),
+                "games": len(games),
+                "sigma": sigma,
+                "sigma_n": len(prior_residuals),
+                "margin_mae": margin_mae,
+                "max_games_played": gp_max,
+                "win_mae": m["mae"],
+                "win_rmse": m["rmse"],
+                "bias": m["bias"],
+                "coverage": cov,
+                "baseline_prior_mae": bp["mae"],
+                "baseline_flat_mae": bf["mae"],
+            }
+        )
+
+        all_proj += [r["projected_wins"] for r in rows]
+        all_act += [r["actual_wins"] for r in rows]
+        all_p10 += [r["p10"] for r in rows]
+        all_p90 += [r["p90"] for r in rows]
+        base_prior += [r["baseline_prior"] for r in rows]
+        base_flat += [r["baseline_flat"] for r in rows]
+        bowl_probs += [r["p_bowl"] for r in rows]
+        bowl_out += [r["actual_wins"] >= BOWL_ELIGIBLE_WINS for r in rows]
+        ten_probs += [r["p_ten"] for r in rows]
+        ten_out += [r["actual_wins"] >= TEN_PLUS_WINS for r in rows]
+
+        prior_residuals.extend(g["actual_margin"] - g["expected_home_margin"] for g in games)
+        prior_actuals[season] = truth
+
+    if not per_season:
+        logger.error("no season could be simulated (insufficient prior residuals throughout)")
+        return 1
+
+    _report(
+        per_season,
+        all_proj,
+        all_act,
+        all_p10,
+        all_p90,
+        base_prior,
+        base_flat,
+        bowl_probs,
+        bowl_out,
+        ten_probs,
+        ten_out,
+        fbs_only,
+    )
+    return 0
+
+
+def _report(
+    per_season,
+    proj,
+    act,
+    p10,
+    p90,
+    base_prior,
+    base_flat,
+    bowl_probs,
+    bowl_out,
+    ten_probs,
+    ten_out,
+    fbs_only,
+):
+    scope = "FBS only" if fbs_only else "all divisions"
+    print(f"\n{'=' * 78}")
+    print(f"PRESEASON BACKTEST -- {MODEL_VERSION} -- week-1 vectors, frozen S-1 fits ({scope})")
+    print(f"{'=' * 78}")
+    print(
+        f"{'season':>6} {'fit':>5} {'teams':>6} {'games':>6} {'maxGP':>6} {'sigma':>7} "
+        f"{'mgnMAE':>7} {'winMAE':>7} {'RMSE':>6} {'bias':>6} {'p10-90':>7} "
+        f"{'basePri':>8} {'baseFlat':>8}"
+    )
+    for r in per_season:
+        print(
+            f"{r['season']:>6} {r['train_through']:>5} {r['teams']:>6} {r['games']:>6} "
+            f"{r['max_games_played']:>6} {r['sigma']:>7.2f} {r['margin_mae']:>7.2f} "
+            f"{r['win_mae']:>7.2f} {r['win_rmse']:>6.2f} {r['bias']:>+6.2f} "
+            f"{r['coverage']:>7.1%} {r['baseline_prior_mae']:>8.2f} {r['baseline_flat_mae']:>8.2f}"
+        )
+
+    # maxGP is the direct evidence that the joined vectors really are
+    # as-of-season-start. Anything above 0 means a "week-1" row already had
+    # games of its own season baked in, and every number above is optimistic.
+    leaky = [r["season"] for r in per_season if r["max_games_played"]]
+    if leaky:
+        print(
+            f"\n*** WARNING: season(s) {leaky} selected a week-1 vector with "
+            "games_played_to_date > 0. Those rows are NOT preseason and their "
+            "errors are understated. ***"
+        )
+
+    overall = win_error_metrics(proj, act)
+    bp = win_error_metrics(base_prior, act)
+    bf = win_error_metrics(base_flat, act)
+    cov = interval_coverage(act, p10, p90)
+    print(f"{'-' * 78}")
+    print(
+        f"OVERALL n={overall['n']} win_mae={overall['mae']:.3f} rmse={overall['rmse']:.3f} "
+        f"bias={overall['bias']:+.3f} p10_p90_coverage={cov:.1%} (nominal 80%)"
+    )
+    print(
+        f"BASELINE prior_season_rate_mae={bp['mae']:.3f}  flat_500_mae={bf['mae']:.3f}  "
+        f"model_beats_prior={'YES' if overall['mae'] < bp['mae'] else 'NO'}  "
+        f"model_beats_flat={'YES' if overall['mae'] < bf['mae'] else 'NO'}"
+    )
+
+    for label, probs, outs in (
+        ("p_bowl_eligible", bowl_probs, bowl_out),
+        ("p_ten_plus", ten_probs, ten_out),
+    ):
+        b = brier(probs, outs)
+        print(f"\n{label} calibration (brier={b:.4f})")
+        print(f"  {'bucket':>10} {'n':>6} {'predicted':>10} {'observed':>9}")
+        for row in calibration_table(probs, outs):
+            print(
+                f"  {row['bucket']:>10} {row['n']:>6} {row['mean_predicted']:>10.3f} "
+                f"{row['observed']:>9.3f}"
+            )
+
+    verdict = "within" if overall["mae"] <= RESPECTABLE_WIN_MAE else "above"
+    print(
+        f"\nBACKTEST_GATE model={MODEL_VERSION} n={overall['n']} "
+        f"win_mae={overall['mae']:.3f} rmse={overall['rmse']:.3f} bias={overall['bias']:+.3f} "
+        f"coverage={cov:.3f} baseline_prior_mae={bp['mae']:.3f} "
+        f"baseline_flat_mae={bf['mae']:.3f} verdict={verdict}_{RESPECTABLE_WIN_MAE}"
+    )
+    print(f"{'=' * 78}\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--start", type=int, default=DEFAULT_START, help="first season to report")
+    parser.add_argument("--end", type=int, default=DEFAULT_END, help="last season to report")
+    parser.add_argument("--sims", type=int, default=DEFAULT_SIMS)
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
+    parser.add_argument(
+        "--all-divisions",
+        action="store_true",
+        help="report every division, not just FBS (FCS/D2 playoff games inflate slates)",
+    )
+    args = parser.parse_args()
+
+    if args.start > args.end:
+        parser.error("--start must not be after --end")
+
+    import psycopg2
+
+    conn = psycopg2.connect(get_db_url())
+    try:
+        rc = run_backtest(
+            conn,
+            start=args.start,
+            end=args.end,
+            n_sims=args.sims,
+            seed=args.seed,
+            fbs_only=not args.all_divisions,
+        )
+    finally:
+        conn.close()
+    sys.exit(rc)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/backtest_preseason.py
+++ b/scripts/backtest_preseason.py
@@ -110,6 +110,12 @@ BACKTEST_SEASON_TYPE = "regular"
 # simulate_season.MIN_SIGMA_GAMES.
 MIN_SIGMA_GAMES = 100
 
+# Chronological per-team slate cap. A preseason FBS schedule is twelve games;
+# anything beyond is a conference championship or a playoff round, whose
+# participants were decided by that season's results. See
+# drop_outcome_dependent.
+PRESEASON_SLATE_GAMES = 12
+
 # Calibration buckets for p_bowl_eligible / p_ten_plus reliability.
 CALIBRATION_EDGES = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
 
@@ -188,6 +194,35 @@ def calibration_table(probs: list[float], outcomes: list[bool]) -> list[dict]:
     return rows
 
 
+def residual_quantiles(projected: list[float], actual: list[float]) -> dict | None:
+    """Empirical quantiles of (actual - projected) wins.
+
+    Codex review on PR #51, P1. MAE is an average loss across team-seasons, not
+    an error bar: for a roughly normal error with MAE 1.79 the SD is about
+    1.79 * 1.253 ~ 2.24, so "+/- MAE" spans only about +/-0.8 SD -- near 58%
+    coverage, not the ~80-90% a reader assumes from a stated range. Quoting a
+    point estimate "+/- MAE" as an honest range is simply wrong.
+
+    These are the empirical quantiles of the realized error instead, so a
+    stated interval means what it says. Interpreting them for one team assumes
+    that team's error is exchangeable with the backtest population -- a real
+    assumption, but a far weaker one than treating MAE as a half-width.
+    """
+    if not projected:
+        return None
+    err = np.asarray(actual, dtype=np.float64) - np.asarray(projected, dtype=np.float64)
+    return {
+        "n": len(err),
+        "p05": float(np.percentile(err, 5)),
+        "p10": float(np.percentile(err, 10)),
+        "p25": float(np.percentile(err, 25)),
+        "p50": float(np.percentile(err, 50)),
+        "p75": float(np.percentile(err, 75)),
+        "p90": float(np.percentile(err, 90)),
+        "p95": float(np.percentile(err, 95)),
+    }
+
+
 def baseline_prior_rate(prior_wins: float | None, prior_games: int | None, games: int) -> float:
     """Prior-season win RATE scaled to this season's simulated slate.
 
@@ -234,7 +269,7 @@ def _week1_games_query() -> str:
             WHERE season = %(season)s
             ORDER BY team, week_index, game_id
         )
-        SELECT g.id AS game_id, g.season, g.season_type, g.week,
+        SELECT g.id AS game_id, g.season, g.season_type, g.week, g.start_date,
                g.neutral_site, g.home_team, g.away_team,
                g.home_points, g.away_points,
                COALESCE(g.conference_game, false) AS conference_game,
@@ -270,6 +305,7 @@ def fetch_preseason_games(conn, season: int) -> list[dict]:
                 "game_id": r["game_id"],
                 "season": r["season"],
                 "week": r["week"],
+                "start_date": r["start_date"],
                 "neutral_site": r["neutral_site"],
                 "home_team": r["home_team"],
                 "away_team": r["away_team"],
@@ -327,11 +363,57 @@ def fetch_fbs_teams(conn, season: int) -> set:
 # =============================================================================
 
 
-def score_season_preseason(conn, season: int, fit: dict) -> list[dict]:
+def drop_outcome_dependent(games: list[dict]) -> tuple[list[dict], int]:
+    """Drop games whose PARTICIPANTS were decided by that season's results.
+
+    Codex review on PR #51, P1. ``season_type = 'regular'`` is not enough.
+    CFBD files conference championship games as 'regular', and below FBS it
+    files the entire FCS/D2 **playoff bracket** as 'regular' too. Nobody could
+    know in August that Georgia would play Texas for the SEC, so handing a team
+    that thirteenth game hands the projection an outcome. It inflates the
+    simulated slate and the actual record together, for exactly the strongest
+    teams, and -- because sigma pools every scored game regardless of the FBS
+    reporting filter -- it contaminated the residual pool even in the default
+    scope.
+
+    The rule: order each team's games chronologically and keep only its first
+    PRESEASON_SLATE_GAMES. A preseason FBS schedule is twelve games; a
+    thirteenth is earned, never scheduled. A game is dropped if it is beyond
+    the cap for EITHER side, so both participants keep identical slates and
+    the actual-wins comparison stays matched.
+
+    Deliberate, conservative imprecision: a team with the Hawaii 13th-game
+    exemption loses a genuinely scheduled game, and its opponent loses that
+    game too. Measured at 0.3-1.2% of team-games per season (2019-2025), and
+    it errs toward dropping real data rather than admitting a leak -- the
+    right direction for a leak check. The count is reported per season so the
+    cost stays visible.
+    """
+    order: dict = {}
+    for g in sorted(
+        games, key=lambda x: (x.get("start_date") is None, x.get("start_date"), x["game_id"])
+    ):
+        for team in (g["home_team"], g["away_team"]):
+            order[team] = order.get(team, 0) + 1
+            g[f"_n_{team}"] = order[team]
+
+    kept, dropped = [], 0
+    for g in games:
+        hn = g.get(f"_n_{g['home_team']}", 1)
+        an = g.get(f"_n_{g['away_team']}", 1)
+        if hn > PRESEASON_SLATE_GAMES or an > PRESEASON_SLATE_GAMES:
+            dropped += 1
+            continue
+        kept.append(g)
+    return kept, dropped
+
+
+def score_season_preseason(conn, season: int, fit: dict) -> tuple[list[dict], int]:
     """Every completed regular-season game of `season`, scored from week-1
-    vectors. Returns game dicts carrying ``expected_home_margin`` and the
-    realized ``actual_margin``."""
-    games = fetch_preseason_games(conn, season)
+    vectors, with outcome-dependent games removed. Returns the game dicts
+    carrying ``expected_home_margin`` and the realized ``actual_margin``,
+    plus the number of games dropped by the slate cap."""
+    games, dropped = drop_outcome_dependent(fetch_preseason_games(conn, season))
     for g in games:
         expected_margin, win_prob = score_game(g, fit)
         g["expected_home_margin"] = expected_margin
@@ -340,7 +422,7 @@ def score_season_preseason(conn, season: int, fit: dict) -> list[dict]:
         # Simulated as PENDING: simulate_wins would otherwise hand the actual
         # winner a deterministic win and score a perfect backtest.
         g["completed"] = False
-    return games
+    return games, dropped
 
 
 def actual_wins_over(games: list[dict]) -> dict:
@@ -371,13 +453,26 @@ def run_backtest(conn, start: int, end: int, n_sims: int, seed: int, fbs_only: b
     available = fetch_available_train_through(conn)
     logger.info("frozen fits available for train_through: %s", sorted(available))
 
+    # Codex review on PR #51, P2: iteration used to begin at `start`, so the
+    # first requested season always had an empty residual pool and was silently
+    # consumed as a sigma seed rather than reported. `--start 2025 --end 2025`
+    # scored 2025, simulated nothing and exited 1 even with years of usable
+    # history sitting there. Walk from the earliest season that has a frozen
+    # S-1 fit so sigma is seeded BEFORE `start`, and restrict only the OUTPUT
+    # to the requested range.
+    earliest = min(available) + 1 if available else start
+    walk_from = min(start, earliest)
+    walk = [s for s in range(walk_from, end + 1) if (s - 1) in available]
     seasons = [s for s in range(start, end + 1)]
-    usable = [s for s in seasons if (s - 1) in available]
-    skipped_no_fit = [s for s in seasons if s not in usable]
+    skipped_no_fit = [s for s in seasons if (s - 1) not in available]
     if skipped_no_fit:
         logger.warning(
             "no frozen S-1 fit for season(s) %s -- excluded from the backtest", skipped_no_fit
         )
+    seed_only = [s for s in walk if s < start]
+    if seed_only:
+        logger.info("scoring season(s) %s for sigma seeding only (not reported)", seed_only)
+    usable = walk
     if not usable:
         logger.error("no season in %d-%d has a frozen S-1 fit; nothing to backtest", start, end)
         return 1
@@ -395,7 +490,7 @@ def run_backtest(conn, start: int, end: int, n_sims: int, seed: int, fbs_only: b
     for season in usable:
         train_through = select_train_through("backfill", season)
         fit = load_fit(conn, train_through)
-        games = score_season_preseason(conn, season, fit)
+        games, dropped = score_season_preseason(conn, season, fit)
         if not games:
             logger.warning("season %d: no scorable games, skipping", season)
             continue
@@ -414,6 +509,13 @@ def run_backtest(conn, start: int, end: int, n_sims: int, seed: int, fbs_only: b
                 len(prior_residuals),
                 MIN_SIGMA_GAMES,
             )
+            prior_residuals.extend(g["actual_margin"] - g["expected_home_margin"] for g in games)
+            prior_actuals[season] = actual_wins_over(games)
+            continue
+
+        if season < start:
+            # Seed-only season: its residuals inform sigma for the reported
+            # range, but it contributes nothing to the output.
             prior_residuals.extend(g["actual_margin"] - g["expected_home_margin"] for g in games)
             prior_actuals[season] = actual_wins_over(games)
             continue
@@ -472,6 +574,7 @@ def run_backtest(conn, start: int, end: int, n_sims: int, seed: int, fbs_only: b
                 "sigma_n": len(prior_residuals),
                 "margin_mae": margin_mae,
                 "max_games_played": gp_max,
+                "dropped_outcome_dependent": dropped,
                 "win_mae": m["mae"],
                 "win_rmse": m["rmse"],
                 "bias": m["bias"],
@@ -535,14 +638,15 @@ def _report(
     print(f"PRESEASON BACKTEST -- {MODEL_VERSION} -- week-1 vectors, frozen S-1 fits ({scope})")
     print(f"{'=' * 78}")
     print(
-        f"{'season':>6} {'fit':>5} {'teams':>6} {'games':>6} {'maxGP':>6} {'sigma':>7} "
+        f"{'season':>6} {'fit':>5} {'teams':>6} {'games':>6} {'drop':>5} {'maxGP':>6} {'sigma':>7} "
         f"{'mgnMAE':>7} {'winMAE':>7} {'RMSE':>6} {'bias':>6} {'p10-90':>7} "
         f"{'basePri':>8} {'baseFlat':>8}"
     )
     for r in per_season:
         print(
             f"{r['season']:>6} {r['train_through']:>5} {r['teams']:>6} {r['games']:>6} "
-            f"{r['max_games_played']:>6} {r['sigma']:>7.2f} {r['margin_mae']:>7.2f} "
+            f"{r['dropped_outcome_dependent']:>5} {r['max_games_played']:>6} "
+            f"{r['sigma']:>7.2f} {r['margin_mae']:>7.2f} "
             f"{r['win_mae']:>7.2f} {r['win_rmse']:>6.2f} {r['bias']:>+6.2f} "
             f"{r['coverage']:>7.1%} {r['baseline_prior_mae']:>8.2f} {r['baseline_flat_mae']:>8.2f}"
         )
@@ -586,12 +690,29 @@ def _report(
                 f"{row['observed']:>9.3f}"
             )
 
+    q = residual_quantiles(proj, act)
+    if q:
+        print(
+            f"\nRESIDUAL QUANTILES of (actual - projected) wins, n={q['n']} -- use THESE for an\n"
+            f"interval, not +/- MAE (which spans only ~58% for a normal error):"
+        )
+        print(
+            f"  p05={q['p05']:+.2f}  p10={q['p10']:+.2f}  p25={q['p25']:+.2f}  "
+            f"p50={q['p50']:+.2f}  p75={q['p75']:+.2f}  p90={q['p90']:+.2f}  p95={q['p95']:+.2f}"
+        )
+        print(
+            f"  => an 80% empirical interval around a projection is "
+            f"[proj{q['p10']:+.2f}, proj{q['p90']:+.2f}]"
+        )
+
     verdict = "within" if overall["mae"] <= RESPECTABLE_WIN_MAE else "above"
     print(
         f"\nBACKTEST_GATE model={MODEL_VERSION} n={overall['n']} "
         f"win_mae={overall['mae']:.3f} rmse={overall['rmse']:.3f} bias={overall['bias']:+.3f} "
         f"coverage={cov:.3f} baseline_prior_mae={bp['mae']:.3f} "
-        f"baseline_flat_mae={bf['mae']:.3f} verdict={verdict}_{RESPECTABLE_WIN_MAE}"
+        f"baseline_flat_mae={bf['mae']:.3f} "
+        f"resid_p10={q['p10']:+.3f} resid_p90={q['p90']:+.3f} "
+        f"verdict={verdict}_{RESPECTABLE_WIN_MAE}"
     )
     print(f"{'=' * 78}\n")
 

--- a/scripts/deploy_schema.py
+++ b/scripts/deploy_schema.py
@@ -84,6 +84,9 @@ COMPUTE_SCRIPTS = {
     # of ingest -- a rate-limited season load should not be able to block
     # season projections, which touch no API at all.
     "simulate_season",
+    # Section 4.3 preseason backtest. Read-only -- re-scores history from
+    # week-1 feature vectors and reports to stdout; writes no rows.
+    "backtest_preseason",
 }
 
 # Marts refreshed after a compute run when plan.refresh is set. One home for

--- a/tests/test_api_views.py
+++ b/tests/test_api_views.py
@@ -1520,16 +1520,20 @@ class TestSeasonOutlook:
         rows, _ = _fetch_all(
             db_conn,
             """
-            WITH actual AS (
-                SELECT season, team, COUNT(*) AS n
-                FROM (
-                    SELECT season, home_team AS team FROM core.games
-                    WHERE season_type = 'regular'
-                    UNION ALL
-                    SELECT season, away_team FROM core.games
-                    WHERE season_type = 'regular'
-                ) g
-                GROUP BY season, team
+            -- Scoped to the seasons the view actually holds. Aggregating all
+            -- of core.games (1869+) to check two seasons scans hundreds of
+            -- thousands of rows for nothing; LATERAL also avoids the second
+            -- pass a home/away UNION ALL would cost.
+            WITH seasons AS (
+                SELECT DISTINCT season FROM api.season_outlook
+            ),
+            actual AS (
+                SELECT g.season, t.team, COUNT(*) AS n
+                FROM core.games g
+                JOIN seasons s ON s.season = g.season
+                CROSS JOIN LATERAL (VALUES (g.home_team), (g.away_team)) AS t(team)
+                WHERE g.season_type = 'regular'
+                GROUP BY g.season, t.team
             )
             SELECT o.season, o.team, o.games_scheduled, a.n AS regular_season_games
             FROM api.season_outlook o

--- a/tests/test_backtest_preseason.py
+++ b/tests/test_backtest_preseason.py
@@ -1,0 +1,175 @@
+"""Unit tests for the preseason backtest's pure metrics (no DB)."""
+
+import numpy as np
+import pytest
+
+from scripts.backtest_preseason import (
+    MIN_SIGMA_GAMES,
+    baseline_prior_rate,
+    brier,
+    calibration_table,
+    interval_coverage,
+    preseason_sigma,
+    win_error_metrics,
+)
+
+
+class TestWinErrorMetrics:
+    def test_perfect_prediction(self):
+        m = win_error_metrics([7.0, 9.0, 3.0], [7.0, 9.0, 3.0])
+        assert m["mae"] == 0.0
+        assert m["rmse"] == 0.0
+        assert m["bias"] == 0.0
+
+    def test_mae_and_rmse(self):
+        m = win_error_metrics([8.0, 6.0], [7.0, 8.0])
+        assert m["mae"] == pytest.approx(1.5)
+        assert m["rmse"] == pytest.approx(np.sqrt((1 + 4) / 2))
+
+    def test_bias_is_signed(self):
+        """A model can be accurate on average and still systematically
+        optimistic; only the signed term shows it."""
+        over = win_error_metrics([9.0, 9.0], [7.0, 7.0])
+        under = win_error_metrics([5.0, 5.0], [7.0, 7.0])
+        assert over["bias"] == pytest.approx(2.0)
+        assert under["bias"] == pytest.approx(-2.0)
+        assert over["mae"] == under["mae"]
+
+    def test_empty_is_not_a_crash(self):
+        m = win_error_metrics([], [])
+        assert m == {"n": 0, "mae": None, "rmse": None, "bias": None}
+
+
+class TestIntervalCoverage:
+    def test_all_inside(self):
+        assert interval_coverage([7, 8], [5, 6], [9, 10]) == 1.0
+
+    def test_all_outside(self):
+        assert interval_coverage([2, 12], [5, 6], [9, 10]) == 0.0
+
+    def test_boundaries_count_as_inside(self):
+        assert interval_coverage([5, 9], [5, 6], [9, 10]) == 1.0
+
+    def test_partial(self):
+        assert interval_coverage([7, 12], [5, 6], [9, 10]) == 0.5
+
+    def test_empty(self):
+        assert interval_coverage([], [], []) is None
+
+
+class TestCalibrationTable:
+    def test_perfectly_calibrated_bucket(self):
+        probs = [0.75] * 100
+        outcomes = [True] * 75 + [False] * 25
+        rows = calibration_table(probs, outcomes)
+        assert len(rows) == 1
+        assert rows[0]["mean_predicted"] == pytest.approx(0.75)
+        assert rows[0]["observed"] == pytest.approx(0.75)
+
+    def test_overconfident_shows_gap(self):
+        probs = [0.9] * 10
+        outcomes = [True] * 3 + [False] * 7
+        rows = calibration_table(probs, outcomes)
+        assert rows[0]["mean_predicted"] > rows[0]["observed"]
+
+    def test_probability_one_lands_in_final_bucket(self):
+        """p == 1.0 must not fall through every half-open bucket."""
+        rows = calibration_table([1.0], [True])
+        assert len(rows) == 1
+        assert rows[0]["bucket"] == "0.9-1.0"
+
+    def test_empty_buckets_are_omitted(self):
+        rows = calibration_table([0.05, 0.95], [False, True])
+        assert [r["bucket"] for r in rows] == ["0.0-0.1", "0.9-1.0"]
+
+    def test_empty_input(self):
+        assert calibration_table([], []) == []
+
+
+class TestBaselinePriorRate:
+    def test_scales_rate_to_this_seasons_slate(self):
+        """The whole point: a 12-game record projected onto a 9-game slate."""
+        assert baseline_prior_rate(9.0, 12, 9) == pytest.approx(6.75)
+
+    def test_no_prior_season_falls_back_to_500(self):
+        assert baseline_prior_rate(None, None, 12) == pytest.approx(6.0)
+
+    def test_zero_prior_games_does_not_divide_by_zero(self):
+        assert baseline_prior_rate(0.0, 0, 12) == pytest.approx(6.0)
+
+    def test_undefeated_prior_projects_full_slate(self):
+        assert baseline_prior_rate(12.0, 12, 11) == pytest.approx(11.0)
+
+
+class TestPreseasonSigma:
+    def test_requires_minimum_sample(self):
+        assert preseason_sigma([1.0] * (MIN_SIGMA_GAMES - 1)) is None
+
+    def test_returns_sd_once_sample_is_large_enough(self):
+        rng = np.random.default_rng(0)
+        residuals = list(rng.normal(0.0, 17.0, size=MIN_SIGMA_GAMES * 20))
+        sigma = preseason_sigma(residuals)
+        assert sigma == pytest.approx(17.0, abs=0.6)
+
+    def test_degenerate_zero_variance_is_rejected(self):
+        """A zero sigma makes every simulated game deterministic; that is a
+        broken distribution, not a confident one."""
+        assert preseason_sigma([5.0] * (MIN_SIGMA_GAMES * 2)) is None
+
+    def test_empty(self):
+        assert preseason_sigma([]) is None
+
+
+class TestBrier:
+    def test_perfect_forecast(self):
+        assert brier([1.0, 0.0], [True, False]) == pytest.approx(0.0)
+
+    def test_worst_forecast(self):
+        assert brier([0.0, 1.0], [True, False]) == pytest.approx(1.0)
+
+    def test_coin_flip(self):
+        assert brier([0.5, 0.5], [True, False]) == pytest.approx(0.25)
+
+    def test_empty(self):
+        assert brier([], []) is None
+
+
+class TestLeakGuards:
+    """The backtest's value rests entirely on these two properties, so they are
+    asserted against the module rather than trusted from the docstring."""
+
+    def test_season_is_scored_with_the_prior_seasons_fit(self):
+        from scripts.score_fitted import select_train_through
+
+        assert select_train_through("backfill", 2022) == 2021
+
+    def test_games_are_simulated_as_pending(self):
+        """simulate_wins hands a completed game a deterministic win, so a
+        backtest that left completed=True would reproduce the actual record and
+        report zero error."""
+        from scripts.simulate_season import simulate_wins
+
+        games = [
+            {
+                "home_team": "A",
+                "away_team": "B",
+                "completed": True,
+                "home_win": True,
+                "conference_game": False,
+            }
+        ]
+        sim = simulate_wins(games, n_sims=50, sigma=17.0, seed=1)
+        assert set(sim["wins"]["A"]) == {1}, "completed games are deterministic -- must be pending"
+
+        pending = [
+            {
+                "home_team": "A",
+                "away_team": "B",
+                "completed": False,
+                "expected_home_margin": 0.0,
+                "conference_game": False,
+            }
+        ]
+        sim2 = simulate_wins(pending, n_sims=500, sigma=17.0, seed=1)
+        wins = sim2["wins"]["A"]
+        assert set(wins) == {0, 1}, "a pending coin-flip game must vary across simulations"

--- a/tests/test_backtest_preseason.py
+++ b/tests/test_backtest_preseason.py
@@ -8,8 +8,10 @@ from scripts.backtest_preseason import (
     baseline_prior_rate,
     brier,
     calibration_table,
+    drop_outcome_dependent,
     interval_coverage,
     preseason_sigma,
+    residual_quantiles,
     win_error_metrics,
 )
 
@@ -173,3 +175,104 @@ class TestLeakGuards:
         sim2 = simulate_wins(pending, n_sims=500, sigma=17.0, seed=1)
         wins = sim2["wins"]["A"]
         assert set(wins) == {0, 1}, "a pending coin-flip game must vary across simulations"
+
+
+class TestDropOutcomeDependent:
+    """Codex PR #51 P1: season_type='regular' still admits conference
+    championship games (and, below FBS, whole playoff brackets), whose
+    participants were decided by that season's results."""
+
+    @staticmethod
+    def _slate(team, n, start_id=0, opponent_prefix="opp"):
+        return [
+            {
+                "game_id": start_id + i,
+                "home_team": team,
+                "away_team": f"{opponent_prefix}{i}",
+                "start_date": f"2024-09-{i + 1:02d}",
+            }
+            for i in range(n)
+        ]
+
+    def test_keeps_a_standard_twelve_game_slate(self):
+        kept, dropped = drop_outcome_dependent(self._slate("A", 12))
+        assert len(kept) == 12
+        assert dropped == 0
+
+    def test_drops_the_thirteenth_game(self):
+        """The conference championship: earned, never scheduled."""
+        kept, dropped = drop_outcome_dependent(self._slate("A", 13))
+        assert len(kept) == 12
+        assert dropped == 1
+
+    def test_drops_a_deep_playoff_run(self):
+        kept, dropped = drop_outcome_dependent(self._slate("A", 15))
+        assert len(kept) == 12
+        assert dropped == 3
+
+    def test_drops_when_beyond_the_cap_for_either_side(self):
+        """Both participants must keep identical slates or the actual-wins
+        comparison stops being matched."""
+        games = self._slate("A", 12)
+        # B's first game, but A's thirteenth.
+        games.append(
+            {"game_id": 99, "home_team": "A", "away_team": "B", "start_date": "2024-12-07"}
+        )
+        kept, dropped = drop_outcome_dependent(games)
+        assert dropped == 1
+        assert all(g["game_id"] != 99 for g in kept)
+
+    def test_ordering_is_chronological_not_insertion_order(self):
+        games = self._slate("A", 13)
+        shuffled = list(reversed(games))
+        kept, dropped = drop_outcome_dependent(shuffled)
+        assert dropped == 1
+        # The dropped game is the LAST by date, whatever order it arrived in.
+        assert all(g["start_date"] != "2024-09-13" for g in kept)
+
+    def test_null_start_dates_do_not_crash(self):
+        games = [
+            {"game_id": 1, "home_team": "A", "away_team": "X", "start_date": None},
+            {"game_id": 2, "home_team": "A", "away_team": "Y", "start_date": "2024-09-01"},
+        ]
+        kept, dropped = drop_outcome_dependent(games)
+        assert len(kept) == 2
+        assert dropped == 0
+
+    def test_empty(self):
+        assert drop_outcome_dependent([]) == ([], 0)
+
+
+class TestResidualQuantiles:
+    """Codex PR #51 P1: MAE is an average loss, not an interval half-width.
+    Quoting `point +/- MAE` as an honest range overstates the coverage badly."""
+
+    def test_quantiles_of_a_known_distribution(self):
+        rng = np.random.default_rng(7)
+        actual = rng.normal(0.0, 1.0, size=20000)
+        projected = np.zeros_like(actual)
+        q = residual_quantiles(list(projected), list(actual))
+        assert q["p10"] == pytest.approx(-1.2816, abs=0.05)
+        assert q["p90"] == pytest.approx(1.2816, abs=0.05)
+        assert q["p50"] == pytest.approx(0.0, abs=0.05)
+
+    def test_sign_convention_is_actual_minus_projected(self):
+        """A model that under-projects must show POSITIVE residuals."""
+        q = residual_quantiles([5.0] * 100, [7.0] * 100)
+        assert q["p50"] == pytest.approx(2.0)
+
+    def test_mae_is_a_narrower_span_than_the_80pct_interval(self):
+        """The actual defect, stated as a test: for a normal error the +/-MAE
+        band is materially narrower than p10..p90, so the two must not be used
+        interchangeably."""
+        rng = np.random.default_rng(11)
+        actual = list(rng.normal(0.0, 2.24, size=20000))
+        projected = [0.0] * len(actual)
+        q = residual_quantiles(projected, actual)
+        mae = win_error_metrics(projected, actual)["mae"]
+        assert (q["p90"] - q["p10"]) > 2 * mae * 1.3, (
+            "p10..p90 must be clearly wider than the +/- MAE band"
+        )
+
+    def test_empty(self):
+        assert residual_quantiles([], []) is None

--- a/tests/test_deploy_schema.py
+++ b/tests/test_deploy_schema.py
@@ -41,6 +41,8 @@ class TestComputeScripts:
             # Phase 4 season projections. Runnable through the deploy path so
             # the compute chain does not depend on a healthy ingest run.
             "simulate_season",
+            # Section 4.3 preseason backtest -- read-only, reports to stdout.
+            "backtest_preseason",
         }
 
 


### PR DESCRIPTION
> **Updated after merge.** The numbers first published in this description were superseded by three Codex fixes pushed into the same PR. The figures below are the final, post-fix results; the authoritative record is appendix A6 in the plan. Two claims in the original body were wrong and are corrected here rather than left standing: the ±MAE "honest range", and "statistically indistinguishable".

## The gate that was skipped

Phase 4 said: report win-MAE and calibration **before publishing any 2026 number**. That didn't happen — Oklahoma's 7.08 shipped with no error bar. This is that gate.

## Why it can't be a query

`score_fitted --backfill` stamps each historical row with the game's own `start_date`, so `predictions.game_predictions` holds **as-of-game-day** predictions: a week-12 game was scored with eleven games of that season's form already in its vector. Simulating from those rows would measure in-season accuracy, look flattering, and be wrong in the one direction nobody checks.

So this re-scores every game of season S from each team's **week-1** `features.team_week` vector with the frozen S-1 fit, reusing `score_fitted.score_game` unchanged — the design matrix, imputation, standardization and Platt calibration stay byte-identical to production, and the only difference is which `team_week` row is joined.

## Leak control

- **The fit** is walk-forward: S scored with `train_through = S-1`.
- **Sigma** from preseason residuals of seasons *strictly before* S.
- **Actual results** never enter: every game simulated as pending, since `simulate_wins` gives completed games a deterministic win. A test pins this against `simulate_wins` directly.
- **Outcome-dependent games excluded** (Codex P1): CFBD files conference championships as `season_type='regular'`, and below FBS the whole FCS/D2 playoff bracket. Each team's slate is capped at its first 12 chronological games, dropped if beyond the cap for either side so both keep matched slates. The same filter feeds the residual pool — it was contaminating sigma even under the FBS reporting scope.
- Confirmed the preseason constants really are preseason: `preseason_sp_rating` joins `sp.year = season - 1`, `returning_production` is a §1f constant. `maxGP = 0` every season is the direct evidence.

## Results (921 FBS team-seasons, 2019–2025)

| season | fit | drop | sigma | **win MAE** | RMSE | bias | p10–p90 | prior-yr base |
|---|---|---|---|---|---|---|---|---|
| 2019 | 2018 | 33 | 19.69 | 1.76 | 2.15 | −0.24 | 76.9% | 2.03 |
| 2020 | 2019 | 0 | 19.37 | 1.43 | 1.84 | −0.06 | 74.8% | 1.72 |
| 2021 | 2020 | 32 | 19.32 | 1.79 | 2.26 | −0.22 | 73.1% | 2.47 |
| 2022 | 2021 | 43 | 20.60 | 1.80 | 2.24 | −0.25 | 73.3% | 2.14 |
| 2023 | 2022 | 12 | 21.64 | 1.77 | 2.16 | −0.26 | 71.4% | 1.98 |
| 2024 | 2023 | 50 | 21.32 | 1.95 | 2.41 | −0.27 | 68.7% | 2.27 |
| 2025 | 2024 | 39 | 21.01 | 1.96 | 2.44 | −0.27 | 64.0% | 2.26 |

**Overall win MAE 1.784, RMSE 2.225, bias −0.226, coverage 71.7%.** Baselines: prior-season win rate 2.128, flat .500 2.140 — **the model beats both.**

**Empirical residual quantiles of (actual − projected), n=921:**

| p05 | p10 | p25 | p50 | p75 | p90 | p95 |
|---|---|---|---|---|---|---|
| −3.38 | **−2.61** | −1.21 | +0.11 | +1.81 | **+3.19** | +4.02 |

## Findings

1. **Real but modest** — a 0.34-win edge (~16%) over "predict last year's record". Misses the plan's ~1.5 aspiration; recorded as measured.
2. **Removing the leak barely moved the headline** (1.791 → 1.784, coverage 72.5% → 71.7%). It was real and had to go, but it was not what made the model look good — recorded so the fix isn't over-credited.
3. **The distribution is too narrow**, shown from opposite ends: `p_bowl_eligible` 0.8–0.9 predicted 0.848, observed **0.720**; `p_ten_plus` 0.2–0.3 predicted 0.246, observed **0.426**. Too little mass in *both* tails is one phenomenon — the v1 independent-draw limitation, measured. This promotes the correlated-draw v1.1 to next.
4. **Coverage decays 76.9% → 64.0%** while sigma rose only 19.7 → 21.0. Real variance is outgrowing the model's spread, plausibly the portal/NIL break §6.0b flags.
5. **A stable −0.23 win bias** in every season but 2020 — correctable with a calibration term.
6. **The error distribution is right-skewed** (p10 −2.61 vs p90 +3.19). Teams overperform projections by more than they underperform them.

## Consequence for the published 2026 numbers

Oklahoma's 7.08 carries an 80% empirical interval of **[4.5, 10.3]**.

~~"±1.79 MAE, so the honest range is 5.3–8.9"~~ — **wrong, and corrected.** MAE is an average loss, not a half-width; for a roughly normal error with MAE 1.78 the SD is ~2.23, so ±MAE spans only ~58%. The symmetric construction also concealed that the real interval is asymmetric.

~~"the model and the market are statistically indistinguishable"~~ — **withdrawn.** That asserted a test never run. The defensible statement is about resolution: a 0.42-win gap is a small fraction of an interval spanning ~5.8 wins, so this backtest gives no basis for preferring either number. Which is also the bar Phase 2 must clear — new features have to **reduce** this error, not merely move the number.

## Notes

Read-only; reports to stdout, writes no rows. In `COMPUTE_SCRIPTS` so it runs through the deploy path, which is how these numbers were produced.

CI green (Tests, Lint & Format, MCP Server). **1,094 passed / 392 skipped.**

For #50: its `TestSeasonOutlook` tests ran for real in CI against prod, not skipped — the `Tests` job supplies `SUPABASE_DB_URL`. That PR's body was more cautious than the facts warranted.