### PR TITLE
Drive-state Markov chain and house expected points (P1)

### DIFF
--- a/docs/brainstorms/2026-08-08-play-sequence-derivatives.md
+++ b/docs/brainstorms/2026-08-08-play-sequence-derivatives.md
@@ -128,3 +128,80 @@ review gates before touching `features.team_week` — predictability and
 discipline metrics in particular are exactly the kind of plausible-sounding
 feature the pre-registration discipline exists to keep honest. Everything here
 is derivable from data already in the warehouse: **zero CFBD API calls.**
+
+---
+
+# Addendum (same day): related work + the scheme/formation question
+
+## Formation data: we have more than we thought
+
+`play_text` was assumed to be bare "Player rush for X yds" text. Empirically
+(2026-08-08):
+
+| season | shotgun-tagged plays | no-huddle-tagged |
+|---|---|---|
+| 2014–2021 | 0.0% | 0.0% |
+| 2022–2024 | ~0.5% | ~0.5% |
+| **2025** | **32.6%** | **23.4%** |
+
+The 2025 text is official NCAA live-stats format —
+`(10:57) No Huddle-Shotgun Player rush middle for 0 yards ...` — and the
+coverage is a **per-game split**: 720 of 1,653 games are fully tagged
+(shotgun rate inside them: 72.3%, consistent with modern CFB), the rest have
+zero tags. So:
+
+- **Shotgun and no-huddle — the exact covariates in the Ötting HMM — are
+  extractable for ~44% of 2025 games and presumably a growing share of 2026.**
+- A cheap regex extraction (`is_shotgun`, `is_no_huddle`, `is_sack`, penalty
+  structure) belongs in the play_epa pipeline regardless of anything else.
+- **Selection-bias guard before any feature use:** which games carry NCAA text
+  is not random (sampled tagged games skew non-P5). Any formation-derived
+  feature needs a `game_is_tagged` indicator and a bias check on the tagged
+  subsample before it goes near `features.team_week`.
+
+## What is genuinely NOT derivable, and the honest substitutes
+
+Alignment, motion, personnel packages (11/12/21), route concepts, and coverage
+shells do not exist in any CFBD field. Options, in increasing cost:
+
+1. **PROE / xpass** (industry standard): fit P(pass | down, distance, field
+   position, score, clock) league-wide; a team's pass rate *over* expected is
+   a scheme-intent fingerprint that needs no formation data at all. Fully
+   derivable today, all seasons. The closest thing to "scheme in one number."
+2. **Skill-personnel proxies from `stats.play_stats`:** co-occurrence of
+   ball-touchers per play/drive approximates personnel rotation breadth
+   (O-linemen never appear, so it is a proxy, not personnel).
+3. **External charting** (PFF/SIS): real formation/coverage labels, paywalled,
+   would enter via the flat-file lane if ever purchased.
+4. **CV on broadcast film:** an active research area, out of scope for this
+   warehouse.
+
+## Reading list (verified links)
+
+| Paper | Why it matters here |
+|---|---|
+| Goldner (2012), *A Markov Model of Football*, JQAS | The Tier 1 blueprint: absorbing chain over (down, distance, yardline), EP = absorption probs × state values. |
+| Chan, Fernandes & Puterman (2021), *Points Gained in Football*, Operations Research | The Tier 1 upgrade path: Bellman/Markov-reward formulation with asymmetric teams; play-level value ("points gained") from the value function. |
+| Brill, Yurko & Wyner (2025), *Analytics, have some humility*, The American Statistician (arXiv:2311.03490) | Mandatory Tier 4 guardrail: bootstrap uncertainty on EP/WP; many 4th-down "decisions" are statistical coin-flips. Report intervals, not verdicts. |
+| Romer (2006), *Do Firms Maximize?* / NBER w9024 dynamic-programming 4th-down analysis | The classic decision baseline. |
+| Ötting (2020), arXiv:2003.10791 | Tier 3 blueprint (HMM play-call regimes). |
+| arXiv:2103.06939, *RL Based Approach to Play Calling* | Play-calling as sequential decision problem — Tier 3/4 bridge. |
+| arXiv:2309.00756, *Learning Risk Preferences in MDPs* (4th down) | Inverse-RL take: infer coach risk preferences from observed decisions — richer than "aggressiveness above expectation." |
+| arXiv:2102.01846, *NFLSimulatoR* | Simulation harness pattern for strategy evaluation. |
+| Yurko, Ventura & Horowitz (2018), *nflWAR* (arXiv:1802.00998) | Tier 5 upgrade: multilevel player value from PBP alone — the road from player EPA to a WAR-style number. |
+| PROE / xpass (industry, nflfastR ecosystem) | Scheme-intent without formation data; Tier 3 item 1 should produce this as its first output. |
+
+## Other gaps surfaced while looking (not sequence-related, all derivable)
+
+- **Rest & travel:** days of rest / bye weeks from the schedule; travel
+  distance and altitude from `ref.venues` lat/lon. Classic HFA decomposition
+  features; never built, zero API calls.
+- **Special teams in the chain:** the Tier 1 EP model needs punt and FG
+  submodels anyway (house FG make-probability curve from `core.plays` FG
+  attempts); that yields FG-attempt EPA and punter field-position value as
+  byproducts.
+- **Weather:** `core.game_weather` is loaded and unscreened as a feature
+  source (wind × pass-rate interactions are the plausible candidate).
+- **QB continuity:** `stats.play_stats` identifies who took snaps; a
+  week-over-week starting-QB-change indicator is derivable and is the single
+  most prediction-relevant availability signal.

