### PR TITLE
Request play stats for completed games only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,14 @@ disables the skip entirely, so a backfill is never silently turned into a no-op;
 **Where the per-game fan-out actually lives:** `stats`, not `plays`. `plays` is
 year+week (16 calls/season). The `stats` source's `play_stats` resource issues one
 `/plays/stats` call **per game** (~1,640/season) and `rosters` one per team, which
-is the cost that exhausted the quota. Because the source is not uniformly priced --
+is the cost that exhausted the quota. `play_stats` now requests **completed games
+only** -- an unplayed game has no play stats, and from 2026-08-01 (when
+`get_current_season()` rolled to 2026, a season that is not final, so nothing was
+skipped) the daily load walked all 1,638 *scheduled* 2026 games every day, was
+429'd partway through, and failed the whole `stats` extract package -- discarding
+`player_returning`'s already-fetched payload and burst-blocking `ratings` and
+`game_stats` behind it. Note that failure mode: a resource that dies inside a
+source takes every sibling resource's data with it. Because the source is not uniformly priced --
 its other seven resources are one call per year -- anything running daily must name
 resources rather than take the whole source: `--sources stats:player_returning`
 (one call), and `PRESEASON_STATS_RESOURCES` in `load_season.py` for the automated

--- a/src/pipelines/sources/stats.py
+++ b/src/pipelines/sources/stats.py
@@ -330,8 +330,25 @@ def play_stats_resource(
                     )
                     games.extend(postseason)
 
-                    game_ids_for_year = [g["id"] for g in games if g.get("id")]
-                    logger.info(f"  Found {len(game_ids_for_year)} games for {year}")
+                    # Only COMPLETED games. An unplayed game has no play stats,
+                    # so requesting one spends a call to receive nothing --
+                    # and this resource spends one call per game. From
+                    # 2026-08-01 `get_current_season()` returned 2026, the
+                    # season was not final so nothing was skipped, and the
+                    # daily load walked all 1,638 *scheduled* 2026 games every
+                    # day. It got ~370 in before CFBD started answering 429,
+                    # which failed the whole `stats` extract package (taking
+                    # player_returning's already-fetched payload down with it)
+                    # and burst-blocked `ratings` and `game_stats` behind it.
+                    # Three consecutive red daily loads, 2026-08-04 onward.
+                    scheduled = [g for g in games if g.get("id")]
+                    completed = [g for g in scheduled if g.get("completed")]
+                    game_ids_for_year = [g["id"] for g in completed]
+                    logger.info(
+                        f"  Found {len(scheduled)} games for {year}, "
+                        f"{len(game_ids_for_year)} completed "
+                        f"({len(scheduled) - len(game_ids_for_year)} unplayed, skipped)"
+                    )
 
                     year_total = 0
                     for i, game_id in enumerate(game_ids_for_year):

--- a/tests/test_sources/test_stats.py
+++ b/tests/test_sources/test_stats.py
@@ -1,0 +1,106 @@
+"""Tests for the stats source's per-game fan-out."""
+
+from unittest.mock import MagicMock, patch
+
+
+def _play_stats_rows(years, games_by_type, stats_by_game):
+    """Materialize play_stats_resource rows with the dlt wrapper unwrapped.
+
+    Returns (rows, requested_game_ids) so a test can assert on which games
+    were actually paid for, not just on what came back.
+    """
+    from src.pipelines.sources.stats import play_stats_resource
+
+    requested: list[int] = []
+
+    def side_effect(client, path, params=None):
+        if path == "/games":
+            return list(games_by_type[params["seasonType"]])
+        if path == "/plays/stats":
+            requested.append(params["gameId"])
+            return list(stats_by_game.get(params["gameId"], []))
+        raise AssertionError(f"unexpected path {path}")
+
+    with (
+        patch("src.pipelines.sources.stats.get_client") as mock_get_client,
+        patch("src.pipelines.sources.stats.make_request") as mock_make_request,
+    ):
+        mock_get_client.return_value = MagicMock()
+        mock_make_request.side_effect = side_effect
+        rows = list(play_stats_resource(years=years))
+
+    return rows, requested
+
+
+class TestPlayStatsSkipsUnplayedGames:
+    """This resource spends one /plays/stats call PER GAME.
+
+    From 2026-08-01 `get_current_season()` returned 2026 and the season was
+    not final, so the daily load walked all 1,638 *scheduled* 2026 games every
+    day. It got ~370 in before CFBD answered 429, which failed the whole
+    `stats` extract package -- discarding player_returning's already-fetched
+    payload -- and burst-blocked `ratings` and `game_stats` behind it. Three
+    consecutive red daily loads.
+    """
+
+    def test_unplayed_games_are_never_requested(self):
+        games = {
+            "regular": [
+                {"id": 1, "completed": True},
+                {"id": 2, "completed": False},
+                {"id": 3, "completed": False},
+            ],
+            "postseason": [],
+        }
+        rows, requested = _play_stats_rows([2026], games, {1: [{"stat": "a"}]})
+
+        assert requested == [1], "an unplayed game has no play stats to return"
+        assert rows == [{"stat": "a"}]
+
+    def test_a_season_with_no_completed_games_costs_nothing(self):
+        """The exact 2026 preseason shape: a full schedule, nothing played."""
+        games = {
+            "regular": [{"id": i, "completed": False} for i in range(1, 51)],
+            "postseason": [],
+        }
+        _, requested = _play_stats_rows([2026], games, {})
+
+        assert requested == []
+
+    def test_a_missing_completed_flag_is_treated_as_unplayed(self):
+        """Absent is not the same as True: paying for a call on a maybe is
+        what this resource cannot afford at one call per game."""
+        games = {"regular": [{"id": 1}], "postseason": []}
+        _, requested = _play_stats_rows([2026], games, {})
+
+        assert requested == []
+
+    def test_completed_postseason_games_still_load(self):
+        games = {
+            "regular": [{"id": 1, "completed": True}],
+            "postseason": [{"id": 9, "completed": True}],
+        }
+        _, requested = _play_stats_rows([2025], games, {})
+
+        assert requested == [1, 9]
+
+    def test_explicit_game_ids_are_not_filtered(self):
+        """A caller naming game ids has already decided what to fetch -- the
+        backfill path must not silently drop them."""
+        from src.pipelines.sources.stats import play_stats_resource
+
+        requested = []
+
+        def side_effect(client, path, params=None):
+            requested.append(params["gameId"])
+            return []
+
+        with (
+            patch("src.pipelines.sources.stats.get_client") as mock_get_client,
+            patch("src.pipelines.sources.stats.make_request") as mock_make_request,
+        ):
+            mock_get_client.return_value = MagicMock()
+            mock_make_request.side_effect = side_effect
+            list(play_stats_resource(game_ids=[11, 22]))
+
+        assert requested == [11, 22]


