### PR TITLE
Fix the daily-load rate-limit waste, and make the preseason screen executable

### DIFF
--- a/scripts/deploy_schema.py
+++ b/scripts/deploy_schema.py
@@ -87,6 +87,11 @@ COMPUTE_SCRIPTS = {
     # Section 4.3 preseason backtest. Read-only -- re-scores history from
     # week-1 feature vectors and reports to stdout; writes no rows.
     "backtest_preseason",
+    # Section 2.5 candidate-feature screen. Read-only -- partial correlations
+    # and column discovery, reports to stdout. Previously runnable only via an
+    # interactive MCP session, which made the gate depend on a connector being
+    # authorized rather than on the deploy path everything else uses.
+    "screen_preseason_features",
 }
 
 # Marts refreshed after a compute run when plan.refresh is set. One home for

--- a/scripts/load_season.py
+++ b/scripts/load_season.py
@@ -75,24 +75,27 @@ ESTIMATED_CALLS = {
 # NOT on this list, deliberately:
 #   reference   -- no year filter and ~10 calls; always cheap, always current.
 #
-# metrics_wp WAS exempted here on the grounds that it is "already
-# self-limiting: it only fetches games still missing win probability, so a
-# fully-backfilled season costs nothing". That argument is wrong, and the
-# 2026-07-26 daily load is the counter-example: it reported
+#   metrics_wp  -- NOT skipped, though it was briefly added here. The 2026-07-26
+#                  daily load showed why it looked like it belonged: it reported
 #
-#     3829 completed games in [2025], 1312 already have win probability,
-#     2517 missing -- Processing 2517 games in 51 batches of up to 50
+#                      3829 completed games in [2025], 1312 already have win
+#                      probability, 2517 missing -- 51 batches of up to 50
 #
-# for a season that ended in January. "Only the missing ones" is self-limiting
-# only if the missing set actually drains to zero. It has not: 66% of a
-# finished season is still missing after months of daily runs, because games
-# CFBD has no win-probability data for stay missing forever. The query returns
-# them every day, so the cost is not amortized -- it is ~2,500 calls a day in
-# perpetuity, 3% of the monthly budget, for a season that cannot change.
+#                  for a season that ended in January, i.e. ~2,500 calls a day
+#                  for data that cannot change. But skipping the whole source
+#                  once a season is final is the wrong remedy (PR #54 review,
+#                  P1): run_metrics_wp_pipeline computes missing games as
+#                  completed-minus-loaded, so a backfill INTERRUPTED by the very
+#                  quota exhaustion that motivated the skip leaves recoverable
+#                  games in that 2,517. The unattended daily path passes no
+#                  --season, so those rows would never be retried and the gap
+#                  would become permanent by construction.
 #
-# In-game win probability for a COMPLETED game is as immutable as its box
-# score, so it belongs here. A live season is unaffected: the skip only applies
-# once season_is_final() is true.
+#                  The real defect was unbounded cost, not eligibility, and it
+#                  is fixed where it lives: run_metrics_wp_pipeline caps games
+#                  per run (MAX_GAMES_PER_RUN) and logs what it deferred, so the
+#                  backlog drains at a bounded price instead of costing
+#                  everything or nothing.
 IMMUTABLE_ONCE_FINAL = frozenset(
     {
         "games",
@@ -105,7 +108,6 @@ IMMUTABLE_ONCE_FINAL = frozenset(
         "betting",
         "draft",
         "metrics",
-        "metrics_wp",
         "rosters",
     }
 )

--- a/scripts/load_season.py
+++ b/scripts/load_season.py
@@ -74,8 +74,25 @@ ESTIMATED_CALLS = {
 #
 # NOT on this list, deliberately:
 #   reference   -- no year filter and ~10 calls; always cheap, always current.
-#   metrics_wp  -- already self-limiting; it only fetches games still missing
-#                  win probability, so a fully-backfilled season costs nothing.
+#
+# metrics_wp WAS exempted here on the grounds that it is "already
+# self-limiting: it only fetches games still missing win probability, so a
+# fully-backfilled season costs nothing". That argument is wrong, and the
+# 2026-07-26 daily load is the counter-example: it reported
+#
+#     3829 completed games in [2025], 1312 already have win probability,
+#     2517 missing -- Processing 2517 games in 51 batches of up to 50
+#
+# for a season that ended in January. "Only the missing ones" is self-limiting
+# only if the missing set actually drains to zero. It has not: 66% of a
+# finished season is still missing after months of daily runs, because games
+# CFBD has no win-probability data for stay missing forever. The query returns
+# them every day, so the cost is not amortized -- it is ~2,500 calls a day in
+# perpetuity, 3% of the monthly budget, for a season that cannot change.
+#
+# In-game win probability for a COMPLETED game is as immutable as its box
+# score, so it belongs here. A live season is unaffected: the skip only applies
+# once season_is_final() is true.
 IMMUTABLE_ONCE_FINAL = frozenset(
     {
         "games",
@@ -88,6 +105,7 @@ IMMUTABLE_ONCE_FINAL = frozenset(
         "betting",
         "draft",
         "metrics",
+        "metrics_wp",
         "rosters",
     }
 )

--- a/scripts/screen_preseason_features.py
+++ b/scripts/screen_preseason_features.py
@@ -347,6 +347,17 @@ CANDIDATE_COLUMNS = [
     "draft_departures",
     # Section 6.0b regime variant.
     "recruiting_points_regime",
+    # Prior-season trench performance (plan section 2.2). Never screened
+    # before: the earlier trench test used roster-headcount continuity, which
+    # counts walk-ons equally with starters and scored ~0. These measure the
+    # line play itself.
+    "prior_line_yards",
+    "prior_power_success",
+    "prior_stuff_rate_allowed",
+    "prior_havoc_allowed_front_seven",
+    "prior_def_line_yards",
+    "prior_def_stuff_rate",
+    "prior_front_seven_havoc",
 ]
 
 # What actually cleared the 2026-07-26 run (see RESULTS in the module
@@ -513,10 +524,33 @@ SELECT
         SELECT SUM(d3.capital)
         FROM draft_out d3
         WHERE d3.team = s.team AND d3.season BETWEEN s.season - 3 AND s.season - 1
-    ), 0) AS draft_capital_3yr
+    ), 0) AS draft_capital_3yr,
+    -- PRIOR-SEASON TRENCH PERFORMANCE (plan section 2.2, "the cheapest win").
+    -- Measured line play rather than inferred continuity: no roster
+    -- dependency, no new ingest, available from 2004, and computable in July.
+    -- This is the trenches thesis tested DIRECTLY -- the earlier headcount
+    -- continuity screen (OL -0.015, DL +0.013) tested whether the same bodies
+    -- returned, which counts a walk-on the same as a starter. These ask
+    -- whether the line actually blocked and the front actually penetrated.
+    --
+    -- Sign conventions differ and matter for reading the results:
+    --   line_yards / power_success / def_stuff_rate / front_seven_havoc -> higher is better
+    --   stuff_rate_allowed / havoc_allowed_front_seven                  -> LOWER is better
+    -- The screen reports signed partials, so a negative on an "allowed"
+    -- column is the thesis being CONFIRMED, not refuted.
+    ats.offense__line_yards AS prior_line_yards,
+    ats.offense__power_success AS prior_power_success,
+    ats.offense__stuff_rate AS prior_stuff_rate_allowed,
+    ats.offense__havoc__front_seven AS prior_havoc_allowed_front_seven,
+    ats.defense__line_yards AS prior_def_line_yards,
+    ats.defense__stuff_rate AS prior_def_stuff_rate,
+    ats.defense__havoc__front_seven AS prior_front_seven_havoc
 FROM spine s
 LEFT JOIN portal_flow pf ON pf.team = s.team AND pf.season = s.season
 LEFT JOIN draft_out dout ON dout.team = s.team AND dout.season = s.season
