### PR TITLE
Expose house EP: api.expected_points, contract entry, handoff, MCP tool

### DIFF
--- a/docs/SCHEMA_CONTRACT.md
+++ b/docs/SCHEMA_CONTRACT.md
@@ -4,7 +4,7 @@
 > only depend on objects listed here as **public**. Everything else is internal and may change
 > without notice.
 
-Last updated: 2026-07-26
+Last updated: 2026-08-08
 
 > **Note on cfb-analytics:** the retired OU-only app (rstover-fo/cfb-analytics) was never a
 > warehouse consumer -- it ran its own DuckDB ingestion. Its unique features (rivals page,
@@ -14,6 +14,24 @@ Last updated: 2026-07-26
 ---
 
 ## Recent Contract Changes
+
+- **2026-08-08 — House expected points: `api.expected_points` added.** First
+  contract surface for the drive-state Markov chain (PRs #66/#69): drive EP,
+  drive-outcome probabilities, and bootstrap SEs per (era, state), with the
+  state key parsed into `down`/`distance_bucket`/`field_zone` columns for
+  direct filtering. Four things consumers must get right, spelled out in
+  `docs/handoffs/2026-08-08-expected-points-handoff.md`:
+  (1) `ep_drive` is the **drive basis** — points this possession is worth —
+  and is NOT comparable to CFBD `ppa`/PPA until `ep_net` (P2) lands;
+  (2) `ep_net` is **NULL on every row today** and NULL means "not yet
+  computed", never zero; (3) join a game to **its own era's** curve
+  (`2004-2013` / `2014-2020` / `2021+`) — the eras differ by up to 0.22 EP at
+  ~15 bootstrap SEs, and the era value `2021+` needs URL-encoding as
+  `eq.2021%2B` in PostgREST queries; (4) `down=4` rows are
+  **go-for-it-conditional** (punts/FGs exit the chain at 3rd down), so 4th
+  down legitimately pricing above 3rd is a property, not a bug — do not
+  render d4 in the same ladder as d1–d3 without that caveat. `se_boot` ships
+  on every row so UIs can show intervals rather than bare point estimates.
 
 - **2026-07-26 — Projection accuracy: `api.model_backtest` added.** The
   preseason backtest that measures how wrong the season-win projections are
@@ -521,6 +539,7 @@ These are the primary PostgREST-accessible views. Queries go through Supabase cl
 | `api.matchup` | **Deployed** | 11,975 | Head-to-head matchup history and current season comparison. Columns: team1, team2, total_games, team1_wins, team2_wins, ties, first_meeting, last_meeting, recent_results (JSONB array), team1/team2 current season stats |
 | `api.leaderboard_teams` | **Deployed** | 3,667 | Team leaderboard with rankings, ratings, EPA. Columns: team, conference, season, classification, wins, losses, win_pct, ppg, opp_ppg, sp_rank, epa_per_play, epa_tier, wins_rank, ppg_rank, defense_ppg_rank, epa_rank. Rank columns are scoped `PARTITION BY season, classification` (see 2026-07-22 changelog entry) -- all rows still returned, no `WHERE fbs` filter. |
 | `api.roster_lookup` | **Deployed** | 340,855 | Stable roster view for player matching |
+| `api.expected_points` | **Deployed** | 483 | House drive EP per (era, state): era, state, down, distance_bucket, field_zone, yards_to_goal_min/max, n_obs, ep_drive, ep_net (NULL until P2), p_td, p_fg, p_punt, p_turnover, se_boot, computed_at. Drive basis, era-scoped, d4 go-conditional — see 2026-08-08 changelog entry. |
 | `api.penalty_log` | **Deployed** | ~250K | Play-derived penalty events (2004+), best-effort parsed from play_text. Columns: play_id, game_id, season, week, season_type, period, down, distance, offense, defense, play_type, is_penalty_play_type, penalized_team, benefiting_team, infraction, penalty_yards, declined, offsetting, no_play, multi_penalty, yards_gained, ppa, play_text, parse_ok. 'Unknown'/NULL = unclassified, not absent (see 2026-07-23 changelog). |
 | `api.team_penalties` | **Deployed** | ~42K | Official box-score penalty counts per (game, team) from totalPenaltiesYards. Columns: game_id, season, week, season_type, team, opponent, home_away, penalties, penalty_yards, opponent_penalties, opponent_penalty_yards. |
 | `api.recruit_lookup` | **Deployed** | 67,179 | Stable recruiting view for recruit data |

--- a/docs/SCHEMA_CONTRACT.md
+++ b/docs/SCHEMA_CONTRACT.md
@@ -30,8 +30,11 @@ Last updated: 2026-08-08
   `eq.2021%2B` in PostgREST queries; (4) `down=4` rows are
   **go-for-it-conditional** (punts/FGs exit the chain at 3rd down), so 4th
   down legitimately pricing above 3rd is a property, not a bug — do not
-  render d4 in the same ladder as d1–d3 without that caveat. `se_boot` ships
-  on every row so UIs can show intervals rather than bare point estimates.
+  render d4 in the same ladder as d1–d3 without that caveat. `se_boot` ships on every row of a
+  standard compute run so UIs can show intervals rather than bare point
+  estimates -- but it is **nullable by contract**: a `--no-bootstrap`
+  recompute writes NULL SEs (PR #70 review). Render a NULL `se_boot` as "no
+  interval available", never as +/-0.
 
 - **2026-07-26 — Projection accuracy: `api.model_backtest` added.** The
   preseason backtest that measures how wrong the season-win projections are
@@ -539,7 +542,7 @@ These are the primary PostgREST-accessible views. Queries go through Supabase cl
 | `api.matchup` | **Deployed** | 11,975 | Head-to-head matchup history and current season comparison. Columns: team1, team2, total_games, team1_wins, team2_wins, ties, first_meeting, last_meeting, recent_results (JSONB array), team1/team2 current season stats |
 | `api.leaderboard_teams` | **Deployed** | 3,667 | Team leaderboard with rankings, ratings, EPA. Columns: team, conference, season, classification, wins, losses, win_pct, ppg, opp_ppg, sp_rank, epa_per_play, epa_tier, wins_rank, ppg_rank, defense_ppg_rank, epa_rank. Rank columns are scoped `PARTITION BY season, classification` (see 2026-07-22 changelog entry) -- all rows still returned, no `WHERE fbs` filter. |
 | `api.roster_lookup` | **Deployed** | 340,855 | Stable roster view for player matching |
-| `api.expected_points` | **Deployed** | 483 | House drive EP per (era, state): era, state, down, distance_bucket, field_zone, yards_to_goal_min/max, n_obs, ep_drive, ep_net (NULL until P2), p_td, p_fg, p_punt, p_turnover, se_boot, computed_at. Drive basis, era-scoped, d4 go-conditional — see 2026-08-08 changelog entry. |
+| `api.expected_points` | **Deployed** | 483 | House drive EP per (era, state): era, state, down, distance_bucket, field_zone, yards_to_goal_min/max, n_obs, ep_drive, ep_net (NULL until P2), p_td, p_fg, p_punt, p_turnover, se_boot (nullable: NULL after a --no-bootstrap recompute, render as no-interval not +/-0), computed_at. Drive basis, era-scoped, d4 go-conditional — see 2026-08-08 changelog entry. |
 | `api.penalty_log` | **Deployed** | ~250K | Play-derived penalty events (2004+), best-effort parsed from play_text. Columns: play_id, game_id, season, week, season_type, period, down, distance, offense, defense, play_type, is_penalty_play_type, penalized_team, benefiting_team, infraction, penalty_yards, declined, offsetting, no_play, multi_penalty, yards_gained, ppa, play_text, parse_ok. 'Unknown'/NULL = unclassified, not absent (see 2026-07-23 changelog). |
 | `api.team_penalties` | **Deployed** | ~42K | Official box-score penalty counts per (game, team) from totalPenaltiesYards. Columns: game_id, season, week, season_type, team, opponent, home_away, penalties, penalty_yards, opponent_penalties, opponent_penalty_yards. |
 | `api.recruit_lookup` | **Deployed** | 67,179 | Stable recruiting view for recruit data |

--- a/docs/handoffs/2026-08-08-expected-points-handoff.md
+++ b/docs/handoffs/2026-08-08-expected-points-handoff.md
@@ -1,0 +1,86 @@
+# Handoff: `api.expected_points` — house drive EP for cfb-app / cfb_mcp
+
+**Date:** 2026-08-08
+**Producer:** cfb-database (PRs #66, #69; design
+`docs/plans/2026-08-08-drive-chain-ep-model-plan.md`)
+**Consumers:** cfb-app (dashboard), the cfb_mcp agent (new
+`get_expected_points` tool ships alongside this handoff)
+
+## What this is
+
+The warehouse's first in-house expected-points model: an absorbing Markov
+chain over drive states (down × distance bucket × field zone) estimated from
+2.5M scrimmage plays, solved per rules era. One row per (era, state) with the
+drive's expected points, its outcome probabilities, and a bootstrap standard
+error. Validation status at publication: zone and down monotonicity pass in
+all three eras; realized-outcome P(TD) calibration MAE 0.0072–0.0077.
+
+```
+GET /rest/v1/expected_points?era=eq.2021%2B&down=eq.1&distance_bucket=eq.standard&field_zone=eq.3
+→ [{"era":"2021+","state":"d1|standard|z3","ep_drive":4.24,"p_td":0.521,"se_boot":0.016,...}]
+```
+
+## The four rules (getting any of these wrong produces confident nonsense)
+
+1. **Drive basis, not net basis.** `ep_drive` = expected points of THIS
+   possession (TD 6.97, FG 3, safety −2, defensive TD −6.97, everything else
+   0). It ignores the field position handed to the opponent, so it is **not
+   comparable to CFBD `ppa`**, nflfastR EP, or any "next score" number. The
+   comparable basis is `ep_net`, which is **NULL on every row until P2** —
+   render NULL as "not yet computed", never as 0, and do not build EPA-style
+   deltas from `ep_drive` across possession changes.
+2. **Era-scope every lookup.** Eras are `2004-2013`, `2014-2020`, `2021+`.
+   A 1st-and-10 at your own 25 is 1.58 EP in the 2000s and 1.80 today — a
+   ~15-SE gap. Join a game to its own era; never average eras. For "current"
+   displays default to `2021+`. Mind the plus sign: PostgREST needs
+   `era=eq.2021%2B` (an unencoded `+` decodes as a space and matches nothing).
+3. **`down=4` rows are go-for-it-conditional.** A 4th-down state exists in
+   the chain only when the offense lined up to go — punts and FGs exit from
+   the 3rd-down play. So `EP(d4)` answers "what is this state worth GIVEN
+   they go", which is exactly what a 4th-down decision UI wants and exactly
+   what a naive down-ladder display gets wrong (d4 can price above d3; both
+   production eras show it). Keep d4 out of d1–d3 ladders or caveat it.
+4. **Show intervals.** `se_boot` is the game-cluster bootstrap SE of
+   `ep_drive`. Anything user-facing should render `ep_drive ± 2·se_boot` or
+   equivalent — the Brill/Yurko/Wyner "intervals, not verdicts" rule is part
+   of this contract's spirit, especially for thin states (check `n_obs`).
+
+## Column reference
+
+| column | notes |
+|---|---|
+| `era` | `2004-2013` \| `2014-2020` \| `2021+` (open-ended: picks up new seasons) |
+| `state` | canonical key `d{down}\|{distance_bucket}\|z{zone}` |
+| `down` | 1–4, parsed from state |
+| `distance_bucket` | down-aware: d1 uses `standard`(=10)/`short`(<10)/`long`(>10)/`goal`; d2–d4 use `short`(≤3)/`med`(4–6)/`long`(7–10)/`xlong`(>10)/`goal` |
+| `field_zone` | 1 (opponent goal line) … 10 (own goal line), 10-yard bands of yards-to-goal |
+| `yards_to_goal_min/max` | the band's bounds, for display |
+| `n_obs` | scrimmage-play observations in this state (garbage time excluded) |
+| `ep_drive` | drive-basis expected points (rule 1) |
+| `ep_net` | NULL until P2; the future CFBD-comparable basis |
+| `p_td` … `p_turnover` | drive-outcome absorption probabilities from this state (`p_turnover` includes defensive-TD turnovers) |
+| `se_boot` | bootstrap SE of ep_drive, game-cluster resampled |
+| `computed_at` | staleness check; rewritten by each compute run |
+
+Not exposed (contract-internal): `analytics.ep_states`,
+`analytics.drive_chain_transitions`. Never read them directly — the
+transitions surface will arrive with the drive-sequences (sunburst) mart.
+
+## Freshness & change policy
+
+Recomputed on demand via the deploy workflow (`compute_drive_chain`), not on
+the daily schedule; `computed_at` is the staleness signal. Additive changes
+(new columns, `ep_net` filling in, a new open era rolling over) will NOT be
+announced as breaking; the row grain (era, state) and existing column
+semantics are stable. When `ep_net` populates, a contract changelog entry
+will say so — until then any UI copy should label these numbers "drive EP
+(house model v1)".
+
+## Suggested first uses in cfb-app
+
+- Field-position value strip on game pages (EP by zone for the current era).
+- 4th-down context chip: `EP(d4 state)` vs `EP(punt-implied next state)`
+  once P2's net basis lands — until then display d4 EP with the go caveat.
+- Agent answers ("what's a drive from the 25 worth?") via the new
+  `get_expected_points` MCP tool, which carries these caveats in its
+  docstring so the model self-qualifies.

--- a/docs/handoffs/2026-08-08-expected-points-handoff.md
+++ b/docs/handoffs/2026-08-08-expected-points-handoff.md
@@ -40,10 +40,13 @@ GET /rest/v1/expected_points?era=eq.2021%2B&down=eq.1&distance_bucket=eq.standar
    they go", which is exactly what a 4th-down decision UI wants and exactly
    what a naive down-ladder display gets wrong (d4 can price above d3; both
    production eras show it). Keep d4 out of d1–d3 ladders or caveat it.
-4. **Show intervals.** `se_boot` is the game-cluster bootstrap SE of
-   `ep_drive`. Anything user-facing should render `ep_drive ± 2·se_boot` or
+4. **Show intervals — and handle their absence.** `se_boot` is the
+   game-cluster bootstrap SE of `ep_drive`; render `ep_drive ± 2·se_boot` or
    equivalent — the Brill/Yurko/Wyner "intervals, not verdicts" rule is part
-   of this contract's spirit, especially for thin states (check `n_obs`).
+   of this contract's spirit, especially for thin states (check `n_obs`:
+   `d4|short|z10` ships with se_boot 0.219, ~10× the healthy states).
+   `se_boot` is **nullable**: a `--no-bootstrap` recompute writes NULL SEs.
+   Render NULL as "interval unavailable", never as ±0.
 
 ## Column reference
 
@@ -59,7 +62,7 @@ GET /rest/v1/expected_points?era=eq.2021%2B&down=eq.1&distance_bucket=eq.standar
 | `ep_drive` | drive-basis expected points (rule 1) |
 | `ep_net` | NULL until P2; the future CFBD-comparable basis |
 | `p_td` … `p_turnover` | drive-outcome absorption probabilities from this state (`p_turnover` includes defensive-TD turnovers) |
-| `se_boot` | bootstrap SE of ep_drive, game-cluster resampled |
+| `se_boot` | bootstrap SE of ep_drive, game-cluster resampled; NULLABLE (NULL after a `--no-bootstrap` recompute — no interval, not ±0) |
 | `computed_at` | staleness check; rewritten by each compute run |
 
 Not exposed (contract-internal): `analytics.ep_states`,

--- a/mcp/src/cfb_mcp/postgrest.py
+++ b/mcp/src/cfb_mcp/postgrest.py
@@ -115,13 +115,18 @@ class PostgrestClient:
         *,
         profile: str = "api",
         limit: int = DEFAULT_ROW_CAP,
+        max_rows: int = DEFAULT_ROW_CAP,
     ) -> list[dict[str, Any]]:
         """GET rows from a PostgREST view (Accept-Profile: <profile>).
 
         The row cap is enforced here, not left to the caller: ``limit`` is
-        clamped to ``DEFAULT_ROW_CAP`` even if a larger value is passed in.
+        clamped to ``max_rows`` even if a larger value is passed in.
+        ``max_rows`` defaults to ``DEFAULT_ROW_CAP``; a tool raises it only
+        for a BOUNDED result space it can name (get_expected_points passes
+        its ~170-state era grid's cap -- PR #70 review: the generic cap
+        silently truncated an unfiltered era lookup).
         """
-        capped_limit = min(limit, DEFAULT_ROW_CAP) if limit else DEFAULT_ROW_CAP
+        capped_limit = min(limit, max_rows) if limit else max_rows
         query: dict[str, Any] = dict(params or {})
         query["limit"] = str(capped_limit)
 

--- a/mcp/src/cfb_mcp/server.py
+++ b/mcp/src/cfb_mcp/server.py
@@ -1,4 +1,4 @@
-"""cfb_mcp FastMCP server: 8 read-only tools over the cfb-database warehouse.
+"""cfb_mcp FastMCP server: 9 read-only tools over the cfb-database warehouse.
 
 Every tool is a thin, LLM-facing wrapper around one or more PostgREST calls
 (see cfb_mcp.postgrest). Tools only touch objects in the public surface
@@ -674,3 +674,112 @@ async def get_data_freshness() -> str:
     except PostgrestError as e:
         return e.message
     return _dump(_wrap("public.get_data_freshness", rows))
+
+
+# ---------------------------------------------------------------------
+# 9. get_expected_points
+# ---------------------------------------------------------------------
+
+
+class EpEra(StrEnum):
+    """Rules-era curves for `get_expected_points` -- see api.expected_points.
+
+    Eras are estimated separately because scoring environments differ by up
+    to 0.22 EP (~15 bootstrap SEs); a game must be priced against its own
+    era's curve. MODERN is the right default for anything current.
+    """
+
+    LEGACY = "2004-2013"
+    MIDDLE = "2014-2020"
+    MODERN = "2021+"
+
+
+@mcp.tool(
+    name="get_expected_points",
+    annotations={"title": "Get Expected Points", **READ_ONLY_ANNOTATIONS},
+)
+async def get_expected_points(
+    down: Annotated[
+        int | None,
+        Field(default=None, ge=1, le=4, description="Down (1-4). Omit for all downs."),
+    ] = None,
+    distance_bucket: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description="Distance bucket. Down-aware vocabulary: 1st down uses "
+            "'standard' (=10), 'short' (<10, post-penalty), 'long' (>10), 'goal'; "
+            "downs 2-4 use 'short' (<=3), 'med' (4-6), 'long' (7-10), 'xlong' (>10), "
+            "'goal'. Omit for all buckets.",
+        ),
+    ] = None,
+    field_zone: Annotated[
+        int | None,
+        Field(
+            default=None,
+            ge=1,
+            le=10,
+            description="10-yard band of yards-to-goal: 1 = inside the opponent 10, "
+            "3 = opponent 21-30 (the 'opp 25'), 8 = own 21-30 (the 'own 25'), "
+            "10 = backed up inside own 10. Omit for the full field.",
+        ),
+    ] = None,
+    era: Annotated[
+        EpEra,
+        Field(
+            default=EpEra.MODERN,
+            description="Rules era whose curve to use. Default '2021+' (modern). "
+            "Historical questions must use the era the game was played in.",
+        ),
+    ] = EpEra.MODERN,
+    limit: Annotated[
+        int, Field(default=DEFAULT_ROW_CAP, ge=1, le=DEFAULT_ROW_CAP)
+    ] = DEFAULT_ROW_CAP,
+) -> str:
+    """Get house expected points for drive states (down / distance / field position).
+
+    When to use: "what's a 1st-and-10 from the opponent 25 worth", "how often
+    does a drive score a TD from midfield", "compare 3rd-and-short vs
+    3rd-and-long at the 40".
+
+    Backed by api.expected_points -- the warehouse's own drive-state Markov
+    chain (2.5M plays, garbage time excluded), not CFBD's model.
+
+    Caveats (repeat these when answering -- they change interpretation):
+      - ep_drive is the DRIVE basis: points this possession is worth (TD 6.97,
+        FG 3). It is NOT comparable to CFBD PPA/EPA numbers; the comparable
+        ep_net column is NULL until the net next-score model lands. Never
+        read a NULL ep_net as zero.
+      - down=4 rows are GO-FOR-IT-CONDITIONAL: the chain only sees a 4th-down
+        snapshot when the offense lined up to go (punts/FGs exit at 3rd
+        down), so 4th-down EP can legitimately exceed 3rd-down EP. Say
+        "given they go for it" when quoting d4 numbers.
+      - Quote intervals: se_boot is the bootstrap SE of ep_drive, so
+        ep_drive +/- 2*se_boot is the honest form, and check n_obs before
+        leaning on a thin state.
+
+    Returns: JSON {"_source": "api.expected_points", "count": int, "rows": [...]},
+    rows ordered by down, then field zone.
+    """
+    params: dict[str, Any] = {"era": eq(era.value)}
+    if down is not None:
+        params["down"] = eq(down)
+    if distance_bucket is not None:
+        params["distance_bucket"] = eq(distance_bucket)
+    if field_zone is not None:
+        params["field_zone"] = eq(field_zone)
+    params["order"] = "down.asc,field_zone.asc,distance_bucket.asc"
+
+    try:
+        client = PostgrestClient()
+        rows = await client.select("expected_points", params, profile="api", limit=limit)
+    except PostgrestError as e:
+        return e.message
+
+    if not rows:
+        return (
+            f"No expected-points states match era={era.value} with the given filters. "
+            "Check the down-aware distance_bucket vocabulary (1st down: standard/short/"
+            "long/goal; downs 2-4: short/med/long/xlong/goal)."
+        )
+    return _dump(_wrap("api.expected_points", rows))

