### PR TITLE
Surface CORE ratings (api.core_ratings + team views) and track freshness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,8 +55,8 @@ The database uses multiple Postgres schemas organized by data domain:
 | `analytics` | Computed analytics | EPA, style profiles |
 | `features` | Fitted-model substrate | team_week (as-of feature vector), model_coefficients, model_metadata |
 | `live` | In-game polling | scoreboard_snapshots, wp_params (house live win prob) |
-| `marts` | Materialized views (39) | Denormalized, query-optimized |
-| `api` | API view layer (36) | Contract surface for cfb-app/cfb-scout |
+| `marts` | Materialized views (42) | Denormalized, query-optimized |
+| `api` | API view layer (44) | Contract surface for cfb-app/cfb-scout |
 | `predictions` | Prediction snapshots | game_predictions, season_projections (append-only daily) |
 | `public` | Convenience views/RPCs (12) | Downstream consumer interface |
 | `meta` | Flat-file load ledger | flat_file_loads |
@@ -64,7 +64,7 @@ The database uses multiple Postgres schemas organized by data domain:
 
 ### Marts System
 
-39 materialized views in the `marts` schema provide denormalized, query-optimized data (plus the plain view `analytics.data_quality_dashboard`). Refresh via:
+42 materialized views in the `marts` schema provide denormalized, query-optimized data (plus the plain view `analytics.data_quality_dashboard`). Refresh via:
 ```bash
 python scripts/refresh_marts.py        # Refresh all marts
 ```
@@ -164,9 +164,9 @@ cfb-database/
 │   │   │   └── rate_limiter.py   # Monthly budget tracking
 │   │   └── run.py                # Pipeline orchestration
 │   └── schemas/
-│       ├── api/                  # 36 API view definitions (contract surface)
+│       ├── api/                  # 44 API view definitions (contract surface)
 │       ├── functions/            # SQL functions
-│       ├── marts/                # 39 materialized view definitions (+1 plain view)
+│       ├── marts/                # 42 materialized view definitions (+1 plain view)
 │       ├── public/               # 12 convenience views + RPCs
 │       └── migrations/           # Schema migrations
 ├── scripts/

--- a/deploys/core-ratings-stage1-manifest.json
+++ b/deploys/core-ratings-stage1-manifest.json
@@ -1,0 +1,11 @@
+{
+  "action": "apply",
+  "files": [
+    "src/schemas/marts/043_core_ratings.sql",
+    "src/schemas/api/044_core_ratings.sql",
+    "src/schemas/marts/028_data_freshness.sql",
+    "src/schemas/public/011_data_freshness_function.sql",
+    "src/schemas/functions/refresh_all_marts.sql",
+    "src/schemas/api/validation_core_ratings.sql"
+  ]
+}

--- a/deploys/core-ratings-stage2-manifest.json
+++ b/deploys/core-ratings-stage2-manifest.json
@@ -1,0 +1,21 @@
+{
+  "action": "apply",
+  "files": [
+    "src/schemas/marts/001_team_season_summary.sql",
+    "src/schemas/marts/013_team_season_trajectory.sql",
+    "src/schemas/marts/023_coaching_tenure.sql",
+    "src/schemas/marts/024_recruiting_roi.sql",
+    "src/schemas/marts/025_transfer_portal_impact.sql",
+    "src/schemas/marts/026_conference_comparison.sql",
+    "src/schemas/api/001_team_detail.sql",
+    "src/schemas/api/002_team_history.sql",
+    "src/schemas/api/004_matchup.sql",
+    "src/schemas/api/005_leaderboard_teams.sql",
+    "src/schemas/api/015_coaching_history.sql",
+    "src/schemas/api/016_recruiting_roi.sql",
+    "src/schemas/api/017_transfer_portal_impact.sql",
+    "src/schemas/api/018_conference_comparison.sql",
+    "src/schemas/public/002_marts_views.sql",
+    "src/schemas/api/validation_core_ratings.sql"
+  ]
+}

--- a/docs/SCHEMA_CONTRACT.md
+++ b/docs/SCHEMA_CONTRACT.md
@@ -15,6 +15,22 @@ Last updated: 2026-08-08
 
 ## Recent Contract Changes
 
+- **2026-08-08 — CFBD CORE ratings surfaced: `api.core_ratings` added;
+  `api.team_detail`/`api.team_history` gain `core_overall`/`core_offense`/
+  `core_defense` (additive).** CORE (Context & Opponent-Relative Efficiency)
+  is CFBD's situation- and opponent-adjusted team rating, ingested into
+  `ratings.core_ratings` (internal) and exposed via `marts.core_ratings` →
+  `api.core_ratings` (full column set incl. `through_week` as-of markers and
+  in-season ranks) plus three embedded columns on the team-page views. Three
+  things consumers must get right: (1) coverage is **2016+ only** — NULL/absent
+  for earlier seasons means not-rated, never zero; (2) **`defense` is
+  lower-better** — "best defense" is `defense_rank ASC` (already ranked
+  ascending), never `ORDER BY defense DESC`; (3) in-season rows are snapshots
+  through `through_week`, advanced in place by the daily load — not final
+  ratings until the season completes. `overall = offense - defense`. Also:
+  `ratings.core_ratings` joined the `get_data_freshness()` tracked set (now
+  24 tables). Handoff: `docs/handoffs/2026-08-08-core-ratings-for-cfb-app.md`.
+
 - **2026-08-08 — `api.expected_points.ep_net` is now populated** (P2, same
   day as the surface shipped). `ep_net` is the **next-score basis** -- the
   one comparable to CFBD PPA, nflfastR EP, and every "expected points"
@@ -558,8 +574,9 @@ These are the primary PostgREST-accessible views. Queries go through Supabase cl
 
 | View | Status | Rows | Description |
 |------|--------|------|-------------|
