### PR TITLE
Load the upcoming season's preseason inputs off-season

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,14 +83,34 @@ open/update a rolling GitHub issue.
 `load_season.py` skips sources whose data cannot change once a season is complete
 (`IMMUTABLE_ONCE_FINAL` -- plays, game_stats, ratings, recruiting, draft, ...).
 Before this, every off-season run re-ingested the entire finished previous season
--- `get_current_season()` returns `year - 1` until August -- and `plays` fans out
-to one `/plays/stats` call **per game**, roughly 2,000 calls a day against the
-then-75,000/month budget for immutable data. That is what exhausted the quota behind
-the 2026-07-25 three-hour rate-limited run. `reference` and `metrics_wp` are
-never skipped (cheap / already self-limiting), and the upcoming-schedule refresh
-is unaffected. An explicit `--season` or `--sources` disables the skip entirely,
-so a backfill is never silently turned into a no-op; `--no-skip-final` forces it
-off on the daily path.
+-- `get_current_season()` returns `year - 1` until August -- roughly 2,000 calls a
+day against the then-75,000/month budget for immutable data. That is what exhausted
+the quota behind the 2026-07-25 three-hour rate-limited run. `reference` and
+`metrics_wp` are never skipped (cheap / already self-limiting), and the
+upcoming-schedule refresh is unaffected. An explicit `--season` or `--sources`
+disables the skip entirely, so a backfill is never silently turned into a no-op;
+`--no-skip-final` forces it off on the daily path.
+
+**Where the per-game fan-out actually lives:** `stats`, not `plays`. `plays` is
+year+week (16 calls/season). The `stats` source's `play_stats` resource issues one
+`/plays/stats` call **per game** (~1,640/season) and `rosters` one per team, which
+is the cost that exhausted the quota. Because the source is not uniformly priced --
+its other seven resources are one call per year -- anything running daily must name
+resources rather than take the whole source: `--sources stats:player_returning`
+(one call), and `PRESEASON_STATS_RESOURCES` in `load_season.py` for the automated
+path.
+
+**Upcoming-season preseason inputs:** off-season the daily run targets `year - 1`,
+so the finished-season skip drops every immutable source for it -- correct, but it
+left the *upcoming* season with no ingest beyond the games/betting schedule refresh.
+Returning production, preseason SP+, talent and team recruiting are published
+progressively through spring/summer and were never requested at all (2026 had a
+schedule loaded since spring and zero rows in all four on 2026-07-28). The
+upcoming-season block now also refreshes `PRESEASON_INPUT_SOURCES` (~11 calls/day);
+an unpublished endpoint returns empty and merges nothing, so it self-heals as each
+lands. `rosters` stays out (one call per team, and it firms up in August).
+`scripts/probe_offseason_availability.py` distinguishes "never asked" from "CFBD
+has not published it yet".
 
 **Season targeting:** the compute chain's `--incremental` resolves target seasons from
 `core.games` via `get_projection_seasons()` -- the most recent season with completed games

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -5,7 +5,14 @@ description = "Read-only MCP server (stdio) for the cfb-database Supabase wareho
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "mcp>=1.6.0",
+    # Upper bound is load-bearing, not caution. mcp 2.0.0 removed
+    # mcp.server.fastmcp (the package's server subpackage is now mcpserver),
+    # so the unpinned floor started resolving to a release that cannot import
+    # server.py at all -- every mcp/tests module failed at collection with
+    # ModuleNotFoundError, on any branch, without a line of this repo
+    # changing. Porting cfb_mcp off FastMCP is its own piece of work; until
+    # then, hold 1.x.
+    "mcp>=1.6.0,<2",
     "httpx>=0.27.0",
 ]
 

--- a/scripts/load_season.py
+++ b/scripts/load_season.py
@@ -206,6 +206,39 @@ PRESEASON_ESTIMATED_CALLS = len(PRESEASON_STATS_RESOURCES) + 5 + 5
 # of magnitude (play_stats is per game, the rest are per year).
 RESOURCE_FILTERABLE = frozenset({"stats"})
 