--- a/mcp/src/cfb_mcp/server.py
+++ b/mcp/src/cfb_mcp/server.py
@@ -756,7 +756,8 @@ async def get_expected_points(
         "given they go for it" when quoting d4 numbers.
       - Quote intervals: se_boot is the bootstrap SE of ep_drive, so
         ep_drive +/- 2*se_boot is the honest form, and check n_obs before
-        leaning on a thin state.
+        leaning on a thin state. se_boot can be NULL (a no-bootstrap
+        recompute): say "interval unavailable", never treat it as +/-0.
 
     Returns: JSON {"_source": "api.expected_points", "count": int, "rows": [...]},
     rows ordered by down, then field zone.

--- a/mcp/src/cfb_mcp/server.py
+++ b/mcp/src/cfb_mcp/server.py
@@ -681,6 +681,13 @@ async def get_data_freshness() -> str:
 # ---------------------------------------------------------------------
 
 
+# One era's full state space is ~160-170 rows -- larger than DEFAULT_ROW_CAP,
+# so a cap of 100 silently truncates an unfiltered era lookup with no signal
+# to the caller (PR #70 review, P1). The space is bounded (the state grid is
+# fixed by construction), so the fix is a cap that always fits one era.
+EP_ROW_CAP = 200
+
+
 class EpEra(StrEnum):
     """Rules-era curves for `get_expected_points` -- see api.expected_points.
 
@@ -732,9 +739,7 @@ async def get_expected_points(
             "Historical questions must use the era the game was played in.",
         ),
     ] = EpEra.MODERN,
-    limit: Annotated[
-        int, Field(default=DEFAULT_ROW_CAP, ge=1, le=DEFAULT_ROW_CAP)
-    ] = DEFAULT_ROW_CAP,
+    limit: Annotated[int, Field(default=EP_ROW_CAP, ge=1, le=EP_ROW_CAP)] = EP_ROW_CAP,
 ) -> str:
     """Get house expected points for drive states (down / distance / field position).
 
@@ -773,7 +778,9 @@ async def get_expected_points(
 
     try:
         client = PostgrestClient()
-        rows = await client.select("expected_points", params, profile="api", limit=limit)
+        rows = await client.select(
+            "expected_points", params, profile="api", limit=limit, max_rows=EP_ROW_CAP
+        )
     except PostgrestError as e:
         return e.message
 

--- a/mcp/tests/test_get_expected_points.py
+++ b/mcp/tests/test_get_expected_points.py
@@ -1,0 +1,82 @@
+"""Tests for the get_expected_points tool: api.expected_points."""
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from cfb_mcp.server import EpEra, get_expected_points
+from tests.conftest import TEST_BASE_URL
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_defaults_to_modern_era():
+    route = respx.get(f"{TEST_BASE_URL}/rest/v1/expected_points").mock(
+        return_value=httpx.Response(
+            200,
+            json=[{"state": "d1|standard|z3", "ep_drive": 4.24, "p_td": 0.521}],
+        )
+    )
+
+    result = json.loads(await get_expected_points(down=1, field_zone=3))
+
+    assert result["_source"] == "api.expected_points"
+    request = route.calls.last.request
+    assert request.url.params["era"] == "eq.2021+"
+    assert request.url.params["down"] == "eq.1"
+    assert request.url.params["field_zone"] == "eq.3"
+    assert request.url.params["order"] == "down.asc,field_zone.asc,distance_bucket.asc"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_era_plus_sign_is_url_encoded_on_the_wire():
+    """The era key '2021+' contains a literal plus; an unencoded '+' decodes
+    as a space server-side and matches nothing. httpx must send %2B."""
+    respx.get(f"{TEST_BASE_URL}/rest/v1/expected_points").mock(
+        return_value=httpx.Response(200, json=[{"state": "d1|standard|z3"}])
+    )
+
+    await get_expected_points(down=1)
+
+    raw_query = respx.calls.last.request.url.query.decode()
+    assert "era=eq.2021%2B" in raw_query
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_historical_era_override():
+    route = respx.get(f"{TEST_BASE_URL}/rest/v1/expected_points").mock(
+        return_value=httpx.Response(200, json=[{"state": "d1|standard|z8", "ep_drive": 1.58}])
+    )
+
+    await get_expected_points(down=1, field_zone=8, era=EpEra.LEGACY)
+
+    assert route.calls.last.request.url.params["era"] == "eq.2004-2013"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_empty_result_names_the_bucket_vocabulary():
+    """The most likely miss is a wrong distance_bucket (the vocabulary is
+    down-aware); the message must teach the fix, not just say 'no rows'."""
+    respx.get(f"{TEST_BASE_URL}/rest/v1/expected_points").mock(
+        return_value=httpx.Response(200, json=[])
+    )
+
+    result = await get_expected_points(down=1, distance_bucket="med")
+
+    assert "standard" in result and "xlong" in result
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_docstring_carries_the_interpretation_caveats():
+    """The tool's docstring is what the calling model reads; the drive-basis,
+    d4-conditional, and interval caveats are the contract's rules 1, 3, 4."""
+    doc = get_expected_points.__doc__ or ""
+    assert "NOT comparable to CFBD" in doc
+    assert "GO-FOR-IT-CONDITIONAL" in doc
+    assert "se_boot" in doc

--- a/mcp/tests/test_get_expected_points.py
+++ b/mcp/tests/test_get_expected_points.py
@@ -80,3 +80,20 @@ async def test_docstring_carries_the_interpretation_caveats():
     assert "NOT comparable to CFBD" in doc
     assert "GO-FOR-IT-CONDITIONAL" in doc
     assert "se_boot" in doc
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_default_limit_fits_a_full_era():
+    """PR #70 review, P1: an era's state space is ~160-170 rows, so the
+    generic 100-row cap silently truncated an unfiltered era lookup with no
+    signal to the caller. The default limit must exceed one era's full grid."""
+    route = respx.get(f"{TEST_BASE_URL}/rest/v1/expected_points").mock(
+        return_value=httpx.Response(200, json=[{"state": f"s{i}"} for i in range(170)])
+    )
+
+    result = json.loads(await get_expected_points())
+
+    assert result["count"] == 170
+    assert respx.calls.last.request.url.params["limit"] == "200"
+    assert route.called

--- a/src/schemas/api/043_expected_points.sql
+++ b/src/schemas/api/043_expected_points.sql
@@ -46,10 +46,15 @@ FROM analytics.ep_states;
 COMMENT ON VIEW api.expected_points IS 'House expected points per drive state and era (Goldner-basis drive EP from the play-by-play Markov chain, with game-cluster bootstrap SEs). ep_net NULL until the net next-score basis lands (P2). down=4 rows are go-for-it-conditional. Backed by analytics.ep_states; see docs/handoffs/2026-08-08-expected-points-handoff.md.';
 
 -- Grants are part of the definition (021 convention: no ALTER DEFAULT
--- PRIVILEGES in this database). The underlying analytics tables were created
--- AFTER grant_read_access_for_security_invoker's blanket GRANT SELECT ON ALL
--- TABLES ran, so the SECURITY INVOKER view needs these explicit table grants
--- or anon reads fail even though the schema USAGE grant exists.
-GRANT SELECT ON analytics.ep_states TO anon, authenticated;
-GRANT SELECT ON analytics.drive_chain_transitions TO anon, authenticated;
+-- PRIVILEGES in this database). Only the VIEW grant is needed: api.* views
+-- run with OWNER rights -- measured 2026-08-08 against pg_class, 0 of 44
+-- api views set security_invoker, unlike public.* where all 13 do (that is
+-- the layer grant_read_access_for_security_invoker exists for). Granting the
+-- underlying analytics tables here would let direct-connection anon/
+-- authenticated callers bypass the contract surface and read tables the
+-- handoff declares internal (PR #70 review). The REVOKEs undo the grants an
+-- earlier revision of this file applied; both are idempotent no-ops on a
+-- fresh database.
+REVOKE SELECT ON analytics.ep_states FROM anon, authenticated;
+REVOKE SELECT ON analytics.drive_chain_transitions FROM anon, authenticated;
 GRANT SELECT ON api.expected_points TO anon, authenticated;

--- a/src/schemas/api/043_expected_points.sql
+++ b/src/schemas/api/043_expected_points.sql
@@ -1,0 +1,55 @@
+-- House expected-points API view
+-- Exposes analytics.ep_states (the drive-state Markov chain solved per era;
+-- design docs/plans/2026-08-08-drive-chain-ep-model-plan.md, populated by
+-- scripts/compute_drive_chain.py) as the contract surface for cfb-app and
+-- the cfb_mcp agent. The state key is parsed into filterable columns so
+-- PostgREST consumers can ask "1st-and-10 at the opponent 25 in the modern
+-- era" without string surgery:
+--   ?era=eq.2021%2B&down=eq.1&distance_bucket=eq.standard&field_zone=eq.3
+-- (note the %2B -- the era value "2021+" contains a literal plus sign).
+--
+-- Consumer contract (docs/SCHEMA_CONTRACT.md + the 2026-08-08 handoff doc):
+--   * ep_drive is the DRIVE basis (points this possession is worth); it is
+--     not comparable to CFBD PPA until ep_net (P2) lands. ep_net is NULL on
+--     every row today -- NULL means "not yet computed", never zero.
+--   * Join a game/play to ITS OWN era's curve; eras differ by up to 0.22 EP
+--     (~15 bootstrap SEs) and must not be mixed or averaged.
+--   * down=4 rows are GO-FOR-IT-CONDITIONAL: a 4th-down state exists only
+--     when the offense lined up to go (punts/FGs exit the chain from the
+--     3rd-down play), so d4 can legitimately price above d3.
+--   * se_boot is the game-cluster bootstrap SE of ep_drive -- surface
+--     intervals, not point estimates.
+-- Exposed via PostgREST as /api/expected_points
+
+DROP VIEW IF EXISTS api.expected_points;
+
+CREATE VIEW api.expected_points AS
+SELECT
+    era,
+    state,
+    substring(state FROM 'd(\d)')::int AS down,
+    split_part(state, '|', 2) AS distance_bucket,
+    substring(state FROM 'z(\d+)')::int AS field_zone,
+    ((substring(state FROM 'z(\d+)')::int - 1) * 10 + 1) AS yards_to_goal_min,
+    LEAST(substring(state FROM 'z(\d+)')::int * 10, 99) AS yards_to_goal_max,
+    n_obs,
+    ep_drive,
+    ep_net,
+    p_td,
+    p_fg,
+    p_punt,
+    p_turnover,
+    se_boot,
+    computed_at
+FROM analytics.ep_states;
+
+COMMENT ON VIEW api.expected_points IS 'House expected points per drive state and era (Goldner-basis drive EP from the play-by-play Markov chain, with game-cluster bootstrap SEs). ep_net NULL until the net next-score basis lands (P2). down=4 rows are go-for-it-conditional. Backed by analytics.ep_states; see docs/handoffs/2026-08-08-expected-points-handoff.md.';
+
+-- Grants are part of the definition (021 convention: no ALTER DEFAULT
+-- PRIVILEGES in this database). The underlying analytics tables were created
+-- AFTER grant_read_access_for_security_invoker's blanket GRANT SELECT ON ALL
+-- TABLES ran, so the SECURITY INVOKER view needs these explicit table grants
+-- or anon reads fail even though the schema USAGE grant exists.
+GRANT SELECT ON analytics.ep_states TO anon, authenticated;
+GRANT SELECT ON analytics.drive_chain_transitions TO anon, authenticated;
+GRANT SELECT ON api.expected_points TO anon, authenticated;

--- a/tests/test_api_views.py
+++ b/tests/test_api_views.py
@@ -377,6 +377,25 @@ GAME_PREDICTIONS_COLUMNS = {
 # projection per (season, team, model). games_unscored is derived in the view
 # (games_scheduled - games_simulated) so a consumer cannot mistake an unscored
 # game for a loss.
+EXPECTED_POINTS_COLUMNS = {
+    "era",
+    "state",
+    "down",
+    "distance_bucket",
+    "field_zone",
+    "yards_to_goal_min",
+    "yards_to_goal_max",
+    "n_obs",
+    "ep_drive",
+    "ep_net",
+    "p_td",
+    "p_fg",
+    "p_punt",
+    "p_turnover",
+    "se_boot",
+    "computed_at",
+}
+
 SEASON_OUTLOOK_COLUMNS = {
     "projection_id",
     "computed_at",
@@ -632,6 +651,9 @@ class TestViewsExistAndReturnRows:
             # one season's worth -- the view is latest-snapshot, so the count
             # does not grow with the append-only daily history.
             ("api.season_outlook", 300),
+            # Drive-chain EP: ~160 states x 3 eras, all written in one compute
+            # run -- conservative floor of two eras' worth.
+            ("api.expected_points", 300),
         ],
         ids=[
             "team_detail",
@@ -654,6 +676,7 @@ class TestViewsExistAndReturnRows:
             "penalty_log",
             "team_penalties",
             "season_outlook",
+            "expected_points",
         ],
     )
     def test_view_returns_rows(self, db_conn, view_name, min_rows):
@@ -699,6 +722,7 @@ class TestViewColumns:
             ("api.penalty_log", PENALTY_LOG_COLUMNS),
             ("api.team_penalties", TEAM_PENALTIES_COLUMNS),
             ("api.season_outlook", SEASON_OUTLOOK_COLUMNS),
+            ("api.expected_points", EXPECTED_POINTS_COLUMNS),
         ],
         ids=[
             "team_detail",
@@ -725,6 +749,7 @@ class TestViewColumns:
             "penalty_log",
             "team_penalties",
             "season_outlook",
+            "expected_points",
         ],
     )
     def test_columns_present(self, db_conn, view_name, expected_columns):


