### PR TITLE
Let load_season load rosters without a team list

### DIFF
--- a/scripts/load_season.py
+++ b/scripts/load_season.py
@@ -62,7 +62,10 @@ ESTIMATED_CALLS = {
     # backfill run resolves far more missing games and costs proportionally
     # more -- this estimate is for the dry-run printout, not a hard cap.
     "metrics_wp": 70,
-    "rosters": 150,
+    # One call per team, and the team list is the season's schedule -- both
+    # sides, so FCS visitors count. 350 for 2026, not the 150 this said when
+    # it meant "FBS only".
+    "rosters": 350,
 }
 
 
@@ -312,6 +315,7 @@ def load_season(
         run_ratings_pipeline,
         run_recruiting_pipeline,
         run_reference_pipeline,
+        run_rosters_pipeline,
         run_stats_pipeline,
     )
     from src.pipelines.utils.rate_limiter import get_rate_limiter
@@ -430,6 +434,11 @@ def load_season(
         "draft": lambda: run_draft_pipeline(years=[season]),
         "metrics": lambda: run_metrics_pipeline(years=[season]),
         "metrics_wp": lambda: run_metrics_wp_pipeline(seasons=[season]),
+        # Excluded from the default active set above (one call per team), so
+        # this only runs when an operator asks for it by name:
+        # --sources rosters. The team list resolves from the season's
+        # schedule -- no --teams required, unlike the `cfb-pipeline` CLI.
+        "rosters": lambda: run_rosters_pipeline(years=[season]),
     }
 
     results = {}

