### PR TITLE
Add CFBD CORE ratings ingestion (/ratings/core)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 College Football Database -- a complete data warehouse for the CFBD (College Football Data) API, powered by Supabase Postgres and dlthub pipelines.
 
 **Goals:**
-- Ingest all 61 CFBD API endpoints into a well-designed Postgres schema
+- Ingest all 62 CFBD API endpoints into a well-designed Postgres schema
 - Support both analytics (read-heavy, denormalized) and application (normalized, transactional) use cases
 - Maintain working pipelines for ongoing 2026 season data
 - Full historical data (no storage constraints -- will upgrade Supabase tier if needed)
@@ -264,7 +264,7 @@ Consult when building or modifying dlt pipelines: `RESTAPIConfig` structure, bea
 | Games & Schedules | 9 | Incremental by year |
 | Plays & Drives | 6 | Incremental by year (largest data) |
 | Stats (player/team) | 6 | Incremental by year |
-| Ratings (SP+, Elo, FPI) | 5 | Incremental by year |
+| Ratings (SP+, Elo, FPI, CORE) | 6 | Incremental by year |
 | Recruiting | 3 | Incremental by year |
 | Betting Lines | 1 | Incremental by year |
 | Metrics (PPA, win prob) | 8 | Incremental by year |

--- a/docs/cfbd-api-endpoints.md
+++ b/docs/cfbd-api-endpoints.md
@@ -1,6 +1,6 @@
 # CFBD API Endpoints Reference
 
-**Total: 61 endpoints across 15 API categories**
+**Total: 62 endpoints across 15 API categories**
 
 Base URL: `https://api.collegefootballdata.com`
 Auth: API Key required (Bearer token)
@@ -90,7 +90,7 @@ Docs: https://api.collegefootballdata.com/
 |--------|----------|-------------|
 | GET | `/rankings` | Poll rankings (AP, Coaches, CFP) |
 
-### RatingsApi (5 endpoints)
+### RatingsApi (6 endpoints)
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | GET | `/ratings/sp` | SP+ ratings |
@@ -98,6 +98,7 @@ Docs: https://api.collegefootballdata.com/
 | GET | `/ratings/srs` | Simple Rating System |
 | GET | `/ratings/elo` | Elo ratings |
 | GET | `/ratings/fpi` | ESPN FPI ratings |
+| GET | `/ratings/core` | CORE (Context & Opponent-Relative Efficiency) ratings, 2016+ |
 
 ### RecruitingApi (3 endpoints)
 | Method | Endpoint | Description |

--- a/docs/pipeline-manifest.md
+++ b/docs/pipeline-manifest.md
@@ -116,6 +116,7 @@ Only 3 actual variant columns in user data tables. dlt internal tables also have
 | 28 | `/ratings/fpi` | ratings.fpi_ratings | ratings.py | fpi_ratings_resource | YES | merge | year, team | 2015-2026 | WORKING |
 | 29 | `/ratings/srs` | ratings.srs_ratings | ratings.py | srs_ratings_resource | YES | merge | year, team | 2015-2026 | WORKING |
 | 30 | `/ratings/sp/conferences` | ratings.sp_conference_ratings | ratings.py | sp_conference_ratings_resource | YES | merge | year, conference | 2015-2026 | WORKING |
+| 30a | `/ratings/core` | ratings.core_ratings | ratings.py | core_ratings_resource | YES | merge | year, team | 2016-2026 | WORKING |
 
 ### Recruiting Data (merge disposition)
 

--- a/scripts/load_season.py
+++ b/scripts/load_season.py
@@ -28,7 +28,7 @@ SOURCE_ORDER = [
     "game_stats",  # Team and player box scores
     "plays",  # Play-by-play (largest dataset)
     "stats",  # Aggregated season stats
-    "ratings",  # SP+, Elo, FPI, SRS
+    "ratings",  # SP+, Elo, FPI, SRS, CORE
     "rankings",  # AP, Coaches polls
     "recruiting",  # Recruits, team composites
     "betting",  # Betting lines
@@ -50,7 +50,7 @@ ESTIMATED_CALLS = {
     # resource count. The old estimate understated a daily run by ~80x and hid
     # this source behind "plays" in every budget projection.
     "stats": 1_650,
-    "ratings": 10,
+    "ratings": 12,
     "rankings": 20,
     "recruiting": 15,
     "betting": 5,
@@ -184,10 +184,10 @@ def sources_to_skip(active_sources, season_final: bool, allow_skip: bool):
 # while player_returning is a single call per year. Running the whole source
 # daily would cost ~1,640 calls a day -- the exact fan-out that exhausted the
 # quota on 2026-07-25 -- so only the resources that carry preseason inputs are
-# named here. `ratings` and `recruiting` are flat: five single-call-per-year
-# resources each, so they run whole.
+# named here. `ratings` and `recruiting` are flat single-call-per-year
+# resources (six and five respectively), so they run whole.
 #
-# Total ~11 calls/day. An endpoint CFBD has not published yet returns an empty
+# Total ~12 calls/day. An endpoint CFBD has not published yet returns an empty
 # list or a 400 the source modules already log and skip, so this merges
 # nothing rather than failing, and self-heals the day each one lands.
 # `rosters` is deliberately NOT here -- one call per team (~150/day) and it
@@ -201,7 +201,7 @@ PRESEASON_INPUT_SOURCES = ("stats", "ratings", "recruiting")
 
 # What the off-season refresh above actually costs per day, as opposed to what
 # ESTIMATED_CALLS says a full source-grain run of the same names would cost.
-PRESEASON_ESTIMATED_CALLS = len(PRESEASON_STATS_RESOURCES) + 5 + 5
+PRESEASON_ESTIMATED_CALLS = len(PRESEASON_STATS_RESOURCES) + 6 + 5
 
 
 # Sources whose runner accepts a resource filter. Only `stats` needs one so

--- a/src/pipelines/config/endpoints.py
+++ b/src/pipelines/config/endpoints.py
@@ -270,6 +270,13 @@ RATINGS_ENDPOINTS = {
         schema="ratings",
         write_disposition="merge",
     ),
+    "core_ratings": EndpointConfig(
+        path="/ratings/core",
+        table_name="core_ratings",
+        primary_key=["year", "team"],
+        schema="ratings",
+        write_disposition="merge",
+    ),
     "sp_conferences": EndpointConfig(
         path="/ratings/sp/conferences",
         table_name="sp_conference_ratings",

--- a/src/pipelines/sources/ratings.py
+++ b/src/pipelines/sources/ratings.py
@@ -1,4 +1,4 @@
-"""Ratings data sources - SP+, Elo, FPI, SRS.
+"""Ratings data sources - SP+, Elo, FPI, SRS, CORE.
 
 Team ratings and rankings by various systems.
 """
@@ -14,6 +14,10 @@ from ..utils.api_client import get_client
 from .base import make_request
 
 logger = logging.getLogger(__name__)
+
+# CFBD publishes retrospective CORE ratings from 2016 onward; earlier years
+# return nothing, so a full backfill skips them instead of spending calls.
+CORE_RATINGS_START = 2016
 
 
 @dlt.source(name="cfbd_ratings")
@@ -38,6 +42,7 @@ def ratings_source(
         elo_ratings_resource(years),
         fpi_ratings_resource(years),
         srs_ratings_resource(years),
+        core_ratings_resource(years),
         sp_conference_ratings_resource(years),
     ]
 
@@ -137,6 +142,39 @@ def srs_ratings_resource(years: list[int]) -> Iterator[dict]:
             logger.info(f"Loading SRS ratings for {year}...")
 
             data = make_request(client, "/ratings/srs", params={"year": year})
+
+            for rating in data:
+                rating["year"] = year
+                yield rating
+
+    finally:
+        client.close()
+
+
+@dlt.resource(
+    name="core_ratings",
+    write_disposition="merge",
+    primary_key=["year", "team"],
+)
+def core_ratings_resource(years: list[int]) -> Iterator[dict]:
+    """Load CORE (Context & Opponent-Relative Efficiency) ratings.
+
+    One snapshot row per team per season; through_week/through_season_type
+    advance in-season and merge keeps the latest.
+
+    Args:
+        years: List of years to load ratings for
+    """
+    client = get_client()
+    try:
+        for year in years:
+            if year < CORE_RATINGS_START:
+                logger.info(f"Skipping CORE ratings for {year} (published from 2016)")
+                continue
+
+            logger.info(f"Loading CORE ratings for {year}...")
+
+            data = make_request(client, "/ratings/core", params={"year": year})
 
             for rating in data:
                 rating["year"] = year

--- a/tests/test_sources/test_ratings.py
+++ b/tests/test_sources/test_ratings.py
@@ -1,0 +1,71 @@
+"""Tests for ratings data sources."""
+
+from unittest.mock import MagicMock, patch
+
+from src.pipelines.sources.ratings import core_ratings_resource, ratings_source
+
+
+def test_ratings_source_returns_all_resources():
+    """ratings_source should expose all six rating systems."""
+    source = ratings_source(years=[2024])
+
+    assert set(source.resources.keys()) == {
+        "sp_ratings",
+        "elo_ratings",
+        "fpi_ratings",
+        "srs_ratings",
+        "core_ratings",
+        "sp_conference_ratings",
+    }
+
+
+def test_core_ratings_resource_yields_rows_with_year():
+    """Rows pass through with year stamped, one request per year."""
+    mock_response = [
+        {
+            "year": 2024,
+            "throughSeasonType": "postseason",
+            "throughWeek": 1,
+            "team": "Ohio State",
+            "conference": "Big Ten",
+            "overall": 42.1,
+            "offense": 21.3,
+            "defense": -20.8,
+            "offensePlays": 950,
+            "defensePlays": 940,
+            "modelVersion": "core_v1",
+        }
+    ]
+
+    with (
+        patch("src.pipelines.sources.ratings.get_client") as mock_get_client,
+        patch("src.pipelines.sources.ratings.make_request") as mock_make_request,
+    ):
+        mock_get_client.return_value = MagicMock()
+        mock_make_request.return_value = mock_response
+
+        results = list(core_ratings_resource(years=[2024]))
+
+        assert len(results) == 1
+        assert results[0]["year"] == 2024
+        assert results[0]["team"] == "Ohio State"
+        mock_make_request.assert_called_once()
+        assert mock_make_request.call_args.args[1] == "/ratings/core"
+        assert mock_make_request.call_args.kwargs["params"] == {"year": 2024}
+
+
+def test_core_ratings_resource_skips_pre_2016_years():
+    """CORE is published from 2016; earlier years must not spend API calls."""
+    with (
+        patch("src.pipelines.sources.ratings.get_client") as mock_get_client,
+        patch("src.pipelines.sources.ratings.make_request") as mock_make_request,
+    ):
+        mock_get_client.return_value = MagicMock()
+        mock_make_request.return_value = []
+
+        list(core_ratings_resource(years=[2004, 2015, 2016, 2017]))
+
+        requested_years = [
+            call.kwargs["params"]["year"] for call in mock_make_request.call_args_list
+        ]
+        assert requested_years == [2016, 2017]


### PR DESCRIPTION
CFBD published a new team rating — [CORE (Context & Opponent-Relative Efficiency)](https://radsportsanalytics.com/blog/introducing-core-college-football-ratings/), exposed at `GET /ratings/core` with retrospective history from 2016. This wires it into the existing ratings pipeline.

## Changes

- **`src/pipelines/sources/ratings.py`** — new `core_ratings_resource` in the `cfbd_ratings` dlt source (merge disposition, PK `year, team`). The API returns one season-to-date snapshot row per team (`overall`, `offense`, `defense`, `offense_plays`, `defense_plays`, `through_week`, `through_season_type`, `model_version` after dlt snake-casing), so in-season merges advance the snapshot in place. Years before 2016 are skipped to avoid spending calls on empty responses during backfills.
- **`src/pipelines/config/endpoints.py`** — `core_ratings` entry in `RATINGS_ENDPOINTS`, landing as `ratings.core_ratings`.
- **`scripts/load_season.py`** — budget estimates updated: `ratings` 10 → 12, `PRESEASON_ESTIMATED_CALLS` +1 (ratings is now six flat single-call-per-year resources). The source keeps its existing `IMMUTABLE_ONCE_FINAL` membership, so finished seasons are not re-fetched on the daily path.
- **Docs** — pipeline manifest row 30a, endpoint reference (61 → 62 endpoints), CLAUDE.md counts.
- **Tests** — new `tests/test_sources/test_ratings.py`: source resource composition, request path/params, pre-2016 skip. Endpoint-config structure tests cover the new entry via parametrization.

Response shape verified against CFBD's OpenAPI spec (`TeamCoreRating`).

## Rollout notes

- Once merged, the daily workflow picks up current-season CORE automatically (~1 call/day; empty until CFBD publishes in-season numbers).
- Historical 2016–2025 rows need a one-off backfill (finished seasons are deliberately skipped daily): `python scripts/load_season.py --season <year> --sources ratings` per year, ~6 calls per season / ~60 total.

## Testing

- `ruff check` and `ruff format --check` pass.
- Full suite: 1,415 passed; the only failure (`test_seed_team_xwalk::TestEndToEndCli::test_sbr_fixture_run`) is pre-existing on a clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146xsoWFq7SsZJKxYgLqNFF

---
_Generated by [Claude Code](https://claude.ai/code/session_0146xsoWFq7SsZJKxYgLqNFF)_

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds CFBD CORE ratings as a sixth ratings resource, stores them by season and team, avoids requests for seasons before 2016, and updates loader estimates and endpoint documentation.

The duplicate or stale-snapshot concern was disproved by two consecutive mocked CORE loads into the same dlt DuckDB destination: the second snapshot retained exactly the original two `(year, team)` keys and replaced their week, season type, and rating values. The focused CORE resource tests also passed.

The change is safe to merge.

<h3>Confidence Score: 5/5</h3>

The new resource correctly skips unavailable seasons and refreshes existing team-season snapshots without duplicating records.

No defects remain in the final review. The central storage behavior was exercised with two sequential loads against a real local dlt DuckDB destination, while mocked upstream responses verified request eligibility and year stamping.

**Files Needing Attention:** No files need follow-up changes.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the core ratings validation script before making changes with mocked CFBD responses into a local DuckDB destination, capturing (2016, Michigan) and (2024, Ohio State) and showing that 2015 was skipped.
- Ran the same script after the changes; it retained exactly two team-season keys and updated both records to week 15 postseason values, confirming no duplicates or stale fields.
- Executed pytest tests for ratings sources; all three tests passed, covering registration, request shape, year stamping, and pre-2016 skipping.
- Before capture, stored (2016, Michigan) at week 9/regular and (2024, Ohio State) at week 10/regular after mocking requests to /ratings/core?year=2016 and 2024.
- After capture, retained exactly those two keys and updated both to week 15/postseason with new overall values; the authored validation source and command captures were uploaded verbatim.

<a href="https://app.greptile.com/trex/runs/17933653/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Add CFBD CORE ratings ingestion"](https://github.com/rstover-fo/cfb-database/commit/9b66392387a1d696cc026f1538faba4d5306dfd5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51446494)</sub>

<!-- /greptile_comment -->