### PR DESCRIPTION
The drive-chain EP tables (#66/#69) are `analytics.*` — contract-internal and invisible to cfb-app and the agent by design. This PR is the exposure, all four handoff artifacts:

## 1. `api.expected_points` (src/schemas/api/043)

View over `analytics.ep_states` with the state key parsed into `down` / `distance_bucket` / `field_zone` / `yards_to_goal_min,max` so PostgREST consumers filter directly:

```
GET /rest/v1/expected_points?era=eq.2021%2B&down=eq.1&distance_bucket=eq.standard&field_zone=eq.3
→ {"state":"d1|standard|z3","ep_drive":4.24,"p_td":0.521,"se_boot":0.016,...}
```

Grants are load-bearing, not ceremony: the analytics tables were created **after** `grant_read_access_for_security_invoker`'s blanket `GRANT SELECT ON ALL TABLES` ran, so without the explicit table grants in this file the SECURITY INVOKER view fails for `anon` even though schema USAGE exists. Parse expressions verified against all 483 production states before shipping.

## 2. `SCHEMA_CONTRACT.md`

Changelog entry + deployed-views row carrying the four consumer rules: `ep_drive` is the **drive basis** (not comparable to CFBD PPA until `ep_net`/P2); `ep_net` is NULL on every row today and NULL ≠ 0; joins are **era-scoped** (`2021+` needs `eq.2021%2B` — an unencoded plus decodes as a space and matches nothing); `down=4` rows are **go-for-it-conditional** and can legitimately price above 3rd down.

## 3. `docs/handoffs/2026-08-08-expected-points-handoff.md`

The cfb-app–facing document: the four rules with the failure each prevents, a full column reference, freshness/change policy (`computed_at` is the staleness signal; additive changes non-breaking), and suggested first uses.

## 4. `get_expected_points` — cfb_mcp tool #9

Era-aware lookup (StrEnum defaulting to `2021+`) whose docstring carries the interpretation caveats so the calling model self-qualifies its answers. Tests pin the things that would silently break: the `%2B` wire encoding of the era value, the era override, an empty-result message that teaches the down-aware bucket vocabulary instead of saying "no rows", and the presence of the caveats in the docstring itself.

## Tests

5 new MCP tests (58 total pass), `api.expected_points` added to all three `test_api_views` inventories (rows ≥300, column set, ids). 1,355 passed / 403 skipped, lint clean.

Worth a reviewer's eye: `d4|short|z10` ships with `se_boot` 0.219 — ~10× the healthy states — which is exactly the thin-state case the interval rule exists for, and why the view exposes `n_obs` and `se_boot` rather than bare point estimates.

After merge: one `deploy-schema` → `apply` with `files=src/schemas/api/043_expected_points.sql` puts the view live; the MCP tool works immediately after the cfb_mcp server restarts.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pfurxa4Ved9U4ZkEo2PbKR)_

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds a public expected-points API view and an MCP query tool while keeping the internal drive-transition matrix unavailable to public database roles. The prior full-era response truncation concern was disproved: a 170-row mocked era curve now returns all rows with the default request, while explicit smaller limits still apply.