+-- Season S-1: what the trenches DID last year, known before season S starts.
+LEFT JOIN stats.advanced_team_stats ats
+       ON ats.team = s.team AND ats.season = s.season - 1
 ORDER BY s.season, s.team
 """
 
@@ -530,6 +564,21 @@ REQUIRED_COLUMNS: list[tuple[str, str, tuple[str, ...]]] = [
     ("recruiting", "transfer_portal", ("season", "origin", "destination", "rating")),
     ("draft", "draft_picks", ("year", "college_team", "round")),
     ("ratings", "sp_ratings", ("year", "team", "rating")),
+    (
+        "stats",
+        "advanced_team_stats",
+        (
+            "season",
+            "team",
+            "offense__line_yards",
+            "offense__power_success",
+            "offense__stuff_rate",
+            "offense__havoc__front_seven",
+            "defense__line_yards",
+            "defense__stuff_rate",
+            "defense__havoc__front_seven",
+        ),
+    ),
 ]
 
 

--- a/scripts/screen_preseason_features.py
+++ b/scripts/screen_preseason_features.py
@@ -499,8 +499,15 @@ UNTESTABLE_COLUMNS = {
 CLASS_DECAY = 0.8
 CLASS_WINDOW = 4
 
-SCREEN_FRAME_QUERY = f"""
-WITH coach_year AS (
+# Head-coach tenure start per (school, year). SHARED between the screen and the
+# imputation audit -- defined once because the audit's whole job is to describe
+# the frame the screen builds, and a hand-copied second version of this logic
+# silently disagreed with it (PR #54 review): without the gaps-and-islands
+# grouping a returning coach's second stint inherits the FIRST stint's start
+# year, widening the regime window, so the audit found classes where the screen
+# saw none and under-reported absent regime values.
+_COACH_TENURE_CTE = """
+coach_year AS (
     -- One head coach per (school, year). A school-year can list several
     -- coaches (interim, co-HC), so take the one who actually coached the most
     -- games. Covers 99.1%% of the sp_ratings spine.
@@ -520,7 +527,10 @@ coach_tenure AS (
     SELECT school, year, coach_id,
            MIN(year) OVER (PARTITION BY school, coach_id, grp) AS tenure_start
     FROM coach_islands
-),
+)"""
+
+SCREEN_FRAME_QUERY = f"""
+WITH {_COACH_TENURE_CTE},
 class_points AS (
     -- Recruiting class quality per (team, year).
     SELECT tr.team, tr.year, tr.points::double precision AS points
@@ -724,17 +734,7 @@ REQUIRED_COLUMNS: list[tuple[str, str, tuple[str, ...]]] = [
 # Counts only -- no correlations, no verdicts, no effect on the screened set or
 # the FDR correction.
 AUDIT_QUERY = f"""
-WITH coach_year AS (
-    SELECT DISTINCT ON (c.school, c.year)
-           c.school, c.year, c._dlt_parent_id AS coach_id
-    FROM ref.coaches__seasons c
-    ORDER BY c.school, c.year, COALESCE(c.games, 0) DESC
-),
-coach_tenure AS (
-    SELECT cy.school, cy.year,
-           MIN(cy.year) OVER (PARTITION BY cy.school, cy.coach_id) AS tenure_start
-    FROM coach_year cy
-),
+WITH {_COACH_TENURE_CTE},
 class_points AS (
     SELECT tr.team, tr.year, tr.points::double precision AS points
     FROM recruiting.team_recruiting tr

--- a/scripts/screen_preseason_features.py
+++ b/scripts/screen_preseason_features.py
@@ -381,8 +381,10 @@ CANDIDATE_COLUMNS = [
     "draft_yield",
     "portal_net_rating",
     "draft_departures",
-    # Section 6.0b regime variant.
+    # Section 6.0b regime variant, plus the coaching-change indicator it used
+    # to absorb via zero-fill (see the SQL and the 2026-07-26 audit).
     "recruiting_points_regime",
+    "hc_first_year",
     # Prior-season trench performance (plan section 2.2). Never screened
     # before: the earlier trench test used roster-headcount continuity, which
     # counts walk-ons equally with starters and scored ~0. These measure the
@@ -505,13 +507,17 @@ draft_out AS (
 spine AS (
     -- One row per (season, team) with the outcome, its control, and the
     -- current staff's tenure start (for the section 6.0b regime variant).
-    -- LEFT JOIN on tenure so the ~1%% of team-seasons with no coach record
-    -- still screen; tenure_start falls back to the window start, making the
-    -- regime variant equal the flat window for those rows.
+    --
+    -- tenure_start is deliberately NOT coalesced. The earlier fallback to the
+    -- window start made the regime variant silently equal the flat window for
+    -- the ~1%% of team-seasons with no coach record, so those rows entered the
+    -- screen as duplicates of a different candidate. NULL here propagates to
+    -- both regime columns below and drops the row from THEIR complete cases
+    -- only, leaving every other candidate on the full frame.
     SELECT sp.year AS season, sp.team,
            sp.rating::double precision AS sp_rating,
            sp0.rating::double precision AS prior_sp_rating,
-           COALESCE(ct.tenure_start, sp.year - {CLASS_WINDOW}) AS tenure_start
+           ct.tenure_start AS tenure_start
     FROM ratings.sp_ratings sp
     JOIN ratings.sp_ratings sp0
       ON sp0.team = sp.team AND sp0.year = sp.year - 1
@@ -532,16 +538,39 @@ SELECT
           AND cp.year BETWEEN s.season - {CLASS_WINDOW} AND s.season - 1
     ), 0) AS recruiting_points_3yr,
     -- Section 6.0b regime variant: same decayed sum, but only classes signed
-    -- from the current staff's tenure start onward. Scores lower alone than
-    -- the flat window yet adds beyond it, because a short window is itself a
-    -- signal ("new coach, inherited roster").
-    COALESCE((
+    -- from the current staff's tenure start onward.
+    --
+    -- NOT zero-filled, and the reason is the 2026-07-26 imputation audit: the
+    -- previous COALESCE(...,0) hit 291 of 1,439 rows (20.2%%). The regime window
+    -- GREATEST(season-4, tenure_start)..season-1 is EMPTY exactly when
+    -- tenure_start >= season -- a first-year head coach -- so a fifth of the
+    -- sample carried a hard 0 that meant "no classes signed by this staff yet",
+    -- not "this staff recruits badly". Worse, that 0 is confounded with the
+    -- coaching change itself, since programs that just fired a coach were
+    -- usually bad, so the column silently blended a continuous recruiting term
+    -- with a de facto new-coach indicator and its partial could not be
+    -- attributed to either.
+    --
+    -- The two are now separated: this column measures recruiting on the rows
+    -- where the staff has actually signed classes, and `hc_first_year` below
+    -- carries the coaching-change effect explicitly where it can be read.
+    --
+    -- CASE rather than a bare NULL tenure_start: Postgres GREATEST IGNORES
+    -- NULL arguments, so GREATEST(season-4, NULL) returns season-4 and would
+    -- quietly restore the flat window instead of yielding NULL.
+    CASE WHEN s.tenure_start IS NULL THEN NULL ELSE (
         SELECT SUM(cp.points * POWER({CLASS_DECAY}, s.season - cp.year - 1))
         FROM class_points cp
         WHERE cp.team = s.team
           AND cp.year BETWEEN GREATEST(s.season - {CLASS_WINDOW}, s.tenure_start)
                           AND s.season - 1
-    ), 0) AS recruiting_points_regime,
+    ) END AS recruiting_points_regime,
+    -- The coaching-change effect the regime column used to absorb, as its own
+    -- screened candidate. NULL where no coach record exists, so it is never
+    -- inferred from missing data.
+    CASE WHEN s.tenure_start IS NULL THEN NULL
+         WHEN s.tenure_start >= s.season THEN 1.0
+         ELSE 0.0 END AS hc_first_year,
     COALESCE((
         SELECT SUM(bc.blue_chips) / NULLIF(SUM(bc.signees), 0)
         FROM blue_chips bc
@@ -658,8 +687,10 @@ blue_chips AS (
     GROUP BY 1, 2
 ),
 spine AS (
+    -- Mirrors SCREEN_FRAME_QUERY's spine, including the uncoalesced
+    -- tenure_start, so the audit measures the frame the screen actually builds.
     SELECT sp.year AS season, sp.team,
-           COALESCE(ct.tenure_start, sp.year - {CLASS_WINDOW}) AS tenure_start
+           ct.tenure_start AS tenure_start
     FROM ratings.sp_ratings sp
     JOIN ratings.sp_ratings sp0
       ON sp0.team = sp.team AND sp0.year = sp.year - 1
@@ -675,13 +706,19 @@ SELECT
         WHERE cp.team = s.team
           AND cp.year BETWEEN s.season - {CLASS_WINDOW} AND s.season - 1
     ) IS NULL) AS recruiting_points_3yr_imputed,
+    -- Now a coverage figure, not an imputation one: these rows are DROPPED
+    -- from the regime column's complete cases rather than zero-filled. The
+    -- CASE mirrors the frame query, since GREATEST ignores NULL arguments.
     COUNT(*) FILTER (WHERE (
-        SELECT SUM(cp.points * POWER({CLASS_DECAY}, s.season - cp.year - 1))
-        FROM class_points cp
-        WHERE cp.team = s.team
-          AND cp.year BETWEEN GREATEST(s.season - {CLASS_WINDOW}, s.tenure_start)
-                          AND s.season - 1
-    ) IS NULL) AS recruiting_points_regime_imputed,
+        CASE WHEN s.tenure_start IS NULL THEN NULL ELSE (
+            SELECT SUM(cp.points * POWER({CLASS_DECAY}, s.season - cp.year - 1))
+            FROM class_points cp
+            WHERE cp.team = s.team
+              AND cp.year BETWEEN GREATEST(s.season - {CLASS_WINDOW}, s.tenure_start)
+                              AND s.season - 1
+        ) END
+    ) IS NULL) AS recruiting_points_regime_absent,
+    COUNT(*) FILTER (WHERE s.tenure_start IS NULL) AS hc_first_year_absent,
     COUNT(*) FILTER (WHERE (
         SELECT SUM(bc.blue_chips) / NULLIF(SUM(bc.signees), 0)
         FROM blue_chips bc

--- a/scripts/screen_preseason_features.py
+++ b/scripts/screen_preseason_features.py
@@ -141,6 +141,24 @@ DEFAULT_TO_SEASON = 2025
 # (see partial_corr_pvalue) stops being safe and the p-value is not reported.
 MIN_DF_FOR_NORMAL_APPROX = 200
 
+# Minimum complete-case rows for a candidate to be screened at all.
+#
+# Candidates are screened on COMPLETE CASES (see `complete_cases`): rows where
+# the candidate and both controls are all present. Most candidates are
+# COALESCEd to 0 in SQL and so cover the whole frame, but the prior-season
+# trench columns come from a LEFT JOIN against stats.advanced_team_stats and go
+# NULL whenever a team had no prior FBS season.
+#
+# Those NULLs must NOT be COALESCEd to 0 the way the churn columns are. Zero is
+# a true value for a count ("no portal transfers" really is a net rating of 0);
+# it is a fabricated EXTREME for a rate, since no team ever posts 0.000 line
+# yards. Worse, the teams missing a prior-season row -- new FBS entrants,
+# programs up from FCS -- are disproportionately bad in season S, so imputing
+# the floor would manufacture a strong trench correlation that is pure artifact.
+# Dropping the row asks the narrower but answerable question: among teams that
+# DID play last season, does line play predict next season?
+MIN_SCREEN_N = 400
+
 # The second control every other candidate is screened against, alongside
 # prior-season rating. It is the strongest single candidate, so "adds signal
 # beyond prior rating" is too weak a bar -- a candidate must add signal beyond
@@ -188,6 +206,24 @@ def partial_correlation(x: list[float], y: list[float], z: list[float]) -> float
     if denom == 0.0:
         return 0.0
     return (r_xy - r_xz * r_yz) / denom
+
+
+def complete_cases(frame: list[dict], columns: list[str]) -> list[dict]:
+    """Rows of `frame` where every column in `columns` is present and finite.
+
+    Available-case analysis, applied per candidate rather than once across the
+    whole set: dropping every row that any candidate is missing would shrink the
+    frame for the columns that are fully populated, so each candidate is scored
+    on the largest sample IT supports. The consequence is that candidates are
+    not all screened on the same n, which is why `screen` reports n per row --
+    a partial measured on 900 rows and one measured on 1,439 are not equally
+    precise, and the reader has to be able to see that.
+    """
+    return [
+        row
+        for row in frame
+        if all(row.get(col) is not None and math.isfinite(float(row[col])) for col in columns)
+    ]
 
 
 def _pearson(a: list[float], b: list[float]) -> float:
@@ -714,14 +750,39 @@ def _as_float(value):
 def screen(frame: list[dict], candidates: list[str]) -> list[dict]:
     """Run the screen over `frame`. Returns one result dict per candidate,
     ordered by descending |partial_r| so the strongest signals read first."""
-    y = [r["sp_rating"] for r in frame]
-    z = [r["prior_sp_rating"] for r in frame]
-    w = [r[PRIMARY_CONTROL] for r in frame]
-    n = len(frame)
+    total = len(frame)
 
     raw: list[dict] = []
     for name in candidates:
-        x = [r[name] for r in frame]
+        # Complete cases for THIS candidate: the candidate plus every control it
+        # will be measured against. A candidate that is NULL for part of the
+        # frame is screened on the part where it exists, not silently imputed.
+        needed = ["sp_rating", "prior_sp_rating", name]
+        if name != PRIMARY_CONTROL:
+            needed.append(PRIMARY_CONTROL)
+        rows = complete_cases(frame, needed)
+        n = len(rows)
+
+        if n < MIN_SCREEN_N:
+            # Too thin to screen. Reported rather than dropped (plan section
+            # 2.5: nulls are findings) and held out of the FDR correction by
+            # p=None, exactly like a candidate whose df is too small to test.
+            raw.append(
+                {
+                    "feature": name,
+                    "n": n,
+                    "coverage": (n / total) if total else 0.0,
+                    "partial_r_vs_prior": 0.0,
+                    "partial_r": 0.0,
+                    "p": None,
+                    "untestable": f"n={n} below MIN_SCREEN_N={MIN_SCREEN_N}",
+                }
+            )
+            continue
+
+        x = [row[name] for row in rows]
+        y = [row["sp_rating"] for row in rows]
+        z = [row["prior_sp_rating"] for row in rows]
         r_first = partial_correlation(x, y, z)
 
         if name == PRIMARY_CONTROL:
@@ -729,6 +790,7 @@ def screen(frame: list[dict], candidates: list[str]) -> list[dict]:
             # the first-order partial alone.
             r_decisive, n_controls = r_first, 1
         else:
+            w = [row[PRIMARY_CONTROL] for row in rows]
             r_decisive = second_order_partial_correlation(x, y, z, w)
             n_controls = 2
 
@@ -737,9 +799,11 @@ def screen(frame: list[dict], candidates: list[str]) -> list[dict]:
             {
                 "feature": name,
                 "n": n,
+                "coverage": (n / total) if total else 0.0,
                 "partial_r_vs_prior": r_first,
                 "partial_r": r_decisive,
                 "p": p,
+                "untestable": None,
             }
         )
 
@@ -752,6 +816,7 @@ def screen(frame: list[dict], candidates: list[str]) -> list[dict]:
         candidate["q"] = q
     for candidate in raw:
         candidate.setdefault("q", None)
+        candidate.setdefault("untestable", None)
         candidate["verdict"] = screen_verdict(candidate["partial_r"], candidate["q"])
 
     return sorted(raw, key=lambda c: abs(c["partial_r"]), reverse=True)
@@ -764,11 +829,13 @@ def report(results: list[dict], from_season: int, to_season: int) -> int:
     for c in results:
         p_str = f"{c['p']:.5f}" if c["p"] is not None else "na"
         q_str = f"{c['q']:.5f}" if c["q"] is not None else "na"
+        cov_str = f"{c['coverage']:.3f}" if c.get("coverage") is not None else "na"
+        note = f" note={c['untestable']}" if c.get("untestable") else ""
         print(
-            f"SCREEN_RESULT feature={c['feature']} n={c['n']} "
+            f"SCREEN_RESULT feature={c['feature']} n={c['n']} coverage={cov_str} "
             f"partial_r_vs_prior={c['partial_r_vs_prior']:+.4f} "
             f"partial_r={c['partial_r']:+.4f} p={p_str} q={q_str} "
-            f"verdict={c['verdict']}"
+            f"verdict={c['verdict']}{note}"
         )
         if c["verdict"] == "ship":
             shipped += 1

--- a/scripts/screen_preseason_features.py
+++ b/scripts/screen_preseason_features.py
@@ -403,7 +403,7 @@ SCREEN_FRAME_QUERY = f"""
 WITH coach_year AS (
     -- One head coach per (school, year). A school-year can list several
     -- coaches (interim, co-HC), so take the one who actually coached the most
-    -- games. Covers 99.1% of the sp_ratings spine.
+    -- games. Covers 99.1%% of the sp_ratings spine.
     SELECT DISTINCT ON (c.school, c.year)
            c.school, c.year, c._dlt_parent_id AS coach_id
     FROM ref.coaches__seasons c
@@ -469,7 +469,7 @@ draft_out AS (
 spine AS (
     -- One row per (season, team) with the outcome, its control, and the
     -- current staff's tenure start (for the section 6.0b regime variant).
-    -- LEFT JOIN on tenure so the ~1% of team-seasons with no coach record
+    -- LEFT JOIN on tenure so the ~1%% of team-seasons with no coach record
     -- still screen; tenure_start falls back to the window start, making the
     -- regime variant equal the flat window for those rows.
     SELECT sp.year AS season, sp.team,

--- a/scripts/screen_preseason_features.py
+++ b/scripts/screen_preseason_features.py
@@ -615,6 +615,29 @@ def check_schema(conn) -> list[str]:
     return problems
 
 
+def probe_columns(conn, schema: str, table: str, like: str | None = None) -> list[str]:
+    """Column names for a table, optionally filtered by substring.
+
+    Exists because the screening frame has to name dlt-flattened columns
+    exactly (``offense__line_yards`` and friends), and the compute role is the
+    only one that can see the source schemas -- api-only roles get nothing back
+    from information_schema for `stats`. Guessing a name and iterating through
+    deploy runs is slower and less reliable than asking once.
+    """
+    sql = """
+        SELECT column_name FROM information_schema.columns
+        WHERE table_schema = %s AND table_name = %s
+    """
+    params: list = [schema, table]
+    if like:
+        sql += " AND column_name ILIKE %s"
+        params.append(f"%{like}%")
+    sql += " ORDER BY column_name"
+    with conn.cursor() as cur:
+        cur.execute(sql, params)
+        return [r[0] for r in cur.fetchall()]
+
+
 def fetch_frame(conn, from_season: int, to_season: int) -> list[dict]:
     """Screening frame: one dict per (season, team) with outcome, control and
     every candidate, composites already derived."""
@@ -729,6 +752,13 @@ def main() -> None:
         help=f"Last season to screen (default {DEFAULT_TO_SEASON})",
     )
     parser.add_argument(
+        "--probe",
+        metavar="SCHEMA.TABLE[:LIKE]",
+        help="Print matching column names for a source table and exit "
+        "(e.g. stats.advanced_team_stats:line). Discovery aid for building "
+        "new candidates against dlt-flattened names.",
+    )
+    parser.add_argument(
         "--check-schema",
         action="store_true",
         help="Verify every source column exists, then exit without screening",
@@ -743,6 +773,19 @@ def main() -> None:
 
     conn = psycopg2.connect(get_db_url())
     try:
+        if args.probe:
+            spec, _, like = args.probe.partition(":")
+            schema, _, table = spec.partition(".")
+            if not schema or not table:
+                logger.error("--probe expects SCHEMA.TABLE[:LIKE], got %r", args.probe)
+                sys.exit(1)
+            cols = probe_columns(conn, schema, table, like or None)
+            print(f"\n{schema}.{table}" + (f"  (matching '{like}')" if like else ""))
+            for c in cols:
+                print(f"  {c}")
+            print(f"\nPROBE_GATE table={schema}.{table} matched={len(cols)}\n")
+            return
+
         problems = check_schema(conn)
         if problems:
             for p in problems:

--- a/scripts/screen_preseason_features.py
+++ b/scripts/screen_preseason_features.py
@@ -618,6 +618,89 @@ REQUIRED_COLUMNS: list[tuple[str, str, tuple[str, ...]]] = [
 ]
 
 
+# Imputation audit (--audit-imputation). Reports, per zero-filled candidate,
+# the share of frame rows whose UNDERLYING source was absent and therefore had
+# a 0 substituted by COALESCE.
+#
+# This exists because zero-filling is safe for a COUNT and unsafe for a RATE,
+# and the screened set contains both. `recruiting_points_3yr` is a summed count
+# -- no classes really is zero points -- but `blue_chip_pipeline` is
+# blue_chips/signees, where a missing recruiting record becomes "0% blue chips",
+# a fabricated floor rather than a neutral value. The same substitution inside
+# PRIMARY_CONTROL would propagate into every second-order partial in the screen,
+# so the audit covers the control too.
+#
+# Counts only -- no correlations, no verdicts, no effect on the screened set or
+# the FDR correction.
+AUDIT_QUERY = f"""
+WITH coach_year AS (
+    SELECT DISTINCT ON (c.school, c.year)
+           c.school, c.year, c._dlt_parent_id AS coach_id
+    FROM ref.coaches__seasons c
+    ORDER BY c.school, c.year, COALESCE(c.games, 0) DESC
+),
+coach_tenure AS (
+    SELECT cy.school, cy.year,
+           MIN(cy.year) OVER (PARTITION BY cy.school, cy.coach_id) AS tenure_start
+    FROM coach_year cy
+),
+class_points AS (
+    SELECT tr.team, tr.year, tr.points::double precision AS points
+    FROM recruiting.team_recruiting tr
+    WHERE tr.points IS NOT NULL
+),
+blue_chips AS (
+    SELECT rc.committed_to AS team, rc.year,
+           COUNT(*) FILTER (WHERE rc.stars >= 4)::double precision AS blue_chips,
+           COUNT(*)::double precision AS signees
+    FROM recruiting.recruits rc
+    WHERE rc.committed_to IS NOT NULL
+    GROUP BY 1, 2
+),
+spine AS (
+    SELECT sp.year AS season, sp.team,
+           COALESCE(ct.tenure_start, sp.year - {CLASS_WINDOW}) AS tenure_start
+    FROM ratings.sp_ratings sp
+    JOIN ratings.sp_ratings sp0
+      ON sp0.team = sp.team AND sp0.year = sp.year - 1
+    LEFT JOIN coach_tenure ct ON ct.school = sp.team AND ct.year = sp.year
+    WHERE sp.year BETWEEN %(from_season)s AND %(to_season)s
+      AND sp.rating IS NOT NULL AND sp0.rating IS NOT NULL
+)
+SELECT
+    COUNT(*) AS total_rows,
+    COUNT(*) FILTER (WHERE (
+        SELECT SUM(cp.points * POWER({CLASS_DECAY}, s.season - cp.year - 1))
+        FROM class_points cp
+        WHERE cp.team = s.team
+          AND cp.year BETWEEN s.season - {CLASS_WINDOW} AND s.season - 1
+    ) IS NULL) AS recruiting_points_3yr_imputed,
+    COUNT(*) FILTER (WHERE (
+        SELECT SUM(cp.points * POWER({CLASS_DECAY}, s.season - cp.year - 1))
+        FROM class_points cp
+        WHERE cp.team = s.team
+          AND cp.year BETWEEN GREATEST(s.season - {CLASS_WINDOW}, s.tenure_start)
+                          AND s.season - 1
+    ) IS NULL) AS recruiting_points_regime_imputed,
+    COUNT(*) FILTER (WHERE (
+        SELECT SUM(bc.blue_chips) / NULLIF(SUM(bc.signees), 0)
+        FROM blue_chips bc
+        WHERE bc.team = s.team
+          AND bc.year BETWEEN s.season - {CLASS_WINDOW} AND s.season - 1
+    ) IS NULL) AS blue_chip_pipeline_imputed
+FROM spine s
+"""
+
+
+def audit_imputation(conn, from_season: int, to_season: int) -> dict:
+    """Count rows where a zero-filled candidate's source was actually absent."""
+    import psycopg2.extras
+
+    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(AUDIT_QUERY, {"from_season": from_season, "to_season": to_season})
+        return dict(cur.fetchone())
+
+
 def derive_composites(row: dict) -> dict:
     """Add the Tier A composites that are cheaper to build in Python than SQL.
 
@@ -879,6 +962,12 @@ def main() -> None:
         action="store_true",
         help="Verify every source column exists, then exit without screening",
     )
+    parser.add_argument(
+        "--audit-imputation",
+        action="store_true",
+        help="Report how many rows each zero-filled candidate had substituted "
+        "by COALESCE, then exit. Diagnostic only -- no verdicts.",
+    )
     args = parser.parse_args()
 
     if args.from_season > args.to_season:
@@ -914,6 +1003,20 @@ def main() -> None:
             sys.exit(1)
         logger.info("Schema preflight passed (%d table(s))", len(REQUIRED_COLUMNS))
         if args.check_schema:
+            return
+
+        if args.audit_imputation:
+            audit = audit_imputation(conn, args.from_season, args.to_season)
+            total = audit.pop("total_rows")
+            for name, imputed in sorted(audit.items()):
+                share = (imputed / total) if total else 0.0
+                print(
+                    f"IMPUTATION_AUDIT candidate={name} imputed={imputed} "
+                    f"total={total} share={share:.4f}"
+                )
+            print(
+                f"IMPUTATION_SUMMARY total_rows={total} window={args.from_season}-{args.to_season}"
+            )
             return
 
         frame = fetch_frame(conn, args.from_season, args.to_season)

--- a/scripts/screen_preseason_features.py
+++ b/scripts/screen_preseason_features.py
@@ -52,51 +52,80 @@ so a re-run reproduces the full table -- deleting them would make the null
 results unreproducible, which is the same failure mode this gate exists to
 prevent.
 
-RESULTS -- run 2026-07-26 against prod, seasons 2015-2025 (n=1,439)
-------------------------------------------------------------------
+RESULTS -- run 2026-07-26 against prod, seasons 2015-2025
+--------------------------------------------------------
+Produced by THIS SCRIPT (deploy run 124). Every figure below is reproducible
+by re-running it, which the earlier recorded table was not: two unescaped
+percent signs meant the frame query had never once executed, so the original
+verdicts came from ad-hoc MCP queries that no longer exist. Where the two
+disagree, these numbers are the ones that stand.
+
 Column 2 controls for prior-season SP+ only; column 3 additionally controls for
 `recruiting_points_3yr`, which is the strongest single candidate and therefore
-the bar every other candidate has to clear.
+the bar every other candidate has to clear. `n`/`coverage` are per candidate:
+each is screened on its own complete cases (see `complete_cases`).
 
-    candidate                   vs prior SP+   + recruiting   verdict
-    recruiting_points_3yr          +0.2642     (is control)   SHIP
-    blue_chip_pipeline             +0.2532        +0.0931     SHIP
-    recruiting_points_regime       +0.1525        +0.0955     SHIP  (see below)
-    talent_stock                   +0.2664     ~+0.002        reject
-    pipeline_index                 +0.0952           --       reject
-    draft_picks_3yr                +0.0949        +0.0068     reject
-    conversion / draft_yield       +0.0760        -0.0007     reject
-    conversion_regime              +0.0876        +0.0344     reject
-    draft_departures               +0.0088           --       reject
-    portal_net_rating (2021-25)    +0.0274        +0.0731     reject, RE-TEST
-    portal_out_n (2021-25)         +0.0586        -0.0139     reject
+    candidate                       n    cov   vs prior   +recr   verdict
+    recruiting_points_3yr        1439  1.000    +0.2642  (ctrl)   SHIP
+    hc_first_year                1426  0.991    -0.1334  -0.1615  SHIP
+    prior_def_line_yards         1423  0.989    -0.0463  -0.0997  SHIP
+    prior_def_stuff_rate         1423  0.989    +0.0536  +0.0816  SHIP (marginal)
+    blue_chip_pipeline           1439  1.000    +0.2532  +0.0782  reject (see below)
+    talent_stock                 1439  1.000    +0.2664  +0.0744  reject
+    draft_departures             1439  1.000    +0.0088  -0.0728  reject
+    recruiting_points_regime     1136  0.789    +0.0712  -0.0620  reject
+    prior_power_success          1423  0.989    +0.0221  +0.0520  reject
+    portal_net_rating            1439  1.000    +0.0247  +0.0481  reject
+    prior_stuff_rate_allowed     1423  0.989    -0.0021  -0.0290  reject
+    prior_line_yards             1423  0.989    -0.0069  +0.0223  reject
+    pipeline_index               1439  1.000    +0.0952  +0.0072  reject
+    draft_picks_3yr              1439  1.000    +0.0949  +0.0068  reject
+    conversion / draft_yield     1439  1.000    +0.0760  -0.0007  reject
+    prior_havoc_allowed_front_7   251  0.174        --       --   untestable
+    prior_front_seven_havoc       251  0.174        --       --   untestable
 
 What the run established:
 
 1. **Trailing recruiting pipeline is the strongest preseason signal found** --
-   3x the pre-registered floor, and STRONGER in the portal era (+0.2840 on
-   2021-25) rather than weaker.
-2. **Draft production is redundant, not absent.** It predicts (+0.0949) until
+   3x the pre-registered floor.
+2. **The trenches thesis half-survives, and it is the DEFENSIVE half.**
+   `prior_def_line_yards` (-0.0997; the column is yards ALLOWED, so negative
+   confirms the thesis) and `prior_def_stuff_rate` (+0.0816) both clear. Every
+   offensive-line measure fails: line yards +0.0223, power success +0.0520,
+   stuff rate allowed -0.0290. Measured line play succeeds where the earlier
+   roster-headcount continuity screen (OL -0.015, DL +0.013) found nothing.
+3. **A first-year head coach is the second-strongest signal in the set**
+   (-0.1615, q < 1e-5), and it was previously invisible. It only became
+   measurable once it was separated from `recruiting_points_regime` -- see 4.
+4. **The regime column's original +0.0955 was not a recruiting signal.** The
+   regime window is empty exactly when the head coach is in year one, and
+   zero-filling put a hard 0 on 291 of 1,439 rows (20.2%, found by
+   --audit-imputation). That 0 is confounded with the coaching change itself,
+   so the column silently blended recruiting with a new-coach indicator. Split
+   apart, the recruiting half falls to -0.0620 and FAILS while the coaching
+   half ships at -0.1615. A column had shipped on a number that measured
+   something other than what the column claimed to measure.
+5. **Draft production is redundant, not absent.** It predicts (+0.0949) until
    recruiting is controlled, then collapses to +0.0068. Draft output identifies
    programs that *recruit* well, not ones that *develop*.
-3. **Regime-scoping is real** (design doc section 6.0b). Restricting the
-   recruiting window to classes signed under the current head coach scores
-   lower on its own (+0.1525 vs +0.2848) but adds +0.0955 BEYOND the flat
-   window -- the two together beat either alone. It partly encodes "new staff,
-   inherited roster", which the flat window cannot express.
-4. **The development term survives regime-scoping but still fails.**
-   `conversion` goes from -0.0007 to +0.0344 once scoped to the current staff
-   -- the right direction, less than half the floor. Draft counts are a coarse,
-   laggy proxy and season-level SP+ may not isolate development; the negative
-   result is on this measurement, not on the concept.
-5. **`draft_departures` is this gate's own justification:** raw correlation
-   +0.3474, partial +0.0088. Losing draft picks correlates with having been
-   good and says nothing about next season.
+6. **`draft_departures` is this gate's own justification:** raw correlation
+   +0.3474, partial -0.0728 -- and it flips sign. Losing draft picks correlates
+   with having been good and says nothing about next season.
+7. **Two candidates are untestable, not null.** The havoc front-seven splits
+   exist for only 17.4% of team-seasons, below MIN_SCREEN_N. That is a
+   data-coverage finding; the thesis they would test is unadjudicated.
 
 Both composites in the original design failed: `pipeline_index`
 (talent_stock x conversion) scores +0.0952 against its own input's +0.2664 --
-the multiplication destroys signal -- and `talent_stock` beats plain recruiting
-by +0.002, complexity for nothing.
+the multiplication destroys signal -- and `talent_stock` (+0.0744) does not
+clear the floor either.
+
+UNRESOLVED. The ad-hoc figures for `blue_chip_pipeline` (+0.0931 vs +0.0782),
+`talent_stock` (~+0.002 vs +0.0744) and `draft_departures` (+0.0088 vs -0.0728,
+sign flip) are not explained by imputation -- the audit found those columns
+1.5% and 0.8% zero-filled, and the zero-fill inflates, so the honest
+blue_chip_pipeline value is at most +0.0782. The ad-hoc SQL is gone and the
+discrepancy is recorded rather than reconciled.
 
 Usage:
     python scripts/screen_preseason_features.py --check-schema
@@ -398,35 +427,68 @@ CANDIDATE_COLUMNS = [
     "prior_front_seven_havoc",
 ]
 
-# What actually cleared the 2026-07-26 run (see RESULTS in the module
-# docstring). This -- NOT CANDIDATE_COLUMNS -- is the set migration 042 should
-# add to features.team_week. CANDIDATE_COLUMNS stays comprehensive so the
-# rejections remain reproducible.
+# What the screen itself ships (deploy run 124; see RESULTS in the module
+# docstring). CANDIDATE_COLUMNS stays comprehensive so the rejections remain
+# reproducible.
 #
-# `recruiting_points_regime` is the section 6.0b variant: the same decayed sum
-# restricted to classes signed from the current head coach's tenure start
-# onward. It is kept ALONGSIDE the flat window rather than replacing it -- it
-# scores lower alone but adds +0.0955 beyond it, so the pair carries more than
-# either does by itself.
+# This list is exactly the set with verdict == "ship", so `screen()` reproduces
+# it. Anything shipped for a reason the screen did not produce belongs in
+# SHIPPED_BY_DECISION below, never here -- collapsing the two is how the gate
+# stops being a gate.
 SHIPPED_COLUMNS = [
     "recruiting_points_3yr",
-    "blue_chip_pipeline",
-    "recruiting_points_regime",
+    "hc_first_year",
+    "prior_def_line_yards",
+    "prior_def_stuff_rate",
 ]
+
+# Shipped by human decision DESPITE a reject verdict, with the argument on the
+# record. Migration 042 adds SHIPPED_COLUMNS + these.
+#
+# Kept separate so the override is legible as an override. The screen's job is
+# to produce a number and apply a pre-registered rule; overruling the rule is a
+# judgment the owner is entitled to make, but it must not be laundered into
+# looking like a measurement.
+SHIPPED_BY_DECISION = {
+    "blue_chip_pipeline": (
+        "+0.0782 vs a 0.08 floor -- short by 0.07 standard errors at n=1,439, "
+        "which the data cannot distinguish, and q=0.0095 says the effect is real. "
+        "The floor separates 'matters' from 'negligible against an 18.5-point "
+        "residual SD'; it was never meant to arbitrate the third decimal."
+    ),
+}
 
 # Rejected, with the reason, so a future reader does not re-propose them
 # without new evidence. Re-test conditions noted where they exist.
 REJECTED_COLUMNS = {
-    "talent_stock": "beats plain recruiting by +0.002 -- complexity for nothing",
-    "pipeline_index": "+0.0952 vs its own input's +0.2664 -- the product destroys signal",
+    "talent_stock": "+0.0744 -- under the floor, and no better than plain recruiting",
+    "pipeline_index": "+0.0072 vs its own input's +0.2664 -- the product destroys signal",
     "draft_picks_3yr": "+0.0068 once recruiting is controlled -- a recruiting proxy",
     "conversion": "-0.0007 once recruiting is controlled",
-    "conversion_regime": "+0.0344 -- regime-scoping helps but stays under the floor",
-    "draft_departures": "+0.0088 partial against +0.3474 raw -- pure confound",
-    "portal_net_rating": (
-        "+0.0731 (2021-25, n=663) -- under floor; RE-TEST as portal history accrues"
+    "draft_yield": "-0.0007 -- identical to conversion by construction",
+    "draft_departures": "-0.0728 partial against +0.3474 raw, sign flipped -- pure confound",
+    "recruiting_points_regime": (
+        "-0.0620 on its 1,136 complete cases. Its earlier +0.0955 was an artifact of "
+        "zero-filling 291 first-year-coach rows; that signal was the coaching change, "
+        "and it now ships separately as hc_first_year (-0.1615)."
     ),
-    "portal_out_n": "-0.0139 once recruiting is controlled",
+    "prior_line_yards": "+0.0223 -- offensive line play carries no signal past recruiting",
+    "prior_power_success": "+0.0520 -- under the floor",
+    "prior_stuff_rate_allowed": "-0.0290 -- under the floor",
+    "portal_net_rating": (
+        "+0.0481 -- under floor; RE-TEST as portal history accrues. Caveat: it is "
+        "COALESCEd to 0 across the full window, but a pre-2021 zero means 'the portal "
+        "did not exist', not 'net zero movement', so the measurement is contaminated "
+        "the same way the trench columns were. Re-test on 2021+ complete cases."
+    ),
+}
+
+# Screened but not scored: too few complete cases to test at all. Recorded
+# because "we could not measure this" is a different finding from "we measured
+# it and it was nothing", and only the second one closes a question.
+UNTESTABLE_COLUMNS = {
+    "prior_havoc_allowed_front_seven": "n=251 (17.4% coverage) -- below MIN_SCREEN_N",
+    "prior_front_seven_havoc": "n=251 (17.4% coverage) -- below MIN_SCREEN_N",
 }
 
 # Recruiting-class decay across the four-year eligibility window: the class

--- a/src/pipelines/run.py
+++ b/src/pipelines/run.py
@@ -489,6 +489,10 @@ def _metrics_wp_db_url() -> str:
 # Games considered for win-probability loading: completed, both scores
 # present. Restricted to the requested seasons so a single-season daily call
 # doesn't rescan all of history.
+# Newest first. The steady-state case -- games that finished since the last run
+# -- must never be starved behind a historical backlog once MAX_GAMES_PER_RUN
+# starts truncating, and recency is the best available proxy for "CFBD actually
+# has win-probability data for this game".
 _METRICS_WP_GAMES_QUERY = """
     SELECT id, season
     FROM core.games
@@ -496,8 +500,24 @@ _METRICS_WP_GAMES_QUERY = """
       AND home_points IS NOT NULL
       AND away_points IS NOT NULL
       AND season = ANY(%s)
-    ORDER BY season, id
+    ORDER BY season DESC, start_date DESC NULLS LAST, id DESC
 """
+
+# Ceiling on games fetched per run -- one API call each.
+#
+# Without it the backlog is unbounded: the 2026-07-26 daily load found 2,517
+# games of a FINISHED 2025 season still missing win probability and queued all
+# of them, ~3% of the monthly budget in a single run, every day. The backlog
+# does not drain on its own because a game CFBD has no data for stays missing
+# and is re-requested forever.
+#
+# Skipping the source entirely once a season is final was the first fix and was
+# wrong (PR #54 review): missing games include ones whose requests failed during
+# the quota exhaustion, and the unattended daily path would never retry them.
+# Capping keeps every game eligible while bounding what a single run can cost,
+# so an interrupted backfill still drains -- 2,517 games in ~9 days at this
+# ceiling -- instead of being abandoned or re-attempted in full.
+MAX_WP_GAMES_PER_RUN = 300
 
 # metrics.win_probability doesn't exist until the first successful pipeline.run()
 # of win_probability_resource creates it (dlt table-on-first-write, same as
@@ -513,6 +533,7 @@ _METRICS_WP_EXISTING_QUERY = """
 def run_metrics_wp_pipeline(
     seasons: list[int] | None = None,
     batch_size: int = 50,
+    max_games: int | None = MAX_WP_GAMES_PER_RUN,
 ) -> dict:
     """Load in-game win probability for completed games missing it.
 
@@ -544,10 +565,14 @@ def run_metrics_wp_pipeline(
             to the current season (matches every other run_*_pipeline's
             incremental default).
         batch_size: Games per pipeline.run() call.
+        max_games: Ceiling on games fetched this run (one API call each), newest
+            first. None disables the cap for a deliberate full backfill. See
+            MAX_WP_GAMES_PER_RUN for why the default is not None.
 
     Returns:
-        Summary dict: seasons, games considered, games missing, batches run,
-        and the list of dlt LoadInfo objects (one per batch).
+        Summary dict: seasons, games considered, `missing` (the FULL backlog,
+        not the capped slice), `loaded_this_run`, `deferred`, batches run, and
+        the list of dlt LoadInfo objects (one per batch).
     """
     import psycopg2
     import psycopg2.errors
@@ -578,18 +603,41 @@ def run_metrics_wp_pipeline(
         conn.close()
 
     missing = [(gid, season) for gid, season in candidate_games if gid not in existing_ids]
+    total_missing = len(missing)
+
+    # Bound the run. Reported, never silent: a truncated backlog that looked
+    # like a completed one is how "2,517 missing" went unnoticed for months.
+    deferred = 0
+    if max_games is not None and total_missing > max_games:
+        deferred = total_missing - max_games
+        missing = missing[:max_games]
+
     game_seasons = dict(missing)
     game_ids = [gid for gid, _ in missing]
 
     print(
         f"  {len(candidate_games)} completed games in {seasons}, "
         f"{len(existing_ids)} already have win probability, "
-        f"{len(game_ids)} missing"
+        f"{total_missing} missing"
     )
+    if deferred:
+        msg = (
+            f"  Backlog capped at {max_games} game(s) this run; {deferred} deferred "
+            f"to a later run (newest first). Re-run to continue draining."
+        )
+        print(msg)
+        logger.info(msg.strip())
 
     if not game_ids:
         print("  Nothing to load.")
-        return {"seasons": seasons, "candidates": len(candidate_games), "missing": 0, "batches": 0}
+        return {
+            "seasons": seasons,
+            "candidates": len(candidate_games),
+            "missing": 0,
+            "loaded_this_run": 0,
+            "deferred": 0,
+            "batches": 0,
+        }
 
     rate_limiter = get_rate_limiter()
     if not rate_limiter.check_budget(len(game_ids)):
@@ -602,7 +650,9 @@ def run_metrics_wp_pipeline(
         return {
             "seasons": seasons,
             "candidates": len(candidate_games),
-            "missing": len(game_ids),
+            "missing": total_missing,
+            "loaded_this_run": 0,
+            "deferred": deferred,
             "batches": 0,
             "error": msg,
         }
@@ -628,7 +678,9 @@ def run_metrics_wp_pipeline(
     return {
         "seasons": seasons,
         "candidates": len(candidate_games),
-        "missing": len(game_ids),
+        "missing": total_missing,
+        "loaded_this_run": len(game_ids),
+        "deferred": deferred,
         "batches": len(batches),
         "info": all_info,
     }

--- a/src/pipelines/utils/api_client.py
+++ b/src/pipelines/utils/api_client.py
@@ -12,13 +12,35 @@ import httpx
 
 logger = logging.getLogger(__name__)
 
-# Consecutive fully-rate-limited requests before the circuit opens.
+# Consecutive HTTP 429 responses before the run is abandoned.
+#
 # Burst throttling clears in ~10 minutes and affects a handful of calls; an
-# exhausted monthly quota 429s everything until the quota resets. After this
-# many requests have each burned their full retry budget without one success,
-# the second explanation is the only one left, and every further minute of
-# waiting is wasted CI time.
-RATE_LIMIT_CIRCUIT_THRESHOLD = 5
+# exhausted monthly quota 429s everything until the quota resets. Once this many
+# responses in a row have been refused without one success, the second
+# explanation is the only one left and every further minute is wasted CI time.
+#
+# Must stay comfortably ABOVE the dlt extract worker pool (.dlt/config.toml sets
+# workers = 5). The counter is shared across the run, so N workers each taking a
+# single transient 429 at the same instant contribute N at once: a threshold of
+# 5 against a 5-worker pool could be reached by one simultaneous blip that every
+# worker would have recovered from on retry, aborting a healthy run. 10 is
+# double the pool, so it needs sustained refusal rather than one bad moment.
+#
+# Read the other way: a fully rate-limited request contributes MAX_RETRIES + 1
+# = 4, so 10 is ~2.5 exhausted requests. Against a spent quota the daily load
+# aborts around six minutes in rather than grinding through every source.
+#
+# Deliberately NOT a multiple of MAX_RETRIES + 1. At an exact multiple the
+# threshold is only ever crossed on a request's FINAL attempt, where the
+# out-of-retries branch raises first, so the mid-request abort below could never
+# fire and a doomed request would always sleep out its whole budget.
+#
+# The trade-off is deliberate and worth stating: CFBD burst-blocks for ~10
+# minutes at a time, and a burst long enough to cross this threshold with no
+# successes in between WILL fail the run. That is the cheaper error for an
+# idempotent job that retries tomorrow and opens an issue when it fails -- the
+# alternative, historically, was a three-hour run that exhausted the quota.
+RATE_LIMIT_CIRCUIT_THRESHOLD = 10
 
 
 class RateLimitExhausted(Exception):

--- a/src/pipelines/utils/api_client.py
+++ b/src/pipelines/utils/api_client.py
@@ -66,6 +66,14 @@ class RateLimitBreaker:
     sources each burning a full retry budget against a spent quota is exactly
     the wasted-CI case it exists to stop.
 
+    **Counted per 429 response, not per exhausted request.** Sharing the
+    counter was necessary but not sufficient: while each increment cost a whole
+    retry budget, reaching 5 took 20 API calls and 15 minutes, and a run with
+    only 4 active sources could never reach it. The 2026-07-26 daily load
+    proved it -- 12 minutes of sleeping against a spent quota, final count 4,
+    breaker never opened. Counting responses makes the threshold mean what it
+    says.
+
     Locked because dlt runs sources on a worker pool, so increments and resets
     genuinely race.
     """
@@ -89,8 +97,18 @@ class RateLimitBreaker:
         with self._lock:
             self._consecutive = 0
 
-    def record_exhausted(self) -> int:
-        """Count one request that burned its whole retry budget on 429s."""
+    def record_rate_limited(self) -> int:
+        """Count one 429 RESPONSE.
+
+        Counted per response, not per fully-exhausted request, and the unit is
+        the whole point. Counting exhausted requests made each increment cost a
+        full retry budget -- 4 API calls and 3 minutes of sleep -- so the
+        threshold of 5 needed 20 wasted calls and 15 minutes before it could
+        fire. An off-season run only has ~4 active sources, so it could not
+        fire at all: the 2026-07-26 daily load spent 12 minutes retrying a
+        spent quota and finished at a count of 4, one short, having never
+        opened the breaker it was built to trigger.
+        """
         with self._lock:
             self._consecutive += 1
             return self._consecutive
@@ -259,8 +277,8 @@ class CFBDClient:
         """
         if self._breaker.is_open():
             raise RateLimitCircuitOpen(
-                f"{self._breaker.consecutive} consecutive request(s) exhausted their "
-                f"retries on HTTP 429 before {endpoint}. The API is refusing everything -- "
+                f"{self._breaker.consecutive} consecutive HTTP 429 response(s) "
+                f"before {endpoint}. The API is refusing everything -- "
                 "most likely the monthly quota is spent. Stopping instead of retrying; "
                 "further requests cannot succeed until the quota resets."
             )
@@ -276,15 +294,30 @@ class CFBDClient:
             except httpx.HTTPStatusError as e:
                 if e.response.status_code == 429:  # Rate limited
                     retry_after = self._parse_retry_after(e.response.headers.get("Retry-After"))
+                    # Every 429 counts, including the ones we are about to
+                    # retry. See RateLimitBreaker.record_rate_limited.
+                    consecutive = self._breaker.record_rate_limited()
                     if attempt >= retries:
-                        # Out of attempts. Count it and fail loudly -- falling
-                        # through to an empty list here would tell the caller
-                        # this endpoint has no data.
-                        consecutive = self._breaker.record_exhausted()
+                        # Out of attempts. Fail loudly -- falling through to an
+                        # empty list here would tell the caller this endpoint
+                        # has no data.
                         raise RateLimitExhausted(
                             f"Rate limited on all {retries + 1} attempt(s) for {endpoint} "
-                            f"(params={params}). Consecutive rate-limited requests: "
+                            f"(params={params}). Consecutive rate-limited responses: "
                             f"{consecutive}."
+                        ) from e
+                    if self._breaker.is_open():
+                        # Checked BEFORE sleeping, not just at the top of get().
+                        # Sleeping out a retry budget we already know is doomed
+                        # is the exact waste the breaker exists to prevent, and
+                        # the top-of-method guard alone cannot stop it because
+                        # a single request can burn its whole budget without
+                        # ever re-entering get().
+                        raise RateLimitCircuitOpen(
+                            f"{consecutive} consecutive HTTP 429 response(s), most recently "
+                            f"{endpoint}. The API is refusing everything -- most likely the "
+                            "monthly quota is spent. Stopping instead of sleeping "
+                            f"{retry_after}s for a retry that cannot succeed."
                         ) from e
                     logger.warning(
                         f"Rate limited on {endpoint}. Waiting {retry_after}s "

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -190,15 +190,29 @@ class TestRateLimitCircuitBreaker:
     for three hours cannot succeed; the sweep must abort in seconds."""
 
     def _exhaust(self, client, n):
+        """Drive `n` fully-rate-limited requests.
+
+        Each records `retries + 1` 429s now that the breaker counts responses,
+        so this trips the threshold far faster than it used to -- which is the
+        entire point of the change. Either rate-limit error is acceptable: once
+        the breaker opens mid-request the raise becomes RateLimitCircuitOpen.
+        """
         with patch.object(client._client, "get", side_effect=_rate_limit_error()):
             with patch("src.pipelines.utils.api_client.time.sleep"):
                 for _ in range(n):
-                    with pytest.raises(RateLimitExhausted):
+                    with pytest.raises(RATE_LIMIT_ERRORS):
                         client.get("/plays/stats")
+
+    def test_one_exhausted_request_counts_every_attempt(self):
+        """The unit is the 429 response, not the exhausted request."""
+        client = CFBDClient(api_key="test-key")
+        self._exhaust(client, 1)
+        assert client._consecutive_rate_limited == CFBDClient.MAX_RETRIES + 1
+        client.close()
 
     def test_circuit_opens_after_threshold(self):
         client = CFBDClient(api_key="test-key")
-        self._exhaust(client, CFBDClient.RATE_LIMIT_CIRCUIT_THRESHOLD)
+        self._exhaust(client, 2)
         # The next call must fail immediately, without sleeping at all.
         with patch("src.pipelines.utils.api_client.time.sleep") as mock_sleep:
             with pytest.raises(RateLimitCircuitOpen, match="quota is spent"):
@@ -208,7 +222,8 @@ class TestRateLimitCircuitBreaker:
 
     def test_circuit_stays_closed_below_threshold(self):
         client = CFBDClient(api_key="test-key")
-        self._exhaust(client, CFBDClient.RATE_LIMIT_CIRCUIT_THRESHOLD - 1)
+        self._exhaust(client, 1)
+        assert client._consecutive_rate_limited < CFBDClient.RATE_LIMIT_CIRCUIT_THRESHOLD
         ok = MagicMock()
         ok.json.return_value = [{"ok": True}]
         ok.raise_for_status = MagicMock()
@@ -221,7 +236,7 @@ class TestRateLimitCircuitBreaker:
         threshold -- otherwise transient throttling eventually halts a healthy
         pipeline."""
         client = CFBDClient(api_key="test-key")
-        self._exhaust(client, CFBDClient.RATE_LIMIT_CIRCUIT_THRESHOLD - 1)
+        self._exhaust(client, 1)
         ok = MagicMock()
         ok.json.return_value = []
         ok.raise_for_status = MagicMock()
@@ -229,9 +244,50 @@ class TestRateLimitCircuitBreaker:
             client.get("/teams")
         assert client._consecutive_rate_limited == 0
         # Full budget available again.
-        self._exhaust(client, CFBDClient.RATE_LIMIT_CIRCUIT_THRESHOLD - 1)
+        self._exhaust(client, 1)
         with patch.object(client._client, "get", return_value=ok):
             assert client.get("/teams") == []
+        client.close()
+
+    def test_breaker_is_checked_before_sleeping_not_only_between_requests(self):
+        """The regression from the 2026-07-26 daily load.
+
+        A single request can burn its entire retry budget without re-entering
+        get(), so the top-of-method guard alone never sees it. Once the
+        threshold is crossed mid-request, the remaining sleeps must be
+        abandoned rather than served.
+        """
+        client = CFBDClient(api_key="test-key")
+        # One request short of the threshold (4 of 5).
+        self._exhaust(client, 1)
+        with patch.object(client._client, "get", side_effect=_rate_limit_error()):
+            with patch("src.pipelines.utils.api_client.time.sleep") as mock_sleep:
+                with pytest.raises(RateLimitCircuitOpen):
+                    client.get("/teams")
+                # The 5th 429 opens the breaker, so this request must not sleep
+                # through the three retries it would otherwise be entitled to.
+                mock_sleep.assert_not_called()
+        client.close()
+
+    def test_offseason_run_shape_trips_the_breaker(self):
+        """Under the old per-request counting this was unreachable.
+
+        The 2026-07-26 daily load ran 4 sources against a spent quota. Each
+        burned 4 attempts and 3 minutes; the counter finished at 4 against a
+        threshold of 5, so the breaker never opened and the run spent 12
+        minutes sleeping. Counting responses, the same shape trips it during
+        the second source.
+        """
+        client = CFBDClient(api_key="test-key")
+        sleeps = []
+        with patch.object(client._client, "get", side_effect=_rate_limit_error()):
+            with patch("src.pipelines.utils.api_client.time.sleep", sleeps.append):
+                for _ in range(4):  # reference, metrics_wp, games, betting
+                    with pytest.raises(RATE_LIMIT_ERRORS):
+                        client.get("/whatever")
+        # Old behaviour slept 3x per source across all four sources.
+        assert len(sleeps) < 3 * 4
+        assert client._consecutive_rate_limited >= CFBDClient.RATE_LIMIT_CIRCUIT_THRESHOLD
         client.close()
 
     def test_non_rate_limit_errors_do_not_trip_the_breaker(self):
@@ -338,6 +394,11 @@ class TestBreakerIsSharedAcrossClients:
     unreachable, and the breaker was dead code: a spent quota still burned a
     full retry budget separately for every one of the ~60 resources."""
 
+    # Each fully-rate-limited request now records MAX_RETRIES + 1 responses, so
+    # two sources are enough to cross a threshold of 5 (see
+    # RateLimitBreaker.record_rate_limited).
+    SOURCES_TO_TRIP = 2
+
     def _exhaust_on_a_fresh_client(self, n):
         """Mimic the real call graph: one new client per rate-limited source."""
         for _ in range(n):
@@ -345,13 +406,13 @@ class TestBreakerIsSharedAcrossClients:
             try:
                 with patch.object(client._client, "get", side_effect=_rate_limit_error()):
                     with patch("src.pipelines.utils.api_client.time.sleep"):
-                        with pytest.raises(RateLimitExhausted):
+                        with pytest.raises(RATE_LIMIT_ERRORS):
                             client.get("/plays/stats")
             finally:
                 client.close()
 
     def test_threshold_is_reachable_across_separate_clients(self):
-        self._exhaust_on_a_fresh_client(CFBDClient.RATE_LIMIT_CIRCUIT_THRESHOLD)
+        self._exhaust_on_a_fresh_client(self.SOURCES_TO_TRIP)
         later = CFBDClient(api_key="test-key")
         with patch("src.pipelines.utils.api_client.time.sleep") as mock_sleep:
             with pytest.raises(RateLimitCircuitOpen, match="quota is spent"):
@@ -360,7 +421,7 @@ class TestBreakerIsSharedAcrossClients:
         later.close()
 
     def test_below_threshold_a_new_client_still_works(self):
-        self._exhaust_on_a_fresh_client(CFBDClient.RATE_LIMIT_CIRCUIT_THRESHOLD - 1)
+        self._exhaust_on_a_fresh_client(1)
         later = CFBDClient(api_key="test-key")
         ok = MagicMock()
         ok.json.return_value = [{"ok": True}]
@@ -370,7 +431,7 @@ class TestBreakerIsSharedAcrossClients:
         later.close()
 
     def test_a_success_on_any_client_clears_the_shared_count(self):
-        self._exhaust_on_a_fresh_client(CFBDClient.RATE_LIMIT_CIRCUIT_THRESHOLD - 1)
+        self._exhaust_on_a_fresh_client(1)
         healthy = CFBDClient(api_key="test-key")
         ok = MagicMock()
         ok.json.return_value = []
@@ -379,7 +440,7 @@ class TestBreakerIsSharedAcrossClients:
             healthy.get("/teams")
         healthy.close()
         # Budget restored for everyone, so the breaker must still be closed.
-        self._exhaust_on_a_fresh_client(CFBDClient.RATE_LIMIT_CIRCUIT_THRESHOLD - 1)
+        self._exhaust_on_a_fresh_client(1)
         later = CFBDClient(api_key="test-key")
         with patch.object(later._client, "get", return_value=ok):
             assert later.get("/games") == []
@@ -387,7 +448,7 @@ class TestBreakerIsSharedAcrossClients:
 
     def test_an_injected_breaker_isolates_a_client(self):
         """The escape hatch: a caller that must not be halted by the run."""
-        self._exhaust_on_a_fresh_client(CFBDClient.RATE_LIMIT_CIRCUIT_THRESHOLD)
+        self._exhaust_on_a_fresh_client(self.SOURCES_TO_TRIP)
         private = CFBDClient(api_key="test-key", breaker=RateLimitBreaker())
         ok = MagicMock()
         ok.json.return_value = [{"ok": True}]
@@ -397,7 +458,7 @@ class TestBreakerIsSharedAcrossClients:
         private.close()
 
     def test_module_level_reset_clears_the_run(self):
-        self._exhaust_on_a_fresh_client(CFBDClient.RATE_LIMIT_CIRCUIT_THRESHOLD)
+        self._exhaust_on_a_fresh_client(self.SOURCES_TO_TRIP)
         reset_rate_limit_circuit()
         later = CFBDClient(api_key="test-key")
         ok = MagicMock()
@@ -418,8 +479,12 @@ class TestCircuitIsTerminalButResettable:
         err = httpx.HTTPStatusError("429", request=MagicMock(), response=_rate_limited_response())
         with patch.object(client._client, "get", side_effect=err):
             with patch("src.pipelines.utils.api_client.time.sleep"):
-                for _ in range(CFBDClient.RATE_LIMIT_CIRCUIT_THRESHOLD):
-                    with pytest.raises(RateLimitExhausted):
+                # Two fully-rate-limited requests now exceed the threshold,
+                # since every 429 response counts rather than every exhausted
+                # request. Loop until it is actually open rather than assuming
+                # a fixed request count.
+                while not client._breaker.is_open():
+                    with pytest.raises(RATE_LIMIT_ERRORS):
                         client.get("/plays/stats")
 
     def test_open_circuit_does_not_self_heal_even_if_the_api_recovers(self):

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,5 +1,6 @@
 """Tests for CFBD API client."""
 
+import math
 from datetime import UTC, datetime, timedelta
 from email.utils import format_datetime
 from unittest.mock import MagicMock, patch
@@ -118,6 +119,15 @@ class TestCFBDClient:
         client.close()
 
 
+# dlt extract worker pool size (.dlt/config.toml: workers = 5). The shared
+# breaker sees all of them, so the circuit threshold has to clear this.
+DLT_EXTRACT_WORKERS = 5
+
+# Fully-rate-limited requests needed to cross the circuit threshold. Derived so
+# the tests stay meaningful if the threshold or the retry budget changes.
+REQUESTS_TO_TRIP = math.ceil(CFBDClient.RATE_LIMIT_CIRCUIT_THRESHOLD / (CFBDClient.MAX_RETRIES + 1))
+
+
 def _rate_limited_response(retry_after="1"):
     r = MagicMock()
     r.status_code = 429
@@ -212,7 +222,7 @@ class TestRateLimitCircuitBreaker:
 
     def test_circuit_opens_after_threshold(self):
         client = CFBDClient(api_key="test-key")
-        self._exhaust(client, 2)
+        self._exhaust(client, REQUESTS_TO_TRIP)
         # The next call must fail immediately, without sleeping at all.
         with patch("src.pipelines.utils.api_client.time.sleep") as mock_sleep:
             with pytest.raises(RateLimitCircuitOpen, match="quota is spent"):
@@ -258,15 +268,42 @@ class TestRateLimitCircuitBreaker:
         abandoned rather than served.
         """
         client = CFBDClient(api_key="test-key")
-        # One request short of the threshold (4 of 5).
-        self._exhaust(client, 1)
+        # Stop one request short of tripping, so the threshold is crossed
+        # partway through the NEXT request rather than between requests.
+        self._exhaust(client, REQUESTS_TO_TRIP - 1)
         with patch.object(client._client, "get", side_effect=_rate_limit_error()):
             with patch("src.pipelines.utils.api_client.time.sleep") as mock_sleep:
                 with pytest.raises(RateLimitCircuitOpen):
                     client.get("/teams")
-                # The 5th 429 opens the breaker, so this request must not sleep
-                # through the three retries it would otherwise be entitled to.
-                mock_sleep.assert_not_called()
+                # It may sleep once or twice before crossing, but it must NOT
+                # serve the full retry budget: abandoning the remaining sleeps
+                # is the whole behaviour under test.
+                assert mock_sleep.call_count < CFBDClient.MAX_RETRIES
+        client.close()
+
+    def test_one_transient_429_per_worker_does_not_trip_the_breaker(self):
+        """The regression introduced BY the per-response counting change.
+
+        The breaker is shared across the run and dlt extracts on a worker pool
+        (.dlt/config.toml: workers = 5). Counting every 429 means N concurrent
+        workers each taking a single transient 429 contribute N at once, so a
+        threshold at or below the pool size could be reached by one simultaneous
+        blip that every worker would have recovered from -- turning five
+        successful retries into an aborted run.
+        """
+        assert CFBDClient.RATE_LIMIT_CIRCUIT_THRESHOLD > DLT_EXTRACT_WORKERS
+
+        client = CFBDClient(api_key="test-key")
+        ok = MagicMock()
+        ok.json.return_value = []
+        ok.raise_for_status = MagicMock()
+        # One 429 then a success, once per worker, with no reset in between
+        # until each recovers -- the shape of a momentary blip across the pool.
+        with patch("src.pipelines.utils.api_client.time.sleep"):
+            for _ in range(DLT_EXTRACT_WORKERS):
+                with patch.object(client._client, "get", side_effect=[_rate_limit_error(), ok]):
+                    assert client.get("/teams") == []
+        assert not client._breaker.is_open()
         client.close()
 
     def test_offseason_run_shape_trips_the_breaker(self):
@@ -397,7 +434,7 @@ class TestBreakerIsSharedAcrossClients:
     # Each fully-rate-limited request now records MAX_RETRIES + 1 responses, so
     # two sources are enough to cross a threshold of 5 (see
     # RateLimitBreaker.record_rate_limited).
-    SOURCES_TO_TRIP = 2
+    SOURCES_TO_TRIP = REQUESTS_TO_TRIP
 
     def _exhaust_on_a_fresh_client(self, n):
         """Mimic the real call graph: one new client per rate-limited source."""

--- a/tests/test_deploy_schema.py
+++ b/tests/test_deploy_schema.py
@@ -43,6 +43,8 @@ class TestComputeScripts:
             "simulate_season",
             # Section 4.3 preseason backtest -- read-only, reports to stdout.
             "backtest_preseason",
+            # Section 2.5 feature screen -- read-only, reports to stdout.
+            "screen_preseason_features",
         }
 
 

--- a/tests/test_load_season.py
+++ b/tests/test_load_season.py
@@ -140,24 +140,27 @@ class TestSourcesToSkip:
         skipped = sources_to_skip(list(SOURCE_ORDER), season_final=True, allow_skip=True)
         assert "reference" not in skipped
 
-    def test_metrics_wp_is_skipped_once_the_season_is_final(self):
-        """It was exempted as "already self-limiting: it fetches only games
-        still missing win probability, so a fully-backfilled season costs
-        nothing". The 2026-07-26 daily load disproved that -- it reported 2,517
-        of 3,829 games still missing for a season that ended in January,
-        because games CFBD has no win-probability data for are missing forever
-        and come back every single day. Self-limiting requires the missing set
-        to drain; this one does not.
+    def test_metrics_wp_stays_eligible_even_on_a_finished_season(self):
+        """PR #54 review, P1.
+
+        It was briefly added to the skip set because the 2026-07-26 daily load
+        queued 2,517 games of a season that ended in January. But
+        run_metrics_wp_pipeline derives missing games as completed-minus-loaded,
+        so that backlog includes requests that failed during the quota
+        exhaustion -- recoverable data, not just games CFBD has nothing for.
+        The unattended daily path passes no --season, so skipping the source
+        would strand those rows permanently.
+
+        The cost problem is bounded in the pipeline instead
+        (run.MAX_WP_GAMES_PER_RUN), which caps a run without making anything
+        ineligible.
         """
         skipped = sources_to_skip(list(SOURCE_ORDER), season_final=True, allow_skip=True)
-        assert "metrics_wp" in skipped
-
-    def test_metrics_wp_still_runs_during_a_live_season(self):
-        """The skip is conditional on the season being FINISHED. In-game win
-        probability for a game that has not been played yet is exactly the data
-        this source exists to collect."""
-        skipped = sources_to_skip(list(SOURCE_ORDER), season_final=False, allow_skip=True)
         assert "metrics_wp" not in skipped
+
+        from src.pipelines.run import MAX_WP_GAMES_PER_RUN
+
+        assert MAX_WP_GAMES_PER_RUN > 0, "the cap is what replaces the skip"
 
     def test_every_immutable_source_is_a_real_source(self):
         """A typo here would silently skip nothing at all."""
@@ -177,3 +180,51 @@ class TestSourcesToSkip:
         skipped = sources_to_skip(default, season_final=True, allow_skip=True)
         after = sum(ESTIMATED_CALLS.get(s, 50) for s in default if s not in skipped)
         assert after < before * 0.15, f"expected a large reduction, got {before} -> {after}"
+
+
+class TestWinProbabilityBacklogIsBounded:
+    """PR #54 review, P1.
+
+    The 2026-07-26 daily load queued 2,517 win-probability calls in one run --
+    ~3% of the monthly budget, every day, for a season that ended in January.
+    The first fix skipped the source once a season was final, which would have
+    stranded any game whose request failed during the quota exhaustion. Capping
+    the run bounds the cost without making anything permanently ineligible.
+    """
+
+    def test_the_cap_is_smaller_than_the_backlog_that_motivated_it(self):
+        from src.pipelines.run import MAX_WP_GAMES_PER_RUN
+
+        assert 0 < MAX_WP_GAMES_PER_RUN < 2517
+
+    def test_newest_games_are_fetched_first(self):
+        """Once the cap truncates, newly-completed games must not be starved
+        behind a historical backlog -- and recency is the best proxy available
+        for 'CFBD actually has win probability for this game'."""
+        from src.pipelines.run import _METRICS_WP_GAMES_QUERY
+
+        order_by = _METRICS_WP_GAMES_QUERY.upper().split("ORDER BY")[1]
+        assert "SEASON DESC" in order_by
+        assert "START_DATE DESC" in order_by
+
+    def test_truncation_is_reported_not_silent(self):
+        """A capped backlog that reads like a completed one is how '2,517
+        missing' went unnoticed for months."""
+        import inspect
+
+        from src.pipelines.run import run_metrics_wp_pipeline
+
+        body = inspect.getsource(run_metrics_wp_pipeline)
+        assert "deferred" in body
+        assert "Backlog capped" in body
+
+    def test_summary_reports_the_full_backlog_not_the_capped_slice(self):
+        """`missing` has to keep meaning "how much is left", or the cap makes
+        the backlog look like it is draining when it is not."""
+        import inspect
+
+        from src.pipelines.run import run_metrics_wp_pipeline
+
+        body = inspect.getsource(run_metrics_wp_pipeline)
+        assert '"missing": total_missing' in body
+        assert '"loaded_this_run"' in body

--- a/tests/test_load_season.py
+++ b/tests/test_load_season.py
@@ -140,10 +140,23 @@ class TestSourcesToSkip:
         skipped = sources_to_skip(list(SOURCE_ORDER), season_final=True, allow_skip=True)
         assert "reference" not in skipped
 
-    def test_metrics_wp_is_never_skipped(self):
-        """Already self-limiting: it fetches only games still missing win
-        probability, so a fully-backfilled season costs nothing anyway."""
+    def test_metrics_wp_is_skipped_once_the_season_is_final(self):
+        """It was exempted as "already self-limiting: it fetches only games
+        still missing win probability, so a fully-backfilled season costs
+        nothing". The 2026-07-26 daily load disproved that -- it reported 2,517
+        of 3,829 games still missing for a season that ended in January,
+        because games CFBD has no win-probability data for are missing forever
+        and come back every single day. Self-limiting requires the missing set
+        to drain; this one does not.
+        """
         skipped = sources_to_skip(list(SOURCE_ORDER), season_final=True, allow_skip=True)
+        assert "metrics_wp" in skipped
+
+    def test_metrics_wp_still_runs_during_a_live_season(self):
+        """The skip is conditional on the season being FINISHED. In-game win
+        probability for a game that has not been played yet is exactly the data
+        this source exists to collect."""
+        skipped = sources_to_skip(list(SOURCE_ORDER), season_final=False, allow_skip=True)
         assert "metrics_wp" not in skipped
 
     def test_every_immutable_source_is_a_real_source(self):

--- a/tests/test_screen_features.py
+++ b/tests/test_screen_features.py
@@ -435,6 +435,52 @@ class TestNullCandidatesAreScreenedOnCompleteCases:
         )
 
 
+class TestRecordedVerdictsAreInternallyConsistent:
+    """The recorded ledger drifted from the screen once already.
+
+    The docstring table said blue_chip_pipeline shipped at +0.0931 and
+    recruiting_points_regime at +0.0955; the first executable run scored them
+    +0.0782 and -0.0620. These assertions cannot verify the numbers without a
+    database, but they can keep the bookkeeping honest -- every candidate
+    accounted for exactly once, and human overrides kept out of the set that is
+    supposed to mirror the screen's own output.
+    """
+
+    def test_every_candidate_has_exactly_one_recorded_verdict(self):
+        from scripts.screen_preseason_features import (
+            CANDIDATE_COLUMNS,
+            REJECTED_COLUMNS,
+            SHIPPED_BY_DECISION,
+            SHIPPED_COLUMNS,
+            UNTESTABLE_COLUMNS,
+        )
+
+        recorded = (
+            list(SHIPPED_COLUMNS)
+            + list(SHIPPED_BY_DECISION)
+            + list(REJECTED_COLUMNS)
+            + list(UNTESTABLE_COLUMNS)
+        )
+        assert len(recorded) == len(set(recorded)), "a candidate has two verdicts"
+        assert set(recorded) == set(CANDIDATE_COLUMNS), (
+            "every screened candidate needs a recorded verdict and vice versa"
+        )
+
+    def test_overrides_are_not_laundered_into_the_shipped_set(self):
+        from scripts.screen_preseason_features import SHIPPED_BY_DECISION, SHIPPED_COLUMNS
+
+        assert not set(SHIPPED_COLUMNS) & set(SHIPPED_BY_DECISION), (
+            "a column shipped against the screen's verdict must stay visible as "
+            "an override, not merge into the set that mirrors the screen"
+        )
+
+    def test_every_override_records_its_argument(self):
+        from scripts.screen_preseason_features import SHIPPED_BY_DECISION
+
+        for column, rationale in SHIPPED_BY_DECISION.items():
+            assert len(rationale) > 40, f"{column} overrides the gate without an argument"
+
+
 class TestRegimeColumnsSeparateRecruitingFromCoachingChange:
     """The 2026-07-26 imputation audit found `recruiting_points_regime`
     zero-filled on 291 of 1,439 rows (20.2%).

--- a/tests/test_screen_features.py
+++ b/tests/test_screen_features.py
@@ -525,6 +525,26 @@ class TestRegimeColumnsSeparateRecruitingFromCoachingChange:
             "tenure_start; GREATEST will not propagate it"
         )
 
+    def test_audit_and_screen_share_one_coach_tenure_definition(self):
+        """PR #54 review, P2. The audit's hand-copied coach CTE omitted the
+        gaps-and-islands grouping, so a coach returning to a school inherited
+        his FIRST stint's start year. That widens the regime window, so the
+        audit found recruiting classes where the screen saw none and
+        under-reported exactly the quantity it exists to measure. Sharing one
+        definition is what makes the two unable to disagree.
+        """
+        from scripts.screen_preseason_features import (
+            _COACH_TENURE_CTE,
+            AUDIT_QUERY,
+            SCREEN_FRAME_QUERY,
+        )
+
+        assert "coach_islands" in _COACH_TENURE_CTE, "islands grouping is the point"
+        for query in (SCREEN_FRAME_QUERY, AUDIT_QUERY):
+            assert _COACH_TENURE_CTE.strip() in query, (
+                "both queries must embed the shared coach-tenure CTE verbatim"
+            )
+
     def test_spine_does_not_coalesce_tenure_start(self):
         from scripts.screen_preseason_features import SCREEN_FRAME_QUERY as q
 

--- a/tests/test_screen_features.py
+++ b/tests/test_screen_features.py
@@ -435,6 +435,59 @@ class TestNullCandidatesAreScreenedOnCompleteCases:
         )
 
 
+class TestRegimeColumnsSeparateRecruitingFromCoachingChange:
+    """The 2026-07-26 imputation audit found `recruiting_points_regime`
+    zero-filled on 291 of 1,439 rows (20.2%).
+
+    The regime window GREATEST(season-4, tenure_start)..season-1 is empty
+    exactly when tenure_start >= season -- a first-year head coach -- so a
+    fifth of the sample carried a hard 0 meaning "no classes signed by this
+    staff yet". That 0 is confounded with the coaching change itself, so the
+    column blended a recruiting measure with a de facto new-coach indicator.
+    The two are now separate columns.
+    """
+
+    def test_regime_column_is_not_zero_filled(self):
+        from scripts.screen_preseason_features import SCREEN_FRAME_QUERY as q
+
+        regime = q[q.index("AS recruiting_points_regime") - 900 :]
+        regime = regime[: regime.index("AS recruiting_points_regime")]
+        assert "COALESCE" not in regime.upper(), (
+            "recruiting_points_regime must not be zero-filled -- an empty "
+            "regime window means 'first-year coach', not 'recruits badly'"
+        )
+
+    def test_hc_first_year_is_screened_separately(self):
+        from scripts.screen_preseason_features import CANDIDATE_COLUMNS
+        from scripts.screen_preseason_features import SCREEN_FRAME_QUERY as q
+
+        assert "hc_first_year" in CANDIDATE_COLUMNS
+        assert "AS hc_first_year" in q
+
+    def test_null_tenure_is_guarded_by_case_not_greatest(self):
+        """Postgres GREATEST IGNORES NULL arguments.
+
+        GREATEST(season - 4, NULL) returns season - 4, so relying on a NULL
+        tenure_start to propagate through GREATEST would quietly restore the
+        flat window instead of yielding NULL -- reintroducing the duplicate
+        candidate this change removes. The CASE guard is what makes it NULL.
+        """
+        from scripts.screen_preseason_features import SCREEN_FRAME_QUERY as q
+
+        assert q.count("WHEN s.tenure_start IS NULL THEN NULL") >= 2, (
+            "both regime columns need an explicit CASE guard on a NULL "
+            "tenure_start; GREATEST will not propagate it"
+        )
+
+    def test_spine_does_not_coalesce_tenure_start(self):
+        from scripts.screen_preseason_features import SCREEN_FRAME_QUERY as q
+
+        assert "COALESCE(ct.tenure_start" not in q, (
+            "coalescing tenure_start to the window start makes the regime "
+            "variant a silent duplicate of the flat window"
+        )
+
+
 class TestFrameQueryIsBindable:
     """The screen has NEVER been able to run its own frame query.
 

--- a/tests/test_screen_features.py
+++ b/tests/test_screen_features.py
@@ -327,3 +327,48 @@ class TestScreenUsesBothControls:
         for r in screen(self._frame(), [PRIMARY_CONTROL, "redundant_candidate"]):
             assert "partial_r_vs_prior" in r
             assert "partial_r" in r
+
+
+class TestFrameQueryIsBindable:
+    """The screen has NEVER been able to run its own frame query.
+
+    Two literal percent signs in SQL comments ("99.1%", "~1%") were not
+    escaped, and psycopg2's pyformat binding treats any bare % as the start of
+    a placeholder -- so fetch_frame raised `TypeError: dict is not a sequence`
+    before touching the database. The recorded verdicts came from ad-hoc MCP
+    queries instead, which is a deeper version of the reproducibility gap the
+    PR #48 review raised: the script could not reproduce its verdicts because
+    it could not execute at all.
+    """
+
+    def test_no_unescaped_percent_signs(self):
+        import re
+
+        from scripts.screen_preseason_features import SCREEN_FRAME_QUERY as q
+
+        # Strip valid named placeholders and doubled literals, then nothing
+        # containing a bare % may remain.
+        stripped = re.sub(r"%\([a-z_]+\)s", "", q).replace("%%", "")
+        assert "%" not in stripped, (
+            "unescaped % in SCREEN_FRAME_QUERY -- psycopg2 will read it as a "
+            "placeholder and parameter binding will fail before the query runs"
+        )
+
+    def test_named_placeholders_are_present(self):
+        from scripts.screen_preseason_features import SCREEN_FRAME_QUERY as q
+
+        assert "%(from_season)s" in q
+        assert "%(to_season)s" in q
+
+    def test_query_binds_against_psycopg2_mogrify_rules(self):
+        """Exercises the actual binding path rather than a regex proxy."""
+        import re
+
+        from scripts.screen_preseason_features import SCREEN_FRAME_QUERY as q
+
+        params = {"from_season": 2015, "to_season": 2025}
+        # Mirror psycopg2's pyformat substitution; a stray % raises here too.
+        rendered = re.sub(r"%\(([a-z_]+)\)s", lambda m: str(params[m.group(1)]), q).replace(
+            "%%", "%"
+        )
+        assert "2015" in rendered and "2025" in rendered

--- a/tests/test_screen_features.py
+++ b/tests/test_screen_features.py
@@ -20,8 +20,10 @@ import pytest
 from scripts.screen_preseason_features import (
     FDR_ALPHA,
     MIN_PARTIAL_R,
+    MIN_SCREEN_N,
     PRIMARY_CONTROL,
     benjamini_hochberg,
+    complete_cases,
     derive_composites,
     partial_corr_pvalue,
     partial_correlation,
@@ -327,6 +329,110 @@ class TestScreenUsesBothControls:
         for r in screen(self._frame(), [PRIMARY_CONTROL, "redundant_candidate"]):
             assert "partial_r_vs_prior" in r
             assert "partial_r" in r
+
+
+class TestNullCandidatesAreScreenedOnCompleteCases:
+    """The trench candidates arrive NULL for teams with no prior FBS season.
+
+    Screen run 121 (2026-07-26) crashed on exactly this: the seven prior-season
+    trench columns come from a LEFT JOIN against stats.advanced_team_stats,
+    unlike every earlier candidate, which SQL COALESCEs to 0. `_pearson` summed
+    a None and raised.
+
+    Both halves matter. Crashing is bad; the tempting fix is worse. COALESCE to
+    0 is right for a COUNT (no portal transfers really is a net rating of zero)
+    and wrong for a RATE -- no team posts 0.000 line yards, and the teams with
+    no prior-season row are disproportionately bad in season S, so the floor
+    would be imputed precisely where the outcome is low and manufacture a trench
+    signal out of nothing.
+    """
+
+    def _frame_with_gaps(self, n=1000, missing_from=600, seed=23):
+        rng = random.Random(seed)
+        rows = []
+        for i in range(n):
+            z = rng.gauss(0.0, 1.0)
+            w = rng.gauss(0.0, 1.0)
+            y = 0.6 * z + 0.45 * w + rng.gauss(0.0, 0.3)
+            row = {
+                "sp_rating": y,
+                "prior_sp_rating": z,
+                PRIMARY_CONTROL: w,
+                # Present throughout, and genuinely informative.
+                "dense_candidate": 0.5 * y + rng.gauss(0.0, 0.5),
+                # NULL past the cutoff, like a LEFT JOIN miss.
+                "sparse_candidate": None if i >= missing_from else rng.gauss(0.0, 1.0),
+            }
+            rows.append(row)
+        return rows
+
+    def test_complete_cases_drops_only_rows_missing_a_named_column(self):
+        frame = self._frame_with_gaps()
+        assert len(complete_cases(frame, ["dense_candidate"])) == 1000
+        assert len(complete_cases(frame, ["sparse_candidate"])) == 600
+
+    def test_screen_does_not_crash_on_null_candidates(self):
+        # Without per-candidate complete cases this raises TypeError, which is
+        # precisely how run 121 failed.
+        results = screen(self._frame_with_gaps(), [PRIMARY_CONTROL, "sparse_candidate"])
+        assert {r["feature"] for r in results} == {PRIMARY_CONTROL, "sparse_candidate"}
+
+    def test_sparse_candidate_reports_its_own_smaller_n(self):
+        results = screen(
+            self._frame_with_gaps(), [PRIMARY_CONTROL, "dense_candidate", "sparse_candidate"]
+        )
+        by_name = {r["feature"]: r for r in results}
+        assert by_name["dense_candidate"]["n"] == 1000
+        assert by_name["sparse_candidate"]["n"] == 600
+        # Coverage is what stops a 600-row partial from reading as a 1,000-row one.
+        assert by_name["sparse_candidate"]["coverage"] == pytest.approx(0.6)
+
+    def test_candidate_below_min_screen_n_is_untestable_not_shipped(self):
+        frame = self._frame_with_gaps(missing_from=MIN_SCREEN_N - 1)
+        result = next(
+            r
+            for r in screen(frame, [PRIMARY_CONTROL, "sparse_candidate"])
+            if r["feature"] == "sparse_candidate"
+        )
+        assert result["p"] is None
+        assert result["verdict"] == "reject"
+        assert "MIN_SCREEN_N" in result["untestable"]
+
+    def test_missing_rate_is_not_imputed_to_zero(self):
+        """The regression that matters: zero-imputation fabricates signal.
+
+        Here the candidate is pure noise among teams that have it, but it is
+        missing exactly where the outcome is lowest. Zero-filling correlates
+        "missing" with "bad" and invents a large partial; complete-case
+        screening correctly returns ~nothing.
+        """
+        rng = random.Random(5)
+        frame = []
+        for _ in range(1200):
+            z = rng.gauss(0.0, 1.0)
+            w = rng.gauss(0.0, 1.0)
+            y = 0.6 * z + 0.45 * w + rng.gauss(0.0, 0.3)
+            # Noise for teams that played; absent for the weakest teams.
+            value = None if y < -1.0 else rng.gauss(4.5, 1.0)
+            frame.append(
+                {"sp_rating": y, "prior_sp_rating": z, PRIMARY_CONTROL: w, "trench": value}
+            )
+
+        honest = next(
+            r for r in screen(frame, [PRIMARY_CONTROL, "trench"]) if r["feature"] == "trench"
+        )
+
+        zero_filled = [
+            dict(r, trench=(r["trench"] if r["trench"] is not None else 0.0)) for r in frame
+        ]
+        fabricated = next(
+            r for r in screen(zero_filled, [PRIMARY_CONTROL, "trench"]) if r["feature"] == "trench"
+        )
+
+        assert abs(honest["partial_r"]) < MIN_PARTIAL_R, "noise must not ship"
+        assert abs(fabricated["partial_r"]) > abs(honest["partial_r"]), (
+            "zero-filling should visibly inflate the partial -- this is the trap"
+        )
 
 
 class TestFrameQueryIsBindable:


### PR DESCRIPTION
## Summary

Two independent threads, both triggered by things that failed today.

1. **Daily load** — the 2026-07-26 run spent 12 minutes retrying a spent CFBD quota and the circuit breaker never fired. Fixes the breaker's counting unit and stops `metrics_wp` re-sweeping a finished season.
2. **Preseason feature screen (§2.5 gate)** — the screen had **never executed its own query**. Now it does, and its verdicts differ from the ones on record.

10 commits, 8 files, +910/−104. **1,157 tests passing**, ruff clean.

> The daily-load half is the time-sensitive part: `daily-load.yml` runs from `main`, so none of it takes effect until this merges.

---

## 1. Daily load

### The breaker was counting the wrong thing

`record_exhausted()` counted fully-exhausted **requests**, so each increment cost 4 API calls and 3 minutes of sleeping. A threshold of 5 therefore needed 20 wasted calls and 15 minutes — and an off-season run only has 4 active sources, so it could **never** fire. Today's run proved it: final count 4, one short, after 12 minutes of retrying an API that had already refused it 16 times.

It now counts every 429 **response**, and `is_open()` is checked **before each sleep** rather than only at the top of `get()`. That second part is load-bearing: a single request can burn its whole budget without ever re-entering `get()`, so the top-of-method guard structurally cannot see it.

### The threshold then collided with the worker pool

Found on an adversarial pass over the first fix, and it was mine. The breaker is shared run-wide and dlt extracts on a **5-worker** pool (`.dlt/config.toml`), so five workers each taking **one transient 429** at the same instant contribute five at once — against a threshold of 5, that aborts a healthy run on five retries that would all have succeeded. The old per-request unit couldn't do this.

Threshold is now **10**: double the pool, still only ~2.5 exhausted requests, so a spent quota aborts around six minutes in.

Deliberately **not** 12 or any other multiple of `MAX_RETRIES + 1`. At an exact multiple the threshold can only be crossed on a request's *final* attempt, where the out-of-retries branch raises first — the mid-request abort would be unreachable and every doomed request would sleep out its full budget anyway. The test for that path would have passed while testing nothing.

### `metrics_wp` was re-sweeping a finished season

It was exempt from `IMMUTABLE_ONCE_FINAL` as *"already self-limiting: it only fetches games still missing win probability."* Today's run:

```
3829 completed games in [2025], 1312 already have win probability, 2517 missing
Processing 2517 games in 51 batches of up to 50
```

for a season that ended in January. Self-limiting requires the missing set to **drain**, and it doesn't — games CFBD has no WP data for stay missing and are re-requested every day. ~2,500 calls daily, in perpetuity, ~3% of the monthly budget, for data that cannot change. Same re-sweep pattern that caused the original exhaustion, hiding behind a source assumed to be cheap.

In-game win probability for a completed game is as immutable as its box score. A live season is unaffected — the skip only applies once `season_is_final()`, and that has its own test.

---

## 2. Preseason feature screen

### It had never run

Two unescaped `%` in SQL comments meant psycopg2 read them as placeholders and `fetch_frame` raised `TypeError: dict is not a sequence` before touching the database. Every recorded verdict came from ad-hoc MCP queries that no longer exist. Fixed, with a regression test that exercises the real binding path.

### NULL handling — and the fix that would have been wrong

The seven prior-season trench candidates come from a `LEFT JOIN` on `stats.advanced_team_stats`, unlike every earlier candidate, which SQL `COALESCE`s to 0. Matching that pattern would have been a serious error: zero is a true value for a **count** (no portal transfers really is a net rating of zero) and a fabricated **extreme** for a rate — no team posts 0.000 line yards. The teams missing a prior-season row are new FBS entrants, which are disproportionately bad in season S, so zero-filling would plant the floor value exactly where the outcome is low and manufacture a trench signal out of nothing.

Each candidate is now screened on its own complete cases with its own `n` and `coverage`. There's a test that demonstrates the trap directly: a candidate that is pure noise where present but missing where the outcome is lowest screens at ~0 under complete cases and inflates measurably under zero-filling.

### The regime column was measuring the wrong thing

An imputation audit (`--audit-imputation`, added here) found `recruiting_points_regime` zero-filled on **291 of 1,439 rows (20.2%)**. The regime window is empty exactly when the head coach is in year one, and that zero is confounded with the coaching change itself — programs that just fired a coach were usually bad. The column silently blended a recruiting term with a de facto new-coach indicator.

Split apart: recruiting falls to **−0.0620 and fails**, while the coaching half ships at **−0.1615**, the second-strongest signal in the screen. A column had shipped on a number that measured something other than what the column claimed to measure.

*(Postgres note: `GREATEST` ignores NULL arguments, so `GREATEST(season-4, NULL)` returns `season-4`. Dropping the `COALESCE` alone would have quietly restored the flat window. Needs an explicit `CASE`, and there's a test pinning it.)*

### Results — 2015-2025, n=1,439, reproducible from this script

| candidate | n | cov | vs prior SP+ | + recruiting | verdict |
|---|---|---|---|---|---|
| `recruiting_points_3yr` | 1439 | 1.000 | +0.2642 | (control) | **ship** |
| `hc_first_year` | 1426 | 0.991 | −0.1334 | **−0.1615** | **ship** |
| `prior_def_line_yards` | 1423 | 0.989 | −0.0463 | **−0.0997** | **ship** |
| `prior_def_stuff_rate` | 1423 | 0.989 | +0.0536 | **+0.0816** | **ship** (marginal) |
| `blue_chip_pipeline` | 1439 | 1.000 | +0.2532 | +0.0782 | reject → override |
| `talent_stock` | 1439 | 1.000 | +0.2664 | +0.0744 | reject |
| `draft_departures` | 1439 | 1.000 | +0.0088 | −0.0728 | reject |
| `recruiting_points_regime` | 1136 | 0.789 | +0.0712 | −0.0620 | reject |
| `prior_power_success` | 1423 | 0.989 | +0.0221 | +0.0520 | reject |
| `portal_net_rating` | 1439 | 1.000 | +0.0247 | +0.0481 | reject |
| `prior_line_yards` | 1423 | 0.989 | −0.0069 | +0.0223 | reject |
| `prior_havoc_allowed_front_seven` | 251 | 0.174 | — | — | untestable |

**The trenches thesis half-survives, and it's the defensive half.** Measured line play clears where the earlier roster-headcount continuity screen (OL −0.015, DL +0.013) found nothing — but every offensive-line measure fails.

`blue_chip_pipeline` is recorded in a separate `SHIPPED_BY_DECISION` map, not `SHIPPED_COLUMNS`. It misses the floor by **0.07 standard errors** at n=1,439, which the data cannot resolve, so shipping it is defensible — but it's a judgment overruling the pre-registered rule, not a measurement, and merging the two would leave the gate unable to report that it had been overruled.

---

## Reviewer attention

- **Threshold of 10 is a judgment call.** A CFBD burst block long enough to cross it with no successes in between *will* fail the run, where the old behaviour would have waited it out. That's the cheaper error for an idempotent job that retries tomorrow and opens an issue — but it is a real trade, not a free win.
- **The `metrics_wp` skip makes the 2025 gap permanent** unless forced with `--season 2025`. Whether that 66% is "CFBD has no WP for these" or "we never finished the backfill" is unresolved and answerable with one query once the quota returns.
- **Unexplained discrepancies, recorded rather than reconciled.** The ad-hoc figures for `blue_chip_pipeline` (+0.0931 vs +0.0782), `talent_stock` (~+0.002 vs +0.0744) and `draft_departures` (+0.0088 vs −0.0728, sign flip) are *not* explained by imputation — the audit found those columns 1.5% and 0.8% zero-filled, and zero-fill inflates, so the honest `blue_chip_pipeline` value is at most +0.0782. The ad-hoc SQL is gone.
- **`portal_net_rating` is contaminated the same way the regime column was** — zero-filled across 2015-2025, but a pre-2021 zero means "the portal didn't exist". Its +0.0481 is measured on that basis. Left alone here rather than changed unilaterally; already marked RE-TEST.

## Not in this PR

Migration 042 and the `build_features` wiring. Worth knowing before that lands: adding to `DIFF_FEATURE_COLUMNS` changes `FEATURE_NAMES`, and `score_fitted.load_fit` builds its coefficient vector by name lookup — so **every stored walk-forward fit becomes unloadable**, with a raw `KeyError`, until all vintages are retrained. That wants to be one deploy, not two.

## Test plan

- [x] `pytest -q` — 1,157 passing, 392 skipped
- [x] `ruff check .` / `ruff format --check .`
- [x] Screen executed against prod (deploy run 124, exit 0, 18 candidates over 1,439 team-seasons)
- [x] Imputation audit executed against prod (deploy run 123)
- [ ] CI green
- [ ] First daily-load run after merge: expect a fast abort while the quota is still spent (resets ~Aug 1), not a 12-minute grind

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVhu1FqpWFakBHAYQShbMq

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVhu1FqpWFakBHAYQShbMq)_