### PR TITLE
Run the backtest daily and gate on its freshness

### DIFF
--- a/.github/workflows/daily-load.yml
+++ b/.github/workflows/daily-load.yml
@@ -86,6 +86,19 @@ jobs:
         run: python scripts/score_fitted.py --upcoming
       - name: Simulate season projections
         run: python scripts/simulate_season.py
+      # Runs DAILY, not annually, even though the measurement only moves on a
+      # refit or a feature rebuild. Two reasons. api.model_backtest.run_date is
+      # what cfb-app checks to decide whether its cached honesty numbers are
+      # stale, and a date that only advances once a year cannot distinguish
+      # "still current" from "nobody has run this since January". And because
+      # the backtest re-measures against the CURRENT feature substrate, a
+      # rebuild that silently changed a column shows up here the next morning
+      # instead of at the next annual refit.
+      #
+      # Cheap (~12s, fixed seed so identical inputs give an identical row) and
+      # append-only per day, which is the drift history the table exists for.
+      - name: Backtest season projections
+        run: python scripts/backtest_preseason.py
       - name: Refresh Tier 2 + Tier 3 marts
         run: python scripts/refresh_marts.py --views marts.house_elo,marts.house_elo_game,marts.team_adjusted_epa,marts.scored_matchup_edges,marts.prediction_accuracy,marts.team_week_features,marts.adjusted_epa_week
       - name: Verify load

--- a/scripts/verify_load.py
+++ b/scripts/verify_load.py
@@ -350,20 +350,42 @@ def check_backtest_freshness(cur, report: Report) -> None:
     FAIL here, not a skip -- "never backtested" and "backtested last week" are
     different problems, but neither is a working state.
     """
+    # Scope to the CANONICAL configuration, not merely to fitted_v1/fbs
+    # (PR #57 review, P2). api.model_backtest deliberately keys on
+    # (model_version, scope, season_start, season_end, strength_share) because
+    # those are different measurements, so a one-off exploratory run -- a
+    # narrower season range, a swept strength_share -- writes its own row with
+    # today's date. A MAX(run_date) over all FBS rows would then be refreshed
+    # by an experiment while the published row sat a month stale, which is the
+    # same shape of not-quite-the-right-check this gate exists to catch.
+    #
+    # The bounds are IMPORTED, not restated. The daily workflow runs
+    # backtest_preseason.py with no arguments, so the script defaults are the
+    # canonical configuration by construction and the gate cannot drift from
+    # what the workflow actually writes. (Restating them here is how the row
+    # published to cfb-app ended up on --start 2019 against a DEFAULT_START of
+    # 2018 -- a configuration the daily job would never reproduce.)
+    from scripts.backtest_preseason import DEFAULT_END, DEFAULT_START
+    from scripts.simulate_season import DEFAULT_STRENGTH_SHARE
+
     cur.execute(
         """
         SELECT MAX(run_date),
                (SELECT COUNT(*) FROM predictions.model_backtest)
         FROM predictions.model_backtest
         WHERE model_version = 'fitted_v1' AND scope = 'fbs'
-        """
+          AND season_start = %(start)s AND season_end = %(end)s
+          AND strength_share = %(share)s
+        """,
+        {"start": DEFAULT_START, "end": DEFAULT_END, "share": DEFAULT_STRENGTH_SHARE},
     )
     latest, total = cur.fetchone()
     if total == 0 or latest is None:
         report.record(
             FAIL,
             "backtest_freshness",
-            "predictions.model_backtest has no fitted_v1/fbs row -- "
+            f"predictions.model_backtest has no fitted_v1/fbs row for the canonical "
+            f"{DEFAULT_START}-{DEFAULT_END} @ {DEFAULT_STRENGTH_SHARE} configuration -- "
             "api.model_backtest publishes nothing and consumers have no honesty numbers",
         )
         return
@@ -372,7 +394,8 @@ def check_backtest_freshness(cur, report: Report) -> None:
     report.record(
         PASS if age <= MAX_BACKTEST_AGE_DAYS else FAIL,
         "backtest_freshness",
-        f"newest fitted_v1/fbs backtest is {age} day(s) old "
+        f"newest canonical fitted_v1/fbs backtest ({DEFAULT_START}-{DEFAULT_END} "
+        f"@ {DEFAULT_STRENGTH_SHARE}) is {age} day(s) old "
         f"(run_date {latest}, threshold {MAX_BACKTEST_AGE_DAYS})",
     )
 

--- a/scripts/verify_load.py
+++ b/scripts/verify_load.py
@@ -328,6 +328,55 @@ def check_fitted_coverage(cur, report: Report) -> None:
     )
 
 