<h3>Confidence Score: 5/5</h3>

Safe to merge: no blocking failure remains.

No blocking failure remains. The expected-points request path was exercised against a PostgREST-style endpoint and returned the complete mocked era curve under the new bounded cap.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a hermetic HTTP/PostgREST boundary harness against get\_expected\_points and verified row-cap behavior; after the PR, the default limit increased to 200 to return all 170 rows, 160-limit returns 160, and oversized requests are clamped to 200, with pytest tests and MCP lint passing.
- Compared old direct transition-table grants with the updated SQL-based revocation approach, reviewed migration ordering and privilege statements, and noted that a live PostgreSQL catalog check could not be performed due to missing psql, PostgreSQL server, Docker, or psycopg2 dependency.
- Concluded that applying 049\_drive\_chain\_ep.sql after historic grants and then 043\_expected\_points.sql supports removing direct table grants from anon and authenticated users, and identified the relevant schema files; a catalog-level has\_table\_privilege check remains required to turn this into a conclusive result.

<a href="https://app.greptile.com/trex/runs/17929472/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["Raise the EP tool row cap to fit a full ..."](https://github.com/rstover-fo/cfb-database/commit/c3886daa2bda0e39cdc88bdbb20b58cc4f634390) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51437691)</sub>

<!-- /greptile_comment -->