--- a/scripts/load_season.py
+++ b/scripts/load_season.py
@@ -338,6 +338,14 @@ def load_season(
         logger.error(f"Unknown sources: {invalid}. Valid: {sorted(valid)}")
         return {"error": f"Unknown sources: {invalid}"}
 
+    # Run in SOURCE_ORDER regardless of how the caller typed them. That list
+    # is dependency order, not presentation order: `--sources rosters,games`
+    # would otherwise resolve roster teams from core.games BEFORE loading the
+    # schedule that populates it, failing the roster load and then loading the
+    # games it needed. Sorting here rather than at parse time keeps the
+    # unknown-source error reporting the operator's own spelling.
+    active_sources = sorted(active_sources, key=SOURCE_ORDER.index)
+
     # Drop immutable sources for a finished season before estimating, so the
     # dry-run figure and the budget check reflect what will actually be
     # fetched rather than what would have been.

--- a/src/pipelines/run.py
+++ b/src/pipelines/run.py
@@ -758,8 +758,19 @@ def run_rosters_pipeline(
         finally:
             conn.close()
         if not teams:
-            print(f"No scheduled teams found for {years}; nothing to load.")
-            return None
+            # Never return quietly here. load_season records a returning
+            # runner as [OK], so an empty resolution would report a
+            # successful roster load that made zero /roster requests -- the
+            # same silent-no-op shape as the finished-season skip turning a
+            # backfill into nothing, and as `--sources rosters` logging "No
+            # runner for source" and exiting 0, which is why core.roster had
+            # no 2026 rows in the first place.
+            raise RuntimeError(
+                f"No teams with scheduled games in {years}: core.games has no rows for "
+                f"{'that season' if len(years) == 1 else 'those seasons'}. /roster is "
+                "requested per team, so there is nothing to ask for. Load the schedule "
+                f"first (--sources games --season {years[0]}), or pass an explicit team list."
+            )
         print(f"Resolved {len(teams)} teams with {years} games from core.games")
 
     years_str = f"years={years}" if years else f"mode={mode}"

--- a/src/pipelines/run.py
+++ b/src/pipelines/run.py
@@ -884,13 +884,24 @@ def main() -> NoReturn:
     }
 
     if args.source == "all":
-        # Run all pipelines
+        # Run all pipelines. Continuing past a failure is deliberate -- one
+        # broken source should not cost the other twelve their data -- but the
+        # exit code has to carry it, or a scheduled `--source all` reports a
+        # clean load while a source failed. Roster resolution now RAISES on an
+        # unloaded schedule precisely so it cannot no-op silently; swallowing
+        # that here would put the silence straight back.
+        failed = []
         for name, runner in source_runners.items():
             try:
                 runner()
             except Exception as e:
                 print(f"ERROR in {name}: {e}")
+                failed.append(name)
                 continue
+        if failed:
+            show_status()
+            print(f"\n{len(failed)} of {len(source_runners)} sources failed: {', '.join(failed)}")
+            sys.exit(1)
     else:
         runner = source_runners.get(args.source)
         if runner:

--- a/src/pipelines/run.py
+++ b/src/pipelines/run.py
@@ -714,14 +714,56 @@ def run_rankings_pipeline(years: list[int] | None = None, mode: str = "increment
     return info
 
 
+_SCHEDULED_TEAMS_QUERY = """
+    SELECT home_team AS team FROM core.games WHERE season = ANY(%s)
+    UNION
+    SELECT away_team FROM core.games WHERE season = ANY(%s)
+    ORDER BY team
+"""
+
+
+def scheduled_teams(conn, years: list[int]) -> list[str]:
+    """Every team with a scheduled game in `years`.
+
+    /roster is one request per team, so the team list is the whole cost of a
+    roster load. Deriving it from the schedule asks for exactly the teams the
+    warehouse has games for -- 350 for 2026, FCS opponents included -- instead
+    of a hand-maintained list that silently rots, or ref.teams' 1,922 rows of
+    which most never play an FBS opponent.
+    """
+    with conn.cursor() as cur:
+        cur.execute(_SCHEDULED_TEAMS_QUERY, (years, years))
+        return [row[0] for row in cur.fetchall() if row[0]]
+
+
 def run_rosters_pipeline(
-    teams: list[str],
+    teams: list[str] | None = None,
     years: list[int] | None = None,
     mode: str = "incremental",
 ):
-    """Run the rosters data pipeline."""
+    """Run the rosters data pipeline.
+
+    `teams=None` resolves the list from the schedule (see scheduled_teams), so
+    an orchestrated load can request a season's rosters without carrying a
+    team list. Passing `teams` explicitly still wins.
+    """
+    if teams is None:
+        if not years:
+            raise ValueError("rosters needs either an explicit team list or years to resolve one")
+        import psycopg2
+
+        conn = psycopg2.connect(_metrics_wp_db_url())
+        try:
+            teams = scheduled_teams(conn, years)
+        finally:
+            conn.close()
+        if not teams:
+            print(f"No scheduled teams found for {years}; nothing to load.")
+            return None
+        print(f"Resolved {len(teams)} teams with {years} games from core.games")
+
     years_str = f"years={years}" if years else f"mode={mode}"
-    print(f"\n=== Loading Rosters Data ({years_str}, teams={teams}) ===\n")
+    print(f"\n=== Loading Rosters Data ({years_str}, {len(teams)} teams) ===\n")
 
     pipeline = dlt.pipeline(
         pipeline_name="cfbd_rosters",

--- a/tests/test_load_season.py
+++ b/tests/test_load_season.py
@@ -346,3 +346,33 @@ class TestResourceFilterValidation:
 
         assert "error" in summary
         assert "Unknown stats resource" in summary["error"]
+
+
+class TestDependencyOrdering:
+    """SOURCE_ORDER is dependency order -- "Source loading order matters:
+    dependencies first" -- so the run order cannot be whatever the operator
+    happened to type."""
+
+    def test_sources_run_in_source_order_not_caller_order(self, capsys):
+        """`--sources rosters,games` must load the schedule first: roster
+        teams resolve FROM core.games, so the reverse order fails the roster
+        load and then loads the games it needed."""
+        load_season(season=2026, sources=["rosters", "games"], dry_run=True)
+
+        out = capsys.readouterr().out
+        assert out.index("games") < out.index("rosters")
+
+    def test_ordering_survives_resource_filters(self, capsys):
+        """A "source:res" spec still has to sort by its source name."""
+        load_season(season=2026, sources=["stats:player_returning", "games"], dry_run=True)
+
+        out = capsys.readouterr().out
+        assert out.index("games") < out.index("stats:player_returning")
+
+    def test_unknown_sources_are_reported_before_sorting(self):
+        """SOURCE_ORDER.index would raise on an unknown name; the operator
+        should get the named error instead of a ValueError."""
+        summary = load_season(season=2026, sources=["games", "nonsense"], dry_run=True)
+
+        assert "Unknown sources" in summary["error"]
+        assert "nonsense" in summary["error"]

--- a/tests/test_sources/test_rosters.py
+++ b/tests/test_sources/test_rosters.py
@@ -103,6 +103,39 @@ class TestScheduledTeamResolution:
         assert "away_team" in _SCHEDULED_TEAMS_QUERY
         assert "UNION" in _SCHEDULED_TEAMS_QUERY.upper()
 
+    def test_an_unloaded_schedule_fails_loudly(self):
+        """load_season reports a returning runner as [OK]. An empty team list
+        would therefore print a successful roster load that made zero /roster
+        requests -- the same silent no-op that left core.roster with no 2026
+        rows to begin with."""
+        from unittest.mock import patch
+
+        import pytest
+
+        from src.pipelines.run import run_rosters_pipeline
+
+        with (
+            patch("src.pipelines.run._metrics_wp_db_url", return_value="postgres://x"),
+            patch("psycopg2.connect", return_value=FakeConn([])),
+            pytest.raises(RuntimeError, match="No teams with scheduled games"),
+        ):
+            run_rosters_pipeline(teams=None, years=[2027])
+
+    def test_the_failure_names_the_fix(self):
+        """An operator hitting this needs to know to load the schedule."""
+        from unittest.mock import patch
+
+        import pytest
+
+        from src.pipelines.run import run_rosters_pipeline
+
+        with (
+            patch("src.pipelines.run._metrics_wp_db_url", return_value="postgres://x"),
+            patch("psycopg2.connect", return_value=FakeConn([])),
+            pytest.raises(RuntimeError, match=r"--sources games --season 2027"),
+        ):
+            run_rosters_pipeline(teams=None, years=[2027])
+
     def test_rosters_without_teams_or_years_is_an_error(self):
         """Refuse rather than guess: with no years there is no schedule to
         resolve against, and mode-derived years would silently load the wrong
@@ -138,3 +171,11 @@ class FakeConn:
 
     def cursor(self):
         return FakeCursor(self._rows)
+
+    def close(self):
+        pass
+
+
+def test_fakeconn_close_is_a_noop():
+    """run_rosters_pipeline closes the connection in a finally block."""
+    FakeConn([]).close()

--- a/tests/test_sources/test_rosters.py
+++ b/tests/test_sources/test_rosters.py
@@ -75,3 +75,66 @@ def test_rosters_source_returns_resource():
 
         # Source should return a list containing the resource
         assert source is not None
+
+
+class TestScheduledTeamResolution:
+    """/roster is one request per team, so the team list IS the cost of a
+    roster load. load_season's `--sources rosters` has no --teams to pass, so
+    the list resolves from the season's schedule."""
+
+    def test_teams_come_from_both_sides_of_the_schedule(self):
+        """An FCS visitor plays exactly one FBS game; missing it would leave a
+        hole in every roster-derived feature for that matchup."""
+        from src.pipelines.run import scheduled_teams
+
+        conn = FakeConn([("Alabama",), ("Chattanooga",), ("Oklahoma",)])
+        assert scheduled_teams(conn, [2026]) == ["Alabama", "Chattanooga", "Oklahoma"]
+
+    def test_null_team_names_are_dropped(self):
+        """A NULL team would become /roster?team=None -- a wasted call."""
+        from src.pipelines.run import scheduled_teams
+
+        assert scheduled_teams(FakeConn([("Alabama",), (None,)]), [2026]) == ["Alabama"]
+
+    def test_query_covers_home_and_away(self):
+        from src.pipelines.run import _SCHEDULED_TEAMS_QUERY
+
+        assert "home_team" in _SCHEDULED_TEAMS_QUERY
+        assert "away_team" in _SCHEDULED_TEAMS_QUERY
+        assert "UNION" in _SCHEDULED_TEAMS_QUERY.upper()
+
+    def test_rosters_without_teams_or_years_is_an_error(self):
+        """Refuse rather than guess: with no years there is no schedule to
+        resolve against, and mode-derived years would silently load the wrong
+        season."""
+        import pytest
+
+        from src.pipelines.run import run_rosters_pipeline
+
+        with pytest.raises(ValueError, match="either an explicit team list or years"):
+            run_rosters_pipeline(teams=None, years=None)
+
+
+class FakeCursor:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def execute(self, *a, **k):
+        pass
+
+    def fetchall(self):
+        return self._rows
+
+
+class FakeConn:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def cursor(self):
+        return FakeCursor(self._rows)

--- a/tests/test_sources/test_rosters.py
+++ b/tests/test_sources/test_rosters.py
@@ -179,3 +179,27 @@ class FakeConn:
 def test_fakeconn_close_is_a_noop():
     """run_rosters_pipeline closes the connection in a finally block."""
     FakeConn([]).close()
+
+
+class TestAllSourcesExitCode:
+    """`--source all` continues past a failure on purpose -- one broken source
+    should not cost the other twelve their data -- but the exit code has to
+    carry the failure, or scheduled automation reads a clean load."""
+
+    def test_the_loop_records_failures_and_exits_nonzero(self):
+        import inspect
+
+        from src.pipelines import run
+
+        body = inspect.getsource(run.main)
+        all_branch = body.split('if args.source == "all":')[1].split("else:")[0]
+        assert "failed.append(name)" in all_branch
+        assert "sys.exit(1)" in all_branch
+
+    def test_failures_are_named_not_just_counted(self):
+        """ "3 sources failed" without names sends an operator back to the log."""
+        import inspect
+
+        from src.pipelines import run
+
+        assert "', '.join(failed)" in inspect.getsource(run.main)


### PR DESCRIPTION
## Problem

`core.roster` has zero 2026 rows, and unlike the other preseason inputs it could not self-heal, because an orchestrated roster load was structurally impossible:

- `rosters_source` raises `ValueError` unless given an explicit `teams` list
- the `cfb-pipeline` CLI enforces the same with `--teams`
- `load_season` had **no runner** for `rosters`, so `--sources rosters` logged `No runner for source: rosters (skipping)` and exited successfully having done nothing

Every other source needed only a season. This one needed a team list nobody could supply through the orchestration path, so it was never loaded — for 2026 or any future season.

## Change

`run_rosters_pipeline(teams=None, years=[...])` resolves the team list from the schedule — `home_team UNION away_team` in `core.games` — and `load_season` gets a `rosters` runner that passes only the season.

Why the schedule and not `ref.teams`: `/roster` is one request per team, so the team list is the entire cost of the load. `ref.teams` holds 1,922 rows of which 138 are classified `fbs` and most never play an FBS opponent; an FBS-only list would also have undercounted badly, since the 2025 roster load covers 315 distinct teams. The schedule asks for exactly the teams the warehouse has games for — **350 for 2026**, FCS visitors included.

Guardrails:

- an explicit `teams` argument still wins — the CLI path is unchanged
- `teams=None` with no `years` raises rather than guessing (mode-derived years would silently load the wrong season)
- a season with no scheduled games logs and returns instead of loading nothing noisily
- `rosters` stays out of `load_season`'s default active set, so it runs only when named: `--sources rosters`

Also corrects `ESTIMATED_CALLS["rosters"]` from 150 to 350. The old value assumed FBS-only and understated a run by more than half — the same class of error as the `stats` estimate corrected in #64.

## Tests

4 new tests in `tests/test_sources/test_rosters.py`: teams resolve from both sides of the schedule (an FCS visitor plays one FBS game and would otherwise leave a hole in every roster-derived feature), NULL team names dropped before they become `/roster?team=None`, the query covers home and away, and no-teams-no-years raises.

1,315 passed, 401 skipped. `ruff check` / `ruff format --check` clean.

## Not included

No automated cadence. At ~350 calls a run this does not belong on the daily path; it stays a manual dispatch. If rosters should refresh through August as they firm up, a weekly cadence with a stop-once-the-season-starts guard is the natural follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pfurxa4Ved9U4ZkEo2PbKR)_

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The previously reported roster-load no-op is resolved. A season without scheduled games now stops with an instruction to load the schedule first, while scheduled home and away teams are resolved and passed to the roster loader. Focused roster and season-loading tests pass.

<h3>Confidence Score: 5/5</h3>

Safe to merge; no blocking failure remains.

No blocking failure remains.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran an isolated roster orchestration harness against run\_rosters\_pipeline for empty and populated schedules.
- In the empty schedule case, the harness raised a RuntimeError with guidance to use --sources games --season 2031 and performed no roster calls.
- In the populated schedule case, both sides resolved to \['Away State', 'Home U'\] and the roster source and pipeline were invoked once.
- Ran focused regression tests (57 tests total) and noted the implementation region in src/pipelines/run.py:717-790 and the related tests in tests/test\_sources/test\_rosters.py:80-148.

<a href="https://app.greptile.com/trex/runs/17905244/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (4): Last reviewed commit: ["Exit non-zero when --source all has a fa..."](https://github.com/rstover-fo/cfb-database/commit/8574fea2d0a16a818ae3ff412ae7119e76b54fb2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51207879)</sub>

<!-- /greptile_comment -->