### PR TITLE
feat: pre-registered in-season feature screen — all six starter-pack candidates rejected

### DIFF
--- a/.github/workflows/model-experiments.yml
+++ b/.github/workflows/model-experiments.yml
@@ -24,7 +24,8 @@ on:
         required: true
         type: choice
         options:
-          - screen            # pre-registered candidate screen (run-once; see header)
+          - screen            # pre-registered candidate screen v1 (already run; see header)
+          - screen-v2         # v2 amendment: control = frozen walk-forward model margin (run-once)
           - backfill          # full features.team_week rebuild (2015+)
 
 concurrency:
@@ -57,6 +58,10 @@ jobs:
       - name: Screen candidates (read-only)
         if: inputs.task == 'screen'
         run: python scripts/screen_week_features.py
+
+      - name: Screen candidates v2 — model-margin control (read-only)
+        if: inputs.task == 'screen-v2'
+        run: python scripts/screen_week_features.py --control-mode model-margin
 
       - name: Full feature substrate rebuild
         if: inputs.task == 'backfill'

--- a/.github/workflows/model-experiments.yml
+++ b/.github/workflows/model-experiments.yml
@@ -20,6 +20,11 @@ on:
           - migrate-048       # U2: apply migration 048 (idempotent)
           - backfill          # U3: full features.team_week rebuild (2015+)
           - evaluate          # U4: no-write candidate evaluation vs production baseline
+  # workflow_dispatch only resolves on the default branch, so while this file
+  # lives on a feature branch each step is triggered by applying the matching
+  # PR label (run-screen, run-migrate-048, run-backfill, run-evaluate).
+  pull_request:
+    types: [labeled]
 
 concurrency:
   group: model-experiments
@@ -31,10 +36,18 @@ permissions:
 env:
   PYTHON_VERSION: "3.11"
   SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+  TASK: >-
+    ${{ inputs.task
+        || (github.event.label.name == 'run-screen' && 'screen')
+        || (github.event.label.name == 'run-migrate-048' && 'migrate-048')
+        || (github.event.label.name == 'run-backfill' && 'backfill')
+        || (github.event.label.name == 'run-evaluate' && 'evaluate')
+        || '' }}
 
 jobs:
   run:
-    name: Run ${{ inputs.task }}
+    name: Run experiment step
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.label.name, 'run-')
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
@@ -49,17 +62,17 @@ jobs:
         run: echo "DESTINATION__POSTGRES__CREDENTIALS=$(printf '%s' "$SUPABASE_DB_URL" | sed 's/^postgresql:/postgres:/')" >> "$GITHUB_ENV"
 
       - name: Screen candidates (read-only)
-        if: inputs.task == 'screen'
+        if: env.TASK == 'screen'
         run: python scripts/screen_week_features.py
 
       - name: Apply migration 048
-        if: inputs.task == 'migrate-048'
+        if: env.TASK == 'migrate-048'
         run: python scripts/run_migrations.py --file src/schemas/migrations/048_team_week_drive_trajectory.sql
 
       - name: Full feature substrate rebuild
-        if: inputs.task == 'backfill'
+        if: env.TASK == 'backfill'
         run: python scripts/build_features.py
 
       - name: Evaluate candidates (no-write)
-        if: inputs.task == 'evaluate'
+        if: env.TASK == 'evaluate'
         run: python scripts/train_model.py --evaluate-candidates

--- a/.github/workflows/model-experiments.yml
+++ b/.github/workflows/model-experiments.yml
@@ -3,11 +3,15 @@ name: Model Feature Experiments
 # Manual runner for model-substrate work that needs warehouse credentials
 # (CI holds the session-pooler secret; local checkouts may not).
 #
-# History: the 2026-07-28 starter-pack candidate screen ran here and rejected
-# all six drive/trajectory candidates — verdicts recorded in
+# History: the 2026-07-28 starter-pack candidate screen ran here (via a
+# temporary PR-label trigger, since removed) and rejected all six
+# drive/trajectory candidates — verdicts recorded in
 # docs/brainstorms/2026-07-21-team-week-feature-design.md ("Decisions made").
 # The screen is pre-registered run-once: do not re-run it against the same
 # frame without a new pre-registration.
+#
+# workflow_dispatch only: no PR-event trigger, so unmerged branch code never
+# runs with the database secret.
 #
 # Requires repo secret:
 #   SUPABASE_DB_URL - Supabase SESSION pooler URL
@@ -21,11 +25,7 @@ on:
         type: choice
         options:
           - screen            # pre-registered candidate screen (run-once; see header)
-          - backfill          # full features.team_week rebuild
-  # workflow_dispatch only resolves on the default branch; while this file
-  # lives on a feature branch, trigger via PR labels run-screen / run-backfill.
-  pull_request:
-    types: [labeled]
+          - backfill          # full features.team_week rebuild (2015+)
 
 concurrency:
   group: model-experiments
@@ -37,16 +37,10 @@ permissions:
 env:
   PYTHON_VERSION: "3.11"
   SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
-  TASK: >-
-    ${{ inputs.task
-        || (github.event.label.name == 'run-screen' && 'screen')
-        || (github.event.label.name == 'run-backfill' && 'backfill')
-        || '' }}
 
 jobs:
   run:
