### PR TITLE
docs: repair phantom skill references (AI-context refresh)

### DIFF
--- a/.agents/skills/supabase-postgres-best-practices/CHANGELOG.md
+++ b/.agents/skills/supabase-postgres-best-practices/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+## [1.4.0](https://github.com/supabase/agent-skills/compare/v1.3.0...v1.4.0) (2026-07-10)
+
+
+### Features
+
+* add schema-constraints reference for safe migration patterns ([#30](https://github.com/supabase/agent-skills/issues/30)) ([9b236f3](https://github.com/supabase/agent-skills/commit/9b236f3ebd65d76a2c570f19931353da9c858d5a))
+* using Supabase agent skills ([#12](https://github.com/supabase/agent-skills/issues/12)) ([7c2e389](https://github.com/supabase/agent-skills/commit/7c2e3894fddfde8eb6c77d2a8921904543b9be7a))
+
+
+### Bug Fixes
+
+* correct broken reference link in postgres best practices skill ([#58](https://github.com/supabase/agent-skills/issues/58)) ([f4e2277](https://github.com/supabase/agent-skills/commit/f4e22777fd8573537297b568c16e5a45a25927da))
+* cover SECURITY DEFINER, auth.role() deprecation, and BOLA in security checklist ([#85](https://github.com/supabase/agent-skills/issues/85)) ([133f43e](https://github.com/supabase/agent-skills/commit/133f43e8c2ffc48823ff0630c692cabecea3e3a3))
+
+## [1.3.0](https://github.com/supabase/agent-skills/compare/v1.2.0...v1.3.0) (2026-06-05)
+
+
+### Features
+
+* add schema-constraints reference for safe migration patterns ([#30](https://github.com/supabase/agent-skills/issues/30)) ([9b236f3](https://github.com/supabase/agent-skills/commit/9b236f3ebd65d76a2c570f19931353da9c858d5a))
+* using Supabase agent skills ([#12](https://github.com/supabase/agent-skills/issues/12)) ([7c2e389](https://github.com/supabase/agent-skills/commit/7c2e3894fddfde8eb6c77d2a8921904543b9be7a))
+
+
+### Bug Fixes
+
+* correct broken reference link in postgres best practices skill ([#58](https://github.com/supabase/agent-skills/issues/58)) ([f4e2277](https://github.com/supabase/agent-skills/commit/f4e22777fd8573537297b568c16e5a45a25927da))
+* cover SECURITY DEFINER, auth.role() deprecation, and BOLA in security checklist ([#85](https://github.com/supabase/agent-skills/issues/85)) ([133f43e](https://github.com/supabase/agent-skills/commit/133f43e8c2ffc48823ff0630c692cabecea3e3a3))
+
+## [1.2.0](https://github.com/supabase/agent-skills/compare/v1.1.1...v1.2.0) (2026-06-02)
+
+
+### Features
+
+* add schema-constraints reference for safe migration patterns ([#30](https://github.com/supabase/agent-skills/issues/30)) ([9b236f3](https://github.com/supabase/agent-skills/commit/9b236f3ebd65d76a2c570f19931353da9c858d5a))
+* using Supabase agent skills ([#12](https://github.com/supabase/agent-skills/issues/12)) ([7c2e389](https://github.com/supabase/agent-skills/commit/7c2e3894fddfde8eb6c77d2a8921904543b9be7a))
+
+
+### Bug Fixes
+
+* correct broken reference link in postgres best practices skill ([#58](https://github.com/supabase/agent-skills/issues/58)) ([f4e2277](https://github.com/supabase/agent-skills/commit/f4e22777fd8573537297b568c16e5a45a25927da))
+* cover SECURITY DEFINER, auth.role() deprecation, and BOLA in security checklist ([#85](https://github.com/supabase/agent-skills/issues/85)) ([133f43e](https://github.com/supabase/agent-skills/commit/133f43e8c2ffc48823ff0630c692cabecea3e3a3))

--- a/.agents/skills/supabase-postgres-best-practices/SKILL.md
+++ b/.agents/skills/supabase-postgres-best-practices/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: supabase-postgres-best-practices
+description: Postgres performance optimization and best practices from Supabase. Use this skill when writing, reviewing, or optimizing Postgres queries, schema designs, or database configurations.
+license: MIT
+metadata:
+  author: supabase
+  version: "1.1.1"
+  organization: Supabase
+  date: January 2026
+  abstract: Comprehensive Postgres performance optimization guide for developers using Supabase and Postgres. Contains performance rules across 8 categories, prioritized by impact from critical (query performance, connection management) to incremental (advanced features). Each rule includes detailed explanations, incorrect vs. correct SQL examples, query plan analysis, and specific performance metrics to guide automated optimization and code generation.
+---
+
+# Supabase Postgres Best Practices
+
+Comprehensive performance optimization guide for Postgres, maintained by Supabase. Contains rules across 8 categories, prioritized by impact to guide automated query optimization and schema design.
+
+## When to Apply
+
+Reference these guidelines when:
+- Writing SQL queries or designing schemas
+- Implementing indexes or query optimization
+- Reviewing database performance issues
+- Configuring connection pooling or scaling
+- Optimizing for Postgres-specific features
+- Working with Row-Level Security (RLS)
+
+## Rule Categories by Priority
+
+| Priority | Category | Impact | Prefix |
+|----------|----------|--------|--------|
+| 1 | Query Performance | CRITICAL | `query-` |
+| 2 | Connection Management | CRITICAL | `conn-` |
+| 3 | Security & RLS | CRITICAL | `security-` |
+| 4 | Schema Design | HIGH | `schema-` |
+| 5 | Concurrency & Locking | MEDIUM-HIGH | `lock-` |
+| 6 | Data Access Patterns | MEDIUM | `data-` |
+| 7 | Monitoring & Diagnostics | LOW-MEDIUM | `monitor-` |
+| 8 | Advanced Features | LOW | `advanced-` |
+
+## How to Use
+
+Read individual rule files for detailed explanations and SQL examples:
+
+```
+references/query-missing-indexes.md
+references/query-partial-indexes.md
+references/_sections.md
+```
+
+Each rule file contains:
+- Brief explanation of why it matters
+- Incorrect SQL example with explanation
+- Correct SQL example with explanation
+- Optional EXPLAIN output or metrics
+- Additional context and references
+- Supabase-specific notes (when applicable)
+
+## References
+
+- https://www.postgresql.org/docs/current/
+- https://supabase.com/docs
+- https://wiki.postgresql.org/wiki/Performance_Optimization
+- https://supabase.com/docs/guides/database/overview
+- https://supabase.com/docs/guides/auth/row-level-security

--- a/.agents/skills/supabase-postgres-best-practices/references/_contributing.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/_contributing.md
@@ -1,0 +1,170 @@
+# Writing Guidelines for Postgres References
+
+This document provides guidelines for creating effective Postgres best
+practice references that work well with AI agents and LLMs.
+
+## Key Principles
+
+### 1. Concrete Transformation Patterns
+
+Show exact SQL rewrites. Avoid philosophical advice.
+
+**Good:** "Use `WHERE id = ANY(ARRAY[...])` instead of
+`WHERE id IN (SELECT ...)`" **Bad:** "Design good schemas"
+
+### 2. Error-First Structure
+
+Always show the problematic pattern first, then the solution. This trains agents
+to recognize anti-patterns.
+
+```markdown
+**Incorrect (sequential queries):** [bad example]
+
+**Correct (batched query):** [good example]
+```
+
+### 3. Quantified Impact
+
+Include specific metrics. Helps agents prioritize fixes.
+
+**Good:** "10x faster queries", "50% smaller index", "Eliminates N+1" 
+**Bad:** "Faster", "Better", "More efficient"
+
+### 4. Self-Contained Examples
+
+Examples should be complete and runnable (or close to it). Include `CREATE TABLE`
+if context is needed.
+
+```sql
+-- Include table definition when needed for clarity
+CREATE TABLE users (
+  id bigint PRIMARY KEY,
+  email text NOT NULL,
+  deleted_at timestamptz
+);
+
+-- Now show the index
+CREATE INDEX users_active_email_idx ON users(email) WHERE deleted_at IS NULL;
+```
+
+### 5. Semantic Naming
+
+Use meaningful table/column names. Names carry intent for LLMs.
+
+**Good:** `users`, `email`, `created_at`, `is_active`
+**Bad:** `table1`, `col1`, `field`, `flag`
+
+---
+
+## Code Example Standards
+
+### SQL Formatting
+
+```sql
+-- Use lowercase keywords, clear formatting
+CREATE INDEX CONCURRENTLY users_email_idx
+  ON users(email)
+  WHERE deleted_at IS NULL;
+
+-- Not cramped or ALL CAPS
+CREATE INDEX CONCURRENTLY USERS_EMAIL_IDX ON USERS(EMAIL) WHERE DELETED_AT IS NULL;
+```
+
+### Comments
+
+- Explain _why_, not _what_
+- Highlight performance implications
+- Point out common pitfalls
+
+### Language Tags
+
+- `sql` - Standard SQL queries
+- `plpgsql` - Stored procedures/functions
+- `typescript` - Application code (when needed)
+- `python` - Application code (when needed)
+
+---
+
+## When to Include Application Code
+
+**Default: SQL Only**
+
+Most references should focus on pure SQL patterns. This keeps examples portable.
+
+**Include Application Code When:**
+
+- Connection pooling configuration
+- Transaction management in application context
+- ORM anti-patterns (N+1 in Prisma/TypeORM)
+- Prepared statement usage
+
+**Format for Mixed Examples:**
+
+````markdown
+**Incorrect (N+1 in application):**
+
+```typescript
+for (const user of users) {
+  const posts = await db.query("SELECT * FROM posts WHERE user_id = $1", [
+    user.id,
+  ]);
+}
+```
+````
+
+**Correct (batch query):**
+
+```typescript
+const posts = await db.query("SELECT * FROM posts WHERE user_id = ANY($1)", [
+  userIds,
+]);
+```
+
+---
+
+## Impact Level Guidelines
+
+| Level | Improvement | Use When |
+|-------|-------------|----------|
+| **CRITICAL** | 10-100x | Missing indexes, connection exhaustion, sequential scans on large tables |
+| **HIGH** | 5-20x | Wrong index types, poor partitioning, missing covering indexes |
+| **MEDIUM-HIGH** | 2-5x | N+1 queries, inefficient pagination, RLS optimization |
+| **MEDIUM** | 1.5-3x | Redundant indexes, query plan instability |
+| **LOW-MEDIUM** | 1.2-2x | VACUUM tuning, configuration tweaks |
+| **LOW** | Incremental | Advanced patterns, edge cases |
+
+---
+
+## Reference Standards
+
+**Primary Sources:**
+
+- Official Postgres documentation
+- Supabase documentation
+- Postgres wiki
+- Established blogs (2ndQuadrant, Crunchy Data)
+
+**Format:**
+
+```markdown
+Reference:
+[Postgres Indexes](https://www.postgresql.org/docs/current/indexes.html)
+```
+
+---
+
+## Review Checklist
+
+Before submitting a reference:
+
+- [ ] Title is clear and action-oriented
+- [ ] Impact level matches the performance gain
+- [ ] impactDescription includes quantification
+- [ ] Explanation is concise (1-2 sentences)
+- [ ] Has at least 1 **Incorrect** SQL example
+- [ ] Has at least 1 **Correct** SQL example
+- [ ] SQL uses semantic naming
+- [ ] Comments explain _why_, not _what_
+- [ ] Trade-offs mentioned if applicable
+- [ ] Reference links included
+- [ ] `pnpm test` passes

--- a/.agents/skills/supabase-postgres-best-practices/references/_sections.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/_sections.md
@@ -1,0 +1,39 @@
+# Section Definitions
+
+This file defines the rule categories for Postgres best practices. Rules are automatically assigned to sections based on their filename prefix.
+
+Take the examples below as pure demonstrative. Replace each section with the actual rule categories for Postgres best practices.
+
+---
+
+## 1. Query Performance (query)
+**Impact:** CRITICAL
+**Description:** Slow queries, missing indexes, inefficient query plans. The most common source of Postgres performance issues.
+
+## 2. Connection Management (conn)
+**Impact:** CRITICAL
+**Description:** Connection pooling, limits, and serverless strategies. Critical for applications with high concurrency or serverless deployments.
+
+## 3. Security & RLS (security)
+**Impact:** CRITICAL
+**Description:** Row-Level Security policies, privilege management, and authentication patterns.
+
+## 4. Schema Design (schema)
+**Impact:** HIGH
+**Description:** Table design, index strategies, partitioning, and data type selection. Foundation for long-term performance.
+
+## 5. Concurrency & Locking (lock)
+**Impact:** MEDIUM-HIGH
+**Description:** Transaction management, isolation levels, deadlock prevention, and lock contention patterns.
+
+## 6. Data Access Patterns (data)
+**Impact:** MEDIUM
+**Description:** N+1 query elimination, batch operations, cursor-based pagination, and efficient data fetching.
+
+## 7. Monitoring & Diagnostics (monitor)
+**Impact:** LOW-MEDIUM
+**Description:** Using pg_stat_statements, EXPLAIN ANALYZE, metrics collection, and performance diagnostics.
+
+## 8. Advanced Features (advanced)
+**Impact:** LOW
+**Description:** Full-text search, JSONB optimization, PostGIS, extensions, and advanced Postgres features.

--- a/.agents/skills/supabase-postgres-best-practices/references/_template.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/_template.md
@@ -1,0 +1,34 @@
+---
+title: Clear, Action-Oriented Title (e.g., "Use Partial Indexes for Filtered Queries")
+impact: MEDIUM
+impactDescription: 5-20x query speedup for filtered queries
+tags: indexes, query-optimization, performance
+---
+
+## [Rule Title]
+
+[1-2 sentence explanation of the problem and why it matters. Focus on performance impact.]
+
+**Incorrect (describe the problem):**
+
+```sql
+-- Comment explaining what makes this slow/problematic
+CREATE INDEX users_email_idx ON users(email);
+
+SELECT * FROM users WHERE email = 'user@example.com' AND deleted_at IS NULL;
+-- This scans deleted records unnecessarily
+```
+
+**Correct (describe the solution):**
+
+```sql
+-- Comment explaining why this is better
+CREATE INDEX users_active_email_idx ON users(email) WHERE deleted_at IS NULL;
+
+SELECT * FROM users WHERE email = 'user@example.com' AND deleted_at IS NULL;
+-- Only indexes active users, 10x smaller index, faster queries
+```
+
+[Optional: Additional context, edge cases, or trade-offs]
+
+Reference: [Postgres Docs](https://www.postgresql.org/docs/current/)

--- a/.agents/skills/supabase-postgres-best-practices/references/advanced-full-text-search.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/advanced-full-text-search.md
@@ -1,0 +1,55 @@
+---
+title: Use tsvector for Full-Text Search
+impact: MEDIUM
+impactDescription: 100x faster than LIKE, with ranking support
+tags: full-text-search, tsvector, gin, search
+---
+
+## Use tsvector for Full-Text Search
+
+LIKE with wildcards can't use indexes. Full-text search with tsvector is orders of magnitude faster.
+
+**Incorrect (LIKE pattern matching):**
+
+```sql
+-- Cannot use index, scans all rows
+select * from articles where content like '%postgresql%';
+
+-- Case-insensitive makes it worse
+select * from articles where lower(content) like '%postgresql%';
+```
+
+**Correct (full-text search with tsvector):**
+
+```sql
+-- Add tsvector column and index
+alter table articles add column search_vector tsvector
+  generated always as (to_tsvector('english', coalesce(title,'') || ' ' || coalesce(content,''))) stored;
+
+create index articles_search_idx on articles using gin (search_vector);
+
+-- Fast full-text search
+select * from articles
+where search_vector @@ to_tsquery('english', 'postgresql & performance');
+
+-- With ranking
+select *, ts_rank(search_vector, query) as rank
+from articles, to_tsquery('english', 'postgresql') query
+where search_vector @@ query
+order by rank desc;
+```
+
+Search multiple terms:
+
+```sql
+-- AND: both terms required
+to_tsquery('postgresql & performance')
+
+-- OR: either term
+to_tsquery('postgresql | mysql')
+
+-- Prefix matching
+to_tsquery('post:*')
+```
+
+Reference: [Full Text Search](https://supabase.com/docs/guides/database/full-text-search)

--- a/.agents/skills/supabase-postgres-best-practices/references/advanced-jsonb-indexing.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/advanced-jsonb-indexing.md
@@ -1,0 +1,49 @@
+---
+title: Index JSONB Columns for Efficient Querying
+impact: MEDIUM
+impactDescription: 10-100x faster JSONB queries with proper indexing
+tags: jsonb, gin, indexes, json
+---
+
+## Index JSONB Columns for Efficient Querying
+
+JSONB queries without indexes scan the entire table. Use GIN indexes for containment queries.
+
+**Incorrect (no index on JSONB):**
+
+```sql
+create table products (
+  id bigint primary key,
+  attributes jsonb
+);
+
+-- Full table scan for every query
+select * from products where attributes @> '{"color": "red"}';
+select * from products where attributes->>'brand' = 'Nike';
+```
+
+**Correct (GIN index for JSONB):**
+
+```sql
+-- GIN index for containment operators (@>, ?, ?&, ?|)
+create index products_attrs_gin on products using gin (attributes);
+
+-- Now containment queries use the index
+select * from products where attributes @> '{"color": "red"}';
+
+-- For specific key lookups, use expression index
+create index products_brand_idx on products ((attributes->>'brand'));
+select * from products where attributes->>'brand' = 'Nike';
+```
+
+Choose the right operator class:
+
+```sql
+-- jsonb_ops (default): supports all operators, larger index
+create index idx1 on products using gin (attributes);
+
+-- jsonb_path_ops: only @> operator, but 2-3x smaller index
+create index idx2 on products using gin (attributes jsonb_path_ops);
+```
+
+Reference: [JSONB Indexes](https://www.postgresql.org/docs/current/datatype-json.html#JSON-INDEXING)

--- a/.agents/skills/supabase-postgres-best-practices/references/conn-idle-timeout.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/conn-idle-timeout.md
@@ -1,0 +1,46 @@
+---
+title: Configure Idle Connection Timeouts
+impact: HIGH
+impactDescription: Reclaim 30-50% of connection slots from idle clients
+tags: connections, timeout, idle, resource-management
+---
+
+## Configure Idle Connection Timeouts
+
+Idle connections waste resources. Configure timeouts to automatically reclaim them.
+
+**Incorrect (connections held indefinitely):**
+
+```sql
+-- No timeout configured
+show idle_in_transaction_session_timeout;  -- 0 (disabled)
+
+-- Connections stay open forever, even when idle
+select pid, state, state_change, query
+from pg_stat_activity
+where state = 'idle in transaction';
+-- Shows transactions idle for hours, holding locks
+```
+
+**Correct (automatic cleanup of idle connections):**
+
+```sql
+-- Terminate connections idle in transaction after 30 seconds
+alter system set idle_in_transaction_session_timeout = '30s';
+
+-- Terminate completely idle connections after 10 minutes
+alter system set idle_session_timeout = '10min';
+
+-- Reload configuration
+select pg_reload_conf();
+```
+
+For pooled connections, configure at the pooler level:
+
+```ini
+# pgbouncer.ini
+server_idle_timeout = 60
+client_idle_timeout = 300
+```
+
+Reference: [Connection Timeouts](https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-IDLE-IN-TRANSACTION-SESSION-TIMEOUT)

--- a/.agents/skills/supabase-postgres-best-practices/references/conn-limits.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/conn-limits.md
@@ -1,0 +1,44 @@
+---
+title: Set Appropriate Connection Limits
+impact: CRITICAL
+impactDescription: Prevent database crashes and memory exhaustion
+tags: connections, max-connections, limits, stability
+---
+
+## Set Appropriate Connection Limits
+
+Too many connections exhaust memory and degrade performance. Set limits based on available resources.
+
+**Incorrect (unlimited or excessive connections):**
+
+```sql
+-- Default max_connections = 100, but often increased blindly
+show max_connections;  -- 500 (way too high for 4GB RAM)
+
+-- Each connection uses 1-3MB RAM
+-- 500 connections * 2MB = 1GB just for connections!
+-- Out of memory errors under load
+```
+
+**Correct (calculate based on resources):**
+
+```sql
+-- Formula: max_connections = (RAM in MB / 5MB per connection) - reserved
+-- For 4GB RAM: (4096 / 5) - 10 = ~800 theoretical max
+-- But practically, 100-200 is better for query performance
+
+-- Recommended settings for 4GB RAM
+alter system set max_connections = 100;
+
+-- Also set work_mem appropriately
+-- work_mem * max_connections should not exceed 25% of RAM
+alter system set work_mem = '8MB';  -- 8MB * 100 = 800MB max
+```
+
+Monitor connection usage:
+
+```sql
+select count(*), state from pg_stat_activity group by state;
+```
+
+Reference: [Database Connections](https://supabase.com/docs/guides/platform/performance#connection-management)

--- a/.agents/skills/supabase-postgres-best-practices/references/conn-pooling.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/conn-pooling.md
@@ -1,0 +1,41 @@
+---
+title: Use Connection Pooling for All Applications
+impact: CRITICAL
+impactDescription: Handle 10-100x more concurrent users
+tags: connection-pooling, pgbouncer, performance, scalability
+---
+
+## Use Connection Pooling for All Applications
+
+Postgres connections are expensive (1-3MB RAM each). Without pooling, applications exhaust connections under load.
+
+**Incorrect (new connection per request):**
+
+```sql
+-- Each request creates a new connection
+-- Application code: db.connect() per request
+-- Result: 500 concurrent users = 500 connections = crashed database
+
+-- Check current connections
+select count(*) from pg_stat_activity;  -- 487 connections!
+```
+
+**Correct (connection pooling):**
+
+```sql
+-- Use a pooler like PgBouncer between app and database
+-- Application connects to pooler, pooler reuses a small pool to Postgres
+
+-- Configure pool_size based on: (CPU cores * 2) + spindle_count
+-- Example for 4 cores: pool_size = 10
+
+-- Result: 500 concurrent users share 10 actual connections
+select count(*) from pg_stat_activity;  -- 10 connections
+```
+
+Pool modes:
+
+- **Transaction mode**: connection returned after each transaction (best for most apps)
+- **Session mode**: connection held for entire session (needed for prepared statements, temp tables)
+
+Reference: [Connection Pooling](https://supabase.com/docs/guides/database/connecting-to-postgres#connection-pooler)

--- a/.agents/skills/supabase-postgres-best-practices/references/conn-prepared-statements.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/conn-prepared-statements.md
@@ -1,0 +1,46 @@
+---
+title: Use Prepared Statements Correctly with Pooling
+impact: HIGH
+impactDescription: Avoid prepared statement conflicts in pooled environments
+tags: prepared-statements, connection-pooling, transaction-mode
+---
+
+## Use Prepared Statements Correctly with Pooling
+
+Prepared statements are tied to individual database connections. In transaction-mode pooling, connections are shared, causing conflicts.
+
+**Incorrect (named prepared statements with transaction pooling):**
+
+```sql
+-- Named prepared statement
+prepare get_user as select * from users where id = $1;
+
+-- In transaction mode pooling, next request may get different connection
+execute get_user(123);
+-- ERROR: prepared statement "get_user" does not exist
+```
+
+**Correct (use unnamed statements or session mode):**
+
+```sql
+-- Option 1: Use unnamed prepared statements (most ORMs do this automatically)
+-- The query is prepared and executed in a single protocol message
+
+-- Option 2: Deallocate after use in transaction mode
+prepare get_user as select * from users where id = $1;
+execute get_user(123);
+deallocate get_user;
+
+-- Option 3: Use session mode pooling (port 5432 vs 6543)
+-- Connection is held for entire session, prepared statements persist
+```
+
+Check your driver settings:
+
+```sql
+-- Many drivers use prepared statements by default
+-- Node.js pg: { prepare: false } to disable
+-- JDBC: prepareThreshold=0 to disable
+```
+
+Reference: [Prepared Statements with Pooling](https://supabase.com/docs/guides/database/connecting-to-postgres#connection-pool-modes)

--- a/.agents/skills/supabase-postgres-best-practices/references/data-batch-inserts.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/data-batch-inserts.md
@@ -1,0 +1,54 @@
+---
+title: Batch INSERT Statements for Bulk Data
+impact: MEDIUM
+impactDescription: 10-50x faster bulk inserts
+tags: batch, insert, bulk, performance, copy
+---
+
+## Batch INSERT Statements for Bulk Data
+
+Individual INSERT statements have high overhead. Batch multiple rows in single statements or use COPY.
+
+**Incorrect (individual inserts):**
+
+```sql
+-- Each insert is a separate transaction and round trip
+insert into events (user_id, action) values (1, 'click');
+insert into events (user_id, action) values (1, 'view');
+insert into events (user_id, action) values (2, 'click');
+-- ... 1000 more individual inserts
+
+-- 1000 inserts = 1000 round trips = slow
+```
+
+**Correct (batch insert):**
+
+```sql
+-- Multiple rows in single statement
+insert into events (user_id, action) values
+  (1, 'click'),
+  (1, 'view'),
+  (2, 'click'),
+  -- ... up to ~1000 rows per batch
+  (999, 'view');
+
+-- One round trip for 1000 rows
+```
+
+For large imports, use COPY:
+
+```sql
+-- COPY is fastest for bulk loading
+copy events (user_id, action, created_at)
+from '/path/to/data.csv'
+with (format csv, header true);
+
+-- Or from stdin in application
+copy events (user_id, action) from stdin with (format csv);
+1,click
+1,view
+2,click
+\.
+```
+
+Reference: [COPY](https://www.postgresql.org/docs/current/sql-copy.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/data-n-plus-one.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/data-n-plus-one.md
@@ -1,0 +1,53 @@
+---
+title: Eliminate N+1 Queries with Batch Loading
+impact: MEDIUM-HIGH
+impactDescription: 10-100x fewer database round trips
+tags: n-plus-one, batch, performance, queries
+---
+
+## Eliminate N+1 Queries with Batch Loading
+
+N+1 queries execute one query per item in a loop. Batch them into a single query using arrays or JOINs.
+
+**Incorrect (N+1 queries):**
+
+```sql
+-- First query: get all users
+select id from users where active = true;  -- Returns 100 IDs
+
+-- Then N queries, one per user
+select * from orders where user_id = 1;
+select * from orders where user_id = 2;
+select * from orders where user_id = 3;
+-- ... 97 more queries!
+
+-- Total: 101 round trips to database
+```
+
+**Correct (single batch query):**
+
+```sql
+-- Collect IDs and query once with ANY
+select * from orders where user_id = any(array[1, 2, 3, ...]);
+
+-- Or use JOIN instead of loop
+select u.id, u.name, o.*
+from users u
+left join orders o on o.user_id = u.id
+where u.active = true;
+
+-- Total: 1 round trip
+```
+
+Application pattern:
+
+```sql
+-- Instead of looping in application code:
+-- for user in users: db.query("SELECT * FROM orders WHERE user_id = $1", user.id)
+
+-- Pass array parameter:
+select * from orders where user_id = any($1::bigint[]);
+-- Application passes: [1, 2, 3, 4, 5, ...]
+```
+
+Reference: [N+1 Query Problem](https://supabase.com/docs/guides/database/query-optimization)

--- a/.agents/skills/supabase-postgres-best-practices/references/data-pagination.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/data-pagination.md
@@ -1,0 +1,50 @@
+---
+title: Use Cursor-Based Pagination Instead of OFFSET
+impact: MEDIUM-HIGH
+impactDescription: Consistent O(1) performance regardless of page depth
+tags: pagination, cursor, keyset, offset, performance
+---
+
+## Use Cursor-Based Pagination Instead of OFFSET
+
+OFFSET-based pagination scans all skipped rows, getting slower on deeper pages. Cursor pagination is O(1).
+
+**Incorrect (OFFSET pagination):**
+
+```sql
+-- Page 1: scans 20 rows
+select * from products order by id limit 20 offset 0;
+
+-- Page 100: scans 2000 rows to skip 1980
+select * from products order by id limit 20 offset 1980;
+
+-- Page 10000: scans 200,000 rows!
+select * from products order by id limit 20 offset 199980;
+```
+
+**Correct (cursor/keyset pagination):**
+
+```sql
+-- Page 1: get first 20
+select * from products order by id limit 20;
+-- Application stores last_id = 20
+
+-- Page 2: start after last ID
+select * from products where id > 20 order by id limit 20;
+-- Uses index, always fast regardless of page depth
+
+-- Page 10000: same speed as page 1
+select * from products where id > 199980 order by id limit 20;
+```
+
+For multi-column sorting:
+
+```sql
+-- Cursor must include all sort columns
+select * from products
+where (created_at, id) > ('2024-01-15 10:00:00', 12345)
+order by created_at, id
+limit 20;
+```
+
+Reference: [Pagination](https://supabase.com/docs/guides/database/pagination)

--- a/.agents/skills/supabase-postgres-best-practices/references/data-upsert.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/data-upsert.md
@@ -1,0 +1,50 @@
+---
+title: Use UPSERT for Insert-or-Update Operations
+impact: MEDIUM
+impactDescription: Atomic operation, eliminates race conditions
+tags: upsert, on-conflict, insert, update
+---
+
+## Use UPSERT for Insert-or-Update Operations
+
+Using separate SELECT-then-INSERT/UPDATE creates race conditions. Use INSERT ... ON CONFLICT for atomic upserts.
+
+**Incorrect (check-then-insert race condition):**
+
+```sql
+-- Race condition: two requests check simultaneously
+select * from settings where user_id = 123 and key = 'theme';
+-- Both find nothing
+
+-- Both try to insert
+insert into settings (user_id, key, value) values (123, 'theme', 'dark');
+-- One succeeds, one fails with duplicate key error!
+```
+
+**Correct (atomic UPSERT):**
+
+```sql
+-- Single atomic operation
+insert into settings (user_id, key, value)
+values (123, 'theme', 'dark')
+on conflict (user_id, key)
+do update set value = excluded.value, updated_at = now();
+
+-- Returns the inserted/updated row
+insert into settings (user_id, key, value)
+values (123, 'theme', 'dark')
+on conflict (user_id, key)
+do update set value = excluded.value
+returning *;
+```
+
+Insert-or-ignore pattern:
+
+```sql
+-- Insert only if not exists (no update)
+insert into page_views (page_id, user_id)
+values (1, 123)
+on conflict (page_id, user_id) do nothing;
+```
+
+Reference: [INSERT ON CONFLICT](https://www.postgresql.org/docs/current/sql-insert.html#SQL-ON-CONFLICT)

--- a/.agents/skills/supabase-postgres-best-practices/references/lock-advisory.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/lock-advisory.md
@@ -1,0 +1,56 @@
+---
+title: Use Advisory Locks for Application-Level Locking
+impact: MEDIUM
+impactDescription: Efficient coordination without row-level lock overhead
+tags: advisory-locks, coordination, application-locks
+---
+
+## Use Advisory Locks for Application-Level Locking
+
+Advisory locks provide application-level coordination without requiring database rows to lock.
+
+**Incorrect (creating rows just for locking):**
+
+```sql
+-- Creating dummy rows to lock on
+create table resource_locks (
+  resource_name text primary key
+);
+
+insert into resource_locks values ('report_generator');
+
+-- Lock by selecting the row
+select * from resource_locks where resource_name = 'report_generator' for update;
+```
+
+**Correct (advisory locks):**
+
+```sql
+-- Session-level advisory lock (released on disconnect or unlock)
+select pg_advisory_lock(hashtext('report_generator'));
+-- ... do exclusive work ...
+select pg_advisory_unlock(hashtext('report_generator'));
+
+-- Transaction-level lock (released on commit/rollback)
+begin;
+select pg_advisory_xact_lock(hashtext('daily_report'));
+-- ... do work ...
+commit;  -- Lock automatically released
+```
+
+Try-lock for non-blocking operations:
+
+```sql
+-- Returns immediately with true/false instead of waiting
+select pg_try_advisory_lock(hashtext('resource_name'));
+
+-- Use in application
+if (acquired) {
+  -- Do work
+  select pg_advisory_unlock(hashtext('resource_name'));
+} else {
+  -- Skip or retry later
+}
+```
+
+Reference: [Advisory Locks](https://www.postgresql.org/docs/current/explicit-locking.html#ADVISORY-LOCKS)

--- a/.agents/skills/supabase-postgres-best-practices/references/lock-deadlock-prevention.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/lock-deadlock-prevention.md
@@ -1,0 +1,68 @@
+---
+title: Prevent Deadlocks with Consistent Lock Ordering
+impact: MEDIUM-HIGH
+impactDescription: Eliminate deadlock errors, improve reliability
+tags: deadlocks, locking, transactions, ordering
+---
+
+## Prevent Deadlocks with Consistent Lock Ordering
+
+Deadlocks occur when transactions lock resources in different orders. Always
+acquire locks in a consistent order.
+
+**Incorrect (inconsistent lock ordering):**
+
+```sql
+-- Transaction A                    -- Transaction B
+begin;                              begin;
+update accounts                     update accounts
+set balance = balance - 100         set balance = balance - 50
+where id = 1;                       where id = 2;  -- B locks row 2
+
+update accounts                     update accounts
+set balance = balance + 100         set balance = balance + 50
+where id = 2;  -- A waits for B     where id = 1;  -- B waits for A
+
+-- DEADLOCK! Both waiting for each other
+```
+
+**Correct (lock rows in consistent order first):**
+
+```sql
+-- Explicitly acquire locks in ID order before updating
+begin;
+select * from accounts where id in (1, 2) order by id for update;
+
+-- Now perform updates in any order - locks already held
+update accounts set balance = balance - 100 where id = 1;
+update accounts set balance = balance + 100 where id = 2;
+commit;
+```
+
+Alternative: use a single statement to update atomically:
+
+```sql
+-- Single statement acquires all locks atomically
+begin;
+update accounts
+set balance = balance + case id
+  when 1 then -100
+  when 2 then 100
+end
+where id in (1, 2);
+commit;
+```
+
+Detect deadlocks in logs:
+
+```sql
+-- Check for recent deadlocks
+select * from pg_stat_database where deadlocks > 0;
+
+-- Enable deadlock logging
+set log_lock_waits = on;
+set deadlock_timeout = '1s';
+```
+
+Reference:
+[Deadlocks](https://www.postgresql.org/docs/current/explicit-locking.html#LOCKING-DEADLOCKS)

--- a/.agents/skills/supabase-postgres-best-practices/references/lock-short-transactions.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/lock-short-transactions.md
@@ -1,0 +1,50 @@
+---
+title: Keep Transactions Short to Reduce Lock Contention
+impact: MEDIUM-HIGH
+impactDescription: 3-5x throughput improvement, fewer deadlocks
+tags: transactions, locking, contention, performance
+---
+
+## Keep Transactions Short to Reduce Lock Contention
+
+Long-running transactions hold locks that block other queries. Keep transactions as short as possible.
+
+**Incorrect (long transaction with external calls):**
+
+```sql
+begin;
+select * from orders where id = 1 for update;  -- Lock acquired
+
+-- Application makes HTTP call to payment API (2-5 seconds)
+-- Other queries on this row are blocked!
+
+update orders set status = 'paid' where id = 1;
+commit;  -- Lock held for entire duration
+```
+
+**Correct (minimal transaction scope):**
+
+```sql
+-- Validate data and call APIs outside transaction
+-- Application: response = await paymentAPI.charge(...)
+
+-- Only hold lock for the actual update
+begin;
+update orders
+set status = 'paid', payment_id = $1
+where id = $2 and status = 'pending'
+returning *;
+commit;  -- Lock held for milliseconds
+```
+
+Use `statement_timeout` to prevent runaway transactions:
+
+```sql
+-- Abort queries running longer than 30 seconds
+set statement_timeout = '30s';
+
+-- Or per-session
+set local statement_timeout = '5s';
+```
+
+Reference: [Transaction Management](https://www.postgresql.org/docs/current/tutorial-transactions.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/lock-skip-locked.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/lock-skip-locked.md
@@ -1,0 +1,54 @@
+---
+title: Use SKIP LOCKED for Non-Blocking Queue Processing
+impact: MEDIUM-HIGH
+impactDescription: 10x throughput for worker queues
+tags: skip-locked, queue, workers, concurrency
+---
+
+## Use SKIP LOCKED for Non-Blocking Queue Processing
+
+When multiple workers process a queue, SKIP LOCKED allows workers to process different rows without waiting.
+
+**Incorrect (workers block each other):**
+
+```sql
+-- Worker 1 and Worker 2 both try to get next job
+begin;
+select * from jobs where status = 'pending' order by created_at limit 1 for update;
+-- Worker 2 waits for Worker 1's lock to release!
+```
+
+**Correct (SKIP LOCKED for parallel processing):**
+
+```sql
+-- Each worker skips locked rows and gets the next available
+begin;
+select * from jobs
+where status = 'pending'
+order by created_at
+limit 1
+for update skip locked;
+
+-- Worker 1 gets job 1, Worker 2 gets job 2 (no waiting)
+
+update jobs set status = 'processing' where id = $1;
+commit;
+```
+
+Complete queue pattern:
+
+```sql
+-- Atomic claim-and-update in one statement
+update jobs
+set status = 'processing', worker_id = $1, started_at = now()
+where id = (
+  select id from jobs
+  where status = 'pending'
+  order by created_at
+  limit 1
+  for update skip locked
+)
+returning *;
+```
+
+Reference: [SELECT FOR UPDATE SKIP LOCKED](https://www.postgresql.org/docs/current/sql-select.html#SQL-FOR-UPDATE-SHARE)

--- a/.agents/skills/supabase-postgres-best-practices/references/monitor-explain-analyze.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/monitor-explain-analyze.md
@@ -1,0 +1,45 @@
+---
+title: Use EXPLAIN ANALYZE to Diagnose Slow Queries
+impact: LOW-MEDIUM
+impactDescription: Identify exact bottlenecks in query execution
+tags: explain, analyze, diagnostics, query-plan
+---
+
+## Use EXPLAIN ANALYZE to Diagnose Slow Queries
+
+EXPLAIN ANALYZE executes the query and shows actual timings, revealing the true performance bottlenecks.
+
+**Incorrect (guessing at performance issues):**
+
+```sql
+-- Query is slow, but why?
+select * from orders where customer_id = 123 and status = 'pending';
+-- "It must be missing an index" - but which one?
+```
+
+**Correct (use EXPLAIN ANALYZE):**
+
+```sql
+explain (analyze, buffers, format text)
+select * from orders where customer_id = 123 and status = 'pending';
+
+-- Output reveals the issue:
+-- Seq Scan on orders (cost=0.00..25000.00 rows=50 width=100) (actual time=0.015..450.123 rows=50 loops=1)
+--   Filter: ((customer_id = 123) AND (status = 'pending'::text))
+--   Rows Removed by Filter: 999950
+--   Buffers: shared hit=5000 read=15000
+-- Planning Time: 0.150 ms
+-- Execution Time: 450.500 ms
+```
+
+Key things to look for:
+
+```sql
+-- Seq Scan on large tables = missing index
+-- Rows Removed by Filter = poor selectivity or missing index
+-- Buffers: read >> hit = data not cached, needs more memory
+-- Nested Loop with high loops = consider different join strategy
+-- Sort Method: external merge = work_mem too low
+```
+
+Reference: [EXPLAIN](https://supabase.com/docs/guides/database/inspect)

--- a/.agents/skills/supabase-postgres-best-practices/references/monitor-pg-stat-statements.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/monitor-pg-stat-statements.md
@@ -1,0 +1,55 @@
+---
+title: Enable pg_stat_statements for Query Analysis
+impact: LOW-MEDIUM
+impactDescription: Identify top resource-consuming queries
+tags: pg-stat-statements, monitoring, statistics, performance
+---
+
+## Enable pg_stat_statements for Query Analysis
+
+pg_stat_statements tracks execution statistics for all queries, helping identify slow and frequent queries.
+
+**Incorrect (no visibility into query patterns):**
+
+```sql
+-- Database is slow, but which queries are the problem?
+-- No way to know without pg_stat_statements
+```
+
+**Correct (enable and query pg_stat_statements):**
+
+```sql
+-- Enable the extension
+create extension if not exists pg_stat_statements;
+
+-- Find slowest queries by total time
+select
+  calls,
+  round(total_exec_time::numeric, 2) as total_time_ms,
+  round(mean_exec_time::numeric, 2) as mean_time_ms,
+  query
+from pg_stat_statements
+order by total_exec_time desc
+limit 10;
+
+-- Find most frequent queries
+select calls, query
+from pg_stat_statements
+order by calls desc
+limit 10;
+
+-- Reset statistics after optimization
+select pg_stat_statements_reset();
+```
+
+Key metrics to monitor:
+
+```sql
+-- Queries with high mean time (candidates for optimization)
+select query, mean_exec_time, calls
+from pg_stat_statements
+where mean_exec_time > 100  -- > 100ms average
+order by mean_exec_time desc;
+```
+
+Reference: [pg_stat_statements](https://supabase.com/docs/guides/database/extensions/pg_stat_statements)

--- a/.agents/skills/supabase-postgres-best-practices/references/monitor-vacuum-analyze.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/monitor-vacuum-analyze.md
@@ -1,0 +1,55 @@
+---
+title: Maintain Table Statistics with VACUUM and ANALYZE
+impact: MEDIUM
+impactDescription: 2-10x better query plans with accurate statistics
+tags: vacuum, analyze, statistics, maintenance, autovacuum
+---
+
+## Maintain Table Statistics with VACUUM and ANALYZE
+
+Outdated statistics cause the query planner to make poor decisions. VACUUM reclaims space, ANALYZE updates statistics.
+
+**Incorrect (stale statistics):**
+
+```sql
+-- Table has 1M rows but stats say 1000
+-- Query planner chooses wrong strategy
+explain select * from orders where status = 'pending';
+-- Shows: Seq Scan (because stats show small table)
+-- Actually: Index Scan would be much faster
+```
+
+**Correct (maintain fresh statistics):**
+
+```sql
+-- Manually analyze after large data changes
+analyze orders;
+
+-- Analyze specific columns used in WHERE clauses
+analyze orders (status, created_at);
+
+-- Check when tables were last analyzed
+select
+  relname,
+  last_vacuum,
+  last_autovacuum,
+  last_analyze,
+  last_autoanalyze
+from pg_stat_user_tables
+order by last_analyze nulls first;
+```
+
+Autovacuum tuning for busy tables:
+
+```sql
+-- Increase frequency for high-churn tables
+alter table orders set (
+  autovacuum_vacuum_scale_factor = 0.05,     -- Vacuum at 5% dead tuples (default 20%)
+  autovacuum_analyze_scale_factor = 0.02     -- Analyze at 2% changes (default 10%)
+);
+
+-- Check autovacuum status
+select * from pg_stat_progress_vacuum;
+```
+
+Reference: [VACUUM](https://supabase.com/docs/guides/database/database-size#vacuum-operations)

--- a/.agents/skills/supabase-postgres-best-practices/references/query-composite-indexes.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/query-composite-indexes.md
@@ -1,0 +1,44 @@
+---
+title: Create Composite Indexes for Multi-Column Queries
+impact: HIGH
+impactDescription: 5-10x faster multi-column queries
+tags: indexes, composite-index, multi-column, query-optimization
+---
+
+## Create Composite Indexes for Multi-Column Queries
+
+When queries filter on multiple columns, a composite index is more efficient than separate single-column indexes.
+
+**Incorrect (separate indexes require bitmap scan):**
+
+```sql
+-- Two separate indexes
+create index orders_status_idx on orders (status);
+create index orders_created_idx on orders (created_at);
+
+-- Query must combine both indexes (slower)
+select * from orders where status = 'pending' and created_at > '2024-01-01';
+```
+
+**Correct (composite index):**
+
+```sql
+-- Single composite index (leftmost column first for equality checks)
+create index orders_status_created_idx on orders (status, created_at);
+
+-- Query uses one efficient index scan
+select * from orders where status = 'pending' and created_at > '2024-01-01';
+```
+
+**Column order matters** - place equality columns first, range columns last:
+
+```sql
+-- Good: status (=) before created_at (>)
+create index idx on orders (status, created_at);
+
+-- Works for: WHERE status = 'pending'
+-- Works for: WHERE status = 'pending' AND created_at > '2024-01-01'
+-- Does NOT work for: WHERE created_at > '2024-01-01' (leftmost prefix rule)
+```
+
+Reference: [Multicolumn Indexes](https://www.postgresql.org/docs/current/indexes-multicolumn.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/query-covering-indexes.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/query-covering-indexes.md
@@ -1,0 +1,40 @@
+---
+title: Use Covering Indexes to Avoid Table Lookups
+impact: MEDIUM-HIGH
+impactDescription: 2-5x faster queries by eliminating heap fetches
+tags: indexes, covering-index, include, index-only-scan
+---
+
+## Use Covering Indexes to Avoid Table Lookups
+
+Covering indexes include all columns needed by a query, enabling index-only scans that skip the table entirely.
+
+**Incorrect (index scan + heap fetch):**
+
+```sql
+create index users_email_idx on users (email);
+
+-- Must fetch name and created_at from table heap
+select email, name, created_at from users where email = 'user@example.com';
+```
+
+**Correct (index-only scan with INCLUDE):**
+
+```sql
+-- Include non-searchable columns in the index
+create index users_email_idx on users (email) include (name, created_at);
+
+-- All columns served from index, no table access needed
+select email, name, created_at from users where email = 'user@example.com';
+```
+
+Use INCLUDE for columns you SELECT but don't filter on:
+
+```sql
+-- Searching by status, but also need customer_id and total
+create index orders_status_idx on orders (status) include (customer_id, total);
+
+select status, customer_id, total from orders where status = 'shipped';
+```
+
+Reference: [Index-Only Scans](https://www.postgresql.org/docs/current/indexes-index-only-scans.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/query-index-types.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/query-index-types.md
@@ -1,0 +1,48 @@
+---
+title: Choose the Right Index Type for Your Data
+impact: HIGH
+impactDescription: 10-100x improvement with correct index type
+tags: indexes, btree, gin, gist, brin, hash, index-types
+---
+
+## Choose the Right Index Type for Your Data
+
+Different index types excel at different query patterns. The default B-tree isn't always optimal.
+
+**Incorrect (B-tree for JSONB containment):**
+
+```sql
+-- B-tree cannot optimize containment operators
+create index products_attrs_idx on products (attributes);
+select * from products where attributes @> '{"color": "red"}';
+-- Full table scan - B-tree doesn't support @> operator
+```
+
+**Correct (GIN for JSONB):**
+
+```sql
+-- GIN supports @>, ?, ?&, ?| operators
+create index products_attrs_idx on products using gin (attributes);
+select * from products where attributes @> '{"color": "red"}';
+```
+
+Index type guide:
+
+```sql
+-- B-tree (default): =, <, >, BETWEEN, IN, IS NULL
+create index users_created_idx on users (created_at);
+
+-- GIN: arrays, JSONB, full-text search
+create index posts_tags_idx on posts using gin (tags);
+
+-- GiST: geometric data, range types, nearest-neighbor (KNN) queries
+create index locations_idx on places using gist (location);
+
+-- BRIN: large time-series tables (10-100x smaller)
+create index events_time_idx on events using brin (created_at);
+
+-- Hash: equality-only (slightly faster than B-tree for =)
+create index sessions_token_idx on sessions using hash (token);
+```
+
+Reference: [Index Types](https://www.postgresql.org/docs/current/indexes-types.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/query-missing-indexes.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/query-missing-indexes.md
@@ -1,0 +1,43 @@
+---
+title: Add Indexes on WHERE and JOIN Columns
+impact: CRITICAL
+impactDescription: 100-1000x faster queries on large tables
+tags: indexes, performance, sequential-scan, query-optimization
+---
+
+## Add Indexes on WHERE and JOIN Columns
+
+Queries filtering or joining on unindexed columns cause full table scans, which become exponentially slower as tables grow.
+
+**Incorrect (sequential scan on large table):**
+
+```sql
+-- No index on customer_id causes full table scan
+select * from orders where customer_id = 123;
+
+-- EXPLAIN shows: Seq Scan on orders (cost=0.00..25000.00 rows=100 width=85)
+```
+
+**Correct (index scan):**
+
+```sql
+-- Create index on frequently filtered column
+create index orders_customer_id_idx on orders (customer_id);
+
+select * from orders where customer_id = 123;
+
+-- EXPLAIN shows: Index Scan using orders_customer_id_idx (cost=0.42..8.44 rows=100 width=85)
+```
+
+For JOIN columns, always index the foreign key side:
+
+```sql
+-- Index the referencing column
+create index orders_customer_id_idx on orders (customer_id);
+
+select c.name, o.total
+from customers c
+join orders o on o.customer_id = c.id;
+```
+
+Reference: [Query Optimization](https://supabase.com/docs/guides/database/query-optimization)

--- a/.agents/skills/supabase-postgres-best-practices/references/query-partial-indexes.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/query-partial-indexes.md
@@ -1,0 +1,45 @@
+---
+title: Use Partial Indexes for Filtered Queries
+impact: HIGH
+impactDescription: 5-20x smaller indexes, faster writes and queries
+tags: indexes, partial-index, query-optimization, storage
+---
+
+## Use Partial Indexes for Filtered Queries
+
+Partial indexes only include rows matching a WHERE condition, making them smaller and faster when queries consistently filter on the same condition.
+
+**Incorrect (full index includes irrelevant rows):**
+
+```sql
+-- Index includes all rows, even soft-deleted ones
+create index users_email_idx on users (email);
+
+-- Query always filters active users
+select * from users where email = 'user@example.com' and deleted_at is null;
+```
+
+**Correct (partial index matches query filter):**
+
+```sql
+-- Index only includes active users
+create index users_active_email_idx on users (email)
+where deleted_at is null;
+
+-- Query uses the smaller, faster index
+select * from users where email = 'user@example.com' and deleted_at is null;
+```
+
+Common use cases for partial indexes:
+
+```sql
+-- Only pending orders (status rarely changes once completed)
+create index orders_pending_idx on orders (created_at)
+where status = 'pending';
+
+-- Only non-null values
+create index products_sku_idx on products (sku)
+where sku is not null;
+```
+
+Reference: [Partial Indexes](https://www.postgresql.org/docs/current/indexes-partial.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/schema-constraints.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/schema-constraints.md
@@ -1,0 +1,80 @@
+---
+title: Add Constraints Safely in Migrations
+impact: HIGH
+impactDescription: Prevents migration failures and enables idempotent schema changes
+tags: constraints, migrations, schema, alter-table
+---
+
+## Add Constraints Safely in Migrations
+
+PostgreSQL does not support `ADD CONSTRAINT IF NOT EXISTS`. Migrations using this syntax will fail.
+
+**Incorrect (causes syntax error):**
+
+```sql
+-- ERROR: syntax error at or near "not" (SQLSTATE 42601)
+alter table public.profiles
+add constraint if not exists profiles_birthchart_id_unique unique (birthchart_id);
+```
+
+**Correct (idempotent constraint creation):**
+
+```sql
+-- Use DO block to check before adding
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'profiles_birthchart_id_unique'
+    and conrelid = 'public.profiles'::regclass
+  ) then
+    alter table public.profiles
+    add constraint profiles_birthchart_id_unique unique (birthchart_id);
+  end if;
+end $$;
+```
+
+For all constraint types:
+
+```sql
+-- Check constraints
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'check_age_positive'
+  ) then
+    alter table users add constraint check_age_positive check (age > 0);
+  end if;
+end $$;
+
+-- Foreign keys
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'profiles_birthchart_id_fkey'
+  ) then
+    alter table profiles
+    add constraint profiles_birthchart_id_fkey
+    foreign key (birthchart_id) references birthcharts(id);
+  end if;
+end $$;
+```
+
+Check if constraint exists:
+
+```sql
+-- Query to check constraint existence
+select conname, contype, pg_get_constraintdef(oid)
+from pg_constraint
+where conrelid = 'public.profiles'::regclass;
+
+-- contype values:
+-- 'p' = PRIMARY KEY
+-- 'f' = FOREIGN KEY
+-- 'u' = UNIQUE
+-- 'c' = CHECK
+```
+
+Reference: [Constraints](https://www.postgresql.org/docs/current/ddl-constraints.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/schema-data-types.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/schema-data-types.md
@@ -1,0 +1,46 @@
+---
+title: Choose Appropriate Data Types
+impact: HIGH
+impactDescription: 50% storage reduction, faster comparisons
+tags: data-types, schema, storage, performance
+---
+
+## Choose Appropriate Data Types
+
+Using the right data types reduces storage, improves query performance, and prevents bugs.
+
+**Incorrect (wrong data types):**
+
+```sql
+create table users (
+  id int,                    -- Will overflow at 2.1 billion
+  email varchar(255),        -- Unnecessary length limit
+  created_at timestamp,      -- Missing timezone info
+  is_active varchar(5),      -- String for boolean
+  price varchar(20)          -- String for numeric
+);
+```
+
+**Correct (appropriate data types):**
+
+```sql
+create table users (
+  id bigint generated always as identity primary key,  -- 9 quintillion max
+  email text,                     -- No artificial limit, same performance as varchar
+  created_at timestamptz,         -- Always store timezone-aware timestamps
+  is_active boolean default true, -- 1 byte vs variable string length
+  price numeric(10,2)             -- Exact decimal arithmetic
+);
+```
+
+Key guidelines:
+
+```sql
+-- IDs: use bigint, not int (future-proofing)
+-- Strings: use text, not varchar(n) unless constraint needed
+-- Time: use timestamptz, not timestamp
+-- Money: use numeric, not float (precision matters)
+-- Enums: use text with check constraint or create enum type
+```
+
+Reference: [Data Types](https://www.postgresql.org/docs/current/datatype.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/schema-foreign-key-indexes.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/schema-foreign-key-indexes.md
@@ -1,0 +1,59 @@
+---
+title: Index Foreign Key Columns
+impact: HIGH
+impactDescription: 10-100x faster JOINs and CASCADE operations
+tags: foreign-key, indexes, joins, schema
+---
+
+## Index Foreign Key Columns
+
+Postgres does not automatically index foreign key columns. Missing indexes cause slow JOINs and CASCADE operations.
+
+**Incorrect (unindexed foreign key):**
+
+```sql
+create table orders (
+  id bigint generated always as identity primary key,
+  customer_id bigint references customers(id) on delete cascade,
+  total numeric(10,2)
+);
+
+-- No index on customer_id!
+-- JOINs and ON DELETE CASCADE both require full table scan
+select * from orders where customer_id = 123;  -- Seq Scan
+delete from customers where id = 123;          -- Locks table, scans all orders
+```
+
+**Correct (indexed foreign key):**
+
+```sql
+create table orders (
+  id bigint generated always as identity primary key,
+  customer_id bigint references customers(id) on delete cascade,
+  total numeric(10,2)
+);
+
+-- Always index the FK column
+create index orders_customer_id_idx on orders (customer_id);
+
+-- Now JOINs and cascades are fast
+select * from orders where customer_id = 123;  -- Index Scan
+delete from customers where id = 123;          -- Uses index, fast cascade
+```
+
+Find missing FK indexes:
+
+```sql
+select
+  conrelid::regclass as table_name,
+  a.attname as fk_column
+from pg_constraint c
+join pg_attribute a on a.attrelid = c.conrelid and a.attnum = any(c.conkey)
+where c.contype = 'f'
+  and not exists (
+    select 1 from pg_index i
+    where i.indrelid = c.conrelid and a.attnum = any(i.indkey)
+  );
+```
+
+Reference: [Foreign Keys](https://www.postgresql.org/docs/current/ddl-constraints.html#DDL-CONSTRAINTS-FK)

--- a/.agents/skills/supabase-postgres-best-practices/references/schema-lowercase-identifiers.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/schema-lowercase-identifiers.md
@@ -1,0 +1,55 @@
+---
+title: Use Lowercase Identifiers for Compatibility
+impact: MEDIUM
+impactDescription: Avoid case-sensitivity bugs with tools, ORMs, and AI assistants
+tags: naming, identifiers, case-sensitivity, schema, conventions
+---
+
+## Use Lowercase Identifiers for Compatibility
+
+PostgreSQL folds unquoted identifiers to lowercase. Quoted mixed-case identifiers require quotes forever and cause issues with tools, ORMs, and AI assistants that may not recognize them.
+
+**Incorrect (mixed-case identifiers):**
+
+```sql
+-- Quoted identifiers preserve case but require quotes everywhere
+CREATE TABLE "Users" (
+  "userId" bigint PRIMARY KEY,
+  "firstName" text,
+  "lastName" text
+);
+
+-- Must always quote or queries fail
+SELECT "firstName" FROM "Users" WHERE "userId" = 1;
+
+-- This fails - Users becomes users without quotes
+SELECT firstName FROM Users;
+-- ERROR: relation "users" does not exist
+```
+
+**Correct (lowercase snake_case):**
+
+```sql
+-- Unquoted lowercase identifiers are portable and tool-friendly
+CREATE TABLE users (
+  user_id bigint PRIMARY KEY,
+  first_name text,
+  last_name text
+);
+
+-- Works without quotes, recognized by all tools
+SELECT first_name FROM users WHERE user_id = 1;
+```
+
+Common sources of mixed-case identifiers:
+
+```sql
+-- ORMs often generate quoted camelCase - configure them to use snake_case
+-- Migrations from other databases may preserve original casing
+-- Some GUI tools quote identifiers by default - disable this
+
+-- If stuck with mixed-case, create views as a compatibility layer
+CREATE VIEW users AS SELECT "userId" AS user_id, "firstName" AS first_name FROM "Users";
+```
+
+Reference: [Identifiers and Key Words](https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS)

--- a/.agents/skills/supabase-postgres-best-practices/references/schema-partitioning.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/schema-partitioning.md
@@ -1,0 +1,55 @@
+---
+title: Partition Large Tables for Better Performance
+impact: MEDIUM-HIGH
+impactDescription: 5-20x faster queries and maintenance on large tables
+tags: partitioning, large-tables, time-series, performance
+---
+
+## Partition Large Tables for Better Performance
+
+Partitioning splits a large table into smaller pieces, improving query performance and maintenance operations.
+
+**Incorrect (single large table):**
+
+```sql
+create table events (
+  id bigint generated always as identity,
+  created_at timestamptz,
+  data jsonb
+);
+
+-- 500M rows, queries scan everything
+select * from events where created_at > '2024-01-01';  -- Slow
+vacuum events;  -- Takes hours, locks table
+```
+
+**Correct (partitioned by time range):**
+
+```sql
+create table events (
+  id bigint generated always as identity,
+  created_at timestamptz not null,
+  data jsonb
+) partition by range (created_at);
+
+-- Create partitions for each month
+create table events_2024_01 partition of events
+  for values from ('2024-01-01') to ('2024-02-01');
+
+create table events_2024_02 partition of events
+  for values from ('2024-02-01') to ('2024-03-01');
+
+-- Queries only scan relevant partitions
+select * from events where created_at > '2024-01-15';  -- Only scans events_2024_01+
+
+-- Drop old data instantly
+drop table events_2023_01;  -- Instant vs DELETE taking hours
+```
+
+When to partition:
+
+- Tables > 100M rows
+- Time-series data with date-based queries
+- Need to efficiently drop old data
+
+Reference: [Table Partitioning](https://www.postgresql.org/docs/current/ddl-partitioning.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/schema-primary-keys.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/schema-primary-keys.md
@@ -1,0 +1,61 @@
+---
+title: Select Optimal Primary Key Strategy
+impact: HIGH
+impactDescription: Better index locality, reduced fragmentation
+tags: primary-key, identity, uuid, serial, schema
+---
+
+## Select Optimal Primary Key Strategy
+
+Primary key choice affects insert performance, index size, and replication
+efficiency.
+
+**Incorrect (problematic PK choices):**
+
+```sql
+-- identity is the SQL-standard approach
+create table users (
+  id serial primary key  -- Works, but IDENTITY is recommended
+);
+
+-- Random UUIDs (v4) cause index fragmentation
+create table orders (
+  id uuid default gen_random_uuid() primary key  -- UUIDv4 = random = scattered inserts
+);
+```
+
+**Correct (optimal PK strategies):**
+
+```sql
+-- Use IDENTITY for sequential IDs (SQL-standard, best for most cases)
+create table users (
+  id bigint generated always as identity primary key
+);
+
+-- For distributed systems needing UUIDs, use UUIDv7 (time-ordered)
+-- Requires pg_uuidv7 extension: create extension pg_uuidv7;
+create table orders (
+  id uuid default uuid_generate_v7() primary key  -- Time-ordered, no fragmentation
+);
+
+-- Alternative: time-prefixed IDs for sortable, distributed IDs (no extension needed)
+create table events (
+  id text default concat(
+    to_char(now() at time zone 'utc', 'YYYYMMDDHH24MISSMS'),
+    gen_random_uuid()::text
+  ) primary key
+);
+```
+
+Guidelines:
+
+- Single database: `bigint identity` (sequential, 8 bytes, SQL-standard)
+- Distributed/exposed IDs: UUIDv7 (requires pg_uuidv7) or ULID (time-ordered, no
+  fragmentation)
+- `serial` works but `identity` is SQL-standard and preferred for new
+  applications
+- Avoid random UUIDs (v4) as primary keys on large tables (causes index
+  fragmentation)
+
+Reference:
+[Identity Columns](https://www.postgresql.org/docs/current/sql-createtable.html#SQL-CREATETABLE-PARMS-GENERATED-IDENTITY)

--- a/.agents/skills/supabase-postgres-best-practices/references/security-privileges.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/security-privileges.md
@@ -1,0 +1,54 @@
+---
+title: Apply Principle of Least Privilege
+impact: MEDIUM
+impactDescription: Reduced attack surface, better audit trail
+tags: privileges, security, roles, permissions
+---
+
+## Apply Principle of Least Privilege
+
+Grant only the minimum permissions required. Never use superuser for application queries.
+
+**Incorrect (overly broad permissions):**
+
+```sql
+-- Application uses superuser connection
+-- Or grants ALL to application role
+grant all privileges on all tables in schema public to app_user;
+grant all privileges on all sequences in schema public to app_user;
+
+-- Any SQL injection becomes catastrophic
+-- drop table users; cascades to everything
+```
+
+**Correct (minimal, specific grants):**
+
+```sql
+-- Create role with no default privileges
+create role app_readonly nologin;
+
+-- Grant only SELECT on specific tables
+grant usage on schema public to app_readonly;
+grant select on public.products, public.categories to app_readonly;
+
+-- Create role for writes with limited scope
+create role app_writer nologin;
+grant usage on schema public to app_writer;
+grant select, insert, update on public.orders to app_writer;
+grant usage on sequence orders_id_seq to app_writer;
+-- No DELETE permission
+
+-- Login role inherits from these
+create role app_user login password 'xxx';
+grant app_writer to app_user;
+```
+
+Revoke public defaults:
+
+```sql
+-- Revoke default public access
+revoke all on schema public from public;
+revoke all on all tables in schema public from public;
+```
+
+Reference: [Roles and Privileges](https://supabase.com/blog/postgres-roles-and-privileges)

--- a/.agents/skills/supabase-postgres-best-practices/references/security-rls-basics.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/security-rls-basics.md
@@ -1,0 +1,50 @@
+---
+title: Enable Row Level Security for Multi-Tenant Data
+impact: CRITICAL
+impactDescription: Database-enforced tenant isolation, prevent data leaks
+tags: rls, row-level-security, multi-tenant, security
+---
+
+## Enable Row Level Security for Multi-Tenant Data
+
+Row Level Security (RLS) enforces data access at the database level, ensuring users only see their own data.
+
+**Incorrect (application-level filtering only):**
+
+```sql
+-- Relying only on application to filter
+select * from orders where user_id = $current_user_id;
+
+-- Bug or bypass means all data is exposed!
+select * from orders;  -- Returns ALL orders
+```
+
+**Correct (database-enforced RLS):**
+
+```sql
+-- Enable RLS on the table
+alter table orders enable row level security;
+
+-- Create policy for users to see only their orders
+create policy orders_user_policy on orders
+  for all
+  using (user_id = current_setting('app.current_user_id')::bigint);
+
+-- Force RLS even for table owners
+alter table orders force row level security;
+
+-- Set user context and query
+set app.current_user_id = '123';
+select * from orders;  -- Only returns orders for user 123
+```
+
+Policy for authenticated role:
+
+```sql
+create policy orders_user_policy on orders
+  for all
+  to authenticated
+  using (user_id = auth.uid());
+```
+
+Reference: [Row Level Security](https://supabase.com/docs/guides/database/postgres/row-level-security)

--- a/.agents/skills/supabase-postgres-best-practices/references/security-rls-performance.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/security-rls-performance.md
@@ -1,0 +1,63 @@
+---
+title: Optimize RLS Policies for Performance
+impact: HIGH
+impactDescription: 5-10x faster RLS queries with proper patterns
+tags: rls, performance, security, optimization
+---
+
+## Optimize RLS Policies for Performance
+
+Poorly written RLS policies can cause severe performance issues. Use subqueries and indexes strategically.
+
+**Incorrect (function called for every row):**
+
+```sql
+create policy orders_policy on orders
+  using (auth.uid() = user_id);  -- auth.uid() called per row!
+
+-- With 1M rows, auth.uid() is called 1M times
+```
+
+**Correct (wrap functions in SELECT):**
+
+```sql
+create policy orders_policy on orders
+  using ((select auth.uid()) = user_id);  -- Called once, cached
+
+-- 100x+ faster on large tables
+```
+
+Use security definer functions for complex checks:
+
+`SECURITY DEFINER` functions run with the creator's privileges and bypass RLS on any tables they touch — which is what makes them useful for internal lookups, but also what makes them dangerous if misused. Always include an explicit `auth.uid()` check inside the function body, keep them in a non-exposed schema, and revoke `EXECUTE` from any role that shouldn't call them directly.
+
+```sql
+-- Create helper function in a private schema
+create or replace function private.is_team_member(team_id bigint)
+returns boolean
+language sql
+security definer
+set search_path = ''
+as $$
+  select exists (
+    select 1 from public.team_members
+    -- always check the calling user's identity inside the function
+    where team_id = $1 and user_id = (select auth.uid())
+  );
+$$;
+
+-- Revoke direct execution from public roles
+revoke execute on function private.is_team_member(bigint) from PUBLIC, anon, authenticated, service_role;
+
+-- Use in policy (indexed lookup, not per-row check)
+create policy team_orders_policy on orders
+  using ((select private.is_team_member(team_id)));
+```
+
+Always add indexes on columns used in RLS policies:
+
+```sql
+create index orders_user_id_idx on orders (user_id);
+```
+
+Reference: [RLS Performance](https://supabase.com/docs/guides/database/postgres/row-level-security#rls-performance-recommendations)

--- a/.claude/agents/modeling-scientist.md
+++ b/.claude/agents/modeling-scientist.md
@@ -1,0 +1,46 @@
+---
+name: modeling-scientist
+description: Feature engineering, screening, model training, backtesting, and predictions work — features.team_week, fitted_v1, Elo/EPA, marts analytics. Use for any change to the modeling substrate or model chain, and for sanity-reviewing analytics outputs.
+---
+
+You are the modeling scientist for cfb-database's prediction stack (house
+Elo, ridge-adjusted EPA, walk-forward fitted_v1).
+
+The binding contract is
+`docs/brainstorms/2026-07-21-team-week-feature-design.md` — read the
+sections your task touches before writing anything, and amend the doc
+BEFORE implementing a change it governs. Non-negotiables:
+
+- **Leak-free as-of, always.** A value entering week_index W uses only
+  same-season rows with week_index strictly less than W
+  (`leak_free_week_index`); postseason weeks are `week + 100`. The only
+  cross-season inputs are the explicitly labeled prior-season fallbacks.
+  NULL early-season per the doc's NULL-never-0 rule; the model imputes.
+- **Pre-registration before measurement.** Screens declare their floor,
+  FDR, controls, window, and run-once status in the design doc before any
+  run; verdicts (including rejections) are recorded there with their
+  numbers. Never re-test a rejected candidate without a new
+  pre-registration. Amendments respond to identified flaws, never to
+  disappointing results.
+- **Gates decide, not enthusiasm.** Model changes ship only through the
+  walk-forward no-regression gate: held-out margin MAE improves and
+  neither Brier nor ATS degrades (per-game metrics from
+  `marts.prediction_accuracy`, not the preseason aggregates). A null
+  result is a valid, recordable completion.
+- **The feature list is a contract.** Changing `DIFF_FEATURE_COLUMNS`
+  invalidates every stored fit vintage — migration, build, and train land
+  together; evaluation runs must never write `features.model_coefficients`
+  / `model_metadata` under the production model_version.
+
+Plausibility review (apply to any analytics/model output before reporting
+it as correct): sign conventions (offensive EPA/PPA higher = better,
+defensive lower = better); magnitudes on the Vegas scale (expected margins
+beyond ~±50 or win probabilities pinned at 0/1 are bugs, not insight);
+rankings smell test (a playoff-caliber program ranked bottom-half deserves
+investigation before publication); coverage (n per season/team consistent
+with the schedule — a "clean" result on 40% of expected rows is a silent
+join failure); and never mistake an empty result set for a null finding —
+a screen or backtest with no data is UNTESTABLE, not negative.
+
+Do not run git commands; report files changed, evidence, gate verdicts
+with their numbers, and any contract amendment you made.

--- a/.claude/agents/pipeline-engineer.md
+++ b/.claude/agents/pipeline-engineer.md
@@ -1,0 +1,32 @@
+---
+name: pipeline-engineer
+description: Builds and modifies dlt ingestion pipelines, data sources, and load orchestration in this repo. Use for adding/changing anything under src/pipelines/, flat-file sources, or load_season/verify_load behavior.
+---
+
+You are the pipeline engineer for cfb-database, a CFBD API -> Supabase
+Postgres warehouse built on dlt.
+
+Before writing code, load the `dlt-pipelines` and `cfbd-api` skills — they
+carry the conventions this role is accountable to. Non-negotiables:
+
+- Merge write-disposition with an explicit primary key unless the task
+  states otherwise; year windows from `YEAR_RANGES`; every request through
+  `make_request` and the rate limiter.
+- New or changed sources: register `ESTIMATED_CALLS`, decide
+  `IMMUTABLE_ONCE_FINAL` membership deliberately, and bound any per-game
+  fan-out with a cap or a DB set-difference skip. State the expected call
+  count for a daily run and a full backfill in your report.
+- Never add live API calls to imports, default tests, or module init.
+  Tests mock `make_request` (see `tests/test_sources/`); unit tests must
+  pass with no DB and no network.
+- Verify loaded column names from `pg_attribute`, not API docs — dlt
+  renames fields.
+- Schema side effects (new tables, columns, grants) route through the
+  `schema-migrations` skill's workflow; do not inline DDL in source
+  modules.
+
+Working style: test-first where the seam allows it; run
+`.venv/bin/pytest <targeted files> -q` and `.venv/bin/ruff check` before
+reporting. Do not run git commands — the orchestrator owns staging,
+commits, and pushes. Report: files changed, evidence (red observation,
+test/lint results), call-count impact, and any deviation from the task.

--- a/.claude/agents/schema-architect.md
+++ b/.claude/agents/schema-architect.md
@@ -1,0 +1,37 @@
+---
+name: schema-architect
+description: Read-only reviewer for schema changes — migrations, new tables/views/matviews, grants, and anything touching the surfaces cfb-app and cfb-scout consume. Use to review a schema diff before it ships; it reports findings, it does not edit.
+---
+
+You are the schema architect for cfb-database — the schema source of truth
+for a three-repo platform (cfb-app reads `public`/`core`/`api`; cfb-scout
+reads `core.roster` and `recruiting.recruits` and owns `scouting`).
+
+You review; you never edit, apply, or commit. Load the `schema-migrations`
+skill for the workflow you are checking against, then review the diff for:
+
+1. **Contract safety.** Does the change touch a surface in
+   `docs/SCHEMA_CONTRACT.md`? Renames, type changes, dropped columns, or
+   semantic changes on consumed surfaces are P0 findings unless the
+   contract doc changes in the same diff and the PR flags downstream
+   coordination.
+2. **Migration mechanics.** Correct next number; header states its
+   application path (ordered chain vs `--file` manifest); idempotent
+   (applies twice); `COMMENT ON COLUMN` provenance present for new
+   columns; NULL semantics follow NULL-never-0 with the documented
+   count-zero exception shape.
+3. **Caller-permission reality.** For any new/changed view or function:
+   SECURITY INVOKER implications walked through as `anon` (schema USAGE +
+   table SELECT on everything the chain touches), RLS on user-facing
+   tables, `SET search_path = ''` on functions. Flag any verification done
+   only as superuser.
+4. **Refresh-chain membership.** New matviews appear in the refresh chain
+   in dependency order; window-function views follow the
+   matview-plus-thin-view pattern; `ref.teams` school-name joins guard the
+   35-duplicate fanout.
+5. **Governed columns.** `features.team_week` changes carry their design-
+   doc amendment (sections 1f/1i/2a, column count) in the same diff.
+
+Report findings with severity (P0 blocks merge, P1 should fix, P2/P3
+noted), file:line evidence, and a one-line fix per finding. If the diff is
+clean, say so explicitly with what you checked.

--- a/.claude/skills/cfbd-api/SKILL.md
+++ b/.claude/skills/cfbd-api/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: cfbd-api
+description: CFBD (CollegeFootballData) API conventions, gotchas, and endpoint-selection guidance. Use when building or debugging anything that calls api.collegefootballdata.com — pipelines, scripts, notebooks — across cfb-database, cfb-app, and cfb-scout.
+---
+
+# CFBD API
+
+Sources: the CFBD AI Builder Pack canonical context (2026) merged with
+gotchas earned in the cfb-database warehouse. The complete 61-endpoint
+inventory lives in `cfb-database/docs/cfbd-api-endpoints.md`; this skill
+carries conventions and traps, not the endpoint list.
+
+## Authentication and identity
+
+- Bearer token via `CFBD_API_KEY` env var or private ignored config
+  (`.dlt/secrets.toml` in cfb-database). Official clients accept the key as
+  an access token and build the header themselves — do not add the `Bearer `
+  prefix twice.
+- Never print keys, Authorization headers, or full environment dumps in
+  logs, prompts, issue reports, or screenshots.
+- Current account: Tier 4, 125,000 calls/month (as of 2026-07; verify in
+  `.dlt/config.toml` — do not hardcode tier quotas in new code, access
+  policies change).
+
+## Parameter and field conventions
+
+- Raw HTTP query params are camelCase (`seasonType`); official Python
+  clients expose snake_case (`season_type`). Use the spelling for your
+  access method; never send an optional param as `null`.
+- Raw JSON responses are camelCase; dlt normalizes to snake_case on load
+  (`homeClassification` -> `home_classification`). **Verify loaded column
+  names via `pg_attribute`, never from API docs** — dlt may rename.
+- `team` params take the full school name ("Ohio State"); `conference`
+  takes the abbreviation ("SEC", "B1G"). Conference membership is
+  season-specific.
+- `year` means season year. Postseason weeks restart at 1 (bowls are
+  postseason week 1) — regular week 1 and postseason week 1 collide unless
+  you key on `season_type` too. cfb-database orders across the boundary
+  with `week_index = week + 100` for postseason.
+- Recruiting class year is not the season year, roster year, or
+  eligibility class. `recruiting.recruits` matches players on `athlete_id`
+  (not `id`) and uses `ranking` (not `national_ranking`).
+- EPA/PPA: PPA is CFBD's implementation of EPA. Confirm sign and
+  perspective per endpoint — offensive PPA higher is better, defensive
+  lower is better.
+
+## Pagination and volume
+
+- There is no native pagination. Do not invent `page`, `offset`, `limit`,
+  or cursor params. Split work only with supported filters (year, week,
+  team, conference, seasonType) and estimate the call count first.
+- `/plays/stats` caps at ~2,000 records per request — complete coverage
+  requires one request per `gameId` (~1,640 calls for a full season).
+  Check for already-loaded games before fanning out.
+- Prefer summary/aggregate endpoints over granular ones when they satisfy
+  the output; do not fetch plays when a game or season summary suffices.
+- Avoid uncontrolled loops over seasons x teams x weeks; never trigger
+  live calls from imports, default tests, or UI renders.
+
+## Failure classification and retries
+
+Classify before retrying: local validation, 400 invalid request, 401 auth,
+403 tier/authorization, 404 missing, 429 rate limit, transient network,
+5xx. Two subtleties:
+
+- An empty `200` is not an error and not proof a tier lacks access; a
+  `403` is not proof the endpoint contract is wrong.
+- Cloudflare burst-blocks (~10 min) surface as 429s that are NOT quota
+  exhaustion. For one-off scripts, do not auto-retry 401/403/429. For
+  long-lived pipelines, the cfb-database pattern is correct: honor
+  `Retry-After` (capped), count consecutive 429s into a circuit breaker,
+  and raise a distinct exhausted error rather than returning `[]` — an
+  empty result must never masquerade as "no data".
+
+## Version and data-shape traps
+
+- v2 has breaking changes from v1; many fields are nullable — inspect a
+  real or fixture response before writing transforms.
+- Games can be marked completed with NULL scores — filter both scores
+  non-null before computing margins.
+- `ref.teams` has 35 legitimate duplicate school names — `DISTINCT ON
+  (school)` before joining on school name or accept fanout.
+- Data depth varies: games 1869+, play-by-play ~2004+, recruiting ~2000+,
+  advanced metrics (SP+/PPA) ~2014+.
+
+## Endpoint discovery
+
+Endpoint names, params, and enums come from official docs/OpenAPI, the
+official client, or an inspected response — never invent them. For a fresh
+machine-readable inventory, the CFBD AI Builder Pack ships an
+`openapi-context-generator` (run per its README) whose output can refresh
+`docs/cfbd-api-endpoints.md` when the API changes. Default tests use
+fixtures or mocks, never live calls; live requests are explicit, narrow,
+and logged.

--- a/.claude/skills/dlt-pipelines/SKILL.md
+++ b/.claude/skills/dlt-pipelines/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: dlt-pipelines
+description: This repo's dlt pipeline conventions — source modules, write dispositions, API budget discipline, skip logic, and test patterns. Use when adding or modifying anything under src/pipelines/, scripts/load_season.py, or a new data source.
+---
+
+# dlt Pipelines (cfb-database)
+
+Generic dlt REST API reference: `docs/dlt-reference.md`. Endpoint-to-pipeline
+status: `docs/pipeline-manifest.md`. CFBD API conventions and traps: the
+`cfbd-api` skill. This file carries what is repo-specific.
+
+## Source module shape
+
+- One module per domain under `src/pipelines/sources/`; resources declared
+  with `@dlt.resource(write_disposition="merge", primary_key=...)` and an
+  `EndpointConfig` entry in `src/pipelines/config/endpoints.py`.
+- **Merge is the default disposition everywhere.** Replace/append is an
+  explicit opt-in used only by the game_stats batch path.
+- Year windows come from `YEAR_RANGES` in `src/pipelines/config/years.py`;
+  `mode` (`incremental` vs `backfill`) selects the year list, never the
+  disposition. `get_current_season()` returns `year - 1` until August — it
+  is an ingest-window rule only; compute chains use
+  `get_projection_seasons()` instead.
+- No dlt incremental cursors for API sources. For per-game fan-outs, skip
+  already-loaded work with a **DB set-difference** before fetching (the
+  `run_metrics_wp_pipeline` pattern in `src/pipelines/run.py`) — merge
+  dedupes rows but does not refund API calls.
+
+## API budget discipline (audit-backed)
+
+- Every request goes through `make_request` -> the rate limiter; never a
+  raw HTTP call. The limiter's JSON state does not survive CI runners —
+  do not treat it as month-to-date truth there.
+- New sources register an entry in `ESTIMATED_CALLS`
+  (`scripts/load_season.py`) and a deliberate decision on
+  `IMMUTABLE_ONCE_FINAL` membership (can this source's data change after a
+  season completes?). The pre-run estimate comparison warns; per-call
+  enforcement is the hard stop.
+- Fan-out sources (`/plays/stats` is one call per game) must bound their
+  per-run cost: caps (`MAX_WP_GAMES_PER_RUN` pattern) or already-present
+  skips. Full context: the 2026-07-28 audit at
+  `docs/solutions/best-practices/2026-07-28-cfbd-api-usage-audit.md`.
+- 429 handling lives in `src/pipelines/utils/api_client.py` (Retry-After,
+  circuit breaker, `RateLimitExhausted`) — do not add per-source retry
+  loops on top of it, and never return `[]` on failure.
+
+## dlt data-shape gotchas
+
+- Nested arrays become child tables `{parent}__{field}` with
+  `_dlt_parent_id`/`_dlt_list_idx`; access via
+  `LEFT JOIN LATERAL ... WHERE _dlt_parent_id = parent._dlt_id`
+  (worked example: `docs/solutions/database-issues/`).
+- dlt snake_cases camelCase API fields — verify loaded names via
+  `pg_attribute` before writing SQL against a new table.
+
+## Test patterns
+
+- Source tests mock `make_request` with side-effect fakes
+  (`tests/test_sources/` pattern) and assert resource composition; no test
+  touches the live API.
+- `conftest.py` provides `db_conn` (autocommit) reading `SUPABASE_DB_URL`
+  or `.dlt/secrets.toml`; integration tests skip cleanly when neither is
+  available — never make a unit test require the DB.
+- Flat-file sources: `FlatFileSpec` registry + pure parsers
+  (`parse(raw, ctx) -> Iterator[dict]`), hash-skip ledger in
+  `meta.flat_file_loads`, synthetic fixtures under
+  `tests/fixtures/flatfiles/`.

--- a/.claude/skills/schema-migrations/SKILL.md
+++ b/.claude/skills/schema-migrations/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: schema-migrations
+description: Schema-change workflow for this repo — migrations, grants/RLS, matview refresh chains, column contracts, and the downstream-consumer gate. Use before writing or applying any migration, altering any schema, adding a matview or API view, or changing anything cfb-app/cfb-scout read.
+---
+
+# Schema Migrations (cfb-database)
+
+## Before touching anything
+
+1. **Downstream gate.** Changes to `core`, `recruiting`, `api`, or `public`
+   can break cfb-app and cfb-scout. Check `docs/SCHEMA_CONTRACT.md` first;
+   if the surface is listed, the change needs a contract update and a
+   heads-up in the PR body.
+2. **Column contracts.** `features.team_week` is governed by
+   `docs/brainstorms/2026-07-21-team-week-feature-design.md`: no column is
+   added without first amending sections 1f (row), 1i (NULL rule), 2a
+   (vector position) and the stated column count. Candidate features also
+   need a recorded screen verdict before a migration ships (see the
+   pre-registration entries in that doc's "Decisions made").
+3. **Verify current state from the catalog**, not docs: column names via
+   `pg_attribute`, view type (matview vs view) before adding to test
+   inventories. dlt renames columns on load.
+
+## Writing the migration
+
+- Numbering: next integer after the highest in `src/schemas/migrations/`,
+  zero-padded 3 digits. Never renumber.
+- Two application paths — pick the one the file header declares:
+  - `MIGRATION_ORDER` in `scripts/run_migrations.py` (the ordered chain).
+  - Deploy-manifest style, applied via `run_migrations.py --file <path>`
+    (the 019-028 / 041+ pattern). State this in the header comment.
+- Idempotent by construction: `ADD COLUMN IF NOT EXISTS`,
+  `CREATE OR REPLACE`, guarded indexes. The verification bar is "applies
+  twice without error".
+- `COMMENT ON COLUMN` carries provenance: screened partial-r values, NULL
+  semantics, and source notes live on the column, not only in docs
+  (mirror migrations 042/046/047).
+- NULL-never-0 for rates and coefficients; a fabricated zero is an extreme
+  value. Counts may use guarded zeros only with an EXISTS check that the
+  source data was actually loaded (the 047 draft-columns exception).
+
+## Grants, RLS, and SECURITY INVOKER (hard-won)
+
+- All API/public views are SECURITY INVOKER: they execute as the caller.
+  `anon`/`authenticated` need `USAGE` on every underlying schema and
+  `SELECT` on the tables a view touches — a new schema in a view chain
+  breaks cfb-app silently otherwise.
+- **Always test as the caller**: `SET ROLE anon;` then query. The MCP/
+  superuser connection masks permission failures.
+- RLS on any user-facing table; `SET search_path = ''` plus fully-qualified
+  names on functions; revoke DML from `anon` on newly exposed schemas.
+
+## Matviews and refresh chains
+
+- New matviews must join the refresh chain (`marts.refresh_all()` layers /
+  `scripts/refresh_marts.py`) in dependency order — an orphaned matview
+  serves stale data forever (the `player_comparison` lesson).
+- Window functions (PERCENT_RANK) belong in a matview with a thin view on
+  top, not a plain view (~2s vs <5ms).
+- `ref.teams` has 35 duplicate school names: `DISTINCT ON (school)` before
+  any school-name join.
+
+## After applying
+
+- Update `tests/` inventories (view lists, column counts, contract tests).
+- Full backfill/rebuild runs that need warehouse credentials can run via
+  the `model-experiments` workflow when local credentials are unavailable.

--- a/.claude/skills/supabase-postgres-best-practices
+++ b/.claude/skills/supabase-postgres-best-practices
@@ -1,0 +1,1 @@
+../../.agents/skills/supabase-postgres-best-practices

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "supabase": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@supabase/mcp-server-supabase@latest",
+        "--project-ref=ibobsbwlewpqslkqbrjd"
+      ],
+      "env": {
+        "SUPABASE_ACCESS_TOKEN": "${SUPABASE_ACCESS_TOKEN}"
+      }
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,8 +207,9 @@ cfb-database/
 In-repo skills (`.claude/skills/`): `cfbd-api` (API conventions and traps), `schema-migrations` (migration workflow, grants/RLS lessons, refresh chains, column contracts), `dlt-pipelines` (source conventions, budget discipline, test patterns). In-repo agents (`.claude/agents/`): `pipeline-engineer` (builds sources), `modeling-scientist` (feature/model work with leak-free and pre-registration guardrails, plus output plausibility review), `schema-architect` (read-only schema-diff reviewer). Cloud and local sessions both see these; `~/.claude/skills/cfbd-api` is a symlink to the main checkout's copy for sibling-repo sessions.
 
 ### Postgres Best Practices (Supabase)
+Location: `.claude/skills/supabase-postgres-best-practices/` (Supabase's official skill, vendored via `npx skills add supabase/agent-skills`; pinned in `skills-lock.json` — re-run the install to upgrade)
 
-Apply these guidelines when designing schema and writing queries:
+The skill carries the full rules catalog with examples and query-plan analysis. The floor that always applies when designing schema and writing queries:
 
 **CRITICAL priority:**
 - Add indexes on WHERE and JOIN columns

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,6 +204,8 @@ cfb-database/
 
 ## Skills & Guidelines
 
+In-repo skills (`.claude/skills/`): `cfbd-api` (API conventions and traps), `schema-migrations` (migration workflow, grants/RLS lessons, refresh chains, column contracts), `dlt-pipelines` (source conventions, budget discipline, test patterns). In-repo agents (`.claude/agents/`): `pipeline-engineer` (builds sources), `modeling-scientist` (feature/model work with leak-free and pre-registration guardrails, plus output plausibility review), `schema-architect` (read-only schema-diff reviewer). Cloud and local sessions both see these; `~/.claude/skills/cfbd-api` is a symlink to the main checkout's copy for sibling-repo sessions.
+
 ### Postgres Best Practices (Supabase)
 
 Apply these guidelines when designing schema and writing queries:
@@ -335,4 +337,4 @@ Historical depth varies by endpoint:
 
 - `pyproject.toml` -- project metadata, dependencies, CLI entry point (`cfb-pipeline`), ruff config (line-length 100, py311), pytest config
 - `.dlt/config.toml` -- runtime config: worker count, file chunking, monthly API budget (125,000). Year ranges live in `src/pipelines/config/years.py`
-- Supabase MCP server enabled in `.claude/settings.local.json` for interactive SQL during development
+- Supabase MCP server defined in `.mcp.json` (project-scoped, committed; token via `SUPABASE_ACCESS_TOKEN` env var — never committed) and enabled per-machine in `.claude/settings.local.json`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,7 +230,7 @@ Apply these guidelines when designing schema and writing queries:
 - Use partial indexes for filtered queries (e.g., active season only)
 
 ### CFBD API Skill
-Location: `~/.claude/skills/cfbd-api/`
+Location: `.claude/skills/cfbd-api/` (canonical, in-repo — available to cloud/CI sessions). `~/.claude/skills/cfbd-api` is a symlink to the main checkout's copy so local cfb-app/cfb-scout sessions get it too.
 
 Use this skill when building or debugging anything that calls the CFBD API:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,7 +205,6 @@ cfb-database/
 ## Skills & Guidelines
 
 ### Postgres Best Practices (Supabase)
-Location: `~/.claude/skills/postgres-best-practices/`
 
 Apply these guidelines when designing schema and writing queries:
 
@@ -233,31 +232,19 @@ Apply these guidelines when designing schema and writing queries:
 ### CFBD API Skill
 Location: `~/.claude/skills/cfbd-api/`
 
-Use this skill for CFBD API reference when building or debugging pipelines:
+Use this skill when building or debugging anything that calls the CFBD API:
 
-- **All 15 API classes** with method signatures and common parameters
-- **Authentication pattern**: Bearer token via `cfbd.Configuration(access_token=...)`
-- **Endpoint coverage**: Games, teams, plays, drives, stats, ratings, rankings, recruiting, betting, metrics, players, coaches, conferences, venues, draft
-- **Common parameters**: `year` (required for most), `week`, `team` (full name, e.g. "Ohio State"), `conference` (abbreviation, e.g. "SEC", "B1G")
-- **Gotchas**: Cloudflare burst blocking (~10 min), nullable fields, v2 breaking changes from v1
+- **Conventions**: auth (no double `Bearer` prefix), camelCase raw vs snake_case client params, dlt column renames (verify via `pg_attribute`), `team` full name vs `conference` abbreviation, postseason week restart
+- **Volume traps**: no native pagination (never invent `page`/`offset`), `/plays/stats` ~2,000-record cap (per-gameId fan-out), estimate-before-loop discipline
+- **Failure classification**: empty-200 vs 403 semantics, Cloudflare burst 429s vs quota exhaustion, when auto-retry is wrong (one-off scripts) vs correct (the pipeline's Retry-After + circuit-breaker pattern)
+- **Data-shape traps**: nullable fields, v2 breaking changes, completed games with NULL scores, duplicate school names
 
-When adding new pipeline sources or debugging API responses, reference this skill for correct method names, parameter types, and response models.
+The complete 61-endpoint inventory stays in `docs/cfbd-api-endpoints.md`; the skill carries conventions and traps, not the endpoint list.
 
-### dlt REST API Source Skill
-Location: `~/.claude/skills/dlt-rest-api/`
+### dlt REST API Reference
+Location: `docs/dlt-reference.md`
 
-Use this skill when building or modifying dlt pipelines:
-
-- **RESTAPIConfig structure**: `client`, `resource_defaults`, `resources` — full field reference
-- **Authentication**: Bearer, API Key, HTTP Basic, OAuth2 — both dict syntax (`"type": "bearer"`) and class imports (`BearerTokenAuth`)
-- **Pagination**: All 7 types (json_link, header_link, offset, page_number, cursor, header_cursor, single_page) with constructor params
-- **Incremental loading**: Placeholder syntax (`{incremental.start_value}`), cursor_path, initial_value
-- **Parent-child resources**: Path placeholders (`{resources.parent.field}`), query params, legacy resolve syntax
-- **Write dispositions**: `append`, `replace`, `merge` — when to use each
-- **Config/secrets**: `.dlt/config.toml`, `.dlt/secrets.toml`, env var patterns (`SOURCES__*`)
-- **Gotchas**: auto-pagination failures, data_selector for wrapped responses, nested table unnesting, state per pipeline_name
-
-Reference this skill when writing `RESTAPIConfig` dicts, debugging pagination, configuring incremental loads, or setting up new source modules.
+Consult when building or modifying dlt pipelines: `RESTAPIConfig` structure, bearer auth via `dlt.secrets`, incremental placeholder syntax (`{incremental.start_value}`), write dispositions (`merge` is this repo's default), pagination notes, and `.dlt/config.toml` / `secrets.toml` patterns. CFBD has no native pagination, so most generic pagination machinery is irrelevant here — this repo's sources iterate year/week programmatically instead. dlt child-table gotchas (`_dlt_parent_id` LATERAL joins, column renames) are documented in `docs/solutions/database-issues/`.
 
 ## CFBD API Categories
 

--- a/docs/dlt-reference.md
+++ b/docs/dlt-reference.md
@@ -18,7 +18,7 @@ config: RESTAPIConfig = {
         "base_url": "https://api.collegefootballdata.com/",
         "auth": {
             "type": "bearer",
-            "token": dlt.secrets["cfbd_api_key"],
+            "token": dlt.secrets["sources.cfbd.api_key"],
         },
     },
     "resource_defaults": {

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "supabase-postgres-best-practices": {
+      "source": "supabase/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/supabase-postgres-best-practices/SKILL.md",
+      "computedHash": "ec56a54fba0e97bee52c7f244ba603bb284bf8d1b739c66a5cc84ec3df709d9d"
+    }
+  }
+}


### PR DESCRIPTION
Third deferred workstream from the starter-pack plan. All three skills referenced in CLAUDE.md's Skills & Guidelines (`cfbd-api`, `dlt-rest-api`, `postgres-best-practices`) were **missing from disk** — every session got pointed at phantom resources.

- **`~/.claude/skills/cfbd-api/` now exists** (created outside this repo): CFBD conventions + traps merged from the AI Builder Pack's canonical context files and this repo's earned gotchas (postseason week restart, /plays/stats cap, Cloudflare-burst vs quota 429s incl. the audit's retry adjudication, dlt column renames, NULL-score completed games). Serves cfb-app and cfb-scout too. The CLAUDE.md section now describes what the skill actually contains, with the 61-endpoint inventory staying in `docs/cfbd-api-endpoints.md`.
- **dlt section** repoints to the real `docs/dlt-reference.md` and notes CFBD-specific irrelevance of generic pagination machinery.
- **postgres section** drops the phantom location line — its guidelines were already inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Expanded: in-repo skills, agents, and MCP config
- **Skills** (`.claude/skills/`): `cfbd-api` (canonical in-repo copy), `schema-migrations` (migration workflow, SECURITY INVOKER/grants lessons, refresh chains, column contracts), `dlt-pipelines` (source conventions, audit-backed budget discipline, test patterns)
- **Agents** (`.claude/agents/`): `pipeline-engineer` (builder), `modeling-scientist` (leak-free/pre-registration/gate guardrails + football-plausibility review), `schema-architect` (read-only schema-diff reviewer keyed to SCHEMA_CONTRACT and downstream consumers)
- **`.mcp.json`**: defines the `supabase` MCP server that `settings.local.json` already enabled but nothing defined — project-scoped, token via `SUPABASE_ACCESS_TOKEN` env var (not committed)

Cloud and local sessions both see all of this from the repo; `~/.claude/skills/cfbd-api` becomes a symlink to the main checkout post-merge.