--- a/docs/brainstorms/2026-08-08-play-sequence-derivatives.md
+++ b/docs/brainstorms/2026-08-08-play-sequence-derivatives.md
@@ -1,0 +1,130 @@
+# Play-Sequence Derivatives: What the PBP/Drives Data Still Owes Us
+
+**Date:** 2026-08-08
+**Status:** Brainstorm — nothing here is committed work; model-feature candidates
+must pass the section 2.5 screen before entering `features.team_week`.
+**Inspirations:**
+- Ötting, *Predicting play calls in the NFL using hidden Markov models*
+  (arXiv:2003.10791) — 2-state HMM over per-drive play sequences, covariates
+  down/distance/shotgun/score-diff, 71.5% out-of-sample play-call accuracy.
+- Mik Panko's NFL plays sunburst (Observable) — hierarchical
+  drive-state → play → outcome visualization.
+
+## The gap, in one sentence
+
+Every play-derived mart we have is **marginal** — a situation bucket mapped to a
+rate (`team_playcalling_tendencies`, `situational_splits`, `team_tempo_metrics`,
+`team_style_profile`, `defensive_havoc`, `scoring_opportunities`) — while both
+inspirations exploit **conditional and sequential structure**: what a team does
+*given what just happened*, and how drives move through a state space. We have
+2.7M plays (2004+) with EPA, ordering (`play_number`, `drive_id`), score state,
+timeouts, and (2018+) wallclock timestamps, and we have never once conditioned
+on the previous play.
+
+## Spot-checks that motivated this (run 2026-08-08, season 2024, non-garbage)
+
+1. **Sequence dependence is large.** On 2nd down, P(pass) after a successful
+   rush is **0.355**; after a failed pass it is **0.527** — a 17-point swing
+   invisible to down/distance conditioning. On 1st down, previous-play identity
+   alone moves P(pass) by ~6 points (0.415 after rush vs 0.475–0.486 after
+   pass).
+2. **Real tempo is measurable.** `core.plays.wallclock` is ≥94.8% populated
+   for every season 2018+ (99%+ most years, 0% in 2014) — actual elapsed
+   seconds between snaps, strictly better than game-clock arithmetic for
+   tempo, hurry-up detection, and end-of-half urgency.
+3. **Unexploited columns already sitting in `core.plays`:**
+   `offense_timeouts`/`defense_timeouts` (clock-management analysis),
+   `play_number` × `drive_id` (sequencing), `wallclock` (real tempo),
+   `play_text` (sack/scramble/screen/PA extraction via regex — never parsed).
+
+## Tier 1 — Drive-state Markov chain (the biggest single unlock)
+
+Model the drive as an absorbing Markov chain. States = (down × distance bucket
+× field zone); absorbing states = TD, FG, punt, turnover, downs, end-of-half.
+Estimate the league transition matrix from all ~2.7M plays; per-team-season
+matrices as deviations (shrunk toward league).
+
+What falls out of one artifact:
+
+- **House expected-points curve.** EP(state) from the chain's absorption
+  values. Today every EPA number we publish inherits CFBD's PPA model;
+  a house EP model makes `marts.play_epa` self-sufficient and lets us define
+  EPA on our own terms (and sanity-check CFBD's).
+- **Drive outcome probabilities from any state** — P(TD | 2nd-and-7 at own 40)
+  — which is exactly the data behind the sunburst (Tier 2).
+- **Sustain vs finish decomposition.** Separate P(earn a new set of downs)
+  from P(points | scoring opportunity). `scoring_opportunities` measures
+  finishing; nothing measures sustaining as a chain property, and the two
+  skills price differently in matchups.
+- **Defense mirror.** The same chain conditioned on defense = a structural
+  defensive profile (where drives die against you), richer than havoc rates.
+
+Shape: `analytics.drive_chain_transitions` (state, next_state, n, p, season,
+team nullable for league) + a compute script following the
+`compute_house_elo.py` pattern. Walk-forward/as-of discipline applies if any
+of it feeds features.
+
+## Tier 2 — Drive sunburst mart (the visualization)
+
+`marts.drive_sequences`: hierarchical aggregation
+(start field zone → first-play category → second-play category → drive result)
+with counts and points, per season and team, garbage-time filtered. Exposed via
+an `api.` view so cfb-app can render the Observable-style sunburst directly —
+the ring hierarchy is precisely a GROUP BY ROLLUP. Cheap (one aggregation over
+`play_epa` × `core.drives`), zero API calls, high dashboard value.
+
+## Tier 3 — Predictability & sequence identity (the HMM paper direction)
+
+1. **Play-call predictability index.** Per team-season, fit a play-call model
+   (logistic with situation + previous-play covariates is enough to start; the
+   paper's 2-state HMM is the upgrade) and score *held-out cross-entropy*.
+   Low entropy = predictable offense. Candidate model feature: does offensive
+   predictability cost EPA/margin? Also a scouting product on its own
+   ("Team X goes run 78% after a successful run on 1st down").
+2. **Sequence entropy vs situation entropy.** We already measure situation mix;
+   add first-order transition entropy P(next category | current category,
+   down). Two teams with identical run/pass splits can be maximally different
+   in sequencing.
+3. **Abandon rate / discipline.** P(stay with run | consecutive failed runs) —
+   how fast a coach abandons the plan. The 2024 spot-check shows the
+   league-wide effect; the per-coach deviation is the interesting object, and
+   it travels with the coach (we have `coaches` + tenure marts to join).
+4. **Opening-script detection.** The HMM's latent-regime idea, minimally: do
+   the first ~12 offensive plays follow a different (more scripted, less
+   score-sensitive) distribution than the rest? Regime-switch frequency as a
+   coach fingerprint.
+
+## Tier 4 — Decision quality (needs Tier 1's EP curve)
+
+1. **4th-down decision model.** With EP(state) in hand, compute
+   go/punt/kick break-evens per state; score every actual 4th-down decision
+   2004+ → coach "aggressiveness above expectation" and EP lost to
+   conservatism. All inputs exist; the only prerequisite is the house EP curve.
+2. **Clock management.** `offense_timeouts`/`defense_timeouts` + wallclock:
+   end-of-half EP with 0/1/2/3 timeouts remaining, timeout-burn timing vs
+   points on the ensuing two-minute drive.
+3. **Real tempo (2018+).** Seconds-between-snaps from wallclock: true
+   hurry-up rate, situational tempo (leading vs trailing), tempo-as-weapon
+   vs tempo-as-identity. Would supersede the play-count proxies in
+   `team_tempo_metrics` for the seasons where wallclock exists.
+
+## Tier 5 — Player sequence structure (via `stats.play_stats`, 2.5M rows)
+
+- **Usage trees:** who touches the ball by (down, leverage, sequence position) —
+  a player-level sunburst; feeds cfb-scout.
+- **Dependence index:** HHI concentration of team EPA across players; a
+  candidate injury-sensitivity modifier when joined against availability
+  reports (`raw.availability_reports`) and rosters.
+- **`play_text` mining:** sack/scramble/screen/play-action extraction by regex
+  — none of it currently parsed out of the free text.
+
+## Ordering and guardrails
+
+Build order that respects dependencies: Tier 1 → (2, 4) with 3 and 5
+independent. Tier 2 is the cheapest shippable win; Tier 1 is the highest
+leverage. Every candidate *feature* goes through
+`screen_preseason_features.py`-style screening and the modeling-scientist
+review gates before touching `features.team_week` — predictability and
+discipline metrics in particular are exactly the kind of plausible-sounding
+feature the pre-registration discipline exists to keep honest. Everything here
+is derivable from data already in the warehouse: **zero CFBD API calls.**

--- a/docs/plans/2026-08-08-drive-chain-ep-model-plan.md
+++ b/docs/plans/2026-08-08-drive-chain-ep-model-plan.md
@@ -1,0 +1,175 @@
+# Drive-State Markov Chain & House Expected Points — Design
+
+**Date:** 2026-08-08
+**Status:** Design (pre-implementation). Companion brainstorm:
+`docs/brainstorms/2026-08-08-play-sequence-derivatives.md` (Tier 1).
+**Anchors:** Goldner (2012, JQAS) absorbing-chain drive model (v1);
+net-next-score handoff recursion (v1.5); Chan, Fernandes & Puterman (2021,
+Operations Research) Markov-reward "points gained" (v2 aspiration).
+**Cost:** zero CFBD API calls (one optional call to `/ppa/predicted` as a
+validation benchmark).
+
+## 1. Objective
+
+An in-house expected-points model built from our own 2.7M plays:
+`EP(state)` for every drive state, drive-outcome probabilities from any state,
+and a house EPA per play. Today every EPA-derived number in the warehouse
+inherits CFBD's PPA model; this makes the EPA layer self-sufficient,
+benchmarkable, and extensible (4th-down model, sunburst, sustain/finish all
+fall out of the same artifact).
+
+## 2. Non-goals (v1)
+
+- No win probability (the live WP model stays as is).
+- No overtime states (OT drives excluded; `POSSESSION (FOR OT DRIVES)` rows
+  dropped).
+- No replacement of `ppa` anywhere downstream until validation gates pass —
+  house EPA lands as a *parallel* column, never a silent swap
+  (SCHEMA_CONTRACT discipline).
+
+## 3. Data foundation (verified 2026-08-08, seasons ≥2014 unless noted)
+
+- **Scrimmage-play vocabulary** (`core.plays.play_type`): Rush 840k,
+  Pass Reception 428k, Pass Incompletion 295k, Sack 49k, Rushing TD 42k,
+  Passing TD 41k, Interception(+return) 19k, Fumble recoveries 21k. Special
+  teams: Punt 118k, Kickoff 117k, FG Good 27.8k / Missed 8.8k / Blocked 1.1k.
+  Non-plays to exclude from transitions: Penalty 113k, Timeout 86k,
+  End Period/Half/Game rows.
+- **Drive outcomes** (`core.drives.drive_result`): PUNT 117k, TD 85k, FG 27k,
+  DOWNS 20k, INT 19k, FUMBLE 13k, MISSED FG 10k, END OF HALF/GAME 18k, plus a
+  defensive-score tail (INT TD 2.0k, FUMBLE TD ~1.1k, PUNT RETURN TD ~0.9k)
+  and `Uncategorized` 2.7k (~1%% — dropped, count logged).
+- **State support:** a flat 160-state grid (4 downs × 4 distance buckets ×
+  10 field zones) has median support 4,861 plays but **38 states under 500**
+  (min 1) — the structurally rare corners (e.g. 1st-and-short away from the
+  goal line). A flat grid is not estimable; smoothing is a requirement, not a
+  refinement (section 5).
+- **FG curve sanity:** make rate declines monotonically 94.2% (≤20yd bucket)
+  → 54.3% (50) → 45.0% (55), n=37k attempts. House FG submodel is feasible
+  on counts alone.
+- **Ordering:** `play_number` within (`game_id`, `drive_id`) plus each play's
+  own (down, distance, yards_to_goal) snapshot. Penalties are handled
+  implicitly: a transition is defined snapshot→snapshot between consecutive
+  *scrimmage* plays in a drive, so a penalty's state change is absorbed into
+  the observed next snapshot without modeling the penalty row itself.
+  `NO PLAY` rows (penalty-nullified, visible in 2025 NCAA text) carry the
+  pre-snap state of the replayed down and are excluded by the same rule.
+
+## 4. State space
+
+**Transient states:** `(down 1–4, distance bucket, field zone)` with
+down-aware distance buckets (this is what fixes the starved corners):
+
+- Down 1: `goal_to_go` | `standard` (distance ≈ 10) | `short` (<10, after
+  penalty) | `long` (>10)
+- Downs 2–4: `short` (≤3) | `med` (4–6) | `long` (7–10) | `xlong` (>10),
+  with `goal_to_go` overriding when distance ≥ yards_to_goal
+- Field zone: 10-yard bands of `yards_to_goal` (1–10 … 91–99)
+
+**Absorbing states** (mapped from `drive_result`): `TD`, `FG`,
+`MISSED_FG`, `PUNT`, `TURNOVER` (INT + FUMBLE), `TURNOVER_TD` (defensive
+score, valued negatively), `DOWNS`, `SAFETY`, `END_OF_HALF`.
+`END OF GAME`/`END OF 4TH QUARTER` fold into `END_OF_HALF`; blocked kicks fold
+into their missed/turnover equivalents; `Uncategorized` dropped with a count
+assertion (<2%% of drives or the build fails).
+
+## 5. Estimation
+
+1. **League matrix per era.** Raw transition counts → row-normalized, with
+   empirical-Bayes shrinkage toward a parent state (drop the distance
+   dimension first, then the zone) so starved cells inherit their parent's
+   distribution. Concentration parameter chosen by held-out log-likelihood
+   (one season left out).
+2. **Eras.** Scoring environment and rules drift 2004→2025 (kickoff rules,
+   clock rules, pace). v1 estimates three era matrices: 2004–2013, 2014–2020,
+   2021–present, and validates stability by comparing EP curves across eras;
+   if adjacent eras agree within bootstrap CIs they may be pooled. EPA is
+   always computed against the play's own era curve.
+3. **Garbage time** excluded using the same `is_garbage_time` definition as
+   `marts.play_epa` — one definition in the codebase, not two.
+4. **Team-level (later phase):** team matrices as shrunk deviations from the
+   era-league matrix (Dirichlet prior centered on league rows); never
+   estimated free-standing.
+
+## 6. The EP ladder
+
+- **v1 — drive EP (Goldner).** `EP_drive(s) = A(s,·) · v` where `A` is the
+  absorption-probability matrix and `v` = {TD: 6.97 (TD + league XP/2pt
+  expectation), FG: 3, SAFETY: −2, TURNOVER_TD: −6.97, else 0}. Simple,
+  interpretable, sufficient for the sunburst and sustain/finish.
+- **v1.5 — net next-score EP.** Non-scoring absorptions are worth
+  `−EP_opponent(handoff state)`: punts through a net-punt-distance model,
+  turnovers through observed return-spot distributions, scores through
+  kickoff start position (era-dependent: touchback rules changed). Solve by
+  fixed-point iteration over field position (converges fast; both Goldner and
+  nflfastR-style EP land here). **This is the basis comparable to CFBD PPA**
+  and the one house EPA uses.
+- **v2 — Chan/Fernandes/Puterman MRP.** Full-game Markov reward process with
+  asymmetric teams and play-level "points gained" from the value function.
+  Recorded as the aspiration; not in scope until v1.5 validates.
+
+## 7. Special-teams submodels (needed by v1.5)
+
+- **FG:** logistic make-probability on attempt distance (era-pooled unless
+  the curve drifts); the empirical curve above is the sanity anchor.
+- **Punt:** net field-position distribution given punt spot (includes
+  touchback compression near the goal line).
+- **Kickoff:** empirical start-position distribution per era.
+
+Byproducts shipped for free: FG-attempt EPA, punter field-position value.
+
+## 8. Deliverables & schema
+
+| Artifact | Shape |
+|---|---|
+| `scripts/compute_drive_chain.py` | `compute_house_elo.py` conventions; `--era`, `--validate`, idempotent rebuild |
+| `analytics.drive_chain_transitions` | (era, state, next_state, n, p_raw, p_shrunk) — league grain first |
+| `analytics.ep_states` | (era, state, ep_drive, ep_net, p_td, p_fg, p_punt, p_turnover, se_boot) |
+| `marts.play_epa.house_epa` | parallel column: `EP(next state) − EP(state)` (+ scoring adjustments), NULL where CFBD ppa is also NULL |
+| `marts.drive_sequences` | Tier 2 sunburst rollup (start zone → play-1 → play-2 → result) + `api.` view |
+
+Bootstrap SEs (cluster-resample by game) stored alongside every EP value —
+the Brill/Yurko/Wyner point: publish intervals, not verdicts.
+
+## 9. Validation gates (all must pass before anything consumes house EPA)
+
+1. **Shape sanity:** EP monotone in yards_to_goal within each down; 1st ≥ 2nd
+   ≥ 3rd ≥ 4th at fixed (distance, zone) for standard distances.
+2. **Benchmark vs CFBD:** play-level corr(house_epa, ppa) on rush/pass plays
+   — expect ≈0.9; a low value means a definition mismatch to explain, not a
+   tweak to hide. Optional single call to `/ppa/predicted` for the
+   state-level comparison.
+3. **Calibration:** predicted vs realized drive-outcome rates by state decile
+   (reliability curves for P(TD), P(punt), P(turnover)).
+4. **Era stability:** EP curves per era with bootstrap bands; pooling
+   decisions documented from this, not assumed.
+5. **Plausibility review** by modeling-scientist conventions: team
+   sustain/finish decomposition must rank known offenses sensibly before the
+   mart ships.
+
+## 10. Phasing
+
+- **P1:** league chain per era + EP v1 + gates 1/3/4 → `ep_states`,
+  `drive_chain_transitions`.
+- **P2:** special-teams submodels + v1.5 net EP + gate 2 → `house_epa`
+  column.
+- **P3:** team-level shrunk deviations → sustain/finish mart + Tier 2
+  sunburst mart + api views.
+- **P4 (separate plan):** 4th-down decision model on top of v1.5, with
+  bootstrap decision intervals per Brill et al.; coach aggressiveness above
+  expectation.
+
+Feature adoption into `features.team_week` is out of scope for all phases —
+any candidate goes through the section 2.5 screen on its own merits later.
+
+## 11. Open questions
+
+1. Half-open drives: `END_OF_HALF` truncation censors long drives — v1
+   treats it as absorbing with value 0 (net basis handles it better); check
+   sensitivity by excluding final-2:00 drives.
+2. 2-pt attempts: fold into the TD value constant (league rate) or model
+   separately? v1 folds.
+3. FCS opponents: include (they're in the data, ~both sides of 350-team
+   schedules) but validate the EP curve on FBS-vs-FBS only.
+4. Where does the era boundary for the 2024 clock-rule change land? Check
+   drive-length distributions before freezing era cuts.

--- a/docs/plans/2026-08-08-drive-chain-ep-model-plan.md
+++ b/docs/plans/2026-08-08-drive-chain-ep-model-plan.md
@@ -162,6 +162,19 @@ the Brill/Yurko/Wyner point: publish intervals, not verdicts.
 Feature adoption into `features.team_week` is out of scope for all phases —
 any candidate goes through the section 2.5 screen on its own merits later.
 
+## 10.5 First real-chain run (2026-08-08, era 2021+, offline via MCP counts)
+
+875,715 scrimmage plays, 162 states, 6,729 unique transitions. Gate 1a
+(zone monotonicity) PASSED: 1st-and-10 drive EP declines smoothly 4.75
+(z2) -> 1.17 (z10); 1st-and-goal inside the 10 = 5.65 with P(TD) 0.758;
+own-25 = 1.80 -- all consistent with published CFB EP curves. Gate 1b
+surfaced a structural property, not an error: d4 transient states are
+GO-FOR-IT-CONDITIONAL (punts/FGs exit the chain from the 3rd-down play), so
+d4 can price above d3 (observed: d4|med|z7 1.40 vs d3|med|z7 1.37). The
+gate now checks downs 2-3 only, with the exemption documented in code; P4's
+4th-down model uses the conditionality directly (EP(go | state) IS the
+d4-state value).
+
 ## 11. Open questions
 
 1. Half-open drives: `END_OF_HALF` truncation censors long drives — v1

--- a/docs/plans/2026-08-08-drive-chain-ep-model-plan.md
+++ b/docs/plans/2026-08-08-drive-chain-ep-model-plan.md
@@ -164,7 +164,12 @@ any candidate goes through the section 2.5 screen on its own merits later.
 
 ## 10.5 First real-chain run (2026-08-08, era 2021+, offline via MCP counts)
 
-875,715 scrimmage plays, 162 states, 6,729 unique transitions. Gate 1a
+Corrected engine after PR #66 review (grandparent-target emission, no
+play_epa join, drive-exact unmapped guard, realized-outcome calibration):
+872,678 scrimmage plays, 158,649 mapped drives (0.90% unmapped), 6,687
+unique transitions, every shrunk row summing to exactly 1. Realized-
+outcome calibration MAE for P(TD) from drive-start states: **0.0076**.
+Gate 1a
 (zone monotonicity) PASSED: 1st-and-10 drive EP declines smoothly 4.75
 (z2) -> 1.17 (z10); 1st-and-goal inside the 10 = 5.65 with P(TD) 0.758;
 own-25 = 1.80 -- all consistent with published CFB EP curves. Gate 1b

--- a/scripts/compute_drive_chain.py
+++ b/scripts/compute_drive_chain.py
@@ -198,12 +198,19 @@ def build_transitions(plays: list[dict]) -> tuple[Counter, Counter, int]:
 
     Returns (transition counts keyed (from_state, to_state),
              per-game counts keyed (game_id, from_state, to_state) -- the
-             bootstrap resampling unit, and the count of drives dropped for
-             an unmapped drive_result).
+             bootstrap resampling unit,
+             drive_outcomes keyed (first_play_state, absorbing) -- the
+             realized-outcome sample the calibration gate compares against,
+             n_mapped drives, and the count of drives dropped for an
+             unmapped drive_result). Drive counts are exact (PR #66 review,
+             P2): the unmapped-share guard must divide by drives, not by
+             game-state pairs.
     """
     transitions: Counter = Counter()
     per_game: Counter = Counter()
+    drive_outcomes: Counter = Counter()
     unmapped_drives = 0
+    n_mapped = 0
 
     by_drive: dict[tuple, list[dict]] = defaultdict(list)
     for row in plays:
@@ -216,14 +223,16 @@ def build_transitions(plays: list[dict]) -> tuple[Counter, Counter, int]:
         if absorb is None:
             unmapped_drives += 1
             continue
+        n_mapped += 1
         states = [state_key(r["down"], r["distance"], r["yards_to_goal"]) for r in rows]
         for a, b in zip(states, states[1:]):
             transitions[(a, b)] += 1
             per_game[(game_id, a, b)] += 1
         transitions[(states[-1], absorb)] += 1
         per_game[(game_id, states[-1], absorb)] += 1
+        drive_outcomes[(states[0], absorb)] += 1
 
-    return transitions, per_game, unmapped_drives
+    return transitions, per_game, drive_outcomes, n_mapped, unmapped_drives
 
 
 def shrink(transitions: Counter, alpha: float = DEFAULT_ALPHA) -> dict[tuple, float]:
@@ -257,16 +266,24 @@ def shrink(transitions: Counter, alpha: float = DEFAULT_ALPHA) -> dict[tuple, fl
         return num / den if den else 0.0
 
     # Candidate targets per from-state: observed targets plus every target the
-    # parent has seen (a starved state must be able to reach outcomes it never
-    # personally observed).
+    # parent OR grandparent has seen. The grandparent union is load-bearing
+    # (PR #66 review, P1): p_parent() mixes grandparent probability into every
+    # target, so a target observed only elsewhere in the same down would carry
+    # positive probability that the row never emits -- the row would sum to
+    # less than 1 and solve_ep() would leak that mass out of the chain,
+    # biasing every absorption probability.
     targets_by_state: dict[str, set] = defaultdict(set)
     parent_targets: dict[str, set] = defaultdict(set)
+    grand_targets: dict[str, set] = defaultdict(set)
     for pk, b in parent_counts:
         parent_targets[pk].add(b)
+    for gk, b in grand_counts:
+        grand_targets[gk].add(b)
     for a, b in transitions:
         targets_by_state[a].add(b)
     for a in row_totals:
         targets_by_state[a] |= parent_targets[parent_key(a)]
+        targets_by_state[a] |= grand_targets[grandparent_key(a)]
 
     shrunk: dict[tuple, float] = {}
     for a in row_totals:
@@ -385,28 +402,31 @@ def check_monotone_down(ep: dict[str, float]) -> list[str]:
 
 
 def calibration_mae(
-    absorb_probs: dict[tuple, float], transitions: Counter, outcome: str = "TD"
+    absorb_probs: dict[tuple, float], drive_outcomes: Counter, outcome: str = "TD"
 ) -> float:
-    """Gate 3: mean |model absorption prob - empirical drive outcome rate|
-    over states, weighted by support. Empirical rate for a state uses drives
-    whose FIRST play was in that state (the chain should reproduce these)."""
-    # Empirical: among transitions, we don't retain drive starts here; the
-    # caller passes first-play transitions separately when available. This
-    # function instead compares model vs empirical one-step-consistent
-    # absorption via the raw matrix -- solving the raw (unshrunk) chain and
-    # comparing to the shrunk one. Deviations flag shrinkage distortion.
-    raw_totals: Counter = Counter()
-    for (a, _), n in transitions.items():
-        raw_totals[a] += n
-    p_raw = {(a, b): n / raw_totals[a] for (a, b), n in transitions.items()}
-    ep_raw, absorb_raw = solve_ep({k: v for k, v in p_raw.items()})
+    """Gate 3: support-weighted mean |model absorption prob - REALIZED drive
+    outcome rate| over drive-start states.
+
+    Realized, not model-vs-model (PR #66 review, P2): the empirical rate for
+    a state is the fraction of drives whose FIRST play was in that state that
+    actually ended in `outcome`. Drive starts are held-out-in-spirit
+    observations of the whole chain: a large MAE flags either miscalibration
+    or a Markov violation, which is exactly what this gate exists to catch.
+    """
+    starts_total: Counter = Counter()
+    starts_outcome: Counter = Counter()
+    for (s, abs_s), n in drive_outcomes.items():
+        starts_total[s] += n
+        if abs_s == outcome:
+            starts_outcome[s] += n
+
     num, den = 0.0, 0
-    for (s, abs_s), p in absorb_probs.items():
-        if abs_s != outcome or (s, abs_s) not in absorb_raw:
+    for s, n in starts_total.items():
+        if (s, outcome) not in absorb_probs or n < 50:  # skip unsupported starts
             continue
-        w = raw_totals[s]
-        num += w * abs(p - absorb_raw[(s, abs_s)])
-        den += w
+        empirical = starts_outcome[s] / n
+        num += n * abs(absorb_probs[(s, outcome)] - empirical)
+        den += n
     return num / den if den else float("nan")
 
 
@@ -414,7 +434,19 @@ def calibration_mae(
 # --- I/O layer ---------------------------------------------------------------
 # =============================================================================
 
-PLAYS_QUERY = """
+# Garbage-time predicate inlined VERBATIM from marts.play_epa
+# (src/schemas/marts/010_play_epa.sql). The mart itself must NOT be joined
+# here (PR #66 review, P1): it is defined WHERE p.ppa IS NOT NULL, so an
+# inner join silently drops any scrimmage play CFBD did not score --
+# corrupting snapshot sequences and re-importing the CFBD-coverage
+# dependency this house model exists to remove. If 010's definition ever
+# changes, change this in the same commit.
+GARBAGE_TIME_SQL = """(
+      (p.period = 4 AND ABS(COALESCE(p.score_diff, 0)) > 28) OR
+      (p.period >= 3 AND ABS(COALESCE(p.score_diff, 0)) > 35)
+)"""
+
+PLAYS_QUERY = f"""
     SELECT p.game_id,
            p.drive_id,
            p.play_number,
@@ -424,13 +456,12 @@ PLAYS_QUERY = """
            d.drive_result
     FROM core.plays p
     JOIN core.drives d ON d.id = p.drive_id AND d.game_id = p.game_id
-    JOIN marts.play_epa pe ON pe.play_id = p.id
     WHERE p.season BETWEEN %(start)s AND %(end)s
       AND p.play_type = ANY(%(types)s)
       AND p.down BETWEEN 1 AND 4
       AND p.distance BETWEEN 1 AND 45
       AND p.yards_to_goal BETWEEN 1 AND 99
-      AND NOT pe.is_garbage_time
+      AND NOT {GARBAGE_TIME_SQL}
       AND d.drive_result <> 'POSSESSION (FOR OT DRIVES)'
 """
 
@@ -534,9 +565,8 @@ def run_era(conn, era: str, alpha: float, do_bootstrap: bool, do_validate: bool)
         logger.error("Era %s: no plays -- is marts.play_epa refreshed?", era)
         return 1
 
-    transitions, per_game, unmapped = build_transitions(plays)
-    n_drives = unmapped + len({(g, a) for (g, a, _) in per_game})  # approx upper bound denom
-    share = unmapped / max(1, n_drives)
+    transitions, per_game, drive_outcomes, n_mapped, unmapped = build_transitions(plays)
+    share = unmapped / max(1, n_mapped + unmapped)
     logger.info(
         "Era %s: %d transitions, %d unmapped drives (%.2f%%)",
         era,
@@ -559,7 +589,7 @@ def run_era(conn, era: str, alpha: float, do_bootstrap: bool, do_validate: bool)
     if do_validate:
         vz = check_monotone_zone(ep)
         vd = check_monotone_down(ep)
-        mae = calibration_mae(absorb_probs, transitions)
+        mae = calibration_mae(absorb_probs, drive_outcomes)
         for v in vz + vd:
             logger.warning("Era %s monotonicity: %s", era, v)
         print(

--- a/scripts/compute_drive_chain.py
+++ b/scripts/compute_drive_chain.py
@@ -361,11 +361,20 @@ def check_monotone_zone(ep: dict[str, float]) -> list[str]:
 
 def check_monotone_down(ep: dict[str, float]) -> list[str]:
     """Gate 1b: at fixed medium distance and zone, earlier downs are worth
-    at least as much as later downs."""
+    at least as much as later downs -- checked for downs 2-3 ONLY.
+
+    4th down is exempt by design, not tolerance: a d4 scrimmage snapshot
+    exists only when the offense lined up to go (punts and FGs exit the
+    chain from the 3rd-down play), so d4 states are go-for-it-conditional
+    and can legitimately price above d3 -- the punt outcome is excluded
+    from their mix. First observed on the real 2021+ chain (d4|med|z7 1.40
+    vs d3|med|z7 1.37) and structural in any Goldner-style drive chain.
+    P4's 4th-down model USES this: EP(go | state) is the d4-state value.
+    """
     violations = []
     for z in range(2, 10):
         chain = []
-        for down, bucket in (("d2", "med"), ("d3", "med"), ("d4", "med")):
+        for down, bucket in (("d2", "med"), ("d3", "med")):
             key = f"{down}|{bucket}|z{z}"
             if key in ep:
                 chain.append((key, ep[key]))

--- a/scripts/compute_drive_chain.py
+++ b/scripts/compute_drive_chain.py
@@ -1,0 +1,591 @@
+#!/usr/bin/env python3
+"""Estimate the drive-state Markov chain and solve house expected points.
+
+Design: docs/plans/2026-08-08-drive-chain-ep-model-plan.md (P1).
+
+Architecture (compute_house_elo.py conventions): everything above the
+`# --- I/O layer ---` marker is pure -- state bucketing, transition
+counting, empirical-Bayes shrinkage, the absorbing-chain solve, and the
+game-cluster bootstrap all operate on plain dicts/arrays and are
+unit-tested without a database (tests/test_drive_chain.py). The I/O layer
+fetches scrimmage plays (garbage-time filtered through marts.play_epa so
+there is ONE garbage-time definition in the codebase), feeds them through
+the engine, and rewrites analytics.drive_chain_transitions /
+analytics.ep_states idempotently (DELETE per era + INSERT).
+
+A transition is snapshot -> snapshot between consecutive scrimmage plays of
+a drive: each play carries its own (down, distance, yards_to_goal), so a
+penalty between two scrimmage plays is absorbed into the observed next
+snapshot without modeling the 113k penalty rows. The last scrimmage play of
+a drive transitions to the absorbing outcome mapped from
+core.drives.drive_result.
+
+Usage:
+    python scripts/compute_drive_chain.py --full            # all eras
+    python scripts/compute_drive_chain.py --era 2021+       # one era
+    python scripts/compute_drive_chain.py --full --validate # + gates 1/3
+    python scripts/compute_drive_chain.py --full --no-bootstrap
+
+Prints one machine-readable line per era after writing:
+    EP_VALIDATION era=<e> states=<n> monotone_zone=<pass|FAIL> \
+        monotone_down=<pass|FAIL> calib_mae_td=<x.xxxx>
+"""
+
+import argparse
+import logging
+import sys
+from collections import Counter, defaultdict
+
+import numpy as np
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+# Eras: rules/scoring environments estimated separately (design doc section
+# "Estimation"). Bounds are inclusive; the open era picks up new seasons
+# automatically so the daily/deploy path never needs a code change at rollover.
+ERAS: dict[str, tuple[int, int | None]] = {
+    "2004-2013": (2004, 2013),
+    "2014-2020": (2014, 2020),
+    "2021+": (2021, None),
+}
+
+# Scrimmage play types: rows that represent a snap from scrimmage with a
+# meaningful pre-snap state. Everything else (Penalty, Timeout, End Period,
+# kickoffs, punts, FG rows...) is either a non-play or a special-teams play
+# that ends/starts possessions -- those enter through the ABSORBING outcome,
+# not as transient states (P2 models them explicitly).
+SCRIMMAGE_TYPES = frozenset(
+    {
+        "Rush",
+        "Pass Reception",
+        "Pass Incompletion",
+        "Pass Completion",
+        "Sack",
+        "Rushing Touchdown",
+        "Passing Touchdown",
+        "Interception",
+        "Pass Interception Return",
+        "Interception Return Touchdown",
+        "Fumble Recovery (Own)",
+        "Fumble Recovery (Opponent)",
+        "Fumble Return Touchdown",
+        "Safety",
+    }
+)
+
+# drive_result -> absorbing state. Verified against the live vocabulary
+# 2026-08-08 (design doc "Data foundation"); anything unmapped is dropped
+# and counted, and the build fails if drops exceed MAX_UNMAPPED_SHARE.
+ABSORB_MAP: dict[str, str] = {
+    "TD": "TD",
+    "RUSHING TD": "TD",
+    "PASSING TD": "TD",
+    "FG": "FG",
+    "MISSED FG": "MISSED_FG",
+    "BLOCKED FG": "MISSED_FG",
+    "MISSED FG TD": "TURNOVER_TD",  # returned for a defensive score
+    "PUNT": "PUNT",
+    "BLOCKED PUNT": "PUNT",
+    "PUNT RETURN TD": "TURNOVER_TD",
+    "PUNT TD": "TURNOVER_TD",
+    "BLOCKED PUNT TD": "TURNOVER_TD",
+    "INT": "TURNOVER",
+    "FUMBLE": "TURNOVER",
+    "INT TD": "TURNOVER_TD",
+    "FUMBLE TD": "TURNOVER_TD",
+    "FUMBLE RETURN TD": "TURNOVER_TD",
+    "DOWNS": "DOWNS",
+    "DOWNS TD": "TURNOVER_TD",
+    "SF": "SAFETY",
+    "END OF HALF": "END_OF_HALF",
+    "END OF HALF TD": "END_OF_HALF",
+    "END OF GAME": "END_OF_HALF",
+    "END OF 4TH QUARTER": "END_OF_HALF",
+}
+
+ABSORBING = (
+    "TD",
+    "FG",
+    "MISSED_FG",
+    "PUNT",
+    "TURNOVER",
+    "TURNOVER_TD",
+    "DOWNS",
+    "SAFETY",
+    "END_OF_HALF",
+)
+
+# Goldner-basis absorbing values. TD carries the league PAT expectation
+# (~0.97 XP make x 1 + small 2pt mix); TURNOVER_TD is the mirror. Everything
+# else is worth 0 on the DRIVE basis -- field position handoff is P2 (ep_net).
+TD_VALUE = 6.97
+ABSORB_VALUES: dict[str, float] = {
+    "TD": TD_VALUE,
+    "FG": 3.0,
+    "SAFETY": -2.0,
+    "TURNOVER_TD": -TD_VALUE,
+}
+
+MAX_UNMAPPED_SHARE = 0.02  # Uncategorized drives ran ~1% live; 2x headroom.
+
+# Empirical-Bayes shrinkage strength (pseudo-observations given to the parent
+# distribution). With median state support ~4.9k, alpha=50 is negligible for
+# healthy states and decisive for the 38 starved ones (support < 500).
+DEFAULT_ALPHA = 50.0
+
+BOOTSTRAP_B = 200
+BOOTSTRAP_SEED = 20260808
+
+
+# =============================================================================
+# Pure engine -- no I/O, no DB, unit-tested directly.
+# =============================================================================
+
+
+def field_zone(yards_to_goal: int) -> int:
+    """10-yard band, 1 (goal line) .. 10 (own goal line)."""
+    return min(10, max(1, (int(yards_to_goal) + 9) // 10))
+
+
+def distance_bucket(down: int, distance: int, yards_to_goal: int) -> str:
+    """Down-aware distance bucket (design doc section 4).
+
+    A flat grid starves structurally rare corners (38 of 160 states under
+    500 plays -- e.g. 1st-and-short away from the goal line), so 1st down
+    gets its own vocabulary: goal_to_go / standard (=10) / short (<10,
+    post-penalty) / long (>10). Downs 2-4 use short/med/long/xlong with
+    goal_to_go overriding when the line to gain is the goal line.
+    """
+    if distance >= yards_to_goal:
+        return "goal"
+    if down == 1:
+        if distance == 10:
+            return "standard"
+        return "short" if distance < 10 else "long"
+    if distance <= 3:
+        return "short"
+    if distance <= 6:
+        return "med"
+    if distance <= 10:
+        return "long"
+    return "xlong"
+
+
+def state_key(down: int, distance: int, yards_to_goal: int) -> str:
+    return f"d{down}|{distance_bucket(down, distance, yards_to_goal)}|z{field_zone(yards_to_goal)}"
+
+
+def parent_key(state: str) -> str:
+    """Shrinkage parent: drop the distance bucket, keep down x zone."""
+    down, _, zone = state.split("|")
+    return f"{down}|*|{zone}"
+
+
+def grandparent_key(state: str) -> str:
+    """Second-level parent: down only."""
+    down, _, _ = state.split("|")
+    return f"{down}|*|*"
+
+
+def build_transitions(plays: list[dict]) -> tuple[Counter, Counter, int]:
+    """Count snapshot->snapshot transitions from ordered scrimmage plays.
+
+    `plays` rows need: game_id, drive_id, play_number, down, distance,
+    yards_to_goal, drive_result. Rows are grouped by (game_id, drive_id) and
+    ordered by play_number; the last play of a drive absorbs into
+    ABSORB_MAP[drive_result].
+
+    Returns (transition counts keyed (from_state, to_state),
+             per-game counts keyed (game_id, from_state, to_state) -- the
+             bootstrap resampling unit, and the count of drives dropped for
+             an unmapped drive_result).
+    """
+    transitions: Counter = Counter()
+    per_game: Counter = Counter()
+    unmapped_drives = 0
+
+    by_drive: dict[tuple, list[dict]] = defaultdict(list)
+    for row in plays:
+        by_drive[(row["game_id"], row["drive_id"])].append(row)
+
+    for (game_id, _), rows in by_drive.items():
+        rows.sort(key=lambda r: r["play_number"])
+        result = (rows[0].get("drive_result") or "").upper()
+        absorb = ABSORB_MAP.get(result)
+        if absorb is None:
+            unmapped_drives += 1
+            continue
+        states = [state_key(r["down"], r["distance"], r["yards_to_goal"]) for r in rows]
+        for a, b in zip(states, states[1:]):
+            transitions[(a, b)] += 1
+            per_game[(game_id, a, b)] += 1
+        transitions[(states[-1], absorb)] += 1
+        per_game[(game_id, states[-1], absorb)] += 1
+
+    return transitions, per_game, unmapped_drives
+
+
+def shrink(transitions: Counter, alpha: float = DEFAULT_ALPHA) -> dict[tuple, float]:
+    """Empirical-Bayes shrink each row toward its parent's distribution.
+
+    p_shrunk(to | from) = (n(from,to) + alpha * p_parent(to | parent(from)))
+                          / (n(from) + alpha)
+
+    The parent pools all distance buckets of the same down x zone; the parent
+    itself is smoothed toward the grandparent (down only) with the same
+    alpha, so even an empty parent row is defined. Healthy states
+    (n >> alpha) are barely moved; starved states inherit their parent.
+    """
+    row_totals: Counter = Counter()
+    parent_counts: Counter = Counter()
+    parent_totals: Counter = Counter()
+    grand_counts: Counter = Counter()
+    grand_totals: Counter = Counter()
+    for (a, b), n in transitions.items():
+        row_totals[a] += n
+        parent_counts[(parent_key(a), b)] += n
+        parent_totals[parent_key(a)] += n
+        grand_counts[(grandparent_key(a), b)] += n
+        grand_totals[grandparent_key(a)] += n
+
+    def p_parent(a: str, b: str) -> float:
+        pk, gk = parent_key(a), grandparent_key(a)
+        g = grand_counts[(gk, b)] / grand_totals[gk] if grand_totals[gk] else 0.0
+        num = parent_counts[(pk, b)] + alpha * g
+        den = parent_totals[pk] + alpha
+        return num / den if den else 0.0
+
+    # Candidate targets per from-state: observed targets plus every target the
+    # parent has seen (a starved state must be able to reach outcomes it never
+    # personally observed).
+    targets_by_state: dict[str, set] = defaultdict(set)
+    parent_targets: dict[str, set] = defaultdict(set)
+    for pk, b in parent_counts:
+        parent_targets[pk].add(b)
+    for a, b in transitions:
+        targets_by_state[a].add(b)
+    for a in row_totals:
+        targets_by_state[a] |= parent_targets[parent_key(a)]
+
+    shrunk: dict[tuple, float] = {}
+    for a in row_totals:
+        den = row_totals[a] + alpha
+        for b in targets_by_state[a]:
+            shrunk[(a, b)] = (transitions[(a, b)] + alpha * p_parent(a, b)) / den
+    return shrunk
+
+
+def solve_ep(probs: dict[tuple, float]) -> tuple[dict[str, float], dict[tuple, float]]:
+    """Solve the absorbing chain: EP per transient state + absorption probs.
+
+    EP = (I - Q)^-1 R v with Q transient->transient, R transient->absorbing,
+    v the ABSORB_VALUES vector. Returns (ep by state, absorption probability
+    by (state, absorbing)).
+    """
+    transient = sorted({a for (a, _) in probs})
+    t_index = {s: i for i, s in enumerate(transient)}
+    a_index = {s: i for i, s in enumerate(ABSORBING)}
+    nt, na = len(transient), len(ABSORBING)
+
+    Q = np.zeros((nt, nt))
+    R = np.zeros((nt, na))
+    for (a, b), p in probs.items():
+        if b in t_index:
+            Q[t_index[a], t_index[b]] = p
+        elif b in a_index:
+            R[t_index[a], a_index[b]] = p
+        # A target that is neither transient nor absorbing cannot occur:
+        # shrink() only emits observed/parent targets, all of which are one
+        # of the two.
+
+    # Fundamental matrix; (I - Q) is invertible because every state reaches
+    # an absorbing outcome (every drive ends).
+    N = np.linalg.solve(np.eye(nt) - Q, np.eye(nt))
+    B = N @ R  # absorption probabilities
+    v = np.array([ABSORB_VALUES.get(s, 0.0) for s in ABSORBING])
+    ep = B @ v
+
+    ep_by_state = {s: float(ep[i]) for s, i in t_index.items()}
+    absorb_probs = {
+        (s, abs_s): float(B[t_index[s], a_index[abs_s]]) for s in transient for abs_s in ABSORBING
+    }
+    return ep_by_state, absorb_probs
+
+
+def bootstrap_se(
+    per_game: Counter,
+    alpha: float = DEFAULT_ALPHA,
+    n_boot: int = BOOTSTRAP_B,
+    seed: int = BOOTSTRAP_SEED,
+) -> dict[str, float]:
+    """Game-cluster bootstrap SE of ep_drive per state.
+
+    Resample games with replacement, rebuild counts, re-shrink, re-solve.
+    Clustering by game (not play) preserves within-game correlation --
+    the Brill/Yurko/Wyner objection to naive play-level resampling.
+    """
+    games = sorted({g for (g, _, _) in per_game})
+    by_game: dict = defaultdict(Counter)
+    for (g, a, b), n in per_game.items():
+        by_game[g][(a, b)] += n
+
+    rng = np.random.default_rng(seed)
+    samples: dict[str, list[float]] = defaultdict(list)
+    for _ in range(n_boot):
+        counts: Counter = Counter()
+        for g in rng.choice(games, size=len(games), replace=True):
+            counts.update(by_game[g])
+        ep, _ = solve_ep(shrink(counts, alpha))
+        for s, val in ep.items():
+            samples[s].append(val)
+    return {s: float(np.std(vals, ddof=1)) for s, vals in samples.items() if len(vals) > 1}
+
+
+# --- Validation gates (pure; consume engine outputs) -------------------------
+
+
+def check_monotone_zone(ep: dict[str, float]) -> list[str]:
+    """Gate 1a: EP must not increase as yards_to_goal grows, per down at
+    standard distances. Returns violation descriptions (empty = pass)."""
+    violations = []
+    for down, bucket in (("d1", "standard"), ("d2", "med"), ("d3", "med"), ("d4", "short")):
+        curve = [
+            (z, ep[f"{down}|{bucket}|z{z}"]) for z in range(1, 11) if f"{down}|{bucket}|z{z}" in ep
+        ]
+        for (z1, e1), (z2, e2) in zip(curve, curve[1:]):
+            if e2 > e1 + 0.02:  # tolerance for estimation noise on adjacent bands
+                violations.append(f"{down}/{bucket}: EP rises z{z1}->z{z2} ({e1:.2f}->{e2:.2f})")
+    return violations
+
+
+def check_monotone_down(ep: dict[str, float]) -> list[str]:
+    """Gate 1b: at fixed medium distance and zone, earlier downs are worth
+    at least as much as later downs."""
+    violations = []
+    for z in range(2, 10):
+        chain = []
+        for down, bucket in (("d2", "med"), ("d3", "med"), ("d4", "med")):
+            key = f"{down}|{bucket}|z{z}"
+            if key in ep:
+                chain.append((key, ep[key]))
+        for (k1, e1), (k2, e2) in zip(chain, chain[1:]):
+            if e2 > e1 + 0.02:
+                violations.append(f"z{z}: {k2} ({e2:.2f}) > {k1} ({e1:.2f})")
+    return violations
+
+
+def calibration_mae(
+    absorb_probs: dict[tuple, float], transitions: Counter, outcome: str = "TD"
+) -> float:
+    """Gate 3: mean |model absorption prob - empirical drive outcome rate|
+    over states, weighted by support. Empirical rate for a state uses drives
+    whose FIRST play was in that state (the chain should reproduce these)."""
+    # Empirical: among transitions, we don't retain drive starts here; the
+    # caller passes first-play transitions separately when available. This
+    # function instead compares model vs empirical one-step-consistent
+    # absorption via the raw matrix -- solving the raw (unshrunk) chain and
+    # comparing to the shrunk one. Deviations flag shrinkage distortion.
+    raw_totals: Counter = Counter()
+    for (a, _), n in transitions.items():
+        raw_totals[a] += n
+    p_raw = {(a, b): n / raw_totals[a] for (a, b), n in transitions.items()}
+    ep_raw, absorb_raw = solve_ep({k: v for k, v in p_raw.items()})
+    num, den = 0.0, 0
+    for (s, abs_s), p in absorb_probs.items():
+        if abs_s != outcome or (s, abs_s) not in absorb_raw:
+            continue
+        w = raw_totals[s]
+        num += w * abs(p - absorb_raw[(s, abs_s)])
+        den += w
+    return num / den if den else float("nan")
+
+
+# =============================================================================
+# --- I/O layer ---------------------------------------------------------------
+# =============================================================================
+
+PLAYS_QUERY = """
+    SELECT p.game_id,
+           p.drive_id,
+           p.play_number,
+           p.down,
+           p.distance,
+           p.yards_to_goal,
+           d.drive_result
+    FROM core.plays p
+    JOIN core.drives d ON d.id = p.drive_id AND d.game_id = p.game_id
+    JOIN marts.play_epa pe ON pe.play_id = p.id
+    WHERE p.season BETWEEN %(start)s AND %(end)s
+      AND p.play_type = ANY(%(types)s)
+      AND p.down BETWEEN 1 AND 4
+      AND p.distance BETWEEN 1 AND 45
+      AND p.yards_to_goal BETWEEN 1 AND 99
+      AND NOT pe.is_garbage_time
+      AND d.drive_result <> 'POSSESSION (FOR OT DRIVES)'
+"""
+
+
+def get_db_url() -> str:
+    """Get database URL from dlt secrets or environment.
+
+    Copied from scripts/compute_house_elo.py's get_db_url pattern (each
+    compute_*.py script keeps its own copy rather than importing across
+    scripts for this one utility).
+    """
+    import os
+
+    import dlt
+
+    url = None
+    try:
+        creds = dlt.secrets.get("destination.postgres.credentials")
+        if creds:
+            url = str(creds)
+    except Exception:
+        pass
+    if not url:
+        url = os.environ.get("SUPABASE_DB_URL") or os.environ.get("DATABASE_URL")
+    if not url:
+        raise RuntimeError(
+            "No database URL found. Set destination.postgres.credentials in "
+            ".dlt/secrets.toml or SUPABASE_DB_URL environment variable."
+        )
+    return url.replace("postgres://", "postgresql://", 1)
+
+
+def fetch_plays(conn, start: int, end: int) -> list[dict]:
+    from psycopg2.extras import RealDictCursor
+
+    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute(PLAYS_QUERY, {"start": start, "end": end, "types": list(SCRIMMAGE_TYPES)})
+        return [dict(r) for r in cur.fetchall()]
+
+
+def write_era(
+    conn,
+    era: str,
+    transitions: Counter,
+    shrunk: dict[tuple, float],
+    ep: dict[str, float],
+    absorb_probs: dict[tuple, float],
+    se: dict[str, float],
+) -> None:
+    from psycopg2.extras import execute_values
+
+    row_totals: Counter = Counter()
+    for (a, _), n in transitions.items():
+        row_totals[a] += n
+
+    trans_rows = [
+        (era, a, b, transitions.get((a, b), 0), transitions.get((a, b), 0) / row_totals[a], p)
+        for (a, b), p in sorted(shrunk.items())
+    ]
+    state_rows = [
+        (
+            era,
+            s,
+            row_totals[s],
+            ep[s],
+            absorb_probs[(s, "TD")],
+            absorb_probs[(s, "FG")],
+            absorb_probs[(s, "PUNT")],
+            absorb_probs[(s, "TURNOVER")] + absorb_probs[(s, "TURNOVER_TD")],
+            se.get(s),
+        )
+        for s in sorted(ep)
+    ]
+
+    with conn.cursor() as cur:
+        cur.execute("DELETE FROM analytics.drive_chain_transitions WHERE era = %s", (era,))
+        cur.execute("DELETE FROM analytics.ep_states WHERE era = %s", (era,))
+        execute_values(
+            cur,
+            "INSERT INTO analytics.drive_chain_transitions "
+            "(era, from_state, to_state, n, p_raw, p_shrunk) VALUES %s",
+            trans_rows,
+        )
+        execute_values(
+            cur,
+            "INSERT INTO analytics.ep_states "
+            "(era, state, n_obs, ep_drive, p_td, p_fg, p_punt, p_turnover, se_boot) VALUES %s",
+            state_rows,
+        )
+    conn.commit()
+    logger.info("%s: wrote %d transitions, %d states", era, len(trans_rows), len(state_rows))
+
+
+def run_era(conn, era: str, alpha: float, do_bootstrap: bool, do_validate: bool) -> int:
+    start, end = ERAS[era]
+    end = end if end is not None else 9999
+    logger.info("Era %s: fetching scrimmage plays %d..%s", era, start, end)
+    plays = fetch_plays(conn, start, end)
+    logger.info("Era %s: %d plays", era, len(plays))
+    if not plays:
+        logger.error("Era %s: no plays -- is marts.play_epa refreshed?", era)
+        return 1
+
+    transitions, per_game, unmapped = build_transitions(plays)
+    n_drives = unmapped + len({(g, a) for (g, a, _) in per_game})  # approx upper bound denom
+    share = unmapped / max(1, n_drives)
+    logger.info(
+        "Era %s: %d transitions, %d unmapped drives (%.2f%%)",
+        era,
+        len(transitions),
+        unmapped,
+        100 * share,
+    )
+    if share > MAX_UNMAPPED_SHARE:
+        logger.error(
+            "Era %s: unmapped drive share %.3f exceeds %.3f", era, share, MAX_UNMAPPED_SHARE
+        )
+        return 1
+
+    shrunk = shrink(transitions, alpha)
+    ep, absorb_probs = solve_ep(shrunk)
+    se = bootstrap_se(per_game, alpha) if do_bootstrap else {}
+
+    write_era(conn, era, transitions, shrunk, ep, absorb_probs, se)
+
+    if do_validate:
+        vz = check_monotone_zone(ep)
+        vd = check_monotone_down(ep)
+        mae = calibration_mae(absorb_probs, transitions)
+        for v in vz + vd:
+            logger.warning("Era %s monotonicity: %s", era, v)
+        print(
+            f"EP_VALIDATION era={era} states={len(ep)} "
+            f"monotone_zone={'pass' if not vz else 'FAIL'} "
+            f"monotone_down={'pass' if not vd else 'FAIL'} "
+            f"calib_mae_td={mae:.4f}"
+        )
+        if vz or vd:
+            return 1
+    return 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Drive-chain EP model (P1)")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--full", action="store_true", help="All eras")
+    group.add_argument("--era", choices=sorted(ERAS), help="Single era")
+    parser.add_argument("--alpha", type=float, default=DEFAULT_ALPHA)
+    parser.add_argument("--no-bootstrap", action="store_true")
+    parser.add_argument("--validate", action="store_true")
+    args = parser.parse_args()
+
+    import psycopg2
+
+    conn = psycopg2.connect(get_db_url())
+    try:
+        eras = sorted(ERAS) if args.full else [args.era]
+        rc = 0
+        for era in eras:
+            rc |= run_era(conn, era, args.alpha, not args.no_bootstrap, args.validate)
+    finally:
+        conn.close()
+    sys.exit(rc)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/deploy_schema.py
+++ b/scripts/deploy_schema.py
@@ -73,6 +73,9 @@ COMPUTE_SCRIPTS = {
     # everything else instead of a one-off workflow.
     "probe_metrics_wp",
     "compute_adjusted_epa_week",
+    # Drive-chain EP model (docs/plans/2026-08-08-drive-chain-ep-model-plan.md,
+    # P1): league transition matrices + Goldner-basis EP per era.
+    "compute_drive_chain",
     "build_features",
     "train_model",
     "score_fitted",

--- a/src/schemas/migrations/049_drive_chain_ep.sql
+++ b/src/schemas/migrations/049_drive_chain_ep.sql
@@ -1,0 +1,74 @@
+-- Drive-state Markov chain: transitions + expected-points states
+-- =============================================================================
+-- Design: docs/plans/2026-08-08-drive-chain-ep-model-plan.md (P1).
+--
+-- Two league-grain tables written by scripts/compute_drive_chain.py:
+--
+--   analytics.drive_chain_transitions -- observed scrimmage-snapshot
+--     transitions per era: (era, from_state, to_state, n, p_raw, p_shrunk).
+--     to_state is either a transient state key or an absorbing outcome
+--     (TD, FG, MISSED_FG, PUNT, TURNOVER, TURNOVER_TD, DOWNS, SAFETY,
+--     END_OF_HALF). State key format: "d{down}|{dist_bucket}|z{zone}".
+--
+--   analytics.ep_states -- the solved chain per era: drive expected points
+--     (ep_drive; Goldner basis: absorption probabilities x scoring values),
+--     the absorption probabilities themselves, bootstrap standard error
+--     (cluster-resampled by game; Brill/Yurko/Wyner "intervals, not
+--     verdicts"), and ep_net reserved NULL until P2's net next-score basis
+--     lands. NULL, never 0: an unsolved or unpublished value must not read
+--     as "zero points".
+--
+-- Era grain, not season: transition probabilities are estimated per rules/
+-- scoring era (2004-2013, 2014-2020, 2021+; see the design doc's era
+-- section). EPA computations must join a play to its own era's curve.
+--
+-- analytics.* is contract-internal (docs/SCHEMA_CONTRACT.md) -- downstream
+-- consumers read marts, never these tables. No anon/authenticated grants.
+--
+-- Idempotent DELETE-per-era + INSERT by the compute script, same tier
+-- convention as analytics.adjusted_epa_week_build (027) / house_elo (025).
+--
+-- Not in MIGRATION_ORDER: applied via run_migrations.py --file (deploy
+-- manifest), like 019-028 and 041+. Idempotent (IF NOT EXISTS throughout).
+
+CREATE SCHEMA IF NOT EXISTS analytics;
+
+CREATE TABLE IF NOT EXISTS analytics.drive_chain_transitions (
+    era text NOT NULL,
+    from_state text NOT NULL,
+    to_state text NOT NULL,
+    n bigint NOT NULL,
+    p_raw double precision NOT NULL,
+    p_shrunk double precision NOT NULL,
+    computed_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (era, from_state, to_state)
+);
+
+COMMENT ON TABLE analytics.drive_chain_transitions IS
+    'League drive-state transition matrix per era. Written by scripts/compute_drive_chain.py; design docs/plans/2026-08-08-drive-chain-ep-model-plan.md. p_shrunk = empirical-Bayes shrink toward the parent state (distance dimension dropped, then zone) so starved cells inherit their parent distribution.';
+
+CREATE TABLE IF NOT EXISTS analytics.ep_states (
+    era text NOT NULL,
+    state text NOT NULL,
+    n_obs bigint NOT NULL,
+    ep_drive double precision NOT NULL,
+    ep_net double precision,
+    p_td double precision NOT NULL,
+    p_fg double precision NOT NULL,
+    p_punt double precision NOT NULL,
+    p_turnover double precision NOT NULL,
+    se_boot double precision,
+    computed_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (era, state)
+);
+
+COMMENT ON TABLE analytics.ep_states IS
+    'Solved drive chain per era: Goldner-basis drive EP and absorption probabilities per state, with game-cluster bootstrap SE. ep_net is NULL until P2 (net next-score basis; the CFBD-PPA-comparable one) -- NULL, never 0.';
+COMMENT ON COLUMN analytics.ep_states.ep_drive IS
+    'Absorption probs x values {TD 6.97, FG 3, SAFETY -2, TURNOVER_TD -6.97, else 0}. Drive-scoring basis: what this possession is worth, ignoring field-position handoff.';
+COMMENT ON COLUMN analytics.ep_states.se_boot IS
+    'Bootstrap SE of ep_drive, cluster-resampled by game_id. NULL when the compute ran with --no-bootstrap.';
+
+CREATE INDEX IF NOT EXISTS idx_ep_states_era ON analytics.ep_states (era);
+CREATE INDEX IF NOT EXISTS idx_dct_era_from
+    ON analytics.drive_chain_transitions (era, from_state);

--- a/tests/test_deploy_schema.py
+++ b/tests/test_deploy_schema.py
@@ -32,6 +32,8 @@ class TestComputeScripts:
             # TEMPORARY (P3.2 Lane B) -- see deploy_schema.py's comment.
             "probe_metrics_wp",
             "compute_adjusted_epa_week",
+            # Drive-chain EP model P1 (2026-08-08 plan).
+            "compute_drive_chain",
             "build_features",
             "train_model",
             "score_fitted",

--- a/tests/test_drive_chain.py
+++ b/tests/test_drive_chain.py
@@ -168,17 +168,20 @@ class TestBuildTransitions:
 
     def test_last_play_absorbs_into_drive_result(self):
         plays = self._drive(1, "d1", "PUNT", [(1, 10, 75), (2, 6, 71), (3, 6, 71)])
-        transitions, per_game, unmapped = build_transitions(plays)
+        transitions, per_game, outcomes, n_mapped, unmapped = build_transitions(plays)
 
         assert unmapped == 0
+        assert n_mapped == 1
+        assert outcomes[(state_key(1, 10, 75), "PUNT")] == 1
         assert transitions[(state_key(1, 10, 75), state_key(2, 6, 71))] == 1
         assert transitions[(state_key(3, 6, 71), "PUNT")] == 1
 
     def test_unmapped_drive_result_is_dropped_and_counted(self):
         plays = self._drive(1, "d1", "Uncategorized", [(1, 10, 75)])
-        transitions, _, unmapped = build_transitions(plays)
+        transitions, _, _, n_mapped, unmapped = build_transitions(plays)
 
         assert unmapped == 1
+        assert n_mapped == 0
         assert not transitions
 
     def test_penalty_gap_is_absorbed_into_next_snapshot(self):
@@ -195,9 +198,72 @@ class TestBuildTransitions:
                 "drive_result": "TD",
             }
         ]
-        transitions, _, _ = build_transitions(plays)
+        transitions, _, _, _, _ = build_transitions(plays)
 
         assert transitions[(state_key(1, 10, 75), state_key(1, 10, 60))] == 1
+
+    def test_drives_are_counted_as_drives(self):
+        """PR #66 review, P2: the unmapped-share denominator is drives.
+        One drive visiting three states is still ONE drive, and two drives
+        revisiting the same state are still TWO."""
+        plays = (
+            self._drive(1, "a", "PUNT", [(1, 10, 75), (2, 6, 71), (3, 6, 71)])
+            + self._drive(1, "b", "TD", [(1, 10, 75)])
+            + self._drive(1, "c", "Uncategorized", [(1, 10, 75)])
+        )
+        _, _, _, n_mapped, unmapped = build_transitions(plays)
+
+        assert n_mapped == 2
+        assert unmapped == 1
+
+
+class TestShrinkageGrandparentTargets:
+    def test_grandparent_only_target_is_emitted(self):
+        """PR #66 review, P1: a target observed only elsewhere in the same
+        down carries grandparent probability through p_parent(); if the row
+        never emits it, the row sums to less than 1 and solve_ep() leaks
+        that mass out of the chain."""
+        counts = Counter(
+            {
+                ("d2|med|z3", "TD"): 100,  # zone 3 parent only ever sees TD
+                ("d2|med|z8", "PUNT"): 100,  # zone 8 parent only ever sees PUNT
+            }
+        )
+        shrunk = shrink(counts, alpha=50.0)
+
+        # Each row must emit BOTH targets and sum to exactly 1.
+        for state in ("d2|med|z3", "d2|med|z8"):
+            row = {b: p for (a, b), p in shrunk.items() if a == state}
+            assert "TD" in row and "PUNT" in row, f"{state} missing a grandparent target"
+            assert sum(row.values()) == pytest.approx(1.0)
+
+
+class TestCalibration:
+    def test_perfect_model_scores_zero(self):
+        from scripts.compute_drive_chain import calibration_mae
+
+        outcomes = Counter({("d1|standard|z8", "TD"): 30, ("d1|standard|z8", "PUNT"): 70})
+        absorb = {("d1|standard|z8", "TD"): 0.3}
+        assert calibration_mae(absorb, outcomes) == pytest.approx(0.0)
+
+    def test_miscalibration_is_measured_against_realized_outcomes(self):
+        """PR #66 review, P2: the gate compares model vs REALIZED drive
+        outcomes, not model vs itself -- a systematically wrong chain must
+        score badly."""
+        from scripts.compute_drive_chain import calibration_mae
+
+        outcomes = Counter({("d1|standard|z8", "TD"): 30, ("d1|standard|z8", "PUNT"): 70})
+        absorb = {("d1|standard|z8", "TD"): 0.6}  # model says 60%, reality 30%
+        assert calibration_mae(absorb, outcomes) == pytest.approx(0.3)
+
+    def test_thin_start_states_are_skipped(self):
+        from scripts.compute_drive_chain import calibration_mae
+
+        outcomes = Counter({("d4|xlong|z2", "TD"): 3})  # 3 drives: noise, not signal
+        absorb = {("d4|xlong|z2", "TD"): 0.9}
+        import math
+
+        assert math.isnan(calibration_mae(absorb, outcomes))
 
 
 class TestMonotoneGates:

--- a/tests/test_drive_chain.py
+++ b/tests/test_drive_chain.py
@@ -215,7 +215,17 @@ class TestMonotoneGates:
         for z in range(2, 10):
             ep[f"d2|med|z{z}"] = 3.0
             ep[f"d3|med|z{z}"] = 2.5
-            ep[f"d4|med|z{z}"] = 2.0
         assert check_monotone_down(ep) == []
-        ep["d4|med|z5"] = 9.0
+        ep["d3|med|z5"] = 9.0
         assert check_monotone_down(ep)
+
+    def test_fourth_down_is_exempt_by_design(self):
+        """d4 snapshots are go-for-it-conditional (punts/FGs exit from the
+        3rd-down play), so d4 above d3 is legitimate -- observed on the real
+        2021+ chain -- and must NOT fail the gate."""
+        ep = {}
+        for z in range(2, 10):
+            ep[f"d2|med|z{z}"] = 3.0
+            ep[f"d3|med|z{z}"] = 2.5
+            ep[f"d4|med|z{z}"] = 2.6  # above d3: allowed
+        assert check_monotone_down(ep) == []

--- a/tests/test_drive_chain.py
+++ b/tests/test_drive_chain.py
@@ -1,0 +1,221 @@
+"""Unit tests for the drive-chain EP engine (no DB, no API).
+
+Design: docs/plans/2026-08-08-drive-chain-ep-model-plan.md. Everything here
+exercises the pure layer of scripts/compute_drive_chain.py.
+"""
+
+from collections import Counter
+
+import pytest
+
+from scripts.compute_drive_chain import (
+    ABSORB_MAP,
+    ABSORB_VALUES,
+    ABSORBING,
+    TD_VALUE,
+    build_transitions,
+    check_monotone_down,
+    check_monotone_zone,
+    distance_bucket,
+    field_zone,
+    parent_key,
+    shrink,
+    solve_ep,
+    state_key,
+)
+
+
+class TestStateBucketing:
+    def test_zone_bands(self):
+        assert field_zone(1) == 1
+        assert field_zone(10) == 1
+        assert field_zone(11) == 2
+        assert field_zone(75) == 8
+        assert field_zone(99) == 10
+
+    def test_first_down_vocabulary_is_down_aware(self):
+        """The fix for the 38 starved states: 1st down does not use the
+        2nd-4th short/med/long ladder."""
+        assert distance_bucket(1, 10, 75) == "standard"
+        assert distance_bucket(1, 5, 75) == "short"  # post-penalty
+        assert distance_bucket(1, 15, 75) == "long"
+        assert distance_bucket(1, 8, 5) == "goal"
+
+    def test_late_down_ladder(self):
+        assert distance_bucket(3, 2, 60) == "short"
+        assert distance_bucket(3, 5, 60) == "med"
+        assert distance_bucket(3, 9, 60) == "long"
+        assert distance_bucket(3, 14, 60) == "xlong"
+
+    def test_goal_to_go_overrides(self):
+        assert distance_bucket(2, 4, 3) == "goal"
+
+    def test_state_key_shape(self):
+        assert state_key(1, 10, 75) == "d1|standard|z8"
+        assert parent_key("d1|standard|z8") == "d1|*|z8"
+
+
+class TestAbsorbMap:
+    def test_every_mapped_target_is_a_known_absorbing_state(self):
+        assert set(ABSORB_MAP.values()) <= set(ABSORBING)
+
+    def test_live_vocabulary_is_covered(self):
+        """The drive_result values observed in production (2026-08-08 check,
+        seasons >= 2014) that the build must not drop."""
+        live = [
+            "PUNT",
+            "TD",
+            "FG",
+            "DOWNS",
+            "INT",
+            "FUMBLE",
+            "MISSED FG",
+            "END OF HALF",
+            "END OF GAME",
+            "INT TD",
+            "END OF 4TH QUARTER",
+            "SF",
+            "FUMBLE RETURN TD",
+            "FUMBLE TD",
+            "PUNT TD",
+            "PUNT RETURN TD",
+            "MISSED FG TD",
+            "DOWNS TD",
+        ]
+        for result in live:
+            assert result in ABSORB_MAP, f"unmapped live drive_result: {result}"
+
+    def test_defensive_scores_are_negative(self):
+        assert ABSORB_VALUES["TURNOVER_TD"] == -TD_VALUE
+
+
+class TestSolveEP:
+    def test_single_state_analytic(self):
+        """P(TD)=0.3, P(PUNT)=0.7 => EP = 0.3 * TD_VALUE exactly."""
+        probs = {("d1|standard|z5", "TD"): 0.3, ("d1|standard|z5", "PUNT"): 0.7}
+        ep, absorb = solve_ep(probs)
+        assert ep["d1|standard|z5"] == pytest.approx(0.3 * TD_VALUE)
+        assert absorb[("d1|standard|z5", "TD")] == pytest.approx(0.3)
+
+    def test_two_state_chain_analytic(self):
+        """A -> {B: 0.5, TD: 0.5}; B -> PUNT. EP(A) = 0.5 * TD_VALUE."""
+        probs = {
+            ("A", "B"): 0.5,
+            ("A", "TD"): 0.5,
+            ("B", "PUNT"): 1.0,
+        }
+        ep, absorb = solve_ep(probs)
+        assert ep["A"] == pytest.approx(0.5 * TD_VALUE)
+        assert ep["B"] == pytest.approx(0.0)
+        assert absorb[("A", "PUNT")] == pytest.approx(0.5)
+
+    def test_self_loop_converges(self):
+        """A stays in A half the time: geometric absorption still sums to 1."""
+        probs = {("A", "A"): 0.5, ("A", "TD"): 0.25, ("A", "PUNT"): 0.25}
+        ep, absorb = solve_ep(probs)
+        assert absorb[("A", "TD")] == pytest.approx(0.5)
+        assert ep["A"] == pytest.approx(0.5 * TD_VALUE)
+
+
+class TestShrinkage:
+    def test_healthy_state_barely_moves(self):
+        counts = Counter({("d2|med|z5", "TD"): 4000, ("d2|med|z5", "PUNT"): 6000})
+        shrunk = shrink(counts, alpha=50.0)
+        assert shrunk[("d2|med|z5", "TD")] == pytest.approx(0.4, abs=0.01)
+
+    def test_starved_state_inherits_parent(self):
+        """One observation must not become a 100% transition; the sibling
+        bucket in the same down x zone dominates through the parent."""
+        counts = Counter(
+            {
+                ("d1|short|z5", "TD"): 1,  # starved: saw only a TD
+                ("d1|standard|z5", "TD"): 300,
+                ("d1|standard|z5", "PUNT"): 700,
+            }
+        )
+        shrunk = shrink(counts, alpha=50.0)
+        assert shrunk[("d1|short|z5", "TD")] < 0.5
+        assert shrunk[("d1|short|z5", "PUNT")] > 0.4  # inherited, never observed
+
+    def test_rows_sum_to_one(self):
+        counts = Counter(
+            {
+                ("d3|long|z4", "TD"): 10,
+                ("d3|long|z4", "PUNT"): 30,
+                ("d3|short|z4", "DOWNS"): 5,
+            }
+        )
+        shrunk = shrink(counts, alpha=25.0)
+        for state in {a for (a, _) in shrunk}:
+            total = sum(p for (a, _), p in shrunk.items() if a == state)
+            assert total == pytest.approx(1.0)
+
+
+class TestBuildTransitions:
+    def _drive(self, game_id, drive_id, result, snapshots):
+        return [
+            {
+                "game_id": game_id,
+                "drive_id": drive_id,
+                "play_number": i + 1,
+                "down": d,
+                "distance": dist,
+                "yards_to_goal": ytg,
+                "drive_result": result,
+            }
+            for i, (d, dist, ytg) in enumerate(snapshots)
+        ]
+
+    def test_last_play_absorbs_into_drive_result(self):
+        plays = self._drive(1, "d1", "PUNT", [(1, 10, 75), (2, 6, 71), (3, 6, 71)])
+        transitions, per_game, unmapped = build_transitions(plays)
+
+        assert unmapped == 0
+        assert transitions[(state_key(1, 10, 75), state_key(2, 6, 71))] == 1
+        assert transitions[(state_key(3, 6, 71), "PUNT")] == 1
+
+    def test_unmapped_drive_result_is_dropped_and_counted(self):
+        plays = self._drive(1, "d1", "Uncategorized", [(1, 10, 75)])
+        transitions, _, unmapped = build_transitions(plays)
+
+        assert unmapped == 1
+        assert not transitions
+
+    def test_penalty_gap_is_absorbed_into_next_snapshot(self):
+        """A penalty between two scrimmage plays is invisible: the next
+        snapshot's state carries its effect (play_number 3 follows 1)."""
+        plays = self._drive(1, "d1", "TD", [(1, 10, 75)]) + [
+            {
+                "game_id": 1,
+                "drive_id": "d1",
+                "play_number": 3,  # play 2 was a penalty row, excluded upstream
+                "down": 1,
+                "distance": 10,
+                "yards_to_goal": 60,
+                "drive_result": "TD",
+            }
+        ]
+        transitions, _, _ = build_transitions(plays)
+
+        assert transitions[(state_key(1, 10, 75), state_key(1, 10, 60))] == 1
+
+
+class TestMonotoneGates:
+    def test_clean_curve_passes(self):
+        ep = {f"d1|standard|z{z}": 6.0 - 0.5 * z for z in range(1, 11)}
+        assert check_monotone_zone(ep) == []
+
+    def test_rising_curve_fails(self):
+        ep = {f"d1|standard|z{z}": 6.0 - 0.5 * z for z in range(1, 11)}
+        ep["d1|standard|z7"] = ep["d1|standard|z6"] + 1.0
+        assert check_monotone_zone(ep)
+
+    def test_down_ordering_gate(self):
+        ep = {}
+        for z in range(2, 10):
+            ep[f"d2|med|z{z}"] = 3.0
+            ep[f"d3|med|z{z}"] = 2.5
+            ep[f"d4|med|z{z}"] = 2.0
+        assert check_monotone_down(ep) == []
+        ep["d4|med|z5"] = 9.0
+        assert check_monotone_down(ep)


### PR DESCRIPTION
## What this is

The first phase of an in-house expected-points model derived entirely from our own play-by-play — the Tier 1 item from the new play-sequence roadmap. Today every EPA number in the warehouse inherits CFBD's PPA model; this builds the machinery to price drive states ourselves. **Zero CFBD API calls** — pure derivation from the 2.7M plays already loaded.

Two docs ride along:
- `docs/brainstorms/2026-08-08-play-sequence-derivatives.md` — the five-tier roadmap (sequence/predictability analytics, sunburst mart, decision quality, player structure) plus a verified reading list and the formation-data findings (2025 play text carries NCAA `Shotgun`/`No Huddle` tags for 720 of 1,653 games).
- `docs/plans/2026-08-08-drive-chain-ep-model-plan.md` — the design: Goldner (2012) absorbing chain as v1, net next-score handoff recursion as v1.5 (the CFBD-PPA-comparable basis), Chan/Fernandes/Puterman MRP recorded as v2 aspiration.

## Implementation (P1)

- **Migration 049** (deploy-manifest style): `analytics.drive_chain_transitions` and `analytics.ep_states`, era grain, contract-internal, `ep_net` NULL until P2 — NULL, never 0.
- **`scripts/compute_drive_chain.py`** (compute_house_elo.py conventions — pure engine over a thin I/O layer):
  - Down-aware state buckets (1st down gets `standard/short/long/goal`, not the 2nd–4th ladder) — the fix for the 38 starved states a flat 160-state grid produces (min support 1).
  - Snapshot→snapshot transitions between consecutive scrimmage plays, so 113k penalty rows are handled structurally rather than modeled; last play absorbs into the mapped `drive_result`, unmapped drives counted with a >2% build-failure guard.
  - Two-level empirical-Bayes shrinkage (parent = down×zone, grandparent = down) so starved cells inherit distributions including outcomes they never personally observed.
  - Fundamental-matrix EP solve; game-cluster bootstrap SEs (Brill/Yurko/Wyner: intervals, not verdicts).
  - Garbage time filtered **through `marts.play_epa`** so the codebase keeps one garbage-time definition.
  - Registered in `deploy_schema.py` `COMPUTE_SCRIPTS` (+ test inventory).
- **21 unit tests** including analytic toy-chain checks (single-state, two-state, self-loop absorption).

## Validated against real data before opening this PR

Ran the engine offline on actual era-2021+ transition counts (875,715 plays, 162 states, 6,729 unique transitions):

| 1st-and-10 at | Drive EP | P(TD) |
|---|---|---|
| opp 15 | 5.65 | .758 |
| opp 25 | 4.24 | .521 |
| midfield | 3.11 | .393 |
| own 25 | 1.80 | .238 |
| own 5 | 1.17 | .171 |

Zone-monotonicity gate **passed**; magnitudes consistent with published CFB EP curves. The down-ordering gate surfaced a structural property rather than a bug: 4th-down scrimmage snapshots exist only when the offense lined up to go (punts/FGs exit from the 3rd-down play), so d4 states are go-for-it-conditional and can price above d3 (observed: `d4|med|z7` 1.40 vs `d3|med|z7` 1.37). The gate now checks downs 2–3 with the exemption documented in code and tested — and P4's 4th-down model will use the conditionality directly, since EP(go | state) *is* the d4-state value.

## After merge (to populate production)

1. `deploy-schema` → `apply` with `files=src/schemas/migrations/049_drive_chain_ep.sql`
2. `deploy-schema` → `compute` with `compute_script=compute_drive_chain`, `compute_args=--full,--validate`

Nothing downstream reads these tables yet (design non-goal: house EPA lands as a parallel column only after the P2 benchmark gate vs CFBD `ppa`).

Tests: 1,344 passed, 401 skipped. `ruff check` / `ruff format --check` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pfurxa4Ved9U4ZkEo2PbKR)_

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds an era-specific drive-state Markov-chain pipeline for computing expected points, including hierarchical transition smoothing, bootstrap uncertainty, validation gates, analytics-table writes, and deployment registration. Two previously reported correctness failures are disproved by executable checks: grandparent-only transition targets are emitted with normalized probability mass, and the unmapped-drive guard measures drives rather than transition states.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

Executable regressions exercised the two previously reported failure paths and observed normalized transition and absorption probabilities plus correct drive-level rejection behavior.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran an authored Python reproduction against shrink() with an immediate-parent-missing, grandparent-observed PUNT target; the check exited successfully with emitted\_PUNT=0.625000000000 and row\_sum=1.000000000000, confirming grandparent-only outcomes and full transition row preservation.
- Ran an authored Python reproduction creating 25 mapped drives and 1 unmapped drive, exercising build\_transitions() and the run\_era() rejection path; the run reported 25 mapped drives, 1 unmapped drive, and a current share of 0.038461538462 (1/26), showing the guard uses drive counts rather than 75 per-game entries.
- Performed a Markov-chain regression with shrink() and solve\_ep(), then ran pytest on tests/test\_drive\_chain.py; historical control had row and absorption totals of 0.944444444444 while the current engine emitted 1.0 for both, and the focused suite passed 26 tests, confirming probability mass is retained through shrinkage and solving.
- Observed result: emitted\_PUNT=0.625000000000, row\_sum=1.000000000000, and authored check exited 0; exact authored source grandparent-only-target-02-after.py and executed output grandparent-only-target-02-after.log were used.
- build\_transitions reported 25 mapped drives, 1 unmapped drive, and 75 per\_game entries; the current denominator yielded 0.038461538462 (1/26), while the legacy per-game-entry approach would yield 0.013157894737 and would not reject.

<a href="https://app.greptile.com/trex/runs/17908366/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["Fix four review findings: mass leak, ppa..."](https://github.com/rstover-fo/cfb-database/commit/e52a7010fee3b22bccd3dfed0dba46ef1d7de8c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51392620)</sub>

<!-- /greptile_comment -->