-| `api.team_detail` | **Deployed** | 136 | Single team page: current season stats, ratings, EPA. Columns: school, mascot, abbreviation, color, alternate_color, logo_url, conference, classification, current_season, games, wins, losses, conf_wins, conf_losses, ppg, opp_ppg, avg_margin, sp_rating, sp_rank, sp_offense, sp_defense, elo, fpi, epa_per_play, epa_tier, success_rate, explosiveness, recruiting_rank, recruiting_points |
-| `api.team_history` | **Deployed** | 3,667 | Multi-season team history with records, ratings, EPA trends. Columns: team, season, conference, games, wins, losses, conf_wins, conf_losses, ppg, opp_ppg, avg_margin, sp_rating, sp_rank, sp_offense, sp_defense, elo, fpi, epa_per_play, epa_tier, success_rate, explosiveness, total_plays, recruiting_rank, recruiting_points (sp_offense/sp_defense added 2026-07-23) |
+| `api.team_detail` | **Deployed** | 136 | Single team page: current season stats, ratings, EPA. Columns: school, mascot, abbreviation, color, alternate_color, logo_url, conference, classification, current_season, games, wins, losses, conf_wins, conf_losses, ppg, opp_ppg, avg_margin, sp_rating, sp_rank, sp_offense, sp_defense, elo, fpi, core_overall, core_offense, core_defense, epa_per_play, epa_tier, success_rate, explosiveness, recruiting_rank, recruiting_points (core_* added 2026-08-08; 2016+ only, NULL = not-rated, core_defense lower-better) |
+| `api.team_history` | **Deployed** | 3,667 | Multi-season team history with records, ratings, EPA trends. Columns: team, season, conference, games, wins, losses, conf_wins, conf_losses, ppg, opp_ppg, avg_margin, sp_rating, sp_rank, sp_offense, sp_defense, elo, fpi, core_overall, core_offense, core_defense, epa_per_play, epa_tier, success_rate, explosiveness, total_plays, recruiting_rank, recruiting_points (sp_offense/sp_defense added 2026-07-23; core_* added 2026-08-08, 2016+ only, NULL = not-rated, core_defense lower-better) |
+| `api.core_ratings` | **Deployed** | ~1,400 | CFBD CORE ratings by team-season, 2016+ only. Columns: season, team, conference, overall, offense, defense, offense_plays, defense_plays, through_week, through_season_type, model_version, overall_rank, offense_rank, defense_rank. `defense` is LOWER-better (`defense_rank` is ranked ascending accordingly); `overall = offense - defense`; in-season rows are snapshots through `through_week`. Backed by `marts.core_ratings`. |
 | `api.game_detail` | **Deployed** | 45,897 | Single game: teams, scores, betting lines, EPA, venue. Columns: game_id, season, week, season_type, start_date, completed, home_team, away_team, home_points, away_points, winner, point_diff, home_spread, over_under, spread_result, ou_result, home_epa, away_epa, pregame_home_win_prob, venue, attendance, excitement_index |
 | `api.matchup` | **Deployed** | 11,975 | Head-to-head matchup history and current season comparison. Columns: team1, team2, total_games, team1_wins, team2_wins, ties, first_meeting, last_meeting, recent_results (JSONB array), team1/team2 current season stats |
 | `api.leaderboard_teams` | **Deployed** | 3,667 | Team leaderboard with rankings, ratings, EPA. Columns: team, conference, season, classification, wins, losses, win_pct, ppg, opp_ppg, sp_rank, epa_per_play, epa_tier, wins_rank, ppg_rank, defense_ppg_rank, epa_rank. Rank columns are scoped `PARTITION BY season, classification` (see 2026-07-22 changelog entry) -- all rows still returned, no `WHERE fbs` filter. |
@@ -657,7 +674,8 @@ cfb-app for advanced features.
 
 | Materialized View | Status | Description |
 |-------------------|--------|-------------|
-| `marts.team_season_summary` | Deployed | One row per team/season: wins, losses, ratings, recruiting |
+| `marts.team_season_summary` | Deployed | One row per team/season: wins, losses, ratings (incl. core_overall/core_offense/core_defense, 2016+), recruiting |
+| `marts.core_ratings` | Deployed | CFBD CORE ratings passthrough of `ratings.core_ratings` (2016+). Grain/unique key: (team, season). In-season rank columns; defense ranked ascending (lower is better). |
 | `marts.team_epa_season` | Deployed | Season-level EPA metrics per team |
 | `marts._game_epa_calc` | Deployed | Per-game EPA calculations (internal building block for api.game_detail) |
 | `marts.team_style_profile` | Deployed | Offensive/defensive style characterization |
@@ -683,7 +701,7 @@ cfb-app for advanced features.
 | `marts.transfer_portal_impact` | Deployed | Portal activity correlated with team performance changes. Portal era only (2021+). 1,374 rows. |
 | `marts.conference_comparison` | Deployed | Per-conference per-season aggregates with PERCENT_RANK percentiles. 347 rows. |
 | `marts.conference_head_to_head` | Deployed | Conference vs conference records by season. Alphabetical ordering to avoid duplicate pairs. 4,818 rows. |
-| `marts.data_freshness` | Deployed | Data freshness tracking for 23 key tables. Row counts, last activity, staleness detection. |
+| `marts.data_freshness` | Deployed | Data freshness tracking for 24 key tables. Row counts, last activity, staleness detection. |
 | `marts.team_wepa_season` | Deployed | Opponent-adjusted EPA (WEPA) by team-season, passthrough of `metrics.wepa_team_season`. Grain: `(team, season)`. Unique key: `(team, season)`. |
 | `marts.player_wepa_season` | Deployed | Player WEPA (passing/rushing) and kicker PAAR, tall union of `metrics.wepa_players_*`. Grain: `(season, athlete_id, category)`. Unique key: `(season, athlete_id, category)`. |
 | `marts.returning_production` | Deployed | Returning production by team-season (PPA and usage returning from prior season), passthrough of `stats.player_returning`. Grain: `(season, team)`. Unique key: `(team, season)`. |
@@ -756,7 +774,7 @@ These reference tables are stable enough for direct access.
 |----------|--------|-------------|
 | `ref.get_era` | `ref` | Returns era code/name for a given year |
 | `analytics.refresh_all_views` | `analytics` | Refreshes all analytics materialized views (admin use) |