-    name: Run experiment step
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.label.name, 'run-')
+    name: Run ${{ inputs.task }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
@@ -61,9 +55,9 @@ jobs:
         run: echo "DESTINATION__POSTGRES__CREDENTIALS=$(printf '%s' "$SUPABASE_DB_URL" | sed 's/^postgresql:/postgres:/')" >> "$GITHUB_ENV"
 
       - name: Screen candidates (read-only)
-        if: env.TASK == 'screen'
+        if: inputs.task == 'screen'
         run: python scripts/screen_week_features.py
 
       - name: Full feature substrate rebuild
-        if: env.TASK == 'backfill'
-        run: python scripts/build_features.py
+        if: inputs.task == 'backfill'
+        run: python scripts/build_features.py --from 2015

--- a/.github/workflows/model-experiments.yml
+++ b/.github/workflows/model-experiments.yml
@@ -1,9 +1,13 @@
 name: Model Feature Experiments
 
-# Manual runner for the starter-pack feature-candidate experiment chain
-# (docs/plans/2026-07-28-001-feat-starter-pack-model-features-plan.md).
-# Each task is an explicit, bounded step; run from the feature branch via
-# workflow_dispatch. Uses the same session-pooler secret as daily-load.yml.
+# Manual runner for model-substrate work that needs warehouse credentials
+# (CI holds the session-pooler secret; local checkouts may not).
+#
+# History: the 2026-07-28 starter-pack candidate screen ran here and rejected
+# all six drive/trajectory candidates — verdicts recorded in
+# docs/brainstorms/2026-07-21-team-week-feature-design.md ("Decisions made").
+# The screen is pre-registered run-once: do not re-run it against the same
+# frame without a new pre-registration.
 #
 # Requires repo secret:
 #   SUPABASE_DB_URL - Supabase SESSION pooler URL
@@ -12,17 +16,14 @@ on:
   workflow_dispatch:
     inputs:
       task:
-        description: "Which experiment step to run"
+        description: "Which step to run"
         required: true
         type: choice
         options:
-          - screen            # U1: read-only candidate screen, prints verdict table
-          - migrate-048       # U2: apply migration 048 (idempotent)
-          - backfill          # U3: full features.team_week rebuild (2015+)
-          - evaluate          # U4: no-write candidate evaluation vs production baseline
-  # workflow_dispatch only resolves on the default branch, so while this file
-  # lives on a feature branch each step is triggered by applying the matching
-  # PR label (run-screen, run-migrate-048, run-backfill, run-evaluate).
+          - screen            # pre-registered candidate screen (run-once; see header)
+          - backfill          # full features.team_week rebuild
+  # workflow_dispatch only resolves on the default branch; while this file
+  # lives on a feature branch, trigger via PR labels run-screen / run-backfill.
   pull_request:
     types: [labeled]
 
@@ -39,9 +40,7 @@ env:
   TASK: >-
     ${{ inputs.task
         || (github.event.label.name == 'run-screen' && 'screen')
-        || (github.event.label.name == 'run-migrate-048' && 'migrate-048')
         || (github.event.label.name == 'run-backfill' && 'backfill')
-        || (github.event.label.name == 'run-evaluate' && 'evaluate')
         || '' }}
 
 jobs:
@@ -65,14 +64,6 @@ jobs:
         if: env.TASK == 'screen'
         run: python scripts/screen_week_features.py
 
-      - name: Apply migration 048
-        if: env.TASK == 'migrate-048'
-        run: python scripts/run_migrations.py --file src/schemas/migrations/048_team_week_drive_trajectory.sql
-
       - name: Full feature substrate rebuild
         if: env.TASK == 'backfill'
         run: python scripts/build_features.py
-
-      - name: Evaluate candidates (no-write)
-        if: env.TASK == 'evaluate'
-        run: python scripts/train_model.py --evaluate-candidates

--- a/.github/workflows/model-experiments.yml
+++ b/.github/workflows/model-experiments.yml
@@ -1,0 +1,65 @@
+name: Model Feature Experiments
+
+# Manual runner for the starter-pack feature-candidate experiment chain
+# (docs/plans/2026-07-28-001-feat-starter-pack-model-features-plan.md).
+# Each task is an explicit, bounded step; run from the feature branch via
+# workflow_dispatch. Uses the same session-pooler secret as daily-load.yml.
+#
+# Requires repo secret:
+#   SUPABASE_DB_URL - Supabase SESSION pooler URL
+
+on:
+  workflow_dispatch:
+    inputs:
+      task:
+        description: "Which experiment step to run"
+        required: true
+        type: choice
+        options:
+          - screen            # U1: read-only candidate screen, prints verdict table
+          - migrate-048       # U2: apply migration 048 (idempotent)
+          - backfill          # U3: full features.team_week rebuild (2015+)
+          - evaluate          # U4: no-write candidate evaluation vs production baseline
+
+concurrency:
+  group: model-experiments
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  PYTHON_VERSION: "3.11"
+  SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+
+jobs:
+  run:
+    name: Run ${{ inputs.task }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+      - run: pip install -e ".[compute]"
+      - name: Set dlt destination credentials
+        # dlt requires the postgres:// scheme (see .dlt/secrets.toml.example)
+        run: echo "DESTINATION__POSTGRES__CREDENTIALS=$(printf '%s' "$SUPABASE_DB_URL" | sed 's/^postgresql:/postgres:/')" >> "$GITHUB_ENV"
+
+      - name: Screen candidates (read-only)
+        if: inputs.task == 'screen'
+        run: python scripts/screen_week_features.py
+
+      - name: Apply migration 048
+        if: inputs.task == 'migrate-048'
+        run: python scripts/run_migrations.py --file src/schemas/migrations/048_team_week_drive_trajectory.sql
+
+      - name: Full feature substrate rebuild
+        if: inputs.task == 'backfill'
+        run: python scripts/build_features.py
+
+      - name: Evaluate candidates (no-write)
+        if: inputs.task == 'evaluate'
+        run: python scripts/train_model.py --evaluate-candidates

--- a/docs/brainstorms/2026-07-21-team-week-feature-design.md
+++ b/docs/brainstorms/2026-07-21-team-week-feature-design.md
@@ -637,3 +637,18 @@ Per-family assertions the gate runs against the freshly-built `team_week`
   would NULL. Not verdict-relevant — both trajectory partials sit an order of
   magnitude below the 0.08 floor — but a future re-registration should carry
   play counts through the weekly aggregates and gate on them.
+  **v2 amendment (pre-registered 2026-07-28, before any v2 run, in response
+  to the PR #59 Codex review):** the v1 controls (Elo + `adj_epa_net` diffs)
+  under-implement the plan's stated "current model's expected margin," and
+  omitted-control suppression means a sub-floor v1 candidate could in
+  principle clear the floor once the full prediction is held constant
+  (`off_ppd` sits at 0.070 vs the 0.08 floor). v2: same floor and BH-FDR,
+  run once, first-order partial correlation controlling for fitted_v1's
+  frozen walk-forward expected margin rebuilt from stored vintages
+  (`train_through_season == season - 1`), window auto-restricted to seasons
+  with a stored prior vintage (`--control-mode model-margin`). Final
+  retirement of the six candidates is keyed to the v2 confirmation run
+  (post-merge, via the model-experiments workflow): if every candidate stays
+  below the floor, the v1 rejections stand as final; if any clears it, that
+  candidate's rejection is void and re-enters the plan's evaluation path
+  (refit + no-regression gate) — a v2 pass alone does not ship a column.

--- a/docs/brainstorms/2026-07-21-team-week-feature-design.md
+++ b/docs/brainstorms/2026-07-21-team-week-feature-design.md
@@ -612,3 +612,20 @@ Per-family assertions the gate runs against the freshly-built `team_week`
   front-seven havoc splits remain untestable at 17.4% coverage.
 - **Feature vector size:** 15 features + unpenalized intercept; `market_*`
   excluded so `edge` stays meaningful.
+- **2026-07-28 in-season screen = all six drive/trajectory candidates REJECTED;
+  no migration shipped.** Pre-registered in `scripts/screen_week_features.py`
+  (run once, 2015–2025, n≈8k completed FBS-involved games): |partial_r| ≥ 0.08
+  AND BH-FDR q ≤ 0.10 against home margin, controlling home-minus-away
+  `elo_pregame` and `adj_epa_net` diffs. Candidates and results — `off_ppd`
+  +0.0700 (p=3.6e-10), `def_ppd_allowed` −0.0583 (p=1.8e-07), `off_field_pos`
+  −0.0547 (p=9.8e-07), `def_field_pos_allowed` +0.0469 (p=2.7e-05),
+  `form_net_epa_last4` +0.0163 (p=0.21, n=5,804), `vol_net_epa` −0.0058
+  (p=0.63, n=7,203). The four drive candidates are significant but all below
+  the pre-registered floor: drive efficiency is real signal the vector already
+  absorbs through Elo and adjusted EPA. The two trajectory candidates are
+  nulls — recent form and volatility add nothing to margin once
+  opponent-adjusted ratings are controlled. Consequence: `features.team_week`
+  gains no drive or trajectory columns; the planned volatility-modulated
+  calibration experiment was dropped with its substrate; do not re-test these
+  six without a new pre-registration that changes the frame or controls
+  (source plan: `docs/plans/2026-07-28-001-feat-starter-pack-model-features-plan.md`).

--- a/docs/brainstorms/2026-07-21-team-week-feature-design.md
+++ b/docs/brainstorms/2026-07-21-team-week-feature-design.md
@@ -629,3 +629,11 @@ Per-family assertions the gate runs against the freshly-built `team_week`
   calibration experiment was dropped with its substrate; do not re-test these
   six without a new pre-registration that changes the frame or controls
   (source plan: `docs/plans/2026-07-28-001-feat-starter-pack-model-features-plan.md`).
+  Disclosed deviation (cross-model review): the screen operationalized
+  trajectory maturity as week-row gates (>= 4 prior weeks for form, >= 2 for
+  volatility) rather than the substrate's `MIN_TEAM_PLAYS = 150` play-count
+  gate. For form the week gate is effectively stricter (4 games is ~260+
+  offensive plays); for volatility it admits some 2-game teams the substrate
+  would NULL. Not verdict-relevant — both trajectory partials sit an order of
+  magnitude below the 0.08 floor — but a future re-registration should carry
+  play counts through the weekly aggregates and gate on them.

--- a/docs/plans/2026-07-28-001-feat-starter-pack-model-features-plan.md
+++ b/docs/plans/2026-07-28-001-feat-starter-pack-model-features-plan.md
@@ -1,0 +1,292 @@
+---
+title: Starter Pack Model Feature Candidates - Plan
+type: feat
+date: 2026-07-28
+topic: starter-pack-model-features
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-brainstorm
+execution: code
+---
+
+# Starter Pack Model Feature Candidates - Plan
+
+## Goal Capsule
+
+- **Objective:** Extract the drive-efficiency and weekly-trajectory concepts from the CFBD Starter Pack notebooks into leak-free feature candidates for the fitted prediction model, shipping only candidates that pass a walk-forward no-regression backtest.
+- **Product authority:** Rob (repo owner). This plan owns only the modeling-methodology area of the packet review; the pipeline audit, AI-context upgrade, and curated-data workstreams are not active scope.
+- **Execution profile:** Single-repo Python + SQL work against the live Supabase warehouse; experiments run offline, production changes flow through the daily automation.
+- **Stop conditions:** Stop before U5 if no candidate passes the adoption gate (record verdicts — a null result is valid completion). Stop and surface if `core.drives` score-delta columns prove unreliable for exact drive points (KTD6 fallback decision needed).
+- **Open blockers:** None.
+
+---
+
+## Product Contract
+
+### Summary
+
+Turn the two Starter Pack concepts the house model stack doesn't already have — drive efficiency (points per drive, starting field position) and weekly trajectory (recent form, volatility) — into as-of feature candidates computed from the warehouse, evaluate them with a walk-forward refit and backtest, and adopt only what strictly improves the production model. A bounded optional experiment uses volatility to modulate win-probability calibration instead of the margin.
+
+### Problem Frame
+
+Three purchased CFBD packets (AI API Launchpad, AI Builder Pack, Starter Pack 2026 Preseason) are sitting in Downloads. A triage pass showed most of their modeling content is below the house stack: the notebooks' SRS and basic opponent adjustments are weaker than the ridge-regression adjusted EPA already in production, and their logistic matchup predictor is weaker than the walk-forward fitted model. Without a deliberate extraction pass, the small amount of genuinely new material — drive-level efficiency and week-over-week trajectory — either goes unmined or gets rediscovered later at higher cost.
+
+### Key Decisions
+
+- KD1. **Offline walk-forward evaluation, not a live 2026 challenger** (session-settled: user-directed — chosen over scoring a parallel model through the season: walk-forward backtest evidence suffices and saves months of dual-model carrying cost). Governs R4.
+- KD2. **Strict no-regression adoption bar** (session-settled: user-directed — chosen over a materiality threshold and case-by-case judgment: mechanical to apply and consistent with how the daily backtest already reports). Governs R5.
+- KD3. **Concepts only; the packet CSVs go unused in this work** (session-settled: user-approved — the warehouse already holds the underlying data; features compute from warehouse tables). Governs R1, R2.
+- KD4. **Candidate sources limited to the drive-efficiency and weekly-trajectory notebooks** (session-settled: user-approved — the remaining notebooks are superseded by stronger house implementations or belong to cfb-app analytics territory). Governs R1, R2.
+- KD5. **The calibration experiment is optional and bounded** (session-settled: user-directed — approach chosen as "feature extension plus optional calibration follow-on"; it must not block the main feature work). Governs R9.
+
+### Requirements
+
+**Feature candidates**
+
+- R1. Derive drive-efficiency candidates — offensive and defensive points per drive, and starting field position — from warehouse drive data at the same team-week as-of grain the existing feature substrate uses.
+- R2. Derive weekly-trajectory candidates — rolling recent-form windows and a volatility (dispersion) measure of team performance — computed walk-forward from games before the prediction week only.
+- R3. Every candidate is leak-free: its value for week W uses only information available before W, and early-season sparsity follows the substrate's existing fallback conventions.
+
+**Evaluation and adoption**
+
+- R4. Evaluate candidates by refitting the production model walk-forward with candidates included and comparing held-out backtest results against the current production baseline.
+- R5. Adopt a candidate only if held-out MAE improves and neither Brier nor ATS hit rate degrades; otherwise reject it.
+- R6. Record every tested candidate's verdict and metrics durably so rejected candidates are not unknowingly retried. A fully null result — no candidate passes — is a valid completion state.
+
+**Production integration**
+
+- R7. Adopted features enter the production substrate and daily automation as a full refit of all stored fit vintages; there is no partial-rollout path for a changed feature list.
+- R8. Prediction history stays append-only and comparable across the transition: predictions from the old and new fits must be distinguishable in stored predictions.
+
+**Optional calibration experiment**
+
+- R9. (Optional) Test volatility-modulated win-probability calibration — volatile matchups receive flatter probabilities, stable ones sharper — under the same adoption discipline with Brier as the primary metric and no MAE or ATS degradation. Dropping R9 does not affect R1–R8.
+
+### Key Flows
+
+- F1. Candidate evaluation
+  - **Trigger:** A candidate concept is defined from R1 or R2.
+  - **Steps:** Build the candidate as an as-of substrate column; refit walk-forward with the candidate included; compare held-out backtest metrics to the production baseline; apply the R5 gate; ship via full refit or record the rejection.
+  - **Outcome:** The production model only ever changes through a gated, recorded experiment.
+  - **Covers:** R3, R4, R5, R6, R7.
+
+### Acceptance Examples
+
+- AE1. **Covers R4, R5, R7.** Given a candidate whose refit improves held-out MAE with Brier and ATS flat, when the gate is applied, then the candidate ships into the substrate and all fit vintages are refit.
+- AE2. **Covers R5, R6.** Given a candidate that improves MAE but degrades ATS, when the gate is applied, then the candidate is rejected and its metrics are recorded.
+- AE3. **Covers R3.** Given week 2 of a season with one prior game for a team, when trajectory candidates are computed, then values follow the substrate's existing fallback conventions rather than leaking later-season data.
+- AE4. **Covers R9.** Given the calibration experiment improves held-out Brier without degrading MAE or ATS, when its gate is applied, then it ships as a calibration-layer change with the margin model untouched.
+
+### Scope Boundaries
+
+**Deferred for later** (separate workstreams — see How This Work Fits Together):
+
+- dlt pipeline audit against the Builder Pack's API-efficiency guides and checklists.
+- AI-context upgrade from the packs' shipped context files and OpenAPI context generator.
+- Curated-data use (cross-validation of the warehouse, test fixtures).
+- Team-similarity analytics (Starter Pack notebook 04) — cfb-app surface territory, not a model input.
+- Automating the R5 gate into backtest tooling — `scripts/check_backtest.py` stays read-only reporting.
+
+**No action:**
+
+- Superseded notebook methods (simple rankings, basic opponent adjustments, SRS variants, logistic matchup predictor) — house implementations are strictly stronger.
+- A live 2026 challenger model (rejected in KD1).
+- The CFBD Model Training Pack — a separate product that was not purchased.
+
+<!-- ce-section: work-relationships -->
+### How This Work Fits Together
+
+This plan owns the modeling-methodology area of the three-packet review. The breakdown below is the current understanding of the surrounding work, not a committed roadmap; later plans may revise or discard it.
+
+- dlt pipeline audit — can proceed independently of this plan; draws on the AI Builder Pack's efficiency guides and audit checklists.
+- AI-context upgrade — can proceed independently of this plan; draws on the Builder Pack context files and OpenAPI context generator.
+- Curated-data use — still to decide whether it is worth doing at all; if pursued, it shares the existing flat-file loading precedent and could enable warehouse cross-validation.
+
+### Dependencies / Assumptions
+
+- Warehouse drive data carries starting field position and drive results sufficient for R1's candidates.
+- The feature substrate is built as-of/walk-forward and currently carries 40 columns; adding candidates means a schema migration plus a backfill rebuild.
+- Changing the production feature list invalidates every stored fit vintage and forces a full refit; this path has been exercised before (the list previously grew from 15 to 20 features), so R7 follows precedent rather than breaking new ground.
+- Backtest tooling reports MAE, Brier, and ATS but intentionally never fails a gate itself; the R5 gate is a decision rule applied to its report.
+- The existing candidate-feature screen operates at season grain (preseason inputs only) and cannot screen weekly in-season candidates as-is.
+- Win-probability calibration is a per-fit scalar transform applied per game, so per-game modulation (R9) is architecturally plausible.
+
+### Sources / Research
+
+- CFBD Starter Pack 2026 Preseason Edition — notebooks `07_drive_efficiency.ipynb` (points per drive, field-position buckets) and `13_weekly_team_trajectory.ipynb` (rolling 4-game form, weekly PPA standard deviation), in the downloaded packet folder `artifacts-2` in the user's Downloads. The other two packets (AI API Launchpad, AI Builder Pack) were triaged; their value routes to the deferred workstreams above.
+- Repo anchors for the planner: `scripts/build_features.py` (as-of substrate build), `scripts/train_model.py` (feature list and the full-refit invalidation rule), `scripts/check_backtest.py` (MAE/Brier/ATS reporting), `scripts/score_fitted.py` (calibration application), `src/schemas/api/025_game_drives.sql` (drive data surface), `src/schemas/migrations/028_features_schema.sql` (substrate schema and fit-vintage keys).
+
+---
+
+## Planning Contract
+
+**Product Contract preservation:** unchanged, except the former Outstanding Questions section — all four deferred-to-planning questions are resolved by KTD1–KTD7 below and one scope line added to Scope Boundaries (gate automation deferred). No scope change.
+
+### Key Technical Decisions
+
+- KTD1. **A pre-registered in-season screen precedes the migration** (session-settled: user-approved — chosen over going straight to refit-and-compare: the repo's column contract requires every candidate to clear a recorded screen before shipping into `features.team_week`, and the existing screen is preseason/season-grain only). A new harness screens candidates at as-of week grain with the same pre-registered discipline as `scripts/screen_preseason_features.py` (|partial_r| >= 0.08 floor, Benjamini-Hochberg FDR 0.10, run once, verdicts recorded). Covers R6.
+- KTD2. **The gate comparison runs isolated; adoption rides the self-healing refit** (session-settled: user-approved — chosen over refitting production directly: protects stored fits and prediction history during evaluation). The candidate refit fits in-memory and never writes `features.model_coefficients` / `features.model_metadata` under `fitted_v1`. Adoption = merging the `DIFF_FEATURE_COLUMNS` change; `train_model.py --refit-if-stale` detects the feature-set mismatch by set equality and rebuilds every vintage on the next daily run. `MODEL_VERSION` stays `fitted_v1`, matching the 15→20 precedent. Covers R4, R5, R7, R8.
+- KTD3. **Rejected candidates' columns stay in the substrate, documented** (session-settled: user-approved — chosen over drop-on-rejection: 20 of `team_week`'s 40 columns already sit outside the model, so substrate-only columns are precedented; dropping adds migration churn). Verdicts recorded in the design-doc amendment satisfy R6.
+- KTD4. **Candidate pool is six columns** (session-settled: user-approved): offensive points per drive, defensive points per drive allowed, offensive average starting field position, defensive average starting field position allowed (all season-to-date as-of), last-4-game net-rating form delta (recent minus season-to-date), and to-date weekly net-rating volatility (standard deviation). The screen prunes from this pool; the form window may vary from 4 only if the screen's pre-registration says so up front. Covers R1, R2.
+- KTD5. **The R5 gate stays a human-applied decision rule over the comparison report** (session-settled: user-approved — chosen over automating into `check_backtest.py`: that script is read-only reporting by design). Covers R5.
+- KTD6. **Drive points come from score-delta columns, not `drive_result` estimates.** `core.drives` carries `start_offense_score` / `end_offense_score`; their difference gives exact drive points, unlike `marts.scoring_opportunities`' TD=7/FG=3 estimates. Validate the delta against estimates during U3; fall back per the Goal Capsule stop condition if unreliable. Covers R1.
+- KTD7. **Trajectory candidates compute from per-week performance aggregates under the substrate's maturity conventions.** The last-4-game form component derives from the per-week EPA aggregates the substrate build already computes (the `off_week_agg`/`def_week_agg` CTE pattern in `scripts/build_features.py`), and volatility is the dispersion of that per-week series — not the `analytics.adjusted_epa_week_build` coefficients, which are cumulative season-to-date fits and cannot yield a genuine recent-form or performance-volatility measure. Candidates apply the `MIN_TEAM_PLAYS = 150` maturity gate and are NULL early-season per the design doc's NULL-never-0 rule (the model imputes frozen train-window means). Covers R3.
+
+### High-Level Technical Design
+
+```mermaid
+flowchart TB
+  A[Six candidate concepts - KTD4] --> B[U1: In-season screen<br/>pre-registered thresholds]
+  B -->|survivors| C[U2: Design-doc amendment<br/>+ migration 048]
+  B -->|rejected| R1[Verdicts recorded in design doc]
+  C --> D[U3: build_features.py as-of<br/>computation + 2015+ backfill]
+  D --> E[U4: Isolated walk-forward refit<br/>held-out MAE / Brier / ATS vs baseline]
+  E -->|gate passes| F[U5: DIFF_FEATURE_COLUMNS merge]
+  E -->|gate fails| R2[Verdicts recorded;<br/>columns stay substrate-only - KTD3]
+  F --> G[Daily run: refit-if-stale rebuilds all vintages<br/>backtest re-measures, verify_load gates]
+  D -.-> H[U6 optional: volatility-modulated<br/>calibration experiment - R9]
+```
+
+Three files must move together at adoption (the 042/046/047 precedent): the migration, `scripts/build_features.py` (`FEATURE_ROWS_QUERY` + `_INSERT_COLUMNS`), and `scripts/train_model.py` (`DIFF_FEATURE_COLUMNS`) — U2/U3 land the first two ahead of the gate; U5 lands the third only on gate pass.
+
+### Assumptions
+
+- `tune_params.py` does not need re-running: it tunes Elo/EPA hyperparameters, not the feature set; ridge alpha selection happens inside `train_model.py`.
+- The full 2015+ backfill rebuild (~10,500 team-week rows) is a routine `build_features.py` run, per the 042/046/047 precedent.
+- The daily workflow (`.github/workflows/daily-load.yml`) needs no changes: `--incremental` build, `--refit-if-stale`, `backtest_preseason.py`, and `verify_load.py` already sequence correctly for a feature-set change.
+
+### Open Questions (deferred to implementation)
+
+- R9's functional form (e.g., volatility-scaled Platt slope vs. a second calibration stage) — U6 decides after prototyping; frozen-parameter, leak-free application is the constraint.
+
+---
+
+## Implementation Units
+
+### U1. In-season candidate screen
+
+- **Goal:** Screen the six KTD4 candidates at as-of week grain with pre-registered thresholds, producing recorded verdicts.
+- **Requirements:** R1, R2, R6; KTD1, KTD4.
+- **Dependencies:** None.
+- **Files:** `scripts/screen_week_features.py` (new), `tests/test_screen_week_features.py` (new).
+- **Approach:**
+  1. Build the candidate frame in-memory at (game, team, week) grain, reusing `build_features.py` helpers (`leak_free_week_index`, the adjusted-EPA week-row fetch) — no substrate writes.
+  2. Compute each candidate as-of per game, then partial correlation with home margin controlling for the current model's expected margin — importing the statistical core from `scripts/screen_preseason_features.py` (partial correlation, p-value, BH-FDR, verdict rule) rather than duplicating it, so a future fix to the math applies to both screens.
+  3. Apply the pre-registered decision rule (|partial_r| >= 0.08, BH-FDR 0.10) via the imported functions; emit a verdict table with partials for every candidate, rejected included.
+- **Patterns to follow:** `scripts/screen_preseason_features.py` (pre-registration framing, verdict output); import its statistical functions directly, the same reuse pattern `tests/test_screen_features.py` already uses.
+- **Test scenarios:**
+  - Partial correlation on synthetic data matches a hand-computed value.
+  - Leak boundary: a candidate value for week W built from a series including week W raises or is excluded (strict `week_index < W`).
+  - BH-FDR gating: a candidate below the floor or failing FDR is marked rejected, not dropped from output.
+  - Verdict table includes all six candidates with numeric partials.
+- **Verification:** Screen runs against the warehouse and prints verdicts for all six candidates; verdicts are stable across re-runs on the same data.
+
+### U2. Design-doc amendment and migration 048
+
+- **Goal:** Amend the team-week design contract and add survivor columns to `features.team_week`.
+- **Requirements:** R1, R2, R6; KTD3.
+- **Dependencies:** U1.
+- **Files:** `docs/brainstorms/2026-07-21-team-week-feature-design.md`, `src/schemas/migrations/048_team_week_drive_trajectory.sql` (new).
+- **Approach:**
+  1. Amend the design doc first (migration 028's column contract): section 1f rows, 1i NULL rules, 2a vector positions, and the stated column count; record U1's rejected candidates with their partials in the same amendment.
+  2. Write migration 048 mirroring 042/046/047: idempotent `ALTER TABLE features.team_week ADD COLUMN IF NOT EXISTS` plus `COMMENT ON COLUMN` carrying the screened partial-r and NULL rule.
+  3. Apply via `run_migrations.py --file` and add to the deploy manifest like 041–047 (not `MIGRATION_ORDER`).
+- **Patterns to follow:** `src/schemas/migrations/042_team_week_preseason_columns.sql` (header contract language, comment shape).
+- **Test scenarios:** Test expectation: none — idempotent schema-only migration; column presence is exercised by U3's build and tests.
+- **Verification:** Migration applies twice without error; design-doc column count matches `features.team_week`'s actual column count.
+
+### U3. As-of computation and 2015+ backfill
+
+- **Goal:** Compute survivor columns leak-free in `build_features.py` and backfill all substrate seasons.
+- **Requirements:** R1, R2, R3; KTD4, KTD6, KTD7.
+- **Dependencies:** U2.
+- **Files:** `scripts/build_features.py`, `tests/test_build_features.py`.
+- **Approach:**
+  1. Drive columns: add a week-bucketed drives CTE off `core.drives` joined to `core.games` for `week_index`, plus lateral joins on the spine filtered `week_index < s.week_index`, mirroring the `off_week_agg`/`def_week_agg` pattern (`scripts/build_features.py:426-447`, `:628-654`); points per KTD6 score-delta; offense and defense sides.
+  2. Trajectory columns: new pure resolver over the per-week EPA performance aggregates (extend the `off_week_agg`/`def_week_agg` CTE pattern to expose the per-week series), computing the last-4-game form measure and to-date standard deviation per KTD7 — not from the cumulative `analytics.adjusted_epa_week_build` series.
+  3. Append the new columns to `_INSERT_COLUMNS` before `feature_build_version`.
+  4. Run the full 2015+ backfill rebuild; CI's `--incremental` path needs no changes.
+- **Patterns to follow:** `resolve_adj_epa` fallback ladder (`scripts/build_features.py:165-220`); NULL-never-0 rule (design doc section 1i).
+- **Test scenarios:**
+  - Form delta and volatility on a synthetic week series match hand-computed values.
+  - Strict leak boundary: the team's own week-W row is excluded from week-W values.
+  - Maturity gate: series below `MIN_TEAM_PLAYS` yields NULL, not 0.
+  - Empty series (week 1, no prior season rows in scope) yields NULL for trajectory columns.
+  - Drive PPD from score deltas matches expected values on synthetic drives, including a defensive-score drive that the TD=7/FG=3 estimate would misprice.
+- **Verification:** Full rebuild completes; a coverage query shows non-NULL drive columns for all seasons 2015+ where drives exist; spot-checks confirm no same-week data in as-of values.
+
+### U4. Isolated walk-forward evaluation and gate
+
+- **Goal:** Produce the held-out MAE/Brier/ATS comparison between the candidate feature list and the production baseline, and record the gate verdict.
+- **Requirements:** R4, R5, R6; KTD2, KTD5.
+- **Dependencies:** U3.
+- **Files:** `scripts/train_model.py` (new no-write evaluation mode, e.g. a `--evaluate-candidates` flag); `tests/test_candidate_evaluation.py` (new).
+- **Approach:**
+  1. Add an evaluation mode to `train_model.py` that reuses its fitting functions in-memory with the candidate `DIFF_FEATURE_COLUMNS` list, walking forward over the same vintages as the canonical fits — a mode, not a new script, so there is no duplicate fitting harness to keep in sync (per KTD2's reuse intent).
+  2. Score held-out games from as-of-game-day weekly feature vectors — not the preseason week-1 path, which leaves trajectory candidates NULL by design — and compute held-out margin MAE, Brier, and ATS per season and aggregated for `scope='fbs'`.
+  3. Emit a comparison report against the production model's per-game accuracy aggregates in `marts.prediction_accuracy` (the metrics `scripts/check_backtest.py` reports: `margin_mae`, `brier`, `ats_hit_rate`); state the R5 gate verdict explicitly per candidate set.
+  4. Record the verdict and metrics in the U2 design-doc amendment.
+- **Execution note:** The evaluation must never write `features.model_coefficients` or `features.model_metadata` under `fitted_v1` — guard this with a test.
+- **Test scenarios:**
+  - Gate logic: MAE improves + Brier/ATS flat → pass; MAE improves + ATS degrades → fail; MAE flat → fail.
+  - Comparison uses identical seasons and scope as the canonical baseline row.
+  - No-write guard: evaluation run performs no INSERT/UPDATE on model tables.
+- **Verification:** Report shows per-metric deltas and an explicit pass/fail verdict; design doc carries the recorded outcome.
+
+### U5. Adoption integration (gate-pass only)
+
+- **Goal:** Ship gate-passing features into the production model through the self-healing refit path.
+- **Requirements:** R5, R7, R8; KTD2.
+- **Dependencies:** U4.
+- **Files:** `scripts/train_model.py`, `tests/test_fitted_model.py`.
+- **Approach:**
+  1. Add survivor `(feature_name, team_week_column)` tuples to `DIFF_FEATURE_COLUMNS`; correct the stale "18 diffs" count comment.
+  2. Update the contract and staleness test suites (feature counts, index lookups, the fit-missing-new-column staleness assertion at `tests/test_fitted_model.py:368-425`).
+  3. Merge; the next daily run's `--refit-if-stale` rebuilds every vintage, `backtest_preseason.py` re-measures, and `verify_load.py`'s coverage (>=90%) and backtest-freshness gates confirm the transition.
+- **Patterns to follow:** the migration-042 adoption commit shape (migration + build + train landing as one deploy).
+- **Test scenarios:**
+  - Staleness suite: a stored fit missing a new column is detected stale and excluded from `existing`.
+  - `FEATURE_NAMES` count and ordering match the updated list; `score_fitted`'s imported `TEAM_WEEK_SOURCE_COLUMNS` stays aligned.
+- **Verification:** Daily run goes green end-to-end: full retrain, coverage gate, backtest freshness gate; the new canonical backtest row is consistent with U4's evaluation.
+
+### U6. Volatility-modulated calibration experiment (optional)
+
+- **Goal:** Test whether per-game volatility modulation of the win-probability calibration improves held-out Brier.
+- **Requirements:** R9; KD5.
+- **Dependencies:** U3 (volatility column), U4 (harness code to extend) — independent of U4's gate verdict, not of its existence.
+- **Files:** `scripts/evaluate_volatility_calibration.py` (new); production files only on gate pass (`scripts/score_fitted.py`, `scripts/train_model.py` Platt handling).
+- **Approach:** Directional guidance, not specification — extend the U4 harness: replace the scalar Platt transform with a volatility-conditioned variant (e.g., slope term `a(v) = a0 + a1 * matchup_volatility` fitted on the train window), compare held-out Brier against the scalar baseline, and require Brier improvement with MAE and ATS unaffected. Ship a production change only on a pass; otherwise record the verdict and stop.
+- **Execution note:** Modulation parameters must be frozen per train vintage — no per-game fitting at scoring time.
+- **Test scenarios:**
+  - Reduces exactly to scalar Platt when the volatility term is zero.
+  - Applied probabilities use only frozen parameters and as-of volatility (leak check).
+  - Gate logic: Brier improves + MAE/ATS flat → pass; otherwise fail.
+- **Verification:** Report with Brier delta and explicit verdict; recorded outcome regardless of result.
+
+---
+
+## Verification Contract
+
+| Gate | Command | Applies to |
+|---|---|---|
+| Lint | `.venv/bin/ruff check .` | All units |
+| Format | `.venv/bin/ruff format --check .` | All units |
+| Tests | `.venv/bin/pytest -q` | All units |
+| Migration idempotence | `python scripts/run_migrations.py --file src/schemas/migrations/048_team_week_drive_trajectory.sql` (twice) | U2 |
+| Substrate rebuild | `python scripts/build_features.py` (full), then coverage query | U3 |
+| Evaluation report | candidate evaluation run with explicit gate verdict | U4, U6 |
+| Deploy gates | `python scripts/verify_load.py` after the first post-merge daily run | U5 |
+
+The pre-push hook (`.githooks/pre-push`) runs ruff + pytest; all three lint/format/test gates must pass before any push.
+
+---
+
+## Definition of Done
+
+- All six candidates screened with verdicts and partials recorded in the design-doc amendment (U1, U2).
+- Survivor columns migrated, documented, and backfilled 2015+ with leak-free tests green (U2, U3).
+- The gated evaluation report exists with an explicit per-metric verdict recorded (U4).
+- On gate pass: feature list merged, contract tests updated, and the next daily run green through retrain, coverage, and backtest-freshness gates (U5). On gate fail: verdicts recorded and columns documented as substrate-only — this is valid completion.
+- U6 either delivers its verdict report or is explicitly dropped without blocking R1–R8.
+- Dead-end experimental code from rejected approaches is removed from the final diff.
+- Feature branch pushed with lint, format, and tests green.

--- a/scripts/screen_week_features.py
+++ b/scripts/screen_week_features.py
@@ -22,13 +22,24 @@ does the warehouse scans and week bucketing; the pure helpers below keep the
 leak boundary and the small-sample rules directly testable without a database.
 A run whose frame or per-candidate sample falls below the coverage floors
 fails loudly as UNTESTABLE rather than reporting rejections.
+
+Control modes:
+  - v1 = the pre-registered 2026-07-28 run: Elo + adj_epa_net controls over
+    2015-2025.
+  - v2 amendment = the same |partial_r| >= 0.08 floor and the same
+    Benjamini-Hochberg FDR q=0.10, run once, using a first-order partial
+    correlation controlling for fitted_v1's frozen walk-forward expected
+    margin; its window is restricted to seasons with a stored prior vintage.
+
+The v2 amendment was pre-registered 2026-07-28 in response to the PR #59
+review before any v2 run.
 """
 
 import argparse
 import math
 import sys
 from collections import defaultdict
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from statistics import pstdev
 from typing import Any
 
@@ -37,16 +48,22 @@ from scripts.build_features import (
     compute_week_index,
     leak_free_week_index,
 )
+from scripts.score_fitted import (
+    fetch_available_train_through,
+    load_fit,
+    score_game,
+)
 from scripts.screen_preseason_features import (
     FDR_ALPHA,
     MIN_PARTIAL_R,
     benjamini_hochberg,
     complete_cases,
     partial_corr_pvalue,
+    partial_correlation,
     screen_verdict,
     second_order_partial_correlation,
 )
-from scripts.train_model import DIFF_FEATURE_COLUMNS
+from scripts.train_model import DIFF_FEATURE_COLUMNS, TEAM_WEEK_SOURCE_COLUMNS
 
 DEFAULT_START_SEASON = 2015
 DEFAULT_END_SEASON = 2025
@@ -62,7 +79,11 @@ CANDIDATE_COLUMNS = (
 
 CONTROL_ELO = "elo_diff"
 CONTROL_ADJ_EPA_NET = "adj_epa_net_diff"
+CONTROL_MODEL_MARGIN = "model_margin"
 SCREEN_CONTROLS = (CONTROL_ELO, CONTROL_ADJ_EPA_NET)
+CONTROL_MODE_FEATURES = "features"
+CONTROL_MODE_MODEL_MARGIN = "model-margin"
+CONTROL_MODES = (CONTROL_MODE_FEATURES, CONTROL_MODE_MODEL_MARGIN)
 
 
 def _diff_source_column(feature_name: str) -> str:
@@ -303,9 +324,36 @@ def build_screen_frame(
                 for candidate in CANDIDATE_COLUMNS
             }
         )
+        if CONTROL_MODEL_MARGIN in game:
+            row[CONTROL_MODEL_MARGIN] = game[CONTROL_MODEL_MARGIN]
         frame.append(row)
 
     return frame
+
+
+def build_model_margin_frame(
+    games: Iterable[Mapping[str, Any]],
+    drives: Iterable[Mapping[str, Any]],
+    weekly_net_epa: Iterable[Mapping[str, Any]],
+    fits_by_train_through: Mapping[int, Mapping[str, Any]],
+    scorer: Callable[[dict[str, Any], Mapping[str, Any]], tuple[float, float]] = score_game,
+) -> list[dict[str, Any]]:
+    """Build the v2 frame using each season's frozen prior fitted margin.
+
+    A game is omitted when ``season - 1`` has no stored vintage. ``scorer`` is
+    injectable solely to keep this filtering/wiring path pure in unit tests;
+    production passes the imported ``score_fitted.score_game`` function.
+    """
+    scored_games: list[dict[str, Any]] = []
+    for game in games:
+        train_through = int(game["season"]) - 1
+        fit = fits_by_train_through.get(train_through)
+        if fit is None:
+            continue
+        scored_game = dict(game)
+        scored_game[CONTROL_MODEL_MARGIN] = float(scorer(scored_game, fit)[0])
+        scored_games.append(scored_game)
+    return build_screen_frame(scored_games, drives, weekly_net_epa)
 
 
 def apply_verdicts(results: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
@@ -327,12 +375,17 @@ def apply_verdicts(results: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]
     return rows
 
 
-def screen_frame(frame: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def screen_frame(
+    frame: list[dict[str, Any]], control_mode: str = CONTROL_MODE_FEATURES
+) -> list[dict[str, Any]]:
     """Screen each candidate on its own complete-case game sample."""
+    if control_mode not in CONTROL_MODES:
+        raise ValueError(f"unknown control mode {control_mode!r}")
+
+    controls = SCREEN_CONTROLS if control_mode == CONTROL_MODE_FEATURES else (CONTROL_MODEL_MARGIN,)
     raw_results: list[dict[str, Any]] = []
-    needed_controls = list(SCREEN_CONTROLS)
     for candidate in CANDIDATE_COLUMNS:
-        rows = complete_cases(frame, ["home_margin", *needed_controls, candidate])
+        rows = complete_cases(frame, ["home_margin", *controls, candidate])
         n_games = len(rows)
         if n_games < 3:
             partial_r = 0.0
@@ -340,10 +393,16 @@ def screen_frame(frame: list[dict[str, Any]]) -> list[dict[str, Any]]:
         else:
             x = [float(row[candidate]) for row in rows]
             y = [float(row["home_margin"]) for row in rows]
-            elo = [float(row[CONTROL_ELO]) for row in rows]
-            adj_epa_net = [float(row[CONTROL_ADJ_EPA_NET]) for row in rows]
-            partial_r = second_order_partial_correlation(x, y, elo, adj_epa_net)
-            p_value = partial_corr_pvalue(partial_r, n_games, n_controls=2)
+            if control_mode == CONTROL_MODE_FEATURES:
+                elo = [float(row[CONTROL_ELO]) for row in rows]
+                adj_epa_net = [float(row[CONTROL_ADJ_EPA_NET]) for row in rows]
+                partial_r = second_order_partial_correlation(x, y, elo, adj_epa_net)
+                n_controls = 2
+            else:
+                model_margin = [float(row[CONTROL_MODEL_MARGIN]) for row in rows]
+                partial_r = partial_correlation(x, y, model_margin)
+                n_controls = 1
+            p_value = partial_corr_pvalue(partial_r, n_games, n_controls=n_controls)
         raw_results.append(
             {
                 "candidate": candidate,
@@ -356,15 +415,22 @@ def screen_frame(frame: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
 
 FBS_INVOLVED = "(g.home_classification = 'fbs' OR g.away_classification = 'fbs')"
+_HOME_TEAM_WEEK_COLUMNS = ",\n           ".join(
+    f"h.{column} AS home_{column}" for column in TEAM_WEEK_SOURCE_COLUMNS
+)
+_AWAY_TEAM_WEEK_COLUMNS = ",\n           ".join(
+    f"a.{column} AS away_{column}" for column in TEAM_WEEK_SOURCE_COLUMNS
+)
 
 GAMES_QUERY = f"""
     SELECT g.id AS game_id, g.season, g.season_type, g.week,
            g.home_team, g.away_team, g.home_points, g.away_points,
+           g.neutral_site,
            COALESCE(g.completed, false) AS completed,
-           h.{ELO_SOURCE_COLUMN} AS home_elo_pregame,
-           a.{ELO_SOURCE_COLUMN} AS away_elo_pregame,
            h.{ADJ_EPA_NET_SOURCE_COLUMN} AS home_adj_epa_net,
-           a.{ADJ_EPA_NET_SOURCE_COLUMN} AS away_adj_epa_net
+           a.{ADJ_EPA_NET_SOURCE_COLUMN} AS away_adj_epa_net,
+           {_HOME_TEAM_WEEK_COLUMNS},
+           {_AWAY_TEAM_WEEK_COLUMNS}
     FROM core.games g
     JOIN features.team_week h
       ON h.game_id = g.id AND h.team = g.home_team
@@ -455,6 +521,17 @@ def get_db_url() -> str:
     return url
 
 
+def _rows_to_screen_games(raw: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Add the nested team-week shape expected by score_fitted.score_game."""
+    games: list[dict[str, Any]] = []
+    for source in raw:
+        row = dict(source)
+        row["home_tw"] = {column: row[f"home_{column}"] for column in TEAM_WEEK_SOURCE_COLUMNS}
+        row["away_tw"] = {column: row[f"away_{column}"] for column in TEAM_WEEK_SOURCE_COLUMNS}
+        games.append(row)
+    return games
+
+
 def fetch_screen_inputs(
     conn: Any, start_season: int, end_season: int
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
@@ -464,7 +541,7 @@ def fetch_screen_inputs(
     params = {"start_season": start_season, "end_season": end_season}
     with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
         cur.execute(GAMES_QUERY, params)
-        games = [dict(row) for row in cur.fetchall()]
+        games = _rows_to_screen_games(cur.fetchall())
         cur.execute(DRIVES_QUERY, params)
         drives = [dict(row) for row in cur.fetchall()]
         cur.execute(EPA_QUERY, params)
@@ -472,8 +549,18 @@ def fetch_screen_inputs(
     return games, drives, weekly_net_epa
 
 
-def report(results: Iterable[Mapping[str, Any]]) -> None:
-    """Print every candidate, including rejected candidates and their numbers."""
+def report(
+    results: Iterable[Mapping[str, Any]],
+    control_mode: str = CONTROL_MODE_FEATURES,
+    effective_seasons: Iterable[int] = (),
+) -> None:
+    """Print mode/window metadata and every candidate, including rejections."""
+    seasons = sorted(set(effective_seasons))
+    effective_window = f"{seasons[0]}-{seasons[-1]}" if seasons else "none"
+    print(
+        f"CONTROL_MODE mode={control_mode} effective_window={effective_window} "
+        f"seasons={','.join(str(season) for season in seasons) or 'none'}"
+    )
     print(
         "candidate                 n_games   partial_r   p_value     bh_q  "
         "bh_pass floor_pass verdict"
@@ -487,6 +574,19 @@ def report(results: Iterable[Mapping[str, Any]]) -> None:
             f"{p_value:>10} {bh_q:>8} {str(row['bh_pass']):>8} "
             f"{str(row['floor_pass']):>10} {row['verdict']:>7}"
         )
+
+
+def load_model_margin_fits(
+    conn: Any, start_season: int, end_season: int
+) -> dict[int, dict[str, Any]]:
+    """Load the frozen prior vintage needed by each requested game season."""
+    available = fetch_available_train_through(conn)
+    train_through_seasons = sorted(
+        train_through
+        for train_through in available
+        if start_season - 1 <= train_through <= end_season - 1
+    )
+    return {train_through: load_fit(conn, train_through) for train_through in train_through_seasons}
 
 
 # Coverage floors: below these, a run is UNTESTABLE, never a rejection. A
@@ -513,10 +613,22 @@ def assert_screen_coverage(frame: list[dict[str, Any]], results: list[dict[str, 
         )
 
 
-def main() -> None:
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser separately so its defaults stay unit-testable."""
     parser = argparse.ArgumentParser(description="Screen in-season team-week features")
     parser.add_argument("--start-season", type=int, default=DEFAULT_START_SEASON)
     parser.add_argument("--end-season", type=int, default=DEFAULT_END_SEASON)
+    parser.add_argument(
+        "--control-mode",
+        choices=CONTROL_MODES,
+        default=CONTROL_MODE_FEATURES,
+        help="features=pre-registered Elo/EPA controls; model-margin=v2 frozen margin control",
+    )
+    return parser
+
+
+def main() -> None:
+    parser = build_arg_parser()
     args = parser.parse_args()
     if args.start_season > args.end_season:
         parser.error("--start-season cannot be after --end-season")
@@ -528,10 +640,14 @@ def main() -> None:
         games, drives, weekly_net_epa = fetch_screen_inputs(
             conn, args.start_season, args.end_season
         )
-        frame = build_screen_frame(games, drives, weekly_net_epa)
-        results = screen_frame(frame)
+        if args.control_mode == CONTROL_MODE_MODEL_MARGIN:
+            fits = load_model_margin_fits(conn, args.start_season, args.end_season)
+            frame = build_model_margin_frame(games, drives, weekly_net_epa, fits)
+        else:
+            frame = build_screen_frame(games, drives, weekly_net_epa)
+        results = screen_frame(frame, args.control_mode)
         assert_screen_coverage(frame, results)
-        report(results)
+        report(results, args.control_mode, (row["season"] for row in frame))
     finally:
         conn.close()
 

--- a/scripts/screen_week_features.py
+++ b/scripts/screen_week_features.py
@@ -1,14 +1,27 @@
 #!/usr/bin/env python3
-# ruff: noqa: E501
 """Screen candidate in-season features for ``features.team_week``.
 
-Pre-registration: decision rule is |partial_r| >= 0.08 AND Benjamini-Hochberg FDR q = 0.10 across the six candidates, run once; outcome variable is home margin (home points minus away points); controls are the model's two dominant existing features as home-minus-away diffs — Elo pregame and adjusted-EPA net — read from features.team_week (resolve the exact column names from DIFF_FEATURE_COLUMNS in scripts/train_model.py: the elo entry and the adjusted-EPA net entry).
+Pre-registration: decision rule is |partial_r| >= 0.08 AND Benjamini-Hochberg
+FDR q = 0.10 across the six candidates, run once; outcome variable is home
+margin (home points minus away points); controls are the model's two dominant
+existing features as home-minus-away diffs — Elo pregame (resolved from the
+``d_elo`` entry in ``DIFF_FEATURE_COLUMNS``) and the substrate's
+``adj_epa_net`` column read directly from ``features.team_week`` (the deployed
+model carries adjusted EPA as separate off/def diffs, so the net column has no
+``DIFF_FEATURE_COLUMNS`` entry).
+
+Trajectory maturity is operationalized as week-row gates (>= 4 prior weeks for
+form, >= 2 for volatility), not the substrate's ``MIN_TEAM_PLAYS`` play-count
+gate — see the 2026-07-28 entry in the team-week design doc for the disclosed
+difference.
 
 The screen is read-only. Candidate values are computed from completed FBS-
 involved games and are strictly as-of: a team-week keyed at ``week_index=W``
 can use only rows with ``week_index < W`` in the same season. The SQL query
 does the warehouse scans and week bucketing; the pure helpers below keep the
 leak boundary and the small-sample rules directly testable without a database.
+A run whose frame or per-candidate sample falls below the coverage floors
+fails loudly as UNTESTABLE rather than reporting rejections.
 """
 
 import argparse
@@ -65,20 +78,12 @@ def _diff_source_column(feature_name: str) -> str:
 
 ELO_SOURCE_COLUMN = _diff_source_column("d_elo")
 
-# The current train_model.py intentionally excludes adj_epa_net from
-# DIFF_FEATURE_COLUMNS because the deployed model uses adj_epa_off and
-# adj_epa_def separately. The feature-table contract in build_features.py
-# still writes the exact net column, so use that confirmed warehouse name and
-# retain this mismatch as an explicit module-level fact rather than silently
-# selecting one of the two component columns.
-ADJ_EPA_NET_SOURCE_COLUMN = next(
-    (
-        column
-        for name, column in DIFF_FEATURE_COLUMNS
-        if name in {"d_adj_epa_net", "adj_epa_net"} or column == "adj_epa_net"
-    ),
-    "adj_epa_net",
-)
+# train_model.py intentionally has no adj_epa_net entry in
+# DIFF_FEATURE_COLUMNS: the deployed model carries adjusted EPA as separate
+# adj_epa_off/adj_epa_def diffs. The feature-table contract in
+# build_features.py still writes the exact net column, so the control reads
+# that warehouse column by its literal name.
+ADJ_EPA_NET_SOURCE_COLUMN = "adj_epa_net"
 
 
 def _finite(value: Any) -> bool:
@@ -375,7 +380,8 @@ GAMES_QUERY = f"""
 
 DRIVES_QUERY = f"""
     SELECT g.season, d.game_id, d.offense, d.defense,
-           CASE WHEN g.season_type = 'postseason' THEN {POSTSEASON_WEEK_OFFSET} + g.week ELSE g.week END
+           CASE WHEN g.season_type = 'postseason'
+                    THEN {POSTSEASON_WEEK_OFFSET} + g.week ELSE g.week END
                AS week_index,
            d.start_yards_to_goal, d.start_offense_score, d.end_offense_score
     FROM core.drives d
@@ -390,7 +396,8 @@ DRIVES_QUERY = f"""
 EPA_QUERY = f"""
     WITH plays_wi AS (
         SELECT g.season, pe.offense, pe.defense, pe.epa,
-               CASE WHEN g.season_type = 'postseason' THEN {POSTSEASON_WEEK_OFFSET} + g.week ELSE g.week END
+               CASE WHEN g.season_type = 'postseason'
+                    THEN {POSTSEASON_WEEK_OFFSET} + g.week ELSE g.week END
                    AS week_index
         FROM marts.play_epa pe
         JOIN core.games g ON g.id = pe.game_id
@@ -482,6 +489,30 @@ def report(results: Iterable[Mapping[str, Any]]) -> None:
         )
 
 
+# Coverage floors: below these, a run is UNTESTABLE, never a rejection. A
+# missing or partially built features.team_week would otherwise drain the
+# frame and let six hollow REJECT verdicts print on a green exit.
+MIN_FRAME_GAMES = 1000
+MIN_CANDIDATE_GAMES = 500
+
+
+def assert_screen_coverage(frame: list[dict[str, Any]], results: list[dict[str, Any]]) -> None:
+    """Fail loudly when the frame or any candidate sample is too thin to screen."""
+    if len(frame) < MIN_FRAME_GAMES:
+        raise RuntimeError(
+            f"UNTESTABLE: screen frame has {len(frame)} games "
+            f"(< {MIN_FRAME_GAMES}); check features.team_week and core.games "
+            "coverage before trusting any verdict"
+        )
+    thin = [r for r in results if r["n_games"] < MIN_CANDIDATE_GAMES]
+    if thin:
+        names = ", ".join(f"{r['candidate']} (n={r['n_games']})" for r in thin)
+        raise RuntimeError(
+            f"UNTESTABLE: candidate sample(s) below {MIN_CANDIDATE_GAMES} games: {names}; "
+            "verdicts withheld"
+        )
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Screen in-season team-week features")
     parser.add_argument("--start-season", type=int, default=DEFAULT_START_SEASON)
@@ -498,7 +529,9 @@ def main() -> None:
             conn, args.start_season, args.end_season
         )
         frame = build_screen_frame(games, drives, weekly_net_epa)
-        report(screen_frame(frame))
+        results = screen_frame(frame)
+        assert_screen_coverage(frame, results)
+        report(results)
     finally:
         conn.close()
 

--- a/scripts/screen_week_features.py
+++ b/scripts/screen_week_features.py
@@ -16,9 +16,14 @@ import math
 import sys
 from collections import defaultdict
 from collections.abc import Iterable, Mapping
+from statistics import pstdev
 from typing import Any
 
-from scripts.build_features import compute_week_index, leak_free_week_index
+from scripts.build_features import (
+    POSTSEASON_WEEK_OFFSET,
+    compute_week_index,
+    leak_free_week_index,
+)
 from scripts.screen_preseason_features import (
     FDR_ALPHA,
     MIN_PARTIAL_R,
@@ -66,13 +71,14 @@ ELO_SOURCE_COLUMN = _diff_source_column("d_elo")
 # still writes the exact net column, so use that confirmed warehouse name and
 # retain this mismatch as an explicit module-level fact rather than silently
 # selecting one of the two component columns.
-_ADJ_EPA_NET_ENTRIES = [
-    column
-    for name, column in DIFF_FEATURE_COLUMNS
-    if name in {"d_adj_epa_net", "adj_epa_net"} or column == "adj_epa_net"
-]
-ADJ_EPA_NET_SOURCE_COLUMN = _ADJ_EPA_NET_ENTRIES[0] if _ADJ_EPA_NET_ENTRIES else "adj_epa_net"
-ADJ_EPA_NET_ENTRY_MISSING_FROM_DIFF_CONTRACT = not bool(_ADJ_EPA_NET_ENTRIES)
+ADJ_EPA_NET_SOURCE_COLUMN = next(
+    (
+        column
+        for name, column in DIFF_FEATURE_COLUMNS
+        if name in {"d_adj_epa_net", "adj_epa_net"} or column == "adj_epa_net"
+    ),
+    "adj_epa_net",
+)
 
 
 def _finite(value: Any) -> bool:
@@ -97,26 +103,17 @@ def drive_points(drive: Mapping[str, Any]) -> float | None:
 def _prior_rows(
     rows: Iterable[Mapping[str, Any]],
     as_of_week_index: int,
-    season: int | None = None,
-    sorted_by_week_index: bool = False,
 ) -> list[Mapping[str, Any]]:
-    """Filter rows to the same season and strict pregame as-of boundary.
-
-    Grouped buckets are sorted, so they can stop at the first current/future
-    row. Raw helper callers leave the flag false and are scanned completely.
-    """
+    """Filter a sorted team bucket to the strict pregame as-of boundary."""
     prior: list[Mapping[str, Any]] = []
     for row in rows:
         week_index = row.get("week_index")
         if week_index is None:
             continue
         week_index = int(week_index)
-        if sorted_by_week_index and not leak_free_week_index(week_index, as_of_week_index):
+        if not leak_free_week_index(week_index, as_of_week_index):
             break
-        if season is not None and row.get("season") != season:
-            continue
-        if leak_free_week_index(week_index, as_of_week_index):
-            prior.append(row)
+        prior.append(row)
     return prior
 
 
@@ -198,29 +195,9 @@ def aggregate_bucketed_drive_features(
 ) -> dict[str, float | None]:
     """Aggregate only the two pre-grouped drive buckets for one team."""
     return _aggregate_drive_sides(
-        _prior_rows(offense_drives, as_of_week_index, sorted_by_week_index=True),
-        _prior_rows(defense_drives, as_of_week_index, sorted_by_week_index=True),
+        _prior_rows(offense_drives, as_of_week_index),
+        _prior_rows(defense_drives, as_of_week_index),
     )
-
-
-def aggregate_drive_features(
-    team: str,
-    as_of_week_index: int,
-    drives: Iterable[Mapping[str, Any]],
-    season: int | None = None,
-) -> dict[str, float | None]:
-    """Aggregate the four drive candidates for one team before a week.
-
-    The same drive can contribute to the offense and defense aggregates, but
-    each side is counted only once in its corresponding points-per-drive and
-    field-position mean. Missing score or field-position values are omitted
-    from that metric; if the team has no prior drive rows, all four values are
-    ``None`` as required by the maturity rule.
-    """
-    prior = _prior_rows(drives, as_of_week_index, season=season)
-    offense_drives = [row for row in prior if row.get("offense") == team]
-    defense_drives = [row for row in prior if row.get("defense") == team]
-    return _aggregate_drive_sides(offense_drives, defense_drives)
 
 
 def _form_and_volatility_from_prior(
@@ -235,27 +212,9 @@ def _form_and_volatility_from_prior(
 
     volatility = None
     if len(values) >= 2:
-        mean = sum(values) / len(values)
-        volatility = math.sqrt(sum((value - mean) ** 2 for value in values) / len(values))
+        volatility = pstdev(values)
 
     return form, volatility
-
-
-def compute_form_and_volatility(
-    weekly_net_epa: Iterable[Mapping[str, Any]],
-    as_of_week_index: int,
-) -> tuple[float | None, float | None]:
-    """Return last-four-minus-season-mean form and population volatility.
-
-    The input is already at ``(team, season, week_index)`` grain. The strict
-    ``week_index < as_of_week_index`` filter is applied here as a second line
-    of defense so callers cannot accidentally include the current game.
-    """
-    prior = [
-        row for row in _prior_rows(weekly_net_epa, as_of_week_index) if _finite(row.get("net_epa"))
-    ]
-    prior.sort(key=lambda row: int(row["week_index"]))
-    return _form_and_volatility_from_prior(prior)
 
 
 def compute_bucketed_form_and_volatility(
@@ -264,33 +223,9 @@ def compute_bucketed_form_and_volatility(
 ) -> tuple[float | None, float | None]:
     """Calculate EPA candidates from a sorted, team-specific bucket."""
     prior = [
-        row
-        for row in _prior_rows(
-            weekly_net_epa,
-            as_of_week_index,
-            sorted_by_week_index=True,
-        )
-        if _finite(row.get("net_epa"))
+        row for row in _prior_rows(weekly_net_epa, as_of_week_index) if _finite(row.get("net_epa"))
     ]
     return _form_and_volatility_from_prior(prior)
-
-
-def compute_as_of_features(
-    team: str,
-    as_of_week_index: int,
-    drives: Iterable[Mapping[str, Any]],
-    weekly_net_epa: Iterable[Mapping[str, Any]],
-    season: int | None = None,
-) -> dict[str, float | None]:
-    """Build all six candidate values for one team-week as-of row."""
-    result = aggregate_drive_features(team, as_of_week_index, drives, season=season)
-    form, volatility = compute_form_and_volatility(
-        [row for row in weekly_net_epa if season is None or row.get("season") == season],
-        as_of_week_index,
-    )
-    result["form_net_epa_last4"] = form
-    result["vol_net_epa"] = volatility
-    return result
 
 
 def compute_bucketed_as_of_features(
@@ -440,7 +375,7 @@ GAMES_QUERY = f"""
 
 DRIVES_QUERY = f"""
     SELECT g.season, d.game_id, d.offense, d.defense,
-           CASE WHEN g.season_type = 'postseason' THEN 100 + g.week ELSE g.week END
+           CASE WHEN g.season_type = 'postseason' THEN {POSTSEASON_WEEK_OFFSET} + g.week ELSE g.week END
                AS week_index,
            d.start_yards_to_goal, d.start_offense_score, d.end_offense_score
     FROM core.drives d
@@ -455,7 +390,7 @@ DRIVES_QUERY = f"""
 EPA_QUERY = f"""
     WITH plays_wi AS (
         SELECT g.season, pe.offense, pe.defense, pe.epa,
-               CASE WHEN g.season_type = 'postseason' THEN 100 + g.week ELSE g.week END
+               CASE WHEN g.season_type = 'postseason' THEN {POSTSEASON_WEEK_OFFSET} + g.week ELSE g.week END
                    AS week_index
         FROM marts.play_epa pe
         JOIN core.games g ON g.id = pe.game_id

--- a/scripts/screen_week_features.py
+++ b/scripts/screen_week_features.py
@@ -1,0 +1,576 @@
+#!/usr/bin/env python3
+# ruff: noqa: E501
+"""Screen candidate in-season features for ``features.team_week``.
+
+Pre-registration: decision rule is |partial_r| >= 0.08 AND Benjamini-Hochberg FDR q = 0.10 across the six candidates, run once; outcome variable is home margin (home points minus away points); controls are the model's two dominant existing features as home-minus-away diffs — Elo pregame and adjusted-EPA net — read from features.team_week (resolve the exact column names from DIFF_FEATURE_COLUMNS in scripts/train_model.py: the elo entry and the adjusted-EPA net entry).
+
+The screen is read-only. Candidate values are computed from completed FBS-
+involved games and are strictly as-of: a team-week keyed at ``week_index=W``
+can use only rows with ``week_index < W`` in the same season. The SQL query
+does the warehouse scans and week bucketing; the pure helpers below keep the
+leak boundary and the small-sample rules directly testable without a database.
+"""
+
+import argparse
+import math
+import sys
+from collections import defaultdict
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from scripts.build_features import compute_week_index, leak_free_week_index
+from scripts.screen_preseason_features import (
+    FDR_ALPHA,
+    MIN_PARTIAL_R,
+    benjamini_hochberg,
+    complete_cases,
+    partial_corr_pvalue,
+    screen_verdict,
+    second_order_partial_correlation,
+)
+from scripts.train_model import DIFF_FEATURE_COLUMNS
+
+DEFAULT_START_SEASON = 2015
+DEFAULT_END_SEASON = 2025
+
+CANDIDATE_COLUMNS = (
+    "off_ppd",
+    "def_ppd_allowed",
+    "off_field_pos",
+    "def_field_pos_allowed",
+    "form_net_epa_last4",
+    "vol_net_epa",
+)
+
+CONTROL_ELO = "elo_diff"
+CONTROL_ADJ_EPA_NET = "adj_epa_net_diff"
+SCREEN_CONTROLS = (CONTROL_ELO, CONTROL_ADJ_EPA_NET)
+
+
+def _diff_source_column(feature_name: str) -> str:
+    """Resolve a named model diff from the training feature contract."""
+    matches = [column for name, column in DIFF_FEATURE_COLUMNS if name == feature_name]
+    if len(matches) != 1:
+        raise RuntimeError(
+            f"DIFF_FEATURE_COLUMNS must contain exactly one {feature_name!r} entry; "
+            f"found {matches!r}"
+        )
+    return matches[0]
+
+
+ELO_SOURCE_COLUMN = _diff_source_column("d_elo")
+
+# The current train_model.py intentionally excludes adj_epa_net from
+# DIFF_FEATURE_COLUMNS because the deployed model uses adj_epa_off and
+# adj_epa_def separately. The feature-table contract in build_features.py
+# still writes the exact net column, so use that confirmed warehouse name and
+# retain this mismatch as an explicit module-level fact rather than silently
+# selecting one of the two component columns.
+_ADJ_EPA_NET_ENTRIES = [
+    column
+    for name, column in DIFF_FEATURE_COLUMNS
+    if name in {"d_adj_epa_net", "adj_epa_net"} or column == "adj_epa_net"
+]
+ADJ_EPA_NET_SOURCE_COLUMN = _ADJ_EPA_NET_ENTRIES[0] if _ADJ_EPA_NET_ENTRIES else "adj_epa_net"
+ADJ_EPA_NET_ENTRY_MISSING_FROM_DIFF_CONTRACT = not bool(_ADJ_EPA_NET_ENTRIES)
+
+
+def _finite(value: Any) -> bool:
+    """Whether a database or test value can safely enter a numeric aggregate."""
+    return value is not None and math.isfinite(float(value))
+
+
+def _mean(values: Iterable[float]) -> float | None:
+    values = list(values)
+    return sum(values) / len(values) if values else None
+
+
+def drive_points(drive: Mapping[str, Any]) -> float | None:
+    """Return exact points scored during a drive from its score delta."""
+    start = drive.get("start_offense_score")
+    end = drive.get("end_offense_score")
+    if not (_finite(start) and _finite(end)):
+        return None
+    return float(end) - float(start)
+
+
+def _prior_rows(
+    rows: Iterable[Mapping[str, Any]],
+    as_of_week_index: int,
+    season: int | None = None,
+    sorted_by_week_index: bool = False,
+) -> list[Mapping[str, Any]]:
+    """Filter rows to the same season and strict pregame as-of boundary.
+
+    Grouped buckets are sorted, so they can stop at the first current/future
+    row. Raw helper callers leave the flag false and are scanned completely.
+    """
+    prior: list[Mapping[str, Any]] = []
+    for row in rows:
+        week_index = row.get("week_index")
+        if week_index is None:
+            continue
+        week_index = int(week_index)
+        if sorted_by_week_index and not leak_free_week_index(week_index, as_of_week_index):
+            break
+        if season is not None and row.get("season") != season:
+            continue
+        if leak_free_week_index(week_index, as_of_week_index):
+            prior.append(row)
+    return prior
+
+
+def group_screen_inputs(
+    drives: Iterable[Mapping[str, Any]],
+    weekly_net_epa: Iterable[Mapping[str, Any]],
+) -> tuple[
+    dict[tuple[int, str], list[Mapping[str, Any]]],
+    dict[tuple[int, str], list[Mapping[str, Any]]],
+    dict[tuple[int, str], list[Mapping[str, Any]]],
+]:
+    """Bucket fetched rows once by ``(season, team)`` and sort each bucket.
+
+    The offense and defense drive indexes share each source drive row, while
+    the EPA index receives one row per team's weekly net EPA. Grouping keeps a
+    later game lookup local to the two teams in that game instead of rescanning
+    every season's raw rows for every game.
+    """
+    offense_by_team: defaultdict[tuple[int, str], list[Mapping[str, Any]]] = defaultdict(list)
+    defense_by_team: defaultdict[tuple[int, str], list[Mapping[str, Any]]] = defaultdict(list)
+    weekly_by_team: defaultdict[tuple[int, str], list[Mapping[str, Any]]] = defaultdict(list)
+
+    for drive in drives:
+        season = drive.get("season")
+        week_index = drive.get("week_index")
+        if season is None or week_index is None:
+            continue
+        if drive.get("offense") is not None:
+            offense_by_team[(int(season), str(drive["offense"]))].append(drive)
+        if drive.get("defense") is not None:
+            defense_by_team[(int(season), str(drive["defense"]))].append(drive)
+
+    for row in weekly_net_epa:
+        season = row.get("season")
+        team = row.get("team")
+        if season is None or team is None or row.get("week_index") is None:
+            continue
+        weekly_by_team[(int(season), str(team))].append(row)
+
+    for buckets in (offense_by_team, defense_by_team, weekly_by_team):
+        for rows in buckets.values():
+            rows.sort(key=lambda row: int(row["week_index"]))
+
+    return dict(offense_by_team), dict(defense_by_team), dict(weekly_by_team)
+
+
+def _aggregate_drive_sides(
+    offense_drives: Iterable[Mapping[str, Any]],
+    defense_drives: Iterable[Mapping[str, Any]],
+) -> dict[str, float | None]:
+    """Aggregate already team-bucketed offense and defense drive rows."""
+
+    def _ppd(rows: Iterable[Mapping[str, Any]]) -> float | None:
+        points = [points for row in rows if (points := drive_points(row)) is not None]
+        return _mean(points)
+
+    def _field_position(rows: Iterable[Mapping[str, Any]]) -> float | None:
+        positions = [
+            float(row["start_yards_to_goal"])
+            for row in rows
+            if _finite(row.get("start_yards_to_goal"))
+        ]
+        return _mean(positions)
+
+    offense_drives = list(offense_drives)
+    defense_drives = list(defense_drives)
+    return {
+        "off_ppd": _ppd(offense_drives) if offense_drives else None,
+        "def_ppd_allowed": _ppd(defense_drives) if defense_drives else None,
+        "off_field_pos": _field_position(offense_drives) if offense_drives else None,
+        "def_field_pos_allowed": (_field_position(defense_drives) if defense_drives else None),
+    }
+
+
+def aggregate_bucketed_drive_features(
+    as_of_week_index: int,
+    offense_drives: Iterable[Mapping[str, Any]],
+    defense_drives: Iterable[Mapping[str, Any]],
+) -> dict[str, float | None]:
+    """Aggregate only the two pre-grouped drive buckets for one team."""
+    return _aggregate_drive_sides(
+        _prior_rows(offense_drives, as_of_week_index, sorted_by_week_index=True),
+        _prior_rows(defense_drives, as_of_week_index, sorted_by_week_index=True),
+    )
+
+
+def aggregate_drive_features(
+    team: str,
+    as_of_week_index: int,
+    drives: Iterable[Mapping[str, Any]],
+    season: int | None = None,
+) -> dict[str, float | None]:
+    """Aggregate the four drive candidates for one team before a week.
+
+    The same drive can contribute to the offense and defense aggregates, but
+    each side is counted only once in its corresponding points-per-drive and
+    field-position mean. Missing score or field-position values are omitted
+    from that metric; if the team has no prior drive rows, all four values are
+    ``None`` as required by the maturity rule.
+    """
+    prior = _prior_rows(drives, as_of_week_index, season=season)
+    offense_drives = [row for row in prior if row.get("offense") == team]
+    defense_drives = [row for row in prior if row.get("defense") == team]
+    return _aggregate_drive_sides(offense_drives, defense_drives)
+
+
+def _form_and_volatility_from_prior(
+    prior: Iterable[Mapping[str, Any]],
+) -> tuple[float | None, float | None]:
+    """Calculate both EPA candidates from already filtered prior rows."""
+    values = [float(row["net_epa"]) for row in prior]
+
+    form = None
+    if len(values) >= 4:
+        form = float(_mean(values[-4:]) - _mean(values))
+
+    volatility = None
+    if len(values) >= 2:
+        mean = sum(values) / len(values)
+        volatility = math.sqrt(sum((value - mean) ** 2 for value in values) / len(values))
+
+    return form, volatility
+
+
+def compute_form_and_volatility(
+    weekly_net_epa: Iterable[Mapping[str, Any]],
+    as_of_week_index: int,
+) -> tuple[float | None, float | None]:
+    """Return last-four-minus-season-mean form and population volatility.
+
+    The input is already at ``(team, season, week_index)`` grain. The strict
+    ``week_index < as_of_week_index`` filter is applied here as a second line
+    of defense so callers cannot accidentally include the current game.
+    """
+    prior = [
+        row for row in _prior_rows(weekly_net_epa, as_of_week_index) if _finite(row.get("net_epa"))
+    ]
+    prior.sort(key=lambda row: int(row["week_index"]))
+    return _form_and_volatility_from_prior(prior)
+
+
+def compute_bucketed_form_and_volatility(
+    weekly_net_epa: Iterable[Mapping[str, Any]],
+    as_of_week_index: int,
+) -> tuple[float | None, float | None]:
+    """Calculate EPA candidates from a sorted, team-specific bucket."""
+    prior = [
+        row
+        for row in _prior_rows(
+            weekly_net_epa,
+            as_of_week_index,
+            sorted_by_week_index=True,
+        )
+        if _finite(row.get("net_epa"))
+    ]
+    return _form_and_volatility_from_prior(prior)
+
+
+def compute_as_of_features(
+    team: str,
+    as_of_week_index: int,
+    drives: Iterable[Mapping[str, Any]],
+    weekly_net_epa: Iterable[Mapping[str, Any]],
+    season: int | None = None,
+) -> dict[str, float | None]:
+    """Build all six candidate values for one team-week as-of row."""
+    result = aggregate_drive_features(team, as_of_week_index, drives, season=season)
+    form, volatility = compute_form_and_volatility(
+        [row for row in weekly_net_epa if season is None or row.get("season") == season],
+        as_of_week_index,
+    )
+    result["form_net_epa_last4"] = form
+    result["vol_net_epa"] = volatility
+    return result
+
+
+def compute_bucketed_as_of_features(
+    as_of_week_index: int,
+    offense_drives: Iterable[Mapping[str, Any]],
+    defense_drives: Iterable[Mapping[str, Any]],
+    weekly_net_epa: Iterable[Mapping[str, Any]],
+) -> dict[str, float | None]:
+    """Build candidates from the three pre-grouped rows for one team."""
+    result = aggregate_bucketed_drive_features(as_of_week_index, offense_drives, defense_drives)
+    form, volatility = compute_bucketed_form_and_volatility(weekly_net_epa, as_of_week_index)
+    result["form_net_epa_last4"] = form
+    result["vol_net_epa"] = volatility
+    return result
+
+
+def _difference(home: float | None, away: float | None) -> float | None:
+    """Home-minus-away difference that preserves candidate NULLs."""
+    if home is None or away is None:
+        return None
+    return float(home) - float(away)
+
+
+def build_screen_frame(
+    games: Iterable[Mapping[str, Any]],
+    drives: Iterable[Mapping[str, Any]],
+    weekly_net_epa: Iterable[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    """Join pure as-of candidates and controls into one row per game."""
+    drives = list(drives)
+    weekly_net_epa = list(weekly_net_epa)
+    offense_by_team, defense_by_team, weekly_by_team = group_screen_inputs(drives, weekly_net_epa)
+    frame: list[dict[str, Any]] = []
+
+    for game in games:
+        if not game.get("completed", True):
+            continue
+        if game.get("home_points") is None or game.get("away_points") is None:
+            continue
+
+        season = int(game["season"])
+        as_of_week_index = compute_week_index(int(game["week"]), game["season_type"])
+        home_key = (season, str(game["home_team"]))
+        away_key = (season, str(game["away_team"]))
+        home_features = compute_bucketed_as_of_features(
+            as_of_week_index,
+            offense_by_team.get(home_key, ()),
+            defense_by_team.get(home_key, ()),
+            weekly_by_team.get(home_key, ()),
+        )
+        away_features = compute_bucketed_as_of_features(
+            as_of_week_index,
+            offense_by_team.get(away_key, ()),
+            defense_by_team.get(away_key, ()),
+            weekly_by_team.get(away_key, ()),
+        )
+
+        row: dict[str, Any] = {
+            "game_id": game.get("game_id"),
+            "season": season,
+            "home_margin": float(game["home_points"]) - float(game["away_points"]),
+            CONTROL_ELO: _difference(game.get("home_elo_pregame"), game.get("away_elo_pregame")),
+            CONTROL_ADJ_EPA_NET: _difference(
+                game.get("home_adj_epa_net"), game.get("away_adj_epa_net")
+            ),
+        }
+        row.update(
+            {
+                candidate: _difference(home_features[candidate], away_features[candidate])
+                for candidate in CANDIDATE_COLUMNS
+            }
+        )
+        frame.append(row)
+
+    return frame
+
+
+def apply_verdicts(results: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Add BH q-values, both pass flags, and an uppercase final verdict."""
+    rows = [dict(row) for row in results]
+    testable = [row for row in rows if row.get("p_value") is not None]
+    qvalues = benjamini_hochberg([float(row["p_value"]) for row in testable])
+    for row, qvalue in zip(testable, qvalues, strict=True):
+        row["bh_q"] = qvalue
+
+    for row in rows:
+        row.setdefault("bh_q", None)
+        partial_r = float(row.get("partial_r", 0.0))
+        floor_pass = abs(partial_r) >= MIN_PARTIAL_R
+        bh_pass = row["bh_q"] is not None and row["bh_q"] <= FDR_ALPHA
+        row["floor_pass"] = floor_pass
+        row["bh_pass"] = bh_pass
+        row["verdict"] = "SHIP" if screen_verdict(partial_r, row["bh_q"]) == "ship" else "REJECT"
+    return rows
+
+
+def screen_frame(frame: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Screen each candidate on its own complete-case game sample."""
+    raw_results: list[dict[str, Any]] = []
+    needed_controls = list(SCREEN_CONTROLS)
+    for candidate in CANDIDATE_COLUMNS:
+        rows = complete_cases(frame, ["home_margin", *needed_controls, candidate])
+        n_games = len(rows)
+        if n_games < 3:
+            partial_r = 0.0
+            p_value = None
+        else:
+            x = [float(row[candidate]) for row in rows]
+            y = [float(row["home_margin"]) for row in rows]
+            elo = [float(row[CONTROL_ELO]) for row in rows]
+            adj_epa_net = [float(row[CONTROL_ADJ_EPA_NET]) for row in rows]
+            partial_r = second_order_partial_correlation(x, y, elo, adj_epa_net)
+            p_value = partial_corr_pvalue(partial_r, n_games, n_controls=2)
+        raw_results.append(
+            {
+                "candidate": candidate,
+                "n_games": n_games,
+                "partial_r": partial_r,
+                "p_value": p_value,
+            }
+        )
+    return apply_verdicts(raw_results)
+
+
+FBS_INVOLVED = "(g.home_classification = 'fbs' OR g.away_classification = 'fbs')"
+
+GAMES_QUERY = f"""
+    SELECT g.id AS game_id, g.season, g.season_type, g.week,
+           g.home_team, g.away_team, g.home_points, g.away_points,
+           COALESCE(g.completed, false) AS completed,
+           h.{ELO_SOURCE_COLUMN} AS home_elo_pregame,
+           a.{ELO_SOURCE_COLUMN} AS away_elo_pregame,
+           h.{ADJ_EPA_NET_SOURCE_COLUMN} AS home_adj_epa_net,
+           a.{ADJ_EPA_NET_SOURCE_COLUMN} AS away_adj_epa_net
+    FROM core.games g
+    JOIN features.team_week h
+      ON h.game_id = g.id AND h.team = g.home_team
+    JOIN features.team_week a
+      ON a.game_id = g.id AND a.team = g.away_team
+    WHERE g.season BETWEEN %(start_season)s AND %(end_season)s
+      AND COALESCE(g.completed, false)
+      AND g.home_points IS NOT NULL
+      AND g.away_points IS NOT NULL
+      AND {FBS_INVOLVED}
+    ORDER BY g.season, g.week, g.id
+"""
+
+DRIVES_QUERY = f"""
+    SELECT g.season, d.game_id, d.offense, d.defense,
+           CASE WHEN g.season_type = 'postseason' THEN 100 + g.week ELSE g.week END
+               AS week_index,
+           d.start_yards_to_goal, d.start_offense_score, d.end_offense_score
+    FROM core.drives d
+    JOIN core.games g ON g.id = d.game_id
+    WHERE g.season BETWEEN %(start_season)s AND %(end_season)s
+      AND COALESCE(g.completed, false)
+      AND g.home_points IS NOT NULL
+      AND g.away_points IS NOT NULL
+      AND {FBS_INVOLVED}
+"""
+
+EPA_QUERY = f"""
+    WITH plays_wi AS (
+        SELECT g.season, pe.offense, pe.defense, pe.epa,
+               CASE WHEN g.season_type = 'postseason' THEN 100 + g.week ELSE g.week END
+                   AS week_index
+        FROM marts.play_epa pe
+        JOIN core.games g ON g.id = pe.game_id
+        WHERE g.season BETWEEN %(start_season)s AND %(end_season)s
+          AND COALESCE(g.completed, false)
+          AND {FBS_INVOLVED}
+          AND NOT pe.is_garbage_time
+    ),
+    off_week_agg AS (
+        SELECT season, offense AS team, week_index,
+               SUM(epa) AS sum_epa, COUNT(*) AS n_plays
+        FROM plays_wi
+        GROUP BY season, offense, week_index
+    ),
+    def_week_agg AS (
+        SELECT season, defense AS team, week_index,
+               SUM(epa) AS sum_epa, COUNT(*) AS n_plays
+        FROM plays_wi
+        GROUP BY season, defense, week_index
+    )
+    SELECT o.season, o.team, o.week_index,
+           o.sum_epa / NULLIF(o.n_plays, 0)
+               - d.sum_epa / NULLIF(d.n_plays, 0) AS net_epa
+    FROM off_week_agg o
+    JOIN def_week_agg d
+      ON d.season = o.season
+     AND d.team = o.team
+     AND d.week_index = o.week_index
+    ORDER BY o.season, o.team, o.week_index
+"""
+
+
+def get_db_url() -> str:
+    """Resolve the warehouse URL using the build_features.py convention."""
+    import os
+
+    import dlt
+
+    url = None
+    try:
+        creds = dlt.secrets.get("destination.postgres.credentials")
+        if creds:
+            url = str(creds)
+    except Exception:
+        pass
+
+    if not url:
+        url = os.environ.get("SUPABASE_DB_URL") or os.environ.get("DATABASE_URL")
+
+    if not url:
+        raise RuntimeError(
+            "No database URL found. Set destination.postgres.credentials in "
+            ".dlt/secrets.toml or SUPABASE_DB_URL environment variable."
+        )
+    return url
+
+
+def fetch_screen_inputs(
+    conn: Any, start_season: int, end_season: int
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    """Read games, drive rows, and weekly EPA rows without mutating the DB."""
+    import psycopg2.extras
+
+    params = {"start_season": start_season, "end_season": end_season}
+    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(GAMES_QUERY, params)
+        games = [dict(row) for row in cur.fetchall()]
+        cur.execute(DRIVES_QUERY, params)
+        drives = [dict(row) for row in cur.fetchall()]
+        cur.execute(EPA_QUERY, params)
+        weekly_net_epa = [dict(row) for row in cur.fetchall()]
+    return games, drives, weekly_net_epa
+
+
+def report(results: Iterable[Mapping[str, Any]]) -> None:
+    """Print every candidate, including rejected candidates and their numbers."""
+    print(
+        "candidate                 n_games   partial_r   p_value     bh_q  "
+        "bh_pass floor_pass verdict"
+    )
+    print("-" * 96)
+    for row in results:
+        p_value = "na" if row["p_value"] is None else f"{row['p_value']:.6g}"
+        bh_q = "na" if row["bh_q"] is None else f"{row['bh_q']:.6g}"
+        print(
+            f"{row['candidate']:<25} {row['n_games']:>7} {row['partial_r']:>11.5f} "
+            f"{p_value:>10} {bh_q:>8} {str(row['bh_pass']):>8} "
+            f"{str(row['floor_pass']):>10} {row['verdict']:>7}"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Screen in-season team-week features")
+    parser.add_argument("--start-season", type=int, default=DEFAULT_START_SEASON)
+    parser.add_argument("--end-season", type=int, default=DEFAULT_END_SEASON)
+    args = parser.parse_args()
+    if args.start_season > args.end_season:
+        parser.error("--start-season cannot be after --end-season")
+
+    import psycopg2
+
+    conn = psycopg2.connect(get_db_url())
+    try:
+        games, drives, weekly_net_epa = fetch_screen_inputs(
+            conn, args.start_season, args.end_season
+        )
+        frame = build_screen_frame(games, drives, weekly_net_epa)
+        report(screen_frame(frame))
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:
+        print(f"screen_week_features: {exc}", file=sys.stderr)
+        raise

--- a/tests/test_screen_week_features.py
+++ b/tests/test_screen_week_features.py
@@ -6,9 +6,10 @@ import pytest
 
 from scripts.screen_week_features import (
     CANDIDATE_COLUMNS,
+    aggregate_bucketed_drive_features,
     apply_verdicts,
-    compute_as_of_features,
-    compute_form_and_volatility,
+    compute_bucketed_as_of_features,
+    compute_bucketed_form_and_volatility,
     drive_points,
     group_screen_inputs,
 )
@@ -18,7 +19,7 @@ class TestFormAndVolatility:
     def test_matches_hand_computed_population_values(self):
         weekly_net_epa = [{"week_index": week, "net_epa": float(week)} for week in range(1, 7)]
 
-        form, volatility = compute_form_and_volatility(weekly_net_epa, as_of_week_index=7)
+        form, volatility = compute_bucketed_form_and_volatility(weekly_net_epa, as_of_week_index=7)
 
         # Season mean = 3.5; last-four mean = 4.5; population variance = 35/12.
         assert form == pytest.approx(1.0)
@@ -50,7 +51,7 @@ class TestAsOfBoundaries:
             {"week_index": 2, "net_epa": 9.0},
         ]
 
-        features = compute_as_of_features("A", 2, drives, weekly_net_epa)
+        features = compute_bucketed_as_of_features(2, drives, [], weekly_net_epa)
 
         assert features["off_ppd"] == pytest.approx(7.0)
         assert features["off_field_pos"] == pytest.approx(80.0)
@@ -61,11 +62,11 @@ class TestAsOfBoundaries:
         three_prior_weeks = [{"week_index": week, "net_epa": float(week)} for week in range(1, 4)]
         one_prior_week = [{"week_index": 1, "net_epa": 2.0}]
 
-        form, volatility = compute_form_and_volatility(three_prior_weeks, 4)
+        form, volatility = compute_bucketed_form_and_volatility(three_prior_weeks, 4)
         assert form is None
         assert volatility == pytest.approx(0.8164965809)
 
-        form, volatility = compute_form_and_volatility(one_prior_week, 2)
+        form, volatility = compute_bucketed_form_and_volatility(one_prior_week, 2)
         assert form is None
         assert volatility is None
 
@@ -122,6 +123,7 @@ class TestDrivePoints:
                 "week_index": 1,
                 "offense": "A",
                 "defense": "B",
+                "drive_result": "Defensive Touchdown",
                 "start_offense_score": 20,
                 "end_offense_score": 26,
                 "start_yards_to_goal": 70,
@@ -136,7 +138,7 @@ class TestDrivePoints:
             },
         ]
 
-        features = compute_as_of_features("A", 2, drives, [])
+        features = aggregate_bucketed_drive_features(2, drives, [])
 
         assert features["off_ppd"] == pytest.approx(4.5)
         assert features["off_field_pos"] == pytest.approx(60.0)

--- a/tests/test_screen_week_features.py
+++ b/tests/test_screen_week_features.py
@@ -6,12 +6,17 @@ import pytest
 
 from scripts.screen_week_features import (
     CANDIDATE_COLUMNS,
+    CONTROL_ADJ_EPA_NET,
+    CONTROL_ELO,
     aggregate_bucketed_drive_features,
     apply_verdicts,
+    assert_screen_coverage,
+    build_screen_frame,
     compute_bucketed_as_of_features,
     compute_bucketed_form_and_volatility,
     drive_points,
     group_screen_inputs,
+    screen_frame,
 )
 
 
@@ -179,3 +184,120 @@ class TestVerdicts:
         assert by_name["bh_fail"]["floor_pass"] is True
         assert by_name["bh_fail"]["bh_pass"] is False
         assert by_name["bh_fail"]["verdict"] == "REJECT"
+
+    def test_ship_verdict_when_floor_and_bh_both_pass(self):
+        raw_results = [
+            {
+                "candidate": "strong",
+                "n_games": 1000,
+                "partial_r": 0.20,
+                "p_value": 1e-9,
+            },
+            {
+                "candidate": "weak",
+                "n_games": 1000,
+                "partial_r": 0.01,
+                "p_value": 0.90,
+            },
+        ]
+
+        by_name = {row["candidate"]: row for row in apply_verdicts(raw_results)}
+
+        assert by_name["strong"]["floor_pass"] is True
+        assert by_name["strong"]["bh_pass"] is True
+        assert by_name["strong"]["verdict"] == "SHIP"
+        assert by_name["weak"]["verdict"] == "REJECT"
+
+
+def _game(game_id, home, away, week, home_points=28, away_points=21):
+    return {
+        "game_id": game_id,
+        "season": 2024,
+        "season_type": "regular",
+        "week": week,
+        "home_team": home,
+        "away_team": away,
+        "home_points": home_points,
+        "away_points": away_points,
+        "completed": True,
+        "home_elo_pregame": 1600.0,
+        "away_elo_pregame": 1500.0,
+        "home_adj_epa_net": 0.20,
+        "away_adj_epa_net": 0.05,
+    }
+
+
+class TestBuildScreenFrame:
+    def test_wires_margin_controls_and_candidate_diffs(self):
+        games = [_game(1, "A", "B", week=2)]
+        drives = [
+            {
+                "season": 2024,
+                "week_index": 1,
+                "offense": "A",
+                "defense": "B",
+                "start_offense_score": 0,
+                "end_offense_score": 7,
+                "start_yards_to_goal": 80,
+            },
+            {
+                "season": 2024,
+                "week_index": 1,
+                "offense": "B",
+                "defense": "A",
+                "start_offense_score": 0,
+                "end_offense_score": 3,
+                "start_yards_to_goal": 60,
+            },
+        ]
+
+        frame = build_screen_frame(games, drives, [])
+
+        assert len(frame) == 1
+        row = frame[0]
+        assert row["home_margin"] == pytest.approx(7.0)
+        assert row[CONTROL_ELO] == pytest.approx(100.0)
+        assert row[CONTROL_ADJ_EPA_NET] == pytest.approx(0.15)
+        # Home offense scored 7/drive, away offense 3/drive.
+        assert row["off_ppd"] == pytest.approx(4.0)
+        # Home defense allowed 3/drive, away defense allowed 7/drive.
+        assert row["def_ppd_allowed"] == pytest.approx(-4.0)
+        # No weekly EPA rows: trajectory diffs stay None.
+        assert row["form_net_epa_last4"] is None
+        assert row["vol_net_epa"] is None
+
+    def test_excludes_incomplete_and_scoreless_games(self):
+        games = [
+            _game(1, "A", "B", week=2) | {"completed": False},
+            _game(2, "A", "B", week=3, home_points=None),
+        ]
+
+        assert build_screen_frame(games, [], []) == []
+
+
+class TestScreenFrame:
+    def test_small_sample_rejects_without_p_value(self):
+        games = [_game(1, "A", "B", week=2)]
+        results = screen_frame(build_screen_frame(games, [], []))
+
+        by_name = {row["candidate"]: row for row in results}
+        assert set(by_name) == set(CANDIDATE_COLUMNS)
+        for row in results:
+            assert row["p_value"] is None
+            assert row["partial_r"] == pytest.approx(0.0)
+            assert row["verdict"] == "REJECT"
+
+
+class TestCoverageFloors:
+    def test_empty_frame_is_untestable_not_rejected(self):
+        with pytest.raises(RuntimeError, match="UNTESTABLE"):
+            assert_screen_coverage([], screen_frame([]))
+
+    def test_thin_candidate_sample_is_untestable(self):
+        frame = [{"home_margin": 1.0}] * 2000
+        results = [
+            {"candidate": name, "n_games": 0, "partial_r": 0.0, "p_value": None}
+            for name in CANDIDATE_COLUMNS
+        ]
+        with pytest.raises(RuntimeError, match="UNTESTABLE"):
+            assert_screen_coverage(frame, results)

--- a/tests/test_screen_week_features.py
+++ b/tests/test_screen_week_features.py
@@ -1,16 +1,22 @@
 """Pure unit tests for the in-season team-week feature screen."""
 
 import math
+import random
 
 import pytest
 
+import scripts.screen_week_features as screen_week_features
 from scripts.screen_week_features import (
     CANDIDATE_COLUMNS,
     CONTROL_ADJ_EPA_NET,
     CONTROL_ELO,
+    CONTROL_MODE_FEATURES,
+    CONTROL_MODE_MODEL_MARGIN,
     aggregate_bucketed_drive_features,
     apply_verdicts,
     assert_screen_coverage,
+    build_arg_parser,
+    build_model_margin_frame,
     build_screen_frame,
     compute_bucketed_as_of_features,
     compute_bucketed_form_and_volatility,
@@ -286,6 +292,84 @@ class TestScreenFrame:
             assert row["p_value"] is None
             assert row["partial_r"] == pytest.approx(0.0)
             assert row["verdict"] == "REJECT"
+
+
+def _model_frame(n=250, candidate_values=None):
+    rng = random.Random(19)
+    control = [rng.gauss(0.0, 1.0) for _ in range(n)]
+    if candidate_values is None:
+        candidate_values = [rng.gauss(0.0, 1.0) for _ in range(n)]
+    margin = [0.8 * x + 0.3 * z + rng.gauss(0.0, 0.2) for x, z in zip(candidate_values, control)]
+    rows = []
+    for i, (z, x, y) in enumerate(zip(control, candidate_values, margin)):
+        row = {
+            "home_margin": y,
+            "model_margin": z,
+        }
+        row.update(
+            {name: (x if name == "off_ppd" else float(i % 11)) for name in CANDIDATE_COLUMNS}
+        )
+        rows.append(row)
+    return rows
+
+
+class TestModelMarginControl:
+    def test_cli_defaults_to_v1_features_mode(self):
+        assert build_arg_parser().parse_args([]).control_mode == CONTROL_MODE_FEATURES
+
+    def test_exact_function_of_frozen_margin_control_has_no_incremental_signal(self):
+        frame = _model_frame()
+        for i, row in enumerate(frame):
+            row["off_ppd"] = 2.0 * row["model_margin"]
+            row["home_margin"] = 0.8 * row["model_margin"] + float(i % 7)
+
+        result = next(
+            row
+            for row in screen_frame(frame, CONTROL_MODE_MODEL_MARGIN)
+            if row["candidate"] == "off_ppd"
+        )
+
+        assert result["partial_r"] == pytest.approx(0.0)
+
+    def test_orthogonal_candidate_tracks_margin_residual(self):
+        frame = _model_frame()
+
+        result = next(
+            row
+            for row in screen_frame(frame, CONTROL_MODE_MODEL_MARGIN)
+            if row["candidate"] == "off_ppd"
+        )
+
+        assert result["partial_r"] > 0.7
+
+    def test_model_margin_p_value_uses_one_control(self, monkeypatch):
+        calls = []
+
+        def fake_pvalue(partial_r, n, n_controls=1):
+            calls.append(n_controls)
+            return 0.01
+
+        monkeypatch.setattr(screen_week_features, "partial_corr_pvalue", fake_pvalue)
+        screen_frame(_model_frame(), CONTROL_MODE_MODEL_MARGIN)
+
+        assert calls == [1] * len(CANDIDATE_COLUMNS)
+
+    def test_games_without_prior_vintage_drop_from_model_margin_frame(self):
+        games = [
+            _game(1, "A", "B", week=2) | {"season": 2017},
+            _game(2, "A", "B", week=2) | {"season": 2018},
+        ]
+
+        frame = build_model_margin_frame(
+            games,
+            [],
+            [],
+            {2017: object()},
+            scorer=lambda game, fit: (12.5, 0.5),
+        )
+
+        assert [row["game_id"] for row in frame] == [2]
+        assert frame[0]["model_margin"] == pytest.approx(12.5)
 
 
 class TestCoverageFloors:

--- a/tests/test_screen_week_features.py
+++ b/tests/test_screen_week_features.py
@@ -1,0 +1,179 @@
+"""Pure unit tests for the in-season team-week feature screen."""
+
+import math
+
+import pytest
+
+from scripts.screen_week_features import (
+    CANDIDATE_COLUMNS,
+    apply_verdicts,
+    compute_as_of_features,
+    compute_form_and_volatility,
+    drive_points,
+    group_screen_inputs,
+)
+
+
+class TestFormAndVolatility:
+    def test_matches_hand_computed_population_values(self):
+        weekly_net_epa = [{"week_index": week, "net_epa": float(week)} for week in range(1, 7)]
+
+        form, volatility = compute_form_and_volatility(weekly_net_epa, as_of_week_index=7)
+
+        # Season mean = 3.5; last-four mean = 4.5; population variance = 35/12.
+        assert form == pytest.approx(1.0)
+        assert volatility == pytest.approx(math.sqrt(35 / 12))
+
+
+class TestAsOfBoundaries:
+    def test_week_w_row_is_excluded_from_week_w_features(self):
+        drives = [
+            {
+                "week_index": 1,
+                "offense": "A",
+                "defense": "B",
+                "start_offense_score": 0,
+                "end_offense_score": 7,
+                "start_yards_to_goal": 80,
+            },
+            {
+                "week_index": 2,
+                "offense": "A",
+                "defense": "B",
+                "start_offense_score": 7,
+                "end_offense_score": 14,
+                "start_yards_to_goal": 60,
+            },
+        ]
+        weekly_net_epa = [
+            {"week_index": 1, "net_epa": 1.0},
+            {"week_index": 2, "net_epa": 9.0},
+        ]
+
+        features = compute_as_of_features("A", 2, drives, weekly_net_epa)
+
+        assert features["off_ppd"] == pytest.approx(7.0)
+        assert features["off_field_pos"] == pytest.approx(80.0)
+        assert features["form_net_epa_last4"] is None
+        assert features["vol_net_epa"] is None
+
+    def test_form_and_volatility_have_strict_maturity_gates(self):
+        three_prior_weeks = [{"week_index": week, "net_epa": float(week)} for week in range(1, 4)]
+        one_prior_week = [{"week_index": 1, "net_epa": 2.0}]
+
+        form, volatility = compute_form_and_volatility(three_prior_weeks, 4)
+        assert form is None
+        assert volatility == pytest.approx(0.8164965809)
+
+        form, volatility = compute_form_and_volatility(one_prior_week, 2)
+        assert form is None
+        assert volatility is None
+
+
+class TestGrouping:
+    def test_buckets_by_season_and_team_and_sorts_each_bucket(self):
+        drives = [
+            {
+                "season": 2024,
+                "week_index": 3,
+                "offense": "A",
+                "defense": "B",
+            },
+            {
+                "season": 2024,
+                "week_index": 1,
+                "offense": "A",
+                "defense": "B",
+            },
+            {
+                "season": 2023,
+                "week_index": 2,
+                "offense": "A",
+                "defense": "B",
+            },
+        ]
+        weekly_net_epa = [
+            {"season": 2024, "team": "A", "week_index": 3, "net_epa": 3.0},
+            {"season": 2024, "team": "A", "week_index": 1, "net_epa": 1.0},
+        ]
+
+        offense, defense, weekly = group_screen_inputs(drives, weekly_net_epa)
+
+        assert [row["week_index"] for row in offense[(2024, "A")]] == [1, 3]
+        assert [row["week_index"] for row in defense[(2024, "B")]] == [1, 3]
+        assert [row["week_index"] for row in weekly[(2024, "A")]] == [1, 3]
+        assert (2023, "A") in offense
+
+
+class TestDrivePoints:
+    def test_uses_score_delta_including_non_touchdown_scoring(self):
+        drive = {
+            "start_offense_score": 20,
+            "end_offense_score": 26,
+        }
+
+        # A TD-shaped drive_result would suggest seven, but the recorded score
+        # delta is six and is the pre-registered source of drive points.
+        assert drive_points(drive) == pytest.approx(6.0)
+
+    def test_points_per_drive_aggregates_score_deltas(self):
+        drives = [
+            {
+                "week_index": 1,
+                "offense": "A",
+                "defense": "B",
+                "start_offense_score": 20,
+                "end_offense_score": 26,
+                "start_yards_to_goal": 70,
+            },
+            {
+                "week_index": 1,
+                "offense": "A",
+                "defense": "B",
+                "start_offense_score": 26,
+                "end_offense_score": 29,
+                "start_yards_to_goal": 50,
+            },
+        ]
+
+        features = compute_as_of_features("A", 2, drives, [])
+
+        assert features["off_ppd"] == pytest.approx(4.5)
+        assert features["off_field_pos"] == pytest.approx(60.0)
+
+
+class TestVerdicts:
+    def test_rejections_remain_in_table_for_floor_and_bh_failures(self):
+        raw_results = [
+            {
+                "candidate": "below_floor",
+                "n_games": 1000,
+                "partial_r": 0.01,
+                "p_value": 0.001,
+            },
+            {
+                "candidate": "bh_fail",
+                "n_games": 1000,
+                "partial_r": 0.20,
+                "p_value": 0.50,
+            },
+            *(
+                {
+                    "candidate": name,
+                    "n_games": 1000,
+                    "partial_r": 0.0,
+                    "p_value": 0.20,
+                }
+                for name in CANDIDATE_COLUMNS[2:]
+            ),
+        ]
+
+        results = apply_verdicts(raw_results)
+        by_name = {row["candidate"]: row for row in results}
+
+        assert set(by_name) == {row["candidate"] for row in raw_results}
+        assert by_name["below_floor"]["floor_pass"] is False
+        assert by_name["below_floor"]["verdict"] == "REJECT"
+        assert by_name["bh_fail"]["floor_pass"] is True
+        assert by_name["bh_fail"]["bh_pass"] is False
+        assert by_name["bh_fail"]["verdict"] == "REJECT"


### PR DESCRIPTION
Implements [docs/plans/2026-07-28-001-feat-starter-pack-model-features-plan.md](docs/plans/2026-07-28-001-feat-starter-pack-model-features-plan.md): drive-efficiency and weekly-trajectory feature candidates for fitted_v1, gated by a pre-registered in-season screen.

## Outcome: null result (valid completion per plan R6)

The screen ran once in CI (2026-07-28, 2015–2025, n≈8k FBS-involved games) and **rejected all six candidates**:

| candidate | n | partial_r | p | verdict |
|---|---|---|---|---|
| off_ppd | 7,992 | +0.070 | 3.6e-10 | REJECT (below 0.08 floor) |
| def_ppd_allowed | 7,992 | −0.058 | 1.8e-07 | REJECT |
| off_field_pos | 7,992 | −0.055 | 9.8e-07 | REJECT |
| def_field_pos_allowed | 7,992 | +0.047 | 2.7e-05 | REJECT |
| form_net_epa_last4 | 5,804 | +0.016 | 0.21 | REJECT (n.s.) |
| vol_net_epa | 7,203 | −0.006 | 0.63 | REJECT (n.s.) |

Drive efficiency is real signal the model already absorbs through Elo + adjusted EPA; recent form and volatility add nothing once opponent-adjusted ratings are controlled. **No migration, no substrate columns, no model change.** Verdicts + a disclosed maturity-gate deviation are durably recorded in the team-week design doc so these six are never unknowingly retried.

## What ships
- `scripts/screen_week_features.py` — pre-registered screen (|partial_r| ≥ 0.08 + BH-FDR 0.10, controls: Elo + adj-EPA-net diffs), coverage floors fail UNTESTABLE rather than emitting hollow verdicts
- `tests/test_screen_week_features.py` — 13 pure-unit tests (leak boundary, maturity gates, score-delta PPD, frame wiring, verdicts, coverage floors)
- `.github/workflows/model-experiments.yml` — workflow_dispatch-only runner (screen + backfill); the temporary PR-label trigger used for the pre-merge run was removed after review
- Design-doc amendment recording verdicts, deviation disclosure, and consequences

## Review
Simplify pass (3 reviewers) + code review (correctness, standards, testing, maintainability + independent cross-model adversarial pass via Codex, requested gpt-5.6-luna xhigh, served model unverified on this route, independence verified). 10 of 11 findings fixed in-branch; correctness independently reproduced the recorded p-values and cleared the null verdict in both directions.

## Known Residuals (accepted)
- P2: no run-ledger keyed by pre-registration + frame hash guarding against re-running the run-once screen (mitigated by design-doc record + workflow header note)
- Raw result table lives in the CI run log ([run 30406080983](https://github.com/rstover-fo/cfb-database/actions/runs/30406080983)) rather than a committed artifact
- core.drives score-delta accuracy accepted on sign/significance coherence; not independently validated against another warehouse measure

## Post-Deploy Monitoring & Validation
No additional operational monitoring required — no production code path, schema, or model changes; the workflow is manual-dispatch-only and the screen is read-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Codex review resolution (post-review commit aa9727e)
The bot's P1 (control under-implements the model's expected margin; suppression risk) is addressed by a **v2 pre-registered amendment**: `--control-mode model-margin` controls for fitted_v1's frozen walk-forward expected margin rebuilt from stored vintages. **The v1 verdicts above are provisional until the v2 confirmation run** (post-merge: workflow_dispatch → `model-experiments` → `screen-v2`). If every candidate stays below the floor, the rejections stand as final; any candidate clearing it re-enters the plan's refit + no-regression path. Details in the design-doc amendment.