### PR DESCRIPTION
Fixes the daily season load, red since 2026-08-04 (issue #53).

## What is failing

```
Loading play stats for 2026...
  Found 1638 games for 2026
GET /plays/stats?gameId=401896383  200 OK          ← game has not been played
...369 per-game calls, then sustained 429...
ERROR stats failed after 150.4s: Rate limited on all 4 attempt(s) for /plays/stats
ERROR ratings failed after 0.6s: Rate limited on /ratings/sp/conferences
ERROR game_stats failed after 14.9s: Rate limited on /games/teams
```

`play_stats` spends one `/plays/stats` call **per game**. From 2026-08-01 `get_current_season()` returns 2026, which is not final, so the finished-season skip drops nothing and the daily load walks all 1,638 *scheduled* 2026 games — every one unplayed, every call returning nothing. It gets ~370 in before CFBD starts answering 429, which fails the whole `stats` extract package and burst-blocks `ratings` and `game_stats` behind it.

## The collateral damage worth naming

`player_returning` had already fetched `/player/returning?year=2026` (200 OK) inside that same package. dlt discards a failed package wholesale, so whatever CFBD returned was thrown away rather than merged — which is why `stats.player_returning` reads 0 rows for 2026 even on days the endpoint answered. A resource that dies inside a source takes every sibling resource's data with it.

## Change

Filter the year-based path to completed games. A missing `completed` flag counts as unplayed — at one call per game, a maybe is not worth paying for. Explicit `game_ids` (the backfill path) are deliberately unfiltered: a caller naming ids has already decided what to fetch.

Cost for a preseason 2026 daily run drops from ~1,640 calls to 0, and rises naturally as games are played.

## Tests

5 new tests in `tests/test_sources/test_stats.py` covering: unplayed games never requested, a full-schedule-nothing-played season costing nothing, a missing `completed` flag treated as unplayed, completed postseason games still loading, and explicit `game_ids` passing through unfiltered.

1,311 passed, 401 skipped. `ruff check` / `ruff format --check` clean.

## Not in scope

`game_stats` failed in the same run on `/games/teams`, but as a victim of the burst block rather than its own volume (~17 calls). It should recover once `play_stats` stops saturating the limiter; if it does not, its weekly loop has the same "iterate weeks with no completed games" shape and deserves the same treatment.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pfurxa4Ved9U4ZkEo2PbKR)_

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change prevents year-based play-stat loading from spending requests on scheduled games that have not been completed, while retaining completed regular-season and postseason coverage and explicit game-ID backfills.

Executed checks compared the prior implementation with this change using the same mocked schedules. The prior implementation requested incomplete and missing-status games; the updated implementation requested only completed game IDs, returned the corresponding rows, and still requested every explicitly named game ID. The focused test suite passed with 5 tests.

No defects were found.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the completed-game filter and explicit backfill behavior were exercised with regular-season, postseason, incomplete, and missing-status schedules.

The executed comparison demonstrated that the previous unwanted requests occur before this change and are absent afterward, while the focused regression suite passed. No review findings remain.

**Files Needing Attention:** No files need additional attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the requested verification, but its local artifact references were not uploaded.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Request play stats for completed games o..."](https://github.com/rstover-fo/cfb-database/commit/0d1f320b3749c0f08349ed22223666053ca5890b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50864387)</sub>

<!-- /greptile_comment -->