+# How old the newest predictions.model_backtest row may be before the honesty
+# numbers count as stale. The daily workflow re-runs the backtest every morning,
+# so anything past a couple of days means the step stopped running -- generous
+# enough to absorb a single failed night without crying wolf.
+MAX_BACKTEST_AGE_DAYS = 3
+
+
+def check_backtest_freshness(cur, report: Report) -> None:
+    """The published accuracy numbers must be current, not merely present.
+
+    cfb-app reads api.model_backtest instead of hardcoding win MAE and the
+    interval, and its staleness check is `run_date`. That only means something
+    if something is actually advancing run_date -- otherwise a consumer reads a
+    plausible row describing a model that no longer exists, and nothing fails.
+    Precisely the shape this table was built to end.
+
+    It is also the failure that already happened once: migration 045 shipped
+    the view before anything had written to it, so api.model_backtest returned
+    zero rows while the handoff said to depend on it. NO ROW is therefore a
+    FAIL here, not a skip -- "never backtested" and "backtested last week" are
+    different problems, but neither is a working state.
+    """
+    cur.execute(
+        """
+        SELECT MAX(run_date),
+               (SELECT COUNT(*) FROM predictions.model_backtest)
+        FROM predictions.model_backtest
+        WHERE model_version = 'fitted_v1' AND scope = 'fbs'
+        """
+    )
+    latest, total = cur.fetchone()
+    if total == 0 or latest is None:
+        report.record(
+            FAIL,
+            "backtest_freshness",
+            "predictions.model_backtest has no fitted_v1/fbs row -- "
+            "api.model_backtest publishes nothing and consumers have no honesty numbers",
+        )
+        return
+    cur.execute("SELECT ((now() AT TIME ZONE 'utc')::date - %s)", (latest,))
+    age = int(cur.fetchone()[0])
+    report.record(
+        PASS if age <= MAX_BACKTEST_AGE_DAYS else FAIL,
+        "backtest_freshness",
+        f"newest fitted_v1/fbs backtest is {age} day(s) old "
+        f"(run_date {latest}, threshold {MAX_BACKTEST_AGE_DAYS})",
+    )
+
+
 def check_freshness(cur, in_season: bool, strict: bool, report: Report) -> None:
     cur.execute(
         """
@@ -369,6 +418,7 @@ def verify(season: int, strict: bool) -> int:
             check_completed_have_team_stats(cur, season, report)
             check_completed_have_plays(cur, season, report)
             check_fitted_coverage(cur, report)
+            check_backtest_freshness(cur, report)
             check_freshness(cur, in_season, strict, report)
             check_massey_composite(cur, season, report)
             check_availability_archive(cur, season, report)

--- a/tests/test_verify_load.py
+++ b/tests/test_verify_load.py
@@ -346,13 +346,58 @@ class TestBacktestFreshnessGate:
         assert 2 <= MAX_BACKTEST_AGE_DAYS <= 7
 
     def test_it_scopes_to_the_published_configuration(self):
-        """api.model_backtest can hold several configurations. Freshness of an
-        all_divisions or alternate-strength_share row says nothing about the
-        fbs row consumers are told to read."""
+        """api.model_backtest keys on (model_version, scope, season_start,
+        season_end, strength_share) because those are different measurements.
+
+        Filtering on model+scope alone is not enough: a one-off exploratory run
+        over a narrower season range writes its own row with today's date, and
+        a MAX(run_date) across all FBS rows would be refreshed by that
+        experiment while the published row sat stale."""
         import inspect
 
         from scripts.verify_load import check_backtest_freshness
 
         src = inspect.getsource(check_backtest_freshness)
-        assert "model_version = 'fitted_v1'" in src
-        assert "scope = 'fbs'" in src
+        for predicate in (
+            "model_version = 'fitted_v1'",
+            "scope = 'fbs'",
+            "season_start = %(start)s",
+            "season_end = %(end)s",
+            "strength_share = %(share)s",
+        ):
+            assert predicate in src, f"gate must pin {predicate}"
+
+    def test_the_canonical_bounds_are_imported_not_restated(self):
+        """The daily workflow runs backtest_preseason.py with NO arguments, so
+        the script defaults ARE the canonical configuration. Importing them is
+        what keeps the gate and the workflow from drifting apart.
+
+        Restating them is exactly how the row first published to cfb-app ended
+        up on --start 2019 against a DEFAULT_START of 2018 -- a configuration
+        the daily job would never reproduce, leaving two FBS rows and no way to
+        tell which one consumers should read."""
+        import inspect
+
+        from scripts.verify_load import check_backtest_freshness
+
+        src = inspect.getsource(check_backtest_freshness)
+        assert "from scripts.backtest_preseason import DEFAULT_END, DEFAULT_START" in src
+        assert "from scripts.simulate_season import DEFAULT_STRENGTH_SHARE" in src
+        # The bounds must reach the query as bound parameters, never literals.
+        assert "%(start)s" in src and "%(end)s" in src
+
+    def test_the_workflow_runs_the_canonical_configuration(self):
+        """The gate checks the defaults, so the workflow must USE the defaults.
+        Any explicit --start/--end here would write a row the gate never looks
+        at, and the gate would then fail every night on a missing canonical
+        row while a perfectly good non-canonical one sat beside it."""
+        import pathlib
+
+        wf = pathlib.Path(".github/workflows/daily-load.yml").read_text()
+        bare = "run: python scripts/backtest_preseason.py"
+        assert bare in wf, "the daily workflow must run the backtest"
+        invoked = next(ln for ln in wf.splitlines() if bare in ln)
+        assert invoked.strip() == bare, (
+            "the daily backtest must run BARE so the script defaults stay "
+            f"canonical; found: {invoked.strip()!r}"
+        )

--- a/tests/test_verify_load.py
+++ b/tests/test_verify_load.py
@@ -302,3 +302,57 @@ class TestCoverageChecksScopedToFbs:
         sql = self._check_sql(check_completed_have_plays)
         assert "g.home_classification = 'fbs'" in sql
         assert "g.away_classification = 'fbs'" in sql
+
+
+class TestBacktestFreshnessGate:
+    """The honesty numbers must be CURRENT, not merely present.
+
+    cfb-app dropped its hardcoded win-MAE constant in favour of reading
+    api.model_backtest, and its staleness check is run_date. That check is only
+    meaningful if something advances run_date -- otherwise a consumer reads a
+    plausible row describing a model that no longer exists and nothing fails.
+
+    This gate exists because the failure already happened: migration 045
+    shipped the view before any run had written to it, so api.model_backtest
+    returned zero rows for a day while the handoff told cfb-app to depend on
+    it. The deploy verified the view existed; nobody verified it had rows."""
+
+    def test_an_empty_table_fails_rather_than_skips(self):
+        """'Never backtested' and 'backtested last week' are different
+        problems, but neither is a working state -- and an empty table is the
+        one that already shipped."""
+        import inspect
+
+        from scripts.verify_load import check_backtest_freshness
+
+        src = inspect.getsource(check_backtest_freshness)
+        assert "total == 0" in src
+        assert "FAIL" in src.split("total == 0")[1][:400], "no row must FAIL, not pass quietly"
+
+    def test_the_gate_is_wired_into_the_run(self):
+        """A gate that is never called is a comment."""
+        import inspect
+
+        import scripts.verify_load as vl
+
+        assert "check_backtest_freshness(cur, report)" in inspect.getsource(vl)
+
+    def test_threshold_absorbs_one_failed_night(self):
+        """The workflow runs daily, so a 1-day threshold would fail on any
+        single bad night. Tight enough to catch the step silently dying,
+        loose enough not to cry wolf."""
+        from scripts.verify_load import MAX_BACKTEST_AGE_DAYS
+
+        assert 2 <= MAX_BACKTEST_AGE_DAYS <= 7
+
+    def test_it_scopes_to_the_published_configuration(self):
+        """api.model_backtest can hold several configurations. Freshness of an
+        all_divisions or alternate-strength_share row says nothing about the
+        fbs row consumers are told to read."""
+        import inspect
+
+        from scripts.verify_load import check_backtest_freshness
+
+        src = inspect.getsource(check_backtest_freshness)
+        assert "model_version = 'fitted_v1'" in src
+        assert "scope = 'fbs'" in src


### PR DESCRIPTION
## Why

`api.model_backtest` shipped as a view over an **empty table**. The backtest ran
in one deploy and migration 045 created its table in the next, so nothing was
ever written — and the handoff told cfb-app to drop its hardcoded win-MAE
constant and read the view instead. They queried it, got zero rows, and found it
before we did.

That is precisely the failure this table was built to end: a surface that exists,
returns nothing, and fails nowhere. The deploy verified the view *existed*; nobody
verified it had *rows*.

The table is populated now (`fitted_v1`/`fbs`, 2019–2025, n=921, win_mae 1.738,
resid_p10 −2.646, resid_p90 +3.024). This PR is about it not recurring.

## Changes

**`daily-load.yml` runs `backtest_preseason.py`** after the season simulation.

Daily rather than annually, though the measurement only moves on a refit or a
feature rebuild. Two reasons:

- `run_date` is what cfb-app checks to decide whether its cached honesty numbers
  are stale. A date that advances once a year cannot distinguish "still current"
  from "nobody has run this since January" — the staleness check has to have
  something advancing it to be worth anything.
- The backtest re-measures against the **current** feature substrate, so a
  rebuild that silently changed a column surfaces the next morning rather than at
  the next annual refit.

Cheap (~12s, fixed seed so identical inputs produce an identical row) and
append-only per day, which is the drift history the table was designed to carry.

**`verify_load.py` gains `check_backtest_freshness`.**

`FAIL` on **no row** as well as on a stale one — "never backtested" and
"backtested last week" are different problems and neither is a working state, and
the no-row case is the one that already shipped. Scoped to the `fitted_v1`/`fbs`
configuration consumers are told to read, because freshness of an
`all_divisions` or alternate-`strength_share` row says nothing about that one.
Threshold 3 days, so a single failed night does not cry wolf.

## Verification

- `ruff check` / `ruff format --check` clean; **1,288 tests passing**
- Four new tests pin the gate: empty-table must FAIL rather than skip, the gate
  must actually be called, the threshold must absorb one failed night, and the
  query must scope to the published configuration
- `api.model_backtest` confirmed returning one row against prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVhu1FqpWFakBHAYQShbMq)_