+# Table/mart names that are easy to reach for but are not the dlt resource
+# name. `returning_production` is the MART; the resource behind it is
+# `player_returning`. Mapping the near-miss beats failing an operator who
+# asked for exactly the right data under the name the warehouse shows them.
+RESOURCE_ALIASES = {"stats": {"returning_production": "player_returning"}}
+
+
+def resolve_resource_names(source: str, names: list[str]) -> list[str]:
+    """Map warehouse-facing aliases onto dlt resource names."""
+    aliases = RESOURCE_ALIASES.get(source, {})
+    return [aliases.get(name, name) for name in names]
+
+
+def validate_resource_filters(filters: dict[str, list[str]]) -> None:
+    """Reject unknown resource names BEFORE any source runs.
+
+    The check already existed inside stats_source, but it fired mid-run: a
+    2026-07-28 backfill got through ratings and recruiting before failing on
+    `stats:returning_production` (the mart name, not the resource name), and
+    the valid-names hint was buried under dlt's load logs. Failing at parse
+    time puts it on the first line of output instead.
+    """
+    from src.pipelines.sources.stats import stats_source
+
+    known = {"stats": {r.name for r in stats_source(years=[2000]).resources.values()}}
+    for source, names in filters.items():
+        unknown = [n for n in names if n not in known.get(source, set())]
+        if unknown:
+            raise ValueError(
+                f"Unknown {source} resource(s): {unknown}. "
+                f"Valid: {sorted(known.get(source, set()))}"
+            )
+
 
 def parse_source_specs(specs: list[str]) -> tuple[list[str], dict[str, list[str]]]:
     """Split "source[:res+res]" specs into source names and resource filters.
@@ -227,7 +260,7 @@ def parse_source_specs(specs: list[str]) -> tuple[list[str], dict[str, list[str]
                 f"Source {name!r} does not support a resource filter "
                 f"(filterable: {sorted(RESOURCE_FILTERABLE)})"
             )
-        filters[name] = [r for r in resources.split("+") if r]
+        filters[name] = resolve_resource_names(name, [r for r in resources.split("+") if r])
     return names, filters
 
 
@@ -287,6 +320,12 @@ def load_season(
     # resources with "source:res+res" -- see parse_source_spec.
     requested = sources if sources else [s for s in SOURCE_ORDER if s != "rosters"]
     active_sources, resource_filters = parse_source_specs(requested)
+    if resource_filters:
+        try:
+            validate_resource_filters(resource_filters)
+        except ValueError as e:
+            logger.error(str(e))
+            return {"error": str(e)}
 
     # Validate sources
     valid = set(SOURCE_ORDER)

--- a/scripts/load_season.py
+++ b/scripts/load_season.py
@@ -153,6 +153,36 @@ def sources_to_skip(active_sources, season_final: bool, allow_skip: bool):
     return [s for s in active_sources if s in IMMUTABLE_ONCE_FINAL]
 
 
+# Sources that carry the UPCOMING season's preseason inputs, refreshed
+# off-season alongside the schedule.
+#
+# WHY THIS EXISTS. Off-season the unattended path resolves `season` to
+# `get_current_season()` = `year - 1`, and that season is finished, so every
+# source in IMMUTABLE_ONCE_FINAL is skipped -- correctly, its data cannot
+# change. But the skip left the upcoming season with no ingest at all beyond
+# the games/betting schedule refresh below. CFBD publishes returning
+# production (/player/returning), preseason SP+ (/ratings/sp), talent and
+# team recruiting for a season during the spring and summer, and nothing in
+# the daily path ever asked for them: on 2026-07-28, with the 2026 schedule
+# loaded since spring, stats.player_returning, ratings.sp_ratings,
+# recruiting.team_talent and recruiting.team_recruiting all had zero 2026
+# rows, so marts.returning_production could not answer "returning production
+# for 2026" and features.team_week had no preseason-known substrate.
+#
+# These are the cheap, season-grain sources (~45 calls total, versus ~2,000
+# for plays/rosters), so running them daily through the off-season costs
+# roughly nothing and self-heals the moment CFBD publishes each one: an
+# unpublished endpoint returns an empty list or a 400 that the source modules
+# already log and skip, which merges nothing rather than failing. `rosters` is
+# deliberately NOT here -- it is one call per team (~150/day) and does not
+# firm up until August, when the normal in-season path picks it up.
+#
+# scripts/probe_offseason_availability.py reports, per endpoint, whether CFBD
+# has published a given season yet; use it to tell "loader is broken" from
+# "CFBD is merely early".
+PRESEASON_INPUT_SOURCES = ("stats", "ratings", "recruiting")
+
+
 def upcoming_schedule_season(season: int, month: int) -> int | None:
     """Return the next season to schedule-refresh during the off-season.
 
@@ -181,8 +211,9 @@ def load_season(
         dry_run: If True, show plan without executing
         skip_refresh: If True, skip mart refresh after loading
         weekly: If True, load game_stats week-by-week (~35K rows per merge)
-        upcoming_schedule: If set, also refresh this season's schedule tables
-            (games source only) after the main load
+        upcoming_schedule: If set, also refresh this season's schedule and
+            betting lines plus its preseason inputs (PRESEASON_INPUT_SOURCES)
+            after the main load
 
     Returns:
         Summary dict with timing and row counts
@@ -271,9 +302,14 @@ def load_season(
         print(f"\n  Total estimated:  ~{total_est:,} calls")
         print(f"  Budget remaining: {remaining:,} calls")
         if upcoming_schedule:
+            preseason_est = sum(ESTIMATED_CALLS.get(s, 50) for s in PRESEASON_INPUT_SOURCES)
             print(
                 f"  + Refresh {upcoming_schedule} schedule + betting lines "
                 "(games + betting sources, ~20 calls)"
+            )
+            print(
+                f"  + Refresh {upcoming_schedule} preseason inputs "
+                f"({', '.join(PRESEASON_INPUT_SOURCES)}, ~{preseason_est:,} calls)"
             )
         if not skip_refresh:
             print("  + Refresh all materialized views after loading")
@@ -327,9 +363,18 @@ def load_season(
     # skipping it would lose exactly the preseason line-movement history the
     # append-only snapshot feature exists to capture.
     if upcoming_schedule:
+        preseason_runners = {
+            "stats": lambda: run_stats_pipeline(years=[upcoming_schedule]),
+            "ratings": lambda: run_ratings_pipeline(years=[upcoming_schedule]),
+            "recruiting": lambda: run_recruiting_pipeline(years=[upcoming_schedule]),
+        }
         upcoming_runners = {
             "games_upcoming": lambda: run_games_pipeline(years=[upcoming_schedule]),
             "betting_upcoming": lambda: run_betting_pipeline(years=[upcoming_schedule]),
+            # Preseason inputs (returning production, SP+, talent, recruiting):
+            # published progressively through the spring/summer, so ask daily
+            # and let an unpublished endpoint no-op.
+            **{f"{src}_upcoming": preseason_runners[src] for src in PRESEASON_INPUT_SOURCES},
         }
         for name, runner in upcoming_runners.items():
             logger.info(f"Refreshing upcoming season {upcoming_schedule}: {name}...")

--- a/scripts/load_season.py
+++ b/scripts/load_season.py
@@ -43,7 +43,12 @@ ESTIMATED_CALLS = {
     "games": 15,
     "game_stats": 200,
     "plays": 400,
-    "stats": 20,
+    # NOT 20. Seven of the stats source's eight resources are one call per
+    # year, but play_stats issues one /plays/stats request PER GAME, so the
+    # source tracks the season's schedule (~1,640 games) rather than its
+    # resource count. The old estimate understated a daily run by ~80x and hid
+    # this source behind "plays" in every budget projection.
+    "stats": 1_650,
     "ratings": 10,
     "rankings": 20,
     "recruiting": 15,
@@ -169,18 +174,30 @@ def sources_to_skip(active_sources, season_final: bool, allow_skip: bool):
 # rows, so marts.returning_production could not answer "returning production
 # for 2026" and features.team_week had no preseason-known substrate.
 #
-# These are the cheap, season-grain sources (~45 calls total, versus ~2,000
-# for plays/rosters), so running them daily through the off-season costs
-# roughly nothing and self-heals the moment CFBD publishes each one: an
-# unpublished endpoint returns an empty list or a 400 that the source modules
-# already log and skip, which merges nothing rather than failing. `rosters` is
-# deliberately NOT here -- it is one call per team (~150/day) and does not
-# firm up until August, when the normal in-season path picks it up.
+# This refresh runs EVERY off-season day, so it is defined at resource grain,
+# not source grain. The `stats` source is not uniformly priced: play_stats
+# issues one /plays/stats request PER GAME (~1,640 for a season's schedule)
+# while player_returning is a single call per year. Running the whole source
+# daily would cost ~1,640 calls a day -- the exact fan-out that exhausted the
+# quota on 2026-07-25 -- so only the resources that carry preseason inputs are
+# named here. `ratings` and `recruiting` are flat: five single-call-per-year
+# resources each, so they run whole.
+#
+# Total ~11 calls/day. An endpoint CFBD has not published yet returns an empty
+# list or a 400 the source modules already log and skip, so this merges
+# nothing rather than failing, and self-heals the day each one lands.
+# `rosters` is deliberately NOT here -- one call per team (~150/day) and it
+# does not firm up until August, when the normal in-season path picks it up.
 #
 # scripts/probe_offseason_availability.py reports, per endpoint, whether CFBD
 # has published a given season yet; use it to tell "loader is broken" from
 # "CFBD is merely early".
+PRESEASON_STATS_RESOURCES = ("player_returning",)
 PRESEASON_INPUT_SOURCES = ("stats", "ratings", "recruiting")
+
+# What the off-season refresh above actually costs per day, as opposed to what
+# ESTIMATED_CALLS says a full source-grain run of the same names would cost.
+PRESEASON_ESTIMATED_CALLS = len(PRESEASON_STATS_RESOURCES) + 5 + 5
 
 
 def upcoming_schedule_season(season: int, month: int) -> int | None:
@@ -302,14 +319,15 @@ def load_season(
         print(f"\n  Total estimated:  ~{total_est:,} calls")
         print(f"  Budget remaining: {remaining:,} calls")
         if upcoming_schedule:
-            preseason_est = sum(ESTIMATED_CALLS.get(s, 50) for s in PRESEASON_INPUT_SOURCES)
             print(
                 f"  + Refresh {upcoming_schedule} schedule + betting lines "
                 "(games + betting sources, ~20 calls)"
             )
             print(
                 f"  + Refresh {upcoming_schedule} preseason inputs "
-                f"({', '.join(PRESEASON_INPUT_SOURCES)}, ~{preseason_est:,} calls)"
+                f"({', '.join(PRESEASON_INPUT_SOURCES)}; stats limited to "
+                f"{', '.join(PRESEASON_STATS_RESOURCES)}, "
+                f"~{PRESEASON_ESTIMATED_CALLS:,} calls)"
             )
         if not skip_refresh:
             print("  + Refresh all materialized views after loading")
@@ -364,7 +382,11 @@ def load_season(
     # append-only snapshot feature exists to capture.
     if upcoming_schedule:
         preseason_runners = {
-            "stats": lambda: run_stats_pipeline(years=[upcoming_schedule]),
+            # Resource-level: the full stats source would fan out one
+            # /plays/stats call per scheduled game, every day.
+            "stats": lambda: run_stats_pipeline(
+                years=[upcoming_schedule], only=list(PRESEASON_STATS_RESOURCES)
+            ),
             "ratings": lambda: run_ratings_pipeline(years=[upcoming_schedule]),
             "recruiting": lambda: run_recruiting_pipeline(years=[upcoming_schedule]),
         }

--- a/scripts/load_season.py
+++ b/scripts/load_season.py
@@ -7,6 +7,7 @@ Usage:
     python scripts/load_season.py                                   # Load current season
     python scripts/load_season.py --season 2025                     # Load everything for 2025
     python scripts/load_season.py --season 2025 --sources games,stats  # Load specific sources
+    python scripts/load_season.py --season 2026 --sources stats:player_returning  # One resource
     python scripts/load_season.py --season 2025 --dry-run           # Show what would run
     python scripts/load_season.py --season 2025 --skip-refresh      # Load data, skip mart refresh
     python scripts/load_season.py --season 2025 --weekly            # game_stats week-by-week
@@ -200,6 +201,36 @@ PRESEASON_INPUT_SOURCES = ("stats", "ratings", "recruiting")
 PRESEASON_ESTIMATED_CALLS = len(PRESEASON_STATS_RESOURCES) + 5 + 5
 
 
+# Sources whose runner accepts a resource filter. Only `stats` needs one so
+# far -- it is the one source whose resources differ in cost by three orders
+# of magnitude (play_stats is per game, the rest are per year).
+RESOURCE_FILTERABLE = frozenset({"stats"})
+
+
+def parse_source_specs(specs: list[str]) -> tuple[list[str], dict[str, list[str]]]:
+    """Split "source[:res+res]" specs into source names and resource filters.
+
+    `--sources stats:player_returning` loads returning production for a season
+    without paying for play_stats' one-request-per-game fan-out -- the
+    difference between ~1 call and ~1,640 for a season with a full schedule.
+    Pure, so the parse is testable without a DB or an API key.
+    """
+    names: list[str] = []
+    filters: dict[str, list[str]] = {}
+    for spec in specs:
+        name, _, resources = spec.partition(":")
+        names.append(name)
+        if not resources:
+            continue
+        if name not in RESOURCE_FILTERABLE:
+            raise ValueError(
+                f"Source {name!r} does not support a resource filter "
+                f"(filterable: {sorted(RESOURCE_FILTERABLE)})"
+            )
+        filters[name] = [r for r in resources.split("+") if r]
+    return names, filters
+
+
 def upcoming_schedule_season(season: int, month: int) -> int | None:
     """Return the next season to schedule-refresh during the off-season.
 
@@ -252,8 +283,10 @@ def load_season(
     )
     from src.pipelines.utils.rate_limiter import get_rate_limiter
 
-    # Determine which sources to run
-    active_sources = sources if sources else [s for s in SOURCE_ORDER if s != "rosters"]
+    # Determine which sources to run. A source may be narrowed to specific
+    # resources with "source:res+res" -- see parse_source_spec.
+    requested = sources if sources else [s for s in SOURCE_ORDER if s != "rosters"]
+    active_sources, resource_filters = parse_source_specs(requested)
 
     # Validate sources
     valid = set(SOURCE_ORDER)
@@ -293,8 +326,13 @@ def load_season(
         elif final:
             logger.info("Season %d is finished but no immutable source was selected", season)
 
-    # Estimate API calls
-    total_est = sum(ESTIMATED_CALLS.get(s, 50) for s in active_sources)
+    # Estimate API calls. A resource-filtered source costs a call per named
+    # resource per season, not the whole source's per-game fan-out.
+    def estimate(src: str) -> int:
+        named = resource_filters.get(src)
+        return len(named) if named else ESTIMATED_CALLS.get(src, 50)
+
+    total_est = sum(estimate(s) for s in active_sources)
 
     # Check rate limit budget
     rate_limiter = get_rate_limiter()
@@ -314,8 +352,9 @@ def load_season(
     if dry_run:
         print(f"\n[DRY RUN] Would load {len(active_sources)} sources for season {season}")
         for src in active_sources:
-            est = ESTIMATED_CALLS.get(src, 50)
-            print(f"  {src:15s}  ~{est:,} API calls")
+            named = resource_filters.get(src)
+            label = f"{src}:{'+'.join(named)}" if named else src
+            print(f"  {label:32s}  ~{estimate(src):,} API calls")
         print(f"\n  Total estimated:  ~{total_est:,} calls")
         print(f"  Budget remaining: {remaining:,} calls")
         if upcoming_schedule:
@@ -344,7 +383,7 @@ def load_season(
         "games": lambda: run_games_pipeline(years=[season]),
         "game_stats": game_stats_runner,
         "plays": lambda: run_plays_pipeline(years=[season]),
-        "stats": lambda: run_stats_pipeline(years=[season]),
+        "stats": lambda: run_stats_pipeline(years=[season], only=resource_filters.get("stats")),
         "ratings": lambda: run_ratings_pipeline(years=[season]),
         "rankings": lambda: run_rankings_pipeline(years=[season]),
         "recruiting": lambda: run_recruiting_pipeline(years=[season]),
@@ -468,7 +507,10 @@ def main() -> None:
         "--sources",
         type=str,
         default=None,
-        help="Comma-separated list of sources to load (default: all)",
+        help="Comma-separated sources to load (default: all). A source may be "
+        "narrowed to specific resources with source:res+res, e.g. "
+        "stats:player_returning -- which loads returning production without "
+        "play_stats' one-request-per-game fan-out.",
     )
     parser.add_argument("--dry-run", action="store_true", help="Show plan without executing")
     parser.add_argument(

--- a/src/pipelines/run.py
+++ b/src/pipelines/run.py
@@ -337,10 +337,19 @@ def run_plays_pipeline(years: list[int] | None = None, mode: str = "incremental"
     return info
 
 
-def run_stats_pipeline(years: list[int] | None = None, mode: str = "incremental"):
-    """Run the stats data pipeline."""
+def run_stats_pipeline(
+    years: list[int] | None = None,
+    mode: str = "incremental",
+    only: list[str] | None = None,
+):
+    """Run the stats data pipeline.
+
+    `only` restricts the run to named resources -- see stats_source: the
+    source's cost is dominated by play_stats, which is one request per game.
+    """
     years_str = f"years={years}" if years else f"mode={mode}"
-    print(f"\n=== Loading Stats Data ({years_str}) ===\n")
+    only_str = f", only={only}" if only else ""
+    print(f"\n=== Loading Stats Data ({years_str}{only_str}) ===\n")
 
     pipeline = dlt.pipeline(
         pipeline_name="cfbd_stats",
@@ -348,7 +357,7 @@ def run_stats_pipeline(years: list[int] | None = None, mode: str = "incremental"
         dataset_name="stats",
     )
 
-    source = stats_source(years=years, mode=mode)
+    source = stats_source(years=years, mode=mode, only=only)
     info = pipeline.run(source)
 
     print(f"\nLoad info: {info}")

--- a/src/pipelines/sources/stats.py
+++ b/src/pipelines/sources/stats.py
@@ -21,12 +21,18 @@ logger = logging.getLogger(__name__)
 def stats_source(
     years: list[int] | None = None,
     mode: str = "incremental",
+    only: list[str] | None = None,
 ) -> DltSource:
     """Source for team and player statistics.
 
     Args:
         years: Specific years to load. If None, uses mode to determine years.
         mode: "incremental" loads current season, "backfill" loads all historical.
+        only: Resource names to run (default: all). The source is NOT uniformly
+            priced -- play_stats issues one /plays/stats request PER GAME
+            (~1,640 for a full season) while every other resource here is a
+            single call per year. Anything that runs daily should name the
+            resources it needs instead of paying for the whole source.
     """
     if years is None:
         if mode == "incremental":
@@ -34,7 +40,7 @@ def stats_source(
         else:  # backfill
             years = YEAR_RANGES["stats"].to_list()
 
-    return [
+    resources = [
         team_season_stats_resource(years),
         player_season_stats_resource(years),
         advanced_team_stats_resource(years),
@@ -44,6 +50,15 @@ def stats_source(
         play_stats_resource(years),
         game_havoc_resource(years),
     ]
+
+    if only is None:
+        return resources
+
+    by_name = {r.name: r for r in resources}
+    unknown = [name for name in only if name not in by_name]
+    if unknown:
+        raise ValueError(f"Unknown stats resource(s): {unknown}. Valid: {sorted(by_name)}")
+    return [by_name[name] for name in only]
 
 
 @dlt.resource(

--- a/tests/test_load_season.py
+++ b/tests/test_load_season.py
@@ -4,7 +4,9 @@ from scripts.load_season import (
     ESTIMATED_CALLS,
     IMMUTABLE_ONCE_FINAL,
     MIN_GAMES_FOR_FINISHED_SEASON,
+    PRESEASON_ESTIMATED_CALLS,
     PRESEASON_INPUT_SOURCES,
+    PRESEASON_STATS_RESOURCES,
     SEASON_COMPLETE_THRESHOLD,
     SOURCE_ORDER,
     load_season,
@@ -54,9 +56,25 @@ class TestPreseasonInputRefresh:
 
     def test_the_refresh_is_cheap(self):
         """It runs every off-season day, so it has to stay far away from the
-        plays/rosters fan-out that exhausted the quota in the first place."""
-        est = sum(ESTIMATED_CALLS.get(s, 50) for s in PRESEASON_INPUT_SOURCES)
-        assert est <= 100, f"preseason refresh costs ~{est} calls/day"
+        per-game fan-out that exhausted the quota in the first place."""
+        assert PRESEASON_ESTIMATED_CALLS <= 100
+
+    def test_stats_is_restricted_to_named_resources(self):
+        """The trap this class exists to avoid. The stats source is not
+        uniformly priced: play_stats is one /plays/stats request PER GAME, so
+        a source-grain daily refresh of `stats` for the upcoming season costs
+        ~1,640 calls a day -- the same fan-out that exhausted the quota. Only
+        the resources carrying preseason inputs may run."""
+        assert "play_stats" not in PRESEASON_STATS_RESOURCES
+        assert "player_returning" in PRESEASON_STATS_RESOURCES
+        assert PRESEASON_ESTIMATED_CALLS < ESTIMATED_CALLS["stats"] / 10
+
+    def test_named_stats_resources_exist(self):
+        """A typo would raise at load time, inside the daily workflow."""
+        from src.pipelines.sources.stats import stats_source
+
+        source = stats_source(years=[2026], only=list(PRESEASON_STATS_RESOURCES))
+        assert {r.name for r in source.resources.values()} == set(PRESEASON_STATS_RESOURCES)
 
     def test_dry_run_reports_the_preseason_refresh(self, capsys):
         load_season(season=2025, sources=["games"], dry_run=True, upcoming_schedule=2026)
@@ -65,6 +83,7 @@ class TestPreseasonInputRefresh:
         assert "2026 preseason inputs" in out
         for src in PRESEASON_INPUT_SOURCES:
             assert src in out
+        assert "player_returning" in out
 
 
 class TestMetricsWpWiring:

--- a/tests/test_load_season.py
+++ b/tests/test_load_season.py
@@ -1,5 +1,7 @@
 """Unit tests for load_season's season-selection helpers (no DB, no API)."""
 
+import pytest
+
 from scripts.load_season import (
     ESTIMATED_CALLS,
     IMMUTABLE_ONCE_FINAL,
@@ -10,6 +12,7 @@ from scripts.load_season import (
     SEASON_COMPLETE_THRESHOLD,
     SOURCE_ORDER,
     load_season,
+    parse_source_specs,
     season_is_final,
     sources_to_skip,
     upcoming_schedule_season,
@@ -27,6 +30,31 @@ class TestUpcomingScheduleSeason:
     def test_in_season_months_skip(self):
         for month in (8, 9, 10, 11, 12):
             assert upcoming_schedule_season(2026, month) is None
+
+
+class TestParseSourceSpecs:
+    """`--sources stats` costs ~1,640 calls for a season with a full schedule
+    because play_stats is one request per game. A one-off load of returning
+    production should not have to pay that."""
+
+    def test_plain_sources_have_no_filter(self):
+        assert parse_source_specs(["games", "stats"]) == (["games", "stats"], {})
+
+    def test_a_resource_filter_is_split_out(self):
+        names, filters = parse_source_specs(["stats:player_returning"])
+        assert names == ["stats"]
+        assert filters == {"stats": ["player_returning"]}
+
+    def test_multiple_resources_use_plus(self):
+        """Comma already separates sources, so it cannot separate resources."""
+        _, filters = parse_source_specs(["stats:player_returning+player_usage"])
+        assert filters["stats"] == ["player_returning", "player_usage"]
+
+    def test_filtering_an_unfilterable_source_is_an_error(self):
+        """Silently ignoring the filter would load the whole source at full
+        price while the operator believed they had narrowed it."""
+        with pytest.raises(ValueError, match="does not support a resource filter"):
+            parse_source_specs(["games:schedule"])
 
 
 class TestPreseasonInputRefresh:

--- a/tests/test_load_season.py
+++ b/tests/test_load_season.py
@@ -16,6 +16,7 @@ from scripts.load_season import (
     season_is_final,
     sources_to_skip,
     upcoming_schedule_season,
+    validate_resource_filters,
 )
 
 
@@ -316,3 +317,32 @@ class TestWinProbabilityBacklogIsBounded:
         body = inspect.getsource(run_metrics_wp_pipeline)
         assert '"missing": total_missing' in body
         assert '"loaded_this_run"' in body
+
+
+class TestResourceFilterValidation:
+    """A 2026-07-28 backfill passed `stats:returning_production` -- the MART
+    name -- and got through ratings and recruiting before stats failed, with
+    the valid-names hint buried under dlt's load logs."""
+
+    def test_the_mart_name_resolves_to_the_resource(self):
+        _, filters = parse_source_specs(["stats:returning_production"])
+        assert filters["stats"] == ["player_returning"]
+
+    def test_a_real_typo_still_fails(self):
+        with pytest.raises(ValueError, match="Unknown stats resource"):
+            validate_resource_filters({"stats": ["player_retuning"]})
+
+    def test_valid_names_are_listed_in_the_error(self):
+        """The whole point: the fix has to be readable off the error."""
+        with pytest.raises(ValueError, match="player_returning"):
+            validate_resource_filters({"stats": ["nope"]})
+
+    def test_known_resources_pass(self):
+        validate_resource_filters({"stats": ["player_returning", "play_stats"]})
+
+    def test_load_season_rejects_before_running_anything(self):
+        """It must fail at parse time, not after other sources have run."""
+        summary = load_season(season=2026, sources=["stats:nope"], dry_run=True)
+
+        assert "error" in summary
+        assert "Unknown stats resource" in summary["error"]

--- a/tests/test_load_season.py
+++ b/tests/test_load_season.py
@@ -4,6 +4,7 @@ from scripts.load_season import (
     ESTIMATED_CALLS,
     IMMUTABLE_ONCE_FINAL,
     MIN_GAMES_FOR_FINISHED_SEASON,
+    PRESEASON_INPUT_SOURCES,
     SEASON_COMPLETE_THRESHOLD,
     SOURCE_ORDER,
     load_season,
@@ -24,6 +25,46 @@ class TestUpcomingScheduleSeason:
     def test_in_season_months_skip(self):
         for month in (8, 9, 10, 11, 12):
             assert upcoming_schedule_season(2026, month) is None
+
+
+class TestPreseasonInputRefresh:
+    """The upcoming season's preseason inputs had no ingest path at all.
+
+    Off-season the unattended run targets `year - 1`, which is finished, so
+    every IMMUTABLE_ONCE_FINAL source is skipped -- and only games/betting
+    were refreshed for the upcoming season. On 2026-07-28 the 2026 schedule
+    had been loaded for months while stats.player_returning,
+    ratings.sp_ratings, recruiting.team_talent and recruiting.team_recruiting
+    all had zero 2026 rows, so 2026 returning production could not be
+    answered at all.
+    """
+
+    def test_preseason_sources_are_real_sources(self):
+        assert set(PRESEASON_INPUT_SOURCES) <= set(SOURCE_ORDER)
+
+    def test_returning_production_source_is_covered(self):
+        """stats carries /player/returning -> stats.player_returning ->
+        marts.returning_production, the table that was empty for 2026."""
+        assert "stats" in PRESEASON_INPUT_SOURCES
+
+    def test_rosters_is_not_a_preseason_input(self):
+        """One call per team (~150/day) and it does not firm up until August,
+        when the normal in-season path picks it up anyway."""
+        assert "rosters" not in PRESEASON_INPUT_SOURCES
+
+    def test_the_refresh_is_cheap(self):
+        """It runs every off-season day, so it has to stay far away from the
+        plays/rosters fan-out that exhausted the quota in the first place."""
+        est = sum(ESTIMATED_CALLS.get(s, 50) for s in PRESEASON_INPUT_SOURCES)
+        assert est <= 100, f"preseason refresh costs ~{est} calls/day"
+
+    def test_dry_run_reports_the_preseason_refresh(self, capsys):
+        load_season(season=2025, sources=["games"], dry_run=True, upcoming_schedule=2026)
+
+        out = capsys.readouterr().out
+        assert "2026 preseason inputs" in out
+        for src in PRESEASON_INPUT_SOURCES:
+            assert src in out
 
 
 class TestMetricsWpWiring:


### PR DESCRIPTION
## Problem

The 2026 schedule has been loaded since spring, but every 2026 preseason input was empty on 2026-07-28:

| table | 2025 | 2026 (before) |
|---|---|---|
| `core.games` | 3,831 | 1,638 |
| `stats.player_returning` | 134 | **0** |
| `ratings.sp_ratings` | 137 | **0** |
| `recruiting.team_talent` | 134 | **0** |
| `recruiting.team_recruiting` | 232 | **0** |

Off-season the unattended daily path resolves `season` to `get_current_season()` = `year - 1`, which is finished, so the `IMMUTABLE_ONCE_FINAL` skip correctly drops every immutable source for it. But the compensating off-season block only refreshed **games + betting** for the upcoming season, so nothing in the daily automation ever requested 2026 returning production, SP+, talent, or team recruiting. `marts.returning_production` could not answer a 2026 question, and `features.team_week` had no preseason-known substrate.

`scripts/probe_offseason_availability.py` was written for exactly this class of problem but is not wired into any workflow, so "loader never asked" and "CFBD has not published it" were indistinguishable from the warehouse side.

## Changes

**Refresh the upcoming season's preseason inputs** alongside the schedule refresh — `PRESEASON_INPUT_SOURCES = (stats, ratings, recruiting)`, ~11 calls/day. An endpoint CFBD has not published yet returns empty or a 400 the source modules already skip, so the refresh merges nothing rather than failing and self-heals the day each one lands.

**Resource-grain, not source-grain.** The `stats` source is not uniformly priced: seven of its eight resources are one call per year, but `play_stats` issues one `/plays/stats` request **per game** (~1,640 for a season's schedule). A source-grain daily refresh would have cost ~1,640 calls/day — re-creating the fan-out that exhausted the quota on 2026-07-25. Adds `stats_source(only=[...])` / `run_stats_pipeline(only=[...])`; the off-season refresh names `player_returning` only.

**`--sources source:res+res`** so one-off loads skip the fan-out too: `--sources stats:player_returning` is 1 call where `--sources stats` is ~1,640. Resource names are validated at parse time (a mid-run failure with the valid-names hint buried under dlt's load logs is how `stats:returning_production` failed a backfill), and the mart name `returning_production` resolves to the `player_returning` resource rather than being rejected.

**Corrected estimates and docs.** `ESTIMATED_CALLS["stats"]` was `20`, understating a run by ~80x. CLAUDE.md attributed the 2026-07-25 quota exhaustion to `plays`, which is year+week at 16 calls/season; the per-game fan-out is `stats.play_stats`.

## Verification

Loaded against production from this branch (`deploy-schema`, `action=backfill`, `2026`):

| table | 2026 rows after |
|---|---|
| `recruiting.recruits` | **3,987** |
| `recruiting.team_recruiting` | **221** |
| `stats.player_returning` | 0 — request succeeded, CFBD has not published 2026 yet |
| `ratings.sp_ratings` | 0 — same |
| `recruiting.team_talent` | 0 — same |

So two of the five were genuinely never-requested and are now loaded; the other three are unpublished upstream and will land automatically on the daily path once this merges. `--sources stats:player_returning` for 2026 cost one API call and completed in ~5s.

Tests: 1,282 passed, 401 skipped. `ruff check` / `ruff format --check` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pfurxa4Ved9U4ZkEo2PbKR)_