-| `marts.refresh_all` | `marts` | Refreshes all 39 mart materialized views in dependency order (7 layers). Returns (view_name, duration_ms, status). |
+| `marts.refresh_all` | `marts` | Refreshes all 42 mart materialized views in dependency order (7 layers). Returns (view_name, duration_ms, status). |
 
 ---
 
@@ -818,7 +836,7 @@ These objects are implementation details. Do not depend on them from downstream 
 |--------|--------|
 | `core` | `games`, `drives`, `plays` (partitioned: `plays_y2004`..`plays_y2026`), `roster`, `roster__recruit_ids`, `records`, `rankings`, `game_media`, `game_weather`, `game_player_stats` (+ nested `__teams`, `__categories`, `__types`, `__athletes`), `game_team_stats` (+ nested `__teams`, `__stats`), `games__home_line_scores`, `games__away_line_scores` |
 | `stats` | `team_season_stats`, `player_season_stats`, `advanced_team_stats`, `advanced_game_stats`, `game_havoc`, `play_stats`, `player_usage`, `player_returning` |
-| `ratings` | `sp_ratings`, `sp_conference_ratings`, `elo_ratings`, `fpi_ratings`, `srs_ratings` |
+| `ratings` | `sp_ratings`, `sp_conference_ratings`, `elo_ratings`, `fpi_ratings`, `srs_ratings`, `core_ratings` |
 | `recruiting` | `recruits`, `team_recruiting`, `team_talent`, `transfer_portal`, `recruiting_groups` |
 | `betting` | `lines`, `team_ats`, `line_snapshots` (append-only line movement snapshots, no PK, `captured_at` stamped per run) |
 | `draft` | `draft_picks` |

--- a/docs/handoffs/2026-08-08-core-ratings-for-cfb-app.md
+++ b/docs/handoffs/2026-08-08-core-ratings-for-cfb-app.md
@@ -1,0 +1,55 @@
+# CORE ratings for cfb-app
+
+**From:** cfb-database
+**Date:** 2026-08-08
+**Status:** Deployed (stage 1: dedicated view; stage 2: team-view embed)
+
+## What changed
+
+CFBD published a new team rating — CORE (Context & Opponent-Relative
+Efficiency): PPA-based performance adjusted for game situation and opponent
+strength, retrospective from 2016. It is now ingested daily
+(`ratings.core_ratings`, internal) and surfaced two ways:
+
+| Surface | Grain | What it carries |
+|---|---|---|
+| `api.core_ratings` (new) | (team, season) | Full column set: `overall`, `offense`, `defense`, `offense_plays`, `defense_plays`, `through_week`, `through_season_type`, `model_version`, plus in-season `overall_rank` / `offense_rank` / `defense_rank` |
+| `api.team_detail` / `api.team_history` (additive) | unchanged | Three new columns next to sp/elo/fpi: `core_overall`, `core_offense`, `core_defense` |
+
+## What cfb-app should do
+
+- Team pages can show CORE alongside SP+/FPI immediately — the three embedded
+  columns are already in the views the pages read. No query changes required;
+  the additions are purely additive.
+- For a ratings table/leaderboard, query `api.core_ratings` directly, e.g.
+  PostgREST: `/api/core_ratings?season=eq.2025&order=overall_rank.asc&limit=25`.
+- The bot reaches it via `run_analyst_query` automatically (api-schema default
+  privileges cover `analyst_ro`).
+
+## Honest-data caveats
+
+1. **Coverage is 2016+ only.** NULL `core_*` on team views (or absent rows in
+   `api.core_ratings`) for earlier seasons means not-rated — never zero.
+2. **`defense` is lower-better.** "Best defense" is `defense_rank ASC`
+   (already ranked ascending) or `ORDER BY defense ASC` — never
+   `ORDER BY defense DESC`. `overall = offense - defense`.
+3. **In-season rows are as-of snapshots.** `through_week` /
+   `through_season_type` mark how much of the season the rating has seen; the
+   daily load advances the row in place. Treat mid-season values as current
+   form, not final ratings.
+4. `offense`/`defense` are per-100-qualifying-plays point margins vs average;
+   `offense_plays`/`defense_plays` are the qualifying volumes behind them
+   (garbage time, OT, FCS games, special teams excluded by CFBD's model).
+
+## Example
+
+Top 10 of 2025 with components:
+
+```sql
+SELECT team, conference, overall, offense, defense,
+       overall_rank, offense_rank, defense_rank
+FROM api.core_ratings
+WHERE season = 2025
+ORDER BY overall_rank
+LIMIT 10;
+```

--- a/scripts/refresh_marts.py
+++ b/scripts/refresh_marts.py
@@ -41,6 +41,7 @@ MARTS_VIEWS = [
     "marts.returning_production",
     "marts.player_usage",
     "marts.team_ats_records",
+    "marts.core_ratings",
     "marts.penalty_log",
     "marts.team_penalty_box",
     # Layer 2: Depends on Layer 1

--- a/src/schemas/api/001_team_detail.sql
+++ b/src/schemas/api/001_team_detail.sql
@@ -35,6 +35,9 @@ SELECT
     tss.sp_defense,
     tss.elo,
     tss.fpi,
+    tss.core_overall,
+    tss.core_offense,
+    tss.core_defense,
 
     -- EPA metrics
     epa.epa_per_play,

--- a/src/schemas/api/002_team_history.sql
+++ b/src/schemas/api/002_team_history.sql
@@ -29,6 +29,9 @@ SELECT
     tss.sp_defense,
     tss.elo,
     tss.fpi,
+    tss.core_overall,
+    tss.core_offense,
+    tss.core_defense,
 
     -- EPA (if available for that season)
     epa.epa_per_play,
@@ -46,7 +49,7 @@ LEFT JOIN marts.team_epa_season epa
     ON epa.team = tss.team AND epa.season = tss.season
 ORDER BY tss.team, tss.season DESC;
 
-COMMENT ON VIEW api.team_history IS 'Multi-season team history with records, ratings (incl. SP+ offense/defense split), and EPA trends';
+COMMENT ON VIEW api.team_history IS 'Multi-season team history with records, ratings (incl. SP+ offense/defense split and CORE, 2016+), and EPA trends';
 
 -- Re-grant on every apply: this file DROPs the view first, which discards
 -- existing grants (no ALTER DEFAULT PRIVILEGES for the PostgREST roles in

--- a/src/schemas/api/044_core_ratings.sql
+++ b/src/schemas/api/044_core_ratings.sql
@@ -1,0 +1,21 @@
+-- CORE ratings API view
+-- Thin passthrough of marts.core_ratings (CFBD CORE team ratings, 2016+).
+-- offense higher-better; defense LOWER-better (defense_rank is ASC);
+-- overall = offense - defense. through_week/through_season_type are as-of
+-- markers: in-season rows are snapshots through that week, not final ratings.
+-- Query with filters: ?season=eq.2025&order=overall_rank.asc
+-- Exposed via PostgREST as /api/core_ratings
+
+DROP VIEW IF EXISTS api.core_ratings;
+
+CREATE VIEW api.core_ratings AS
+SELECT *
+FROM marts.core_ratings;
+
+COMMENT ON VIEW api.core_ratings IS 'CFBD CORE ratings by team-season (2016+): overall/offense/defense with in-season overall_rank/offense_rank/defense_rank (defense ranked ascending -- lower is better) and through_week as-of markers. Backed by marts.core_ratings.';
+
+-- Grants are part of the definition: an apply that DROPs/recreates the
+-- view would otherwise leave the PostgREST roles without read access
+-- (no ALTER DEFAULT PRIVILEGES for them in this database; analyst_ro is
+-- covered by the api-schema default privileges in public/012).
+GRANT SELECT ON api.core_ratings TO anon, authenticated;

--- a/src/schemas/api/validation_core_ratings.sql
+++ b/src/schemas/api/validation_core_ratings.sql
@@ -128,6 +128,16 @@ BEGIN
                 END IF;
             END LOOP;
         END LOOP;
+        -- Trajectory chain: the 013 rebuild must carry the rank/alias columns
+        -- public/002 and get_trajectory_averages() select (the 2026-08-08
+        -- drift), and they must be populated, not just present.
+        SELECT COUNT(*) INTO total
+        FROM public.team_season_trajectory
+        WHERE season = 2024 AND off_epa_rank IS NOT NULL AND def_epa_rank IS NOT NULL;
+        IF total < 100 THEN
+            RAISE EXCEPTION 'public.team_season_trajectory: only % 2024 rows with EPA ranks -- trajectory rebuild is broken', total;
+        END IF;
+
         RAISE NOTICE 'stage-2 embed validation passed';
     ELSE
         RAISE NOTICE 'stage-2 embed not applied yet -- skipped (d)';

--- a/src/schemas/api/validation_core_ratings.sql
+++ b/src/schemas/api/validation_core_ratings.sql
@@ -1,0 +1,137 @@
+-- Behavioral validation for the CORE ratings surface -- applied as its OWN
+-- file/transaction (stage 1: after marts 043 + api 044 + marts 028 + public
+-- 011; stage 2: after the team_season_summary rebuild) so a failed assertion
+-- reports without rolling back the DDL. Read-only; safe to re-run any time
+-- as a health check.
+--
+-- Assertion groups:
+--   (a) freshness surface: marts.data_freshness carries 24 tracked tables
+--       including a core_ratings row with real pg_stat activity (a typo'd
+--       schema/table name in 028's VALUES list degrades silently into a
+--       permanently-stale row -- this is the guard).
+--   (b) mart shape: api.core_ratings row floor and internal consistency
+--       (overall = offense - defense; defense_rank = 1 is the season's
+--       LOWEST defense value).
+--   (c) grant tripwires, checked with has_table_privilege rather than SET
+--       ROLE (runner may not hold the roles): anon/authenticated kept
+--       SELECT on api.core_ratings AND on marts.data_freshness (the plain
+--       SQL RPC public.get_data_freshness executes as the caller).
+--   (d) stage-2 embed: team_season_summary carries core_* columns and the
+--       CASCADE-dropped api views were all re-created with grants intact.
+--       Guarded to no-op before stage 2 so this file validates stage 1 alone.
+
+DO $$
+DECLARE
+    tracked INT;
+    fresh RECORD;
+    total BIGINT;
+    bad_identity BIGINT;
+    best_defense_rank_value NUMERIC;
+    min_defense_value NUMERIC;
+    role_name TEXT;
+    view_name TEXT;
+    stage2 BOOLEAN;
+BEGIN
+    -- (a) freshness tracking
+    SELECT COUNT(*) INTO tracked FROM marts.data_freshness;
+    IF tracked <> 24 THEN
+        RAISE EXCEPTION 'data_freshness: expected 24 tracked tables, found %', tracked;
+    END IF;
+
+    SELECT * INTO fresh
+    FROM marts.data_freshness
+    WHERE schema_name = 'ratings' AND table_name = 'core_ratings';
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'data_freshness: no ratings.core_ratings row';
+    END IF;
+    IF fresh.row_count = 0 OR fresh.days_since_activity IS NULL THEN
+        RAISE EXCEPTION 'data_freshness: core_ratings row looks like a name typo (row_count=%, days_since_activity=%)',
+            fresh.row_count, fresh.days_since_activity;
+    END IF;
+    RAISE NOTICE 'data_freshness core_ratings: % rows, days_since_activity=%, stale=%',
+        fresh.row_count, fresh.days_since_activity, fresh.is_stale;
+
+    -- (b) mart shape and internal consistency
+    SELECT COUNT(*) INTO total FROM api.core_ratings;
+    RAISE NOTICE 'api.core_ratings rows: %', total;
+    IF total < 1000 THEN
+        RAISE EXCEPTION 'api.core_ratings: implausibly few rows (%) -- 2016-2025 backfill should give 1300+', total;
+    END IF;
+
+    SELECT COUNT(*) INTO bad_identity
+    FROM api.core_ratings
+    WHERE ABS(overall - (offense - defense)) > 0.05;
+    IF bad_identity > 0 THEN
+        RAISE EXCEPTION 'api.core_ratings: % rows violate overall = offense - defense', bad_identity;
+    END IF;
+
+    SELECT defense INTO best_defense_rank_value
+    FROM api.core_ratings WHERE season = 2024 AND defense_rank = 1 LIMIT 1;
+    SELECT MIN(defense) INTO min_defense_value
+    FROM api.core_ratings WHERE season = 2024;
+    IF best_defense_rank_value IS DISTINCT FROM min_defense_value THEN
+        RAISE EXCEPTION 'api.core_ratings: defense_rank=1 (%) is not the lowest 2024 defense (%) -- rank direction is wrong',
+            best_defense_rank_value, min_defense_value;
+    END IF;
+
+    -- (c) grant tripwires
+    FOREACH role_name IN ARRAY ARRAY['anon', 'authenticated'] LOOP
+        IF NOT has_table_privilege(role_name, 'api.core_ratings', 'SELECT') THEN
+            RAISE EXCEPTION 'api.core_ratings: role % lost SELECT after apply', role_name;
+        END IF;
+        IF NOT has_table_privilege(role_name, 'marts.data_freshness', 'SELECT') THEN
+            RAISE EXCEPTION 'marts.data_freshness: role % lost SELECT after 028 re-apply -- public.get_data_freshness() RPC is broken for PostgREST callers', role_name;
+        END IF;
+    END LOOP;
+
+    -- (d) stage-2 embed (no-op until team_season_summary carries core_overall)
+    SELECT EXISTS (
+        SELECT 1 FROM pg_attribute a
+        JOIN pg_class c ON a.attrelid = c.oid
+        JOIN pg_namespace n ON c.relnamespace = n.oid
+        WHERE n.nspname = 'marts' AND c.relname = 'team_season_summary'
+          AND a.attname = 'core_overall' AND NOT a.attisdropped
+    ) INTO stage2;
+
+    IF stage2 THEN
+        SELECT COUNT(*) INTO total
+        FROM marts.team_season_summary
+        WHERE season = 2024 AND core_overall IS NOT NULL;
+        IF total < 100 THEN
+            RAISE EXCEPTION 'team_season_summary: only % rows have core_overall for 2024 -- embed join is broken', total;
+        END IF;
+
+        -- Every matview the team_season_summary CASCADE drops must be rebuilt.
+        FOREACH view_name IN ARRAY ARRAY[
+            'marts.team_season_trajectory', 'marts.coaching_tenure',
+            'marts.recruiting_roi', 'marts.transfer_portal_impact',
+            'marts.conference_comparison'
+        ] LOOP
+            IF to_regclass(view_name) IS NULL THEN
+                RAISE EXCEPTION '% was CASCADE-dropped by the team_season_summary rebuild and not re-created', view_name;
+            END IF;
+        END LOOP;
+
+        -- Every view the CASCADE drops must be back, readable by PostgREST roles.
+        FOREACH view_name IN ARRAY ARRAY[
+            'api.team_detail', 'api.team_history', 'api.matchup',
+            'api.leaderboard_teams', 'api.coaching_history', 'api.recruiting_roi',
+            'api.transfer_portal_impact', 'api.conference_comparison',
+            'public.team_season_trajectory'
+        ] LOOP
+            IF to_regclass(view_name) IS NULL THEN
+                RAISE EXCEPTION '% was CASCADE-dropped by the team_season_summary rebuild and not re-created', view_name;
+            END IF;
+            FOREACH role_name IN ARRAY ARRAY['anon', 'authenticated'] LOOP
+                IF NOT has_table_privilege(role_name, view_name, 'SELECT') THEN
+                    RAISE EXCEPTION '%: role % lost SELECT after the stage-2 rebuild', view_name, role_name;
+                END IF;
+            END LOOP;
+        END LOOP;
+        RAISE NOTICE 'stage-2 embed validation passed';
+    ELSE
+        RAISE NOTICE 'stage-2 embed not applied yet -- skipped (d)';
+    END IF;
+
+    RAISE NOTICE 'core ratings validation passed';
+END $$;

--- a/src/schemas/functions/refresh_all_marts.sql
+++ b/src/schemas/functions/refresh_all_marts.sql
@@ -2,7 +2,8 @@
 --
 -- Layers:
 --   1: _game_epa_calc, play_epa, player_comparison, conference_head_to_head, team_wepa_season,
---      player_wepa_season, returning_production, player_usage, team_ats_records (no mart dependencies)
+--      player_wepa_season, returning_production, player_usage, team_ats_records, core_ratings,
+--      penalty_log, team_penalty_box (no mart dependencies)
 --   2: team_epa_season, team_season_summary, player_game_epa, defensive_havoc, scoring_opportunities,
 --      team_playcalling_tendencies, team_situational_success
 --   3: situational_splits, player_season_epa, coach_record, matchup_history, recruiting_class,
@@ -39,7 +40,12 @@ BEGIN
         'player_wepa_season',
         'returning_production',
         'player_usage',
-        'team_ats_records'
+        'team_ats_records',
+        'core_ratings',
+        -- penalty_log/team_penalty_box were in scripts/refresh_marts.py but
+        -- missing here (drift); repaired alongside the core_ratings addition.
+        'penalty_log',
+        'team_penalty_box'
     ];
     v_layer := 1;
 
@@ -232,5 +238,5 @@ END;
 $$;
 
 COMMENT ON FUNCTION marts.refresh_all IS
-'Refreshes all 39 materialized views in the marts schema in dependency order (7 layers). '
+'Refreshes all 42 materialized views in the marts schema in dependency order (7 layers). '
 'Returns timing and status for each view. Errors are caught per-view so one failure does not abort the rest.';

--- a/src/schemas/marts/001_team_season_summary.sql
+++ b/src/schemas/marts/001_team_season_summary.sql
@@ -110,6 +110,11 @@ SELECT
     sp."defense__rating" AS sp_defense,
     elo.elo,
     fpi.fpi,
+    -- CORE covers 2016+ only: NULL means not-rated (pre-2016 or non-CORE
+    -- team), never zero. core_defense is LOWER-better.
+    cr.overall AS core_overall,
+    cr.offense AS core_offense,
+    cr.defense AS core_defense,
 
     -- Recruiting
     rec.rank AS recruiting_rank,
@@ -119,6 +124,7 @@ FROM team_records tr
 LEFT JOIN ratings.sp_ratings sp ON tr.team = sp.team AND tr.season = sp.year
 LEFT JOIN ratings.elo_ratings elo ON tr.team = elo.team AND tr.season = elo.year
 LEFT JOIN ratings.fpi_ratings fpi ON tr.team = fpi.team AND tr.season = fpi.year
+LEFT JOIN ratings.core_ratings cr ON tr.team = cr.team AND tr.season = cr.year
 LEFT JOIN recruiting.team_recruiting rec ON tr.team = rec.team AND tr.season = rec.year;
 
 -- Required for REFRESH CONCURRENTLY

--- a/src/schemas/marts/013_team_season_trajectory.sql
+++ b/src/schemas/marts/013_team_season_trajectory.sql
@@ -1,10 +1,45 @@
 -- Team performance trajectory year-over-year with era awareness
--- Depends on: marts.team_epa_season, ref.eras
+-- Depends on: marts.team_epa_season, marts.team_season_summary,
+--             marts.defensive_havoc, ref.eras, core.games, ref.teams
+--
+-- 2026-08-08: reconstructed to carry off_epa_rank/def_epa_rank and the
+-- wins/games column names that public.team_season_trajectory (public/002) and
+-- get_trajectory_averages (public/008) select. The live matview had these
+-- columns from an uncommitted apply; this file had drifted behind it, which
+-- surfaced when the CORE-ratings stage-2 deploy rebuilt the matview from
+-- source (the team_season_summary CASCADE). Rank semantics copied from
+-- public.team_epa_season in public/002: RANK within (season, classification)
+-- -- classification season-accurate from core.games with ref.teams fallback --
+-- by epa_per_play DESC for offense and defensive_havoc.opp_epa_per_play ASC
+-- (999 when NULL) for defense. The pre-drift names (total_wins, games_played,
+-- ...) are kept alongside the aliases so both column vocabularies resolve.
 
 DROP MATERIALIZED VIEW IF EXISTS marts.team_season_trajectory CASCADE;
 
 CREATE MATERIALIZED VIEW marts.team_season_trajectory AS
-WITH team_metrics AS (
+WITH team_season_class AS (
+    -- Season-accurate classification from the games actually played
+    SELECT team, season, MAX(classification) AS classification
+    FROM (
+        SELECT g.home_team AS team, g.season, g.home_classification AS classification
+        FROM core.games g
+        WHERE g.home_classification IS NOT NULL
+        UNION ALL
+        SELECT g.away_team, g.season, g.away_classification
+        FROM core.games g
+        WHERE g.away_classification IS NOT NULL
+    ) x
+    GROUP BY team, season
+),
+teams_deduped AS (
+    -- ref.teams has ~35 duplicate school names; pick FBS classification first, else first row
+    -- fallback only: current membership, used when core.games has no rows for a team-season
+    SELECT DISTINCT ON (school)
+        school, classification
+    FROM ref.teams
+    ORDER BY school, classification NULLS LAST
+),
+team_metrics AS (
     SELECT
         t.team,
         t.season,
@@ -20,10 +55,25 @@ WITH team_metrics AS (
         s.conf_losses,
         -- Recruiting rank
         r.rank AS recruiting_rank,
-        r.points AS recruiting_points
+        r.points AS recruiting_points,
+        -- EPA ranks within (season, classification), matching public.team_epa_season
+        (RANK() OVER (
+            PARTITION BY t.season, COALESCE(tsc.classification, td.classification)
+            ORDER BY t.epa_per_play DESC
+        ))::INT AS off_epa_rank,
+        (RANK() OVER (
+            PARTITION BY t.season, COALESCE(tsc.classification, td.classification)
+            ORDER BY COALESCE(d.opp_epa_per_play, 999::NUMERIC)
+        ))::INT AS def_epa_rank
     FROM marts.team_epa_season t
     LEFT JOIN marts.team_season_summary s
         ON t.team = s.team AND t.season = s.season
+    LEFT JOIN marts.defensive_havoc d
+        ON t.team = d.team AND t.season = d.season
+    LEFT JOIN team_season_class tsc
+        ON tsc.team = t.team AND tsc.season = t.season
+    LEFT JOIN teams_deduped td
+        ON td.school = t.team
     LEFT JOIN recruiting.team_recruiting r
         ON t.team = r.team AND t.season = r.year
 )
@@ -35,7 +85,9 @@ SELECT
     m.epa_tier,
     m.total_plays,
     m.games_played,
+    m.games_played AS games,
     m.total_wins,
+    m.total_wins AS wins,
     m.total_losses,
     -- Win percentage
     CASE
@@ -47,6 +99,8 @@ SELECT
     m.conf_losses,
     m.recruiting_rank,
     m.recruiting_points,
+    m.off_epa_rank,
+    m.def_epa_rank,
     -- Era assignment (primary era for the season)
     (SELECT e.era_code FROM ref.get_era(m.season::INT) e ORDER BY e.era_code LIMIT 1) AS era_code,
     (SELECT e.era_name FROM ref.get_era(m.season::INT) e ORDER BY e.era_code LIMIT 1) AS era_name,

--- a/src/schemas/marts/028_data_freshness.sql
+++ b/src/schemas/marts/028_data_freshness.sql
@@ -23,6 +23,7 @@ WITH tracked_tables AS (
         ('ratings', 'elo_ratings', 'weekly'),
         ('ratings', 'fpi_ratings', 'seasonal'),
         ('ratings', 'srs_ratings', 'seasonal'),
+        ('ratings', 'core_ratings', 'weekly'),
         ('recruiting', 'recruits', 'seasonal'),
         ('recruiting', 'team_recruiting', 'seasonal'),
         ('recruiting', 'transfer_portal', 'seasonal'),
@@ -72,3 +73,12 @@ ORDER BY tt.schema_name, tt.table_name;
 
 -- Required for REFRESH CONCURRENTLY
 CREATE UNIQUE INDEX ON marts.data_freshness (schema_name, table_name);
+
+-- Re-grant on every apply: this file DROPs the matview, which discards its
+-- grants (no ALTER DEFAULT PRIVILEGES for the PostgREST roles in marts), and
+-- public.get_data_freshness() is a plain SQL function executing as the CALLER,
+-- so anon/authenticated need direct SELECT here for the RPC to work. Do NOT
+-- fix a lost grant by re-running migrations/grant_read_access_for_security_invoker.sql
+-- -- its blanket GRANT ... ALL TABLES IN SCHEMA analytics would re-grant
+-- analytics.ep_states, undoing the deliberate revoke in api/043_expected_points.sql.
+GRANT SELECT ON marts.data_freshness TO anon, authenticated;

--- a/src/schemas/marts/043_core_ratings.sql
+++ b/src/schemas/marts/043_core_ratings.sql
@@ -1,0 +1,56 @@
+-- marts.core_ratings
+-- CFBD CORE (Context & Opponent-Relative Efficiency) ratings by team-season:
+-- passthrough of ratings.core_ratings (year -> season).
+-- Grain: (team, season) -- one row per team per season, 2016+ only (CFBD
+-- publishes retrospective CORE from 2016; earlier seasons are absent, not zero).
+-- Semantics: offense = points created above average per 100 qualifying plays
+-- (higher is better); defense = points allowed above average per 100 plays
+-- (LOWER is better); overall = offense - defense. through_week /
+-- through_season_type are as-of markers: in-season the row is a snapshot
+-- through that week, advanced in place by the daily merge load.
+
+DROP MATERIALIZED VIEW IF EXISTS marts.core_ratings CASCADE;
+
+CREATE MATERIALIZED VIEW marts.core_ratings AS
+SELECT
+    r.year AS season,
+    r.team,
+    r.conference,
+
+    -- Ratings
+    ROUND(r.overall::numeric, 2) AS overall,
+    ROUND(r.offense::numeric, 2) AS offense,
+    ROUND(r.defense::numeric, 2) AS defense,
+
+    -- Qualifying-play volume behind the ratings
+    r.offense_plays,
+    r.defense_plays,
+
+    -- As-of markers + model provenance
+    r.through_week,
+    r.through_season_type,
+    r.model_version,
+
+    -- Computed rankings within season. Defense ranked ASC: lower is better.
+    RANK() OVER (PARTITION BY r.year ORDER BY r.overall DESC NULLS LAST) AS overall_rank,
+    RANK() OVER (PARTITION BY r.year ORDER BY r.offense DESC NULLS LAST) AS offense_rank,
+    RANK() OVER (PARTITION BY r.year ORDER BY r.defense ASC NULLS LAST) AS defense_rank
+
+FROM ratings.core_ratings r;
+
+-- Required for REFRESH CONCURRENTLY
+CREATE UNIQUE INDEX ON marts.core_ratings (team, season);
+
+-- Query indexes
+CREATE INDEX ON marts.core_ratings (season);
+CREATE INDEX ON marts.core_ratings (season, overall_rank);
+
+-- Empty-guard: ratings.core_ratings backs this mart. If it ever refreshes to
+-- zero rows, fail loudly at deploy time instead of silently serving an empty
+-- mart downstream.
+DO $$
+BEGIN
+    IF (SELECT count(*) FROM marts.core_ratings) = 0 THEN
+        RAISE EXCEPTION 'marts.core_ratings is empty: ratings.core_ratings has no rows. Run the ratings backfill (2016+, e.g. deploy-schema action=backfill sources=ratings) and re-apply before use.';
+    END IF;
+END $$;

--- a/tests/test_api_views.py
+++ b/tests/test_api_views.py
@@ -51,6 +51,10 @@ TEAM_DETAIL_COLUMNS = {
     "sp_defense",
     "elo",
     "fpi",
+    # CORE ratings (2016+; NULL = not-rated). Added 2026-08-08.
+    "core_overall",
+    "core_offense",
+    "core_defense",
     "epa_per_play",
     "epa_tier",
     "success_rate",
@@ -77,6 +81,10 @@ TEAM_HISTORY_COLUMNS = {
     "sp_defense",
     "elo",
     "fpi",
+    # CORE ratings (2016+; NULL = not-rated). Added 2026-08-08.
+    "core_overall",
+    "core_offense",
+    "core_defense",
     "epa_per_play",
     "epa_tier",
     "success_rate",
@@ -269,6 +277,25 @@ POLL_RANKINGS_COLUMNS = {
     "conference",
     "first_place_votes",
     "points",
+}
+
+# CFBD CORE ratings passthrough (api.core_ratings, added 2026-08-08).
+# defense is LOWER-better; defense_rank is ranked ascending accordingly.
+CORE_RATINGS_COLUMNS = {
+    "season",
+    "team",
+    "conference",
+    "overall",
+    "offense",
+    "defense",
+    "offense_plays",
+    "defense_plays",
+    "through_week",
+    "through_season_type",
+    "model_version",
+    "overall_rank",
+    "offense_rank",
+    "defense_rank",
 }
 
 TEAM_ELO_COLUMNS = {
@@ -654,6 +681,10 @@ class TestViewsExistAndReturnRows:
             # Drive-chain EP: ~160 states x 3 eras, all written in one compute
             # run -- conservative floor of two eras' worth.
             ("api.expected_points", 300),
+            # CFBD CORE ratings: ~130-136 FBS teams x 10 backfilled seasons
+            # (2016-2025) = ~1,300+; conservative floor below the backfill,
+            # 2026 in-season rows are upside.
+            ("api.core_ratings", 1000),
         ],
         ids=[
             "team_detail",
@@ -677,6 +708,7 @@ class TestViewsExistAndReturnRows:
             "team_penalties",
             "season_outlook",
             "expected_points",
+            "core_ratings",
         ],
     )
     def test_view_returns_rows(self, db_conn, view_name, min_rows):
@@ -723,6 +755,7 @@ class TestViewColumns:
             ("api.team_penalties", TEAM_PENALTIES_COLUMNS),
             ("api.season_outlook", SEASON_OUTLOOK_COLUMNS),
             ("api.expected_points", EXPECTED_POINTS_COLUMNS),
+            ("api.core_ratings", CORE_RATINGS_COLUMNS),
         ],
         ids=[
             "team_detail",
@@ -750,6 +783,7 @@ class TestViewColumns:
             "team_penalties",
             "season_outlook",
             "expected_points",
+            "core_ratings",
         ],
     )
     def test_columns_present(self, db_conn, view_name, expected_columns):

--- a/tests/test_marts.py
+++ b/tests/test_marts.py
@@ -18,6 +18,7 @@ MARTS_VIEWS = [
     "conference_comparison",
     "conference_era_summary",
     "conference_head_to_head",
+    "core_ratings",
     "data_freshness",
     "defensive_havoc",
     "matchup_edges",
@@ -153,6 +154,10 @@ class TestTeamSeasonSummaryColumns:
         "sp_defense",
         "elo",
         "fpi",
+        # CORE ratings (2016+; NULL = not-rated). Added 2026-08-08.
+        "core_overall",
+        "core_offense",
+        "core_defense",
         "recruiting_rank",
         "recruiting_points",
     }


### PR DESCRIPTION
Follow-up to #72/#73: `ratings.core_ratings` is loaded (2016–2025 + daily) but was invisible downstream — not in the `get_data_freshness()` tracked set, and not on the contract surface. This PR fixes both. **Heads-up for cfb-app**: additive contract change — see `docs/handoffs/2026-08-08-core-ratings-for-cfb-app.md`.

## Changes

**Freshness** — `ratings.core_ratings` joins the tracked set in `marts.data_freshness` (24 tables, `weekly`). The rebuild file now carries its own `GRANT SELECT ... TO anon, authenticated`: the `DROP` discards grants, and `public.get_data_freshness()` executes as the caller, so a rebuild without it silently breaks the PostgREST RPC. Deliberately *not* fixed via the blanket grant migration, which would re-grant `analytics.ep_states` and undo the api/043 revoke.

**Dedicated surface** — `marts.core_ratings` + `api.core_ratings` passthrough pair (029/019 pattern): `year→season`, in-season `overall_rank`/`offense_rank`/`defense_rank` (**defense ranked ASC — lower is better**), empty-guard, unique `(team, season)` index for concurrent refresh.

**Team-view embed** — `team_season_summary` gains `core_overall`/`core_offense`/`core_defense` (fourth ratings join), passed through `api.team_detail` and `api.team_history`. Additive per contract rule 2 (precedent: 2026-07-23 `sp_offense`/`sp_defense`). NULL pre-2016 = not-rated, never zero.

**Refresh chain** — registered in `refresh_marts.py` Layer 1, `tests/test_marts.py`, and `marts.refresh_all()` — which also repairs pre-existing drift: `penalty_log`/`team_penalty_box` were missing from the SQL function's Layer 1 (present in the Python list); comment count corrected to 42.

**Validation** — `src/schemas/api/validation_core_ratings.sql` (re-runnable): 24-row freshness check with typo guard (a misspelled table name degrades silently into a permanently-stale row), `overall = offense − defense` identity, defense-rank direction, grant tripwires, and stage-2 checks that every object the `team_season_summary` CASCADE drops came back readable.

**Docs** — SCHEMA_CONTRACT changelog + view/mart/RPC rows, cfb-app handoff doc, CLAUDE.md counts (42 matviews / 44 api views — previous numbers were stale).

Deliberately skipped: an index migration for `ratings.core_ratings` (~1,400 rows; only readers are the mart build and dlt's merge — an index is pure ceremony).

## Deploy (before merge — two stages via `deploy-schema.yml`)

Manifests committed under `deploys/`. Stage 1 (new surfaces + freshness): marts/043 → api/044 → marts/028 → public/011 → functions/refresh_all_marts → validation. Stage 2 (embed; rebuilds `team_season_summary`, whose CASCADE drops 5 marts + 8 api views + 1 public view, all re-applied in-manifest): marts 001/013/023/024/025/026 → api 001/002/004/005/015–018 → public/002 → validation. Deploy precedes merge so the daily refresh never sees an unregistered matview.

## Testing

- `ruff` clean; unit tests pass (1,401 passed; integration tests skip without DB and run against live during deploy).
- Deploy-time verification is in-band: empty-guard + validation assertions fail the workflow loudly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146xsoWFq7SsZJKxYgLqNFF

---
_Generated by [Claude Code](https://claude.ai/code/session_0146xsoWFq7SsZJKxYgLqNFF)_

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

CORE ratings are now available through a dedicated API view and embedded in team detail and history responses. The rebuilt trajectory materialized view preserves the ranking columns required by the public trajectory interface; the source-contract check reproduced the missing-column failure in the parent revision and passed on the current revision.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

The current revision passed the checked deployment-manifest, dependency-rebuild, grant, refresh-order, ranking, and public trajectory contract checks. The trajectory endpoint incompatibility present in the parent revision is corrected by the current materialized-view definition.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Before: HEAD^ contract run exited 1 due to the rebuilt trajectory mart/view missing off\_epa\_rank and def\_epa\_rank; After: HEAD contract run exited 0 with manifest sequencing, dependent rebuild declarations, API and freshness grants, ranking direction, refresh order, and trajectory projection columns all validated.
- The CORE deployment-contract validation script was run against HEAD^ and exited 1 because the rebuilt trajectory view lacked off\_epa\_rank and def\_epa\_rank.
- The same script was run against HEAD and exited 0, confirming manifest sequencing, rebuild declarations, API/freshness grants, rank direction, refresh order, and trajectory projection columns pass.
- Parsed both deployment manifests through the repository deployment planner and ran the refresh driver in dry-run mode, which produced the expected concurrent dependency order from CORE ratings through freshness.
- A live PostgreSQL refresh and database integration suite were attempted, but credentials were unavailable, so live DB validation was not exercised.

<a href="https://app.greptile.com/trex/runs/17939502/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["Reconstruct team\_season\_trajectory drift..."](https://github.com/rstover-fo/cfb-database/commit/e2074a40e0329f11cfe479b923716617698ab620) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51457096)</sub>

<!-- /greptile_comment -->