### PR TITLE
Rollout hotfixes: CFP response shapes, NCAA coercion, pooler statement timeout

### DIFF
--- a/.github/workflows/probe-endpoints.yml
+++ b/.github/workflows/probe-endpoints.yml
@@ -8,12 +8,6 @@ name: Probe 2026 Endpoints
 # No schedule: run it by hand when a response shape needs to be confirmed
 # before writing the corresponding dlt source module.
 #
-# The push trigger exists because workflow_dispatch resolves workflow files
-# against the default branch, and this workflow lives only on its feature
-# branch until merged: it fires only for pushes to that branch that touch
-# the probe files themselves, so ordinary source-work pushes never spend
-# API calls. Remove the push trigger once the file reaches main.
-#
 # Requires repo secret:
 #   CFBD_API_KEY - collegefootballdata.com API key
 
@@ -24,12 +18,6 @@ on:
         description: "Comma-separated probe numbers to run, e.g. 4,9,12 (default: all 13)"
         required: false
         type: string
-  push:
-    branches:
-      - claude/cfbd-cfb-package-updates-7iabg2
-    paths:
-      - .github/workflows/probe-endpoints.yml
-      - scripts/probe_2026_endpoints.py
 
 permissions:
   contents: read

--- a/scripts/refresh_marts.py
+++ b/scripts/refresh_marts.py
@@ -204,6 +204,16 @@ def refresh_marts(
     db_url = get_db_url()
     conn = psycopg2.connect(db_url)
 
+    # get_db_url() appends statement_timeout=0 as an `options=` STARTUP
+    # parameter, but Supabase's session pooler (Supavisor) silently ignores
+    # startup options -- the role-default 2-minute timeout still applied, and
+    # marts.play_epa (the one refresh that exceeds it under load) was
+    # cancelled at exactly ~120s in two runs on 2026-08-30. Setting it as a
+    # real session statement survives the pooler.
+    with conn.cursor() as _cur:
+        _cur.execute("SET statement_timeout = 0")
+    conn.commit()
+
     failures = 0
     try:
         for view in views:

--- a/scripts/refresh_marts.py
+++ b/scripts/refresh_marts.py
@@ -204,18 +204,20 @@ def refresh_marts(
     db_url = get_db_url()
     conn = psycopg2.connect(db_url)
 
-    # get_db_url() appends statement_timeout=0 as an `options=` STARTUP
-    # parameter, but Supabase's session pooler (Supavisor) silently ignores
-    # startup options -- the role-default 2-minute timeout still applied, and
-    # marts.play_epa (the one refresh that exceeds it under load) was
-    # cancelled at exactly ~120s in two runs on 2026-08-30. Setting it as a
-    # real session statement survives the pooler.
-    with conn.cursor() as _cur:
-        _cur.execute("SET statement_timeout = 0")
-    conn.commit()
-
     failures = 0
     try:
+        # get_db_url() appends statement_timeout=0 as an `options=` STARTUP
+        # parameter, but Supabase's session pooler (Supavisor) silently
+        # ignores startup options -- the role-default 2-minute timeout still
+        # applied, and marts.play_epa (the one refresh that exceeds it under
+        # load) was cancelled at exactly ~120s in two runs on 2026-08-30.
+        # Setting it as a real session statement survives the pooler; it
+        # lives inside this try so a setup failure still returns the pooled
+        # connection via the finally below.
+        with conn.cursor() as _cur:
+            _cur.execute("SET statement_timeout = 0")
+        conn.commit()
+
         for view in views:
             if not refresh_view(view, conn, concurrently, dry_run):
                 failures += 1

--- a/src/pipelines/sources/flatfile_parsers/ncaa.py
+++ b/src/pipelines/sources/flatfile_parsers/ncaa.py
@@ -172,12 +172,28 @@ PLAYER_STAT_COLUMNS = (
 )
 
 
+def _blank_to_none(value):
+    """Treat an empty or whitespace-only string as a missing value, same as
+    None. stats.ncaa.org's parquet exports ship ``''`` for some missing
+    numeric-ish fields (confirmed: ``ncaa_mfb_rosters_2025``'s ``height``
+    column has blank-string rows, which crashed ``float('')`` in
+    ``_height_inches`` -- ledger row ``ncaa_rosters:2025``) rather than a
+    proper null. Non-string values (including already-None) pass through
+    unchanged.
+    """
+    if isinstance(value, str) and value.strip() == "":
+        return None
+    return value
+
+
 def _to_float(value) -> float | None:
-    """Coerce a stats.ncaa.org numeric value to float, tolerating None.
+    """Coerce a stats.ncaa.org numeric value to float, tolerating None and
+    blank strings.
 
     Defensive against the observed comma-thousands-separator quirk (e.g.
     ``"1,043.20"``) -- strips commas from strings before casting.
     """
+    value = _blank_to_none(value)
     if value is None:
         return None
     if isinstance(value, str):
@@ -186,14 +202,18 @@ def _to_float(value) -> float | None:
 
 
 def _to_int(value) -> int | None:
-    """Coerce a stats.ncaa.org numeric-string id column to int, tolerating None."""
+    """Coerce a stats.ncaa.org numeric-string id column to int, tolerating
+    None and blank strings."""
+    value = _blank_to_none(value)
     if value is None:
         return None
     return int(value)
 
 
 def _height_inches(value: str | None) -> float | None:
-    """ "6-0" (feet-inches, stats.ncaa.org's roster height format) -> 72.0 inches."""
+    """ "6-0" (feet-inches, stats.ncaa.org's roster height format) -> 72.0
+    inches. Tolerates None and blank strings (see ``_blank_to_none``)."""
+    value = _blank_to_none(value)
     if value is None:
         return None
     if isinstance(value, str) and "-" in value:
@@ -277,7 +297,11 @@ def parse_schedule(raw: bytes, ctx: ParseContext) -> Iterator[dict]:
     out = []
 
     for row in rows:
-        if row.get("contest_id") is None or row.get("team_id") is None or row.get("season") is None:
+        if (
+            _blank_to_none(row.get("contest_id")) is None
+            or _blank_to_none(row.get("team_id")) is None
+            or row.get("season") is None
+        ):
             dropped_count += 1
             continue
 
@@ -318,7 +342,7 @@ def parse_teams(raw: bytes, ctx: ParseContext) -> Iterator[dict]:
     out = []
 
     for row in rows:
-        if row.get("team_id") is None or row.get("season") is None:
+        if _blank_to_none(row.get("team_id")) is None or row.get("season") is None:
             dropped_count += 1
             continue
 
@@ -344,6 +368,10 @@ def parse_rosters(raw: bytes, ctx: ParseContext) -> Iterator[dict]:
     same as ``ncaa_team_id`` -- verified by cross-referencing 82 players
     common to Alabama's 2024 and 2025 rosters by name: every one carries a
     different id between the two seasons (see module docstring).
+
+    ``height`` ships blank (``""``) for some rows (confirmed live:
+    ``ncaa_mfb_rosters_2025``) rather than null -- ``_height_inches`` treats
+    a blank string as missing and yields ``None``, not a crash.
     """
     table = pyarrow.parquet.read_table(io.BytesIO(raw))
     schema_names = set(table.column_names)
@@ -354,7 +382,11 @@ def parse_rosters(raw: bytes, ctx: ParseContext) -> Iterator[dict]:
     out = []
 
     for row in rows:
-        if row.get("team_id") is None or row.get("player_id") is None or row.get("season") is None:
+        if (
+            _blank_to_none(row.get("team_id")) is None
+            or _blank_to_none(row.get("player_id")) is None
+            or row.get("season") is None
+        ):
             dropped_count += 1
             continue
 
@@ -396,7 +428,7 @@ def parse_linescores(raw: bytes, ctx: ParseContext) -> Iterator[dict]:
 
     for row in rows:
         if (
-            row.get("contest_id") is None
+            _blank_to_none(row.get("contest_id")) is None
             or row.get("team") is None
             or row.get("period") is None
             or row.get("season") is None
@@ -452,8 +484,8 @@ def parse_player_stats(raw: bytes, ctx: ParseContext) -> Iterator[dict]:
 
     for row in rows:
         if (
-            row.get("contest_id") is None
-            or row.get("team_id") is None
+            _blank_to_none(row.get("contest_id")) is None
+            or _blank_to_none(row.get("team_id")) is None
             or row.get("category") is None
             or row.get("season") is None
         ):
@@ -511,7 +543,7 @@ def parse_team_stats(raw: bytes, ctx: ParseContext) -> Iterator[dict]:
 
     for row in rows:
         if (
-            row.get("contest_id") is None
+            _blank_to_none(row.get("contest_id")) is None
             or row.get("category") is None
             or row.get("stat") is None
             or row.get("period") is None
@@ -571,7 +603,7 @@ def parse_pbp(raw: bytes, ctx: ParseContext) -> Iterator[dict]:
 
     for row in rows:
         if (
-            row.get("contest_id") is None
+            _blank_to_none(row.get("contest_id")) is None
             or row.get("drive_number") is None
             or row.get("play_number") is None
             or row.get("season") is None

--- a/src/pipelines/sources/flatfile_parsers/ncaa.py
+++ b/src/pipelines/sources/flatfile_parsers/ncaa.py
@@ -212,12 +212,18 @@ def _to_int(value) -> int | None:
 
 def _height_inches(value: str | None) -> float | None:
     """ "6-0" (feet-inches, stats.ncaa.org's roster height format) -> 72.0
-    inches. Tolerates None and blank strings (see ``_blank_to_none``)."""
+    inches. Tolerates None and blank strings (see ``_blank_to_none``), and
+    malformed heights whose SPLIT PARTS are blank -- the real 2025 file
+    carries values like "6-" and "-" (found live 2026-08-30), so a blank
+    feet or inches part means the height is unusable and coerces to None
+    rather than crashing float('')."""
     value = _blank_to_none(value)
     if value is None:
         return None
     if isinstance(value, str) and "-" in value:
         feet, _, inches = value.partition("-")
+        if feet.strip() == "" or inches.strip() == "":
+            return None
         return float(feet) * 12 + float(inches)
     return float(value)
 

--- a/src/pipelines/sources/playoffs.py
+++ b/src/pipelines/sources/playoffs.py
@@ -59,10 +59,18 @@ def cfp_bracket_resource(years: list[int]) -> Iterator[dict]:
     and `rounds` arrays (and `rounds`' nested `matchups`/`slots`) via the
     standard `_dlt_parent_id` mechanism -- no manual flattening needed here.
 
-    The 2024 response carried a top-level `season` field; the 2025 response
-    evidently omits it, which left `season` (the primary key) unbound and
-    failed normalize. `season` is stamped from the request year whenever
-    the record doesn't already carry one, so both shapes load correctly.
+    Response shape is not stable across seasons: the 2024 response is a
+    one-element JSON array wrapping the bracket document (with a top-level
+    `season` field), while the 2025 response is a bare JSON object -- no
+    wrapping array -- which also omits `season`. The array-vs-object
+    difference first broke `yield from data` (iterating a dict yields its
+    string keys, surfacing as `'str' object has no attribute 'get'` at
+    extract time); the missing `season` field separately left the primary
+    key unbound and failed normalize. Both are handled here: the response is
+    normalized to a list of records (a dict is wrapped as a one-element
+    list) before iterating, and `season` is stamped from the request year
+    whenever a record doesn't already carry one -- so both shapes load
+    correctly.
 
     Args:
         years: List of years to load the bracket for
@@ -88,7 +96,23 @@ def cfp_bracket_resource(years: list[int]) -> Iterator[dict]:
                 logger.info(f"No CFP bracket data for {year}, skipping")
                 continue
 
-            for record in data:
+            if isinstance(data, dict):
+                records = [data]
+            elif isinstance(data, list):
+                records = data
+            else:
+                logger.warning(
+                    f"Unexpected /playoffs/cfp response type {type(data).__name__} "
+                    f"for {year}, skipping"
+                )
+                continue
+
+            for record in records:
+                if not isinstance(record, dict):
+                    logger.warning(
+                        f"Skipping non-dict CFP bracket record ({type(record).__name__}) for {year}"
+                    )
+                    continue
                 if record.get("season") is None:
                     record["season"] = year
                 yield record

--- a/src/pipelines/sources/playoffs.py
+++ b/src/pipelines/sources/playoffs.py
@@ -59,6 +59,11 @@ def cfp_bracket_resource(years: list[int]) -> Iterator[dict]:
     and `rounds` arrays (and `rounds`' nested `matchups`/`slots`) via the
     standard `_dlt_parent_id` mechanism -- no manual flattening needed here.
 
+    The 2024 response carried a top-level `season` field; the 2025 response
+    evidently omits it, which left `season` (the primary key) unbound and
+    failed normalize. `season` is stamped from the request year whenever
+    the record doesn't already carry one, so both shapes load correctly.
+
     Args:
         years: List of years to load the bracket for
     """
@@ -83,7 +88,10 @@ def cfp_bracket_resource(years: list[int]) -> Iterator[dict]:
                 logger.info(f"No CFP bracket data for {year}, skipping")
                 continue
 
-            yield from data
+            for record in data:
+                if record.get("season") is None:
+                    record["season"] = year
+                yield record
 
     finally:
         client.close()

--- a/tests/test_flatfile_ncaa.py
+++ b/tests/test_flatfile_ncaa.py
@@ -39,6 +39,23 @@ def _ctx(source: str, season: int = 2025) -> ParseContext:
 # ---------------------------------------------------------------------------
 
 
+class TestBlankToNone:
+    def test_passes_through_none(self):
+        assert ncaa._blank_to_none(None) is None
+
+    def test_empty_string_becomes_none(self):
+        assert ncaa._blank_to_none("") is None
+
+    def test_whitespace_only_string_becomes_none(self):
+        assert ncaa._blank_to_none("   ") is None
+
+    def test_non_blank_string_passes_through(self):
+        assert ncaa._blank_to_none("6-0") == "6-0"
+
+    def test_non_string_passes_through(self):
+        assert ncaa._blank_to_none(7) == 7
+
+
 class TestToFloat:
     def test_passes_through_none(self):
         assert ncaa._to_float(None) is None
@@ -52,6 +69,31 @@ class TestToFloat:
     def test_casts_native_number(self):
         assert ncaa._to_float(7) == 7.0
 
+    def test_empty_string_returns_none(self):
+        """Live crash: ncaa_mfb_rosters_2025 shipped '' for some numeric-ish
+        fields -- float('') raises ValueError without this guard."""
+        assert ncaa._to_float("") is None
+
+    def test_whitespace_only_string_returns_none(self):
+        assert ncaa._to_float("   ") is None
+
+
+class TestToInt:
+    def test_passes_through_none(self):
+        assert ncaa._to_int(None) is None
+
+    def test_casts_numeric_string(self):
+        assert ncaa._to_int("42") == 42
+
+    def test_casts_native_number(self):
+        assert ncaa._to_int(42) == 42
+
+    def test_empty_string_returns_none(self):
+        assert ncaa._to_int("") is None
+
+    def test_whitespace_only_string_returns_none(self):
+        assert ncaa._to_int("  ") is None
+
 
 class TestHeightInches:
     def test_passes_through_none(self):
@@ -60,6 +102,15 @@ class TestHeightInches:
     def test_parses_feet_inches(self):
         assert ncaa._height_inches("6-0") == 72.0
         assert ncaa._height_inches("5-11") == 71.0
+
+    def test_empty_string_returns_none(self):
+        """Exact live failure: ledger row ncaa_rosters:2025 --
+        `could not convert string to float: ''` from ``float('')`` on a
+        blank height value."""
+        assert ncaa._height_inches("") is None
+
+    def test_whitespace_only_string_returns_none(self):
+        assert ncaa._height_inches("   ") is None
 
 
 class TestParseDates:
@@ -127,6 +178,52 @@ class TestParseSchedule:
         with pytest.raises(ParserStructureError, match="missing column.*contest_id"):
             list(ncaa.parse_schedule(buf.getvalue(), _ctx("ncaa_schedule")))
 
+    def test_blank_contest_id_dropped_as_null_pk_component(self, caplog):
+        schema = pa.schema(
+            [
+                ("team_id", pa.string()),
+                ("contest_id", pa.string()),
+                ("season", pa.int64()),
+            ]
+        )
+        buf = io.BytesIO()
+        pyarrow.parquet.write_table(
+            pa.table({"team_id": ["1"], "contest_id": [""], "season": [2025]}, schema=schema),
+            buf,
+        )
+        with caplog.at_level(logging.INFO):
+            rows = list(ncaa.parse_schedule(buf.getvalue(), _ctx("ncaa_schedule")))
+        assert rows == []
+        assert "dropped 1" in caplog.text
+
+    def test_blank_espn_game_id_parses_to_none_no_exception(self):
+        """espn_game_id is not a PK component -- blank is a null value, kept
+        (not dropped), same _to_int() idiom as everywhere else."""
+        schema = pa.schema(
+            [
+                ("team_id", pa.string()),
+                ("contest_id", pa.string()),
+                ("espn_game_id", pa.string()),
+                ("season", pa.int64()),
+            ]
+        )
+        buf = io.BytesIO()
+        pyarrow.parquet.write_table(
+            pa.table(
+                {
+                    "team_id": ["1"],
+                    "contest_id": ["100"],
+                    "espn_game_id": [""],
+                    "season": [2025],
+                },
+                schema=schema,
+            ),
+            buf,
+        )
+        rows = list(ncaa.parse_schedule(buf.getvalue(), _ctx("ncaa_schedule")))
+        assert len(rows) == 1
+        assert rows[0]["espn_game_id"] is None
+
 
 # ---------------------------------------------------------------------------
 # parse_teams
@@ -184,6 +281,88 @@ class TestParseRosters:
         )
         with pytest.raises(ParserStructureError, match="missing column.*player_id"):
             list(ncaa.parse_rosters(buf.getvalue(), _ctx("ncaa_rosters")))
+
+    def test_empty_string_height_parses_to_none_no_exception(self):
+        """Reproduces the live ncaa_rosters:2025 failure
+        (`could not convert string to float: ''`) -- the checked-in fixture
+        slice happens not to contain a blank height row, so this is built
+        in-test. A blank height is a null value, not a dropped row (height
+        is not a PK component)."""
+        schema = pa.schema(
+            [
+                ("team_id", pa.string()),
+                ("player_id", pa.string()),
+                ("player_name", pa.string()),
+                ("height", pa.string()),
+                ("season", pa.int64()),
+            ]
+        )
+        buf = io.BytesIO()
+        pyarrow.parquet.write_table(
+            pa.table(
+                {
+                    "team_id": ["605986"],
+                    "player_id": ["9999999"],
+                    "player_name": ["Blank Height Player"],
+                    "height": [""],
+                    "season": [2025],
+                },
+                schema=schema,
+            ),
+            buf,
+        )
+        rows = list(ncaa.parse_rosters(buf.getvalue(), _ctx("ncaa_rosters")))
+        assert len(rows) == 1
+        assert rows[0]["height_inches"] is None
+
+    def test_whitespace_only_height_parses_to_none_no_exception(self):
+        schema = pa.schema(
+            [
+                ("team_id", pa.string()),
+                ("player_id", pa.string()),
+                ("player_name", pa.string()),
+                ("height", pa.string()),
+                ("season", pa.int64()),
+            ]
+        )
+        buf = io.BytesIO()
+        pyarrow.parquet.write_table(
+            pa.table(
+                {
+                    "team_id": ["605986"],
+                    "player_id": ["9999998"],
+                    "player_name": ["Whitespace Height Player"],
+                    "height": ["   "],
+                    "season": [2025],
+                },
+                schema=schema,
+            ),
+            buf,
+        )
+        rows = list(ncaa.parse_rosters(buf.getvalue(), _ctx("ncaa_rosters")))
+        assert len(rows) == 1
+        assert rows[0]["height_inches"] is None
+
+    def test_blank_team_id_dropped_as_null_pk_component(self, caplog):
+        """A blank string is a null value -- but team_id is a PK component,
+        so it follows the existing null-PK-drop convention (drop + log
+        count) rather than loading with a null ncaa_team_id."""
+        schema = pa.schema(
+            [
+                ("team_id", pa.string()),
+                ("player_id", pa.string()),
+                ("season", pa.int64()),
+            ]
+        )
+        buf = io.BytesIO()
+        pyarrow.parquet.write_table(
+            pa.table({"team_id": [""], "player_id": ["1"], "season": [2025]}, schema=schema),
+            buf,
+        )
+        with caplog.at_level(logging.INFO):
+            rows = list(ncaa.parse_rosters(buf.getvalue(), _ctx("ncaa_rosters")))
+        assert rows == []
+        assert "dropped 1" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -288,6 +467,59 @@ class TestParsePlayerStats:
         with pytest.raises(ParserStructureError, match="missing column.*category"):
             list(ncaa.parse_player_stats(buf.getvalue(), _ctx("ncaa_player_stats")))
 
+    def test_empty_string_stat_value_parses_to_none_no_exception(self):
+        """Same _to_float() idiom as parse_rosters' height -- hardened
+        identically even though the live run loaded this parser's data
+        fine (no blank rows in that day's file)."""
+        schema = pa.schema(
+            [
+                ("contest_id", pa.string()),
+                ("team_id", pa.string()),
+                ("category", pa.string()),
+                ("pass_eff", pa.string()),
+                ("season", pa.int64()),
+            ]
+        )
+        buf = io.BytesIO()
+        pyarrow.parquet.write_table(
+            pa.table(
+                {
+                    "contest_id": ["1"],
+                    "team_id": ["1"],
+                    "category": ["passing"],
+                    "pass_eff": [""],
+                    "season": [2025],
+                },
+                schema=schema,
+            ),
+            buf,
+        )
+        rows = list(ncaa.parse_player_stats(buf.getvalue(), _ctx("ncaa_player_stats")))
+        assert len(rows) == 1
+        assert rows[0]["pass_eff"] is None
+
+    def test_blank_contest_id_dropped_as_null_pk_component(self, caplog):
+        schema = pa.schema(
+            [
+                ("contest_id", pa.string()),
+                ("team_id", pa.string()),
+                ("category", pa.string()),
+                ("season", pa.int64()),
+            ]
+        )
+        buf = io.BytesIO()
+        pyarrow.parquet.write_table(
+            pa.table(
+                {"contest_id": [""], "team_id": ["1"], "category": ["passing"], "season": [2025]},
+                schema=schema,
+            ),
+            buf,
+        )
+        with caplog.at_level(logging.INFO):
+            rows = list(ncaa.parse_player_stats(buf.getvalue(), _ctx("ncaa_player_stats")))
+        assert rows == []
+        assert "dropped 1" in caplog.text
+
 
 # ---------------------------------------------------------------------------
 # parse_team_stats
@@ -346,6 +578,36 @@ class TestParseTeamStats:
         )
         with pytest.raises(ParserStructureError, match="missing column.*stat"):
             list(ncaa.parse_team_stats(buf.getvalue(), _ctx("ncaa_team_stats")))
+
+    def test_empty_string_value_parses_to_none_no_exception(self):
+        schema = pa.schema(
+            [
+                ("contest_id", pa.string()),
+                ("category", pa.string()),
+                ("stat", pa.string()),
+                ("period", pa.string()),
+                ("away_value", pa.string()),
+                ("season", pa.int64()),
+            ]
+        )
+        buf = io.BytesIO()
+        pyarrow.parquet.write_table(
+            pa.table(
+                {
+                    "contest_id": ["1"],
+                    "category": ["Rushing"],
+                    "stat": ["Yards"],
+                    "period": ["total"],
+                    "away_value": [""],
+                    "season": [2025],
+                },
+                schema=schema,
+            ),
+            buf,
+        )
+        rows = list(ncaa.parse_team_stats(buf.getvalue(), _ctx("ncaa_team_stats")))
+        assert len(rows) == 1
+        assert rows[0]["away_value"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_flatfile_ncaa.py
+++ b/tests/test_flatfile_ncaa.py
@@ -112,6 +112,15 @@ class TestHeightInches:
     def test_whitespace_only_string_returns_none(self):
         assert ncaa._height_inches("   ") is None
 
+    def test_blank_split_parts_return_none(self):
+        """The ACTUAL live failure shape (2026-08-30, second round): the
+        real 2025 file carries heights whose feet or inches PART is blank
+        after the dash split -- "6-", "-11", "-" -- which the whole-value
+        blank guard missed and float('') rejected."""
+        assert ncaa._height_inches("6-") is None
+        assert ncaa._height_inches("-11") is None
+        assert ncaa._height_inches("-") is None
+
 
 class TestParseDates:
     def test_parse_mmddyyyy(self):

--- a/tests/test_sources/test_playoffs.py
+++ b/tests/test_sources/test_playoffs.py
@@ -126,6 +126,50 @@ class TestCfpBracketResource:
             assert len(results) == 1
             assert results[0]["season"] == 2025
 
+    def test_bare_dict_response_yields_one_row(self):
+        """The live 2025 response is a bare JSON object, not a one-element
+        array like 2024 -- `yield from data` on a dict iterates its string
+        keys, which is what broke the live 2025 backfill a second time
+        (`'str' object has no attribute 'get'`). A dict response must
+        normalize to a single yielded record."""
+        from src.pipelines.sources.playoffs import cfp_bracket_resource
+
+        fixture = _load("playoffs_cfp.json")
+        bare_object = dict(fixture[0])
+
+        with (
+            patch("src.pipelines.sources.playoffs.get_client") as mock_get_client,
+            patch("src.pipelines.sources.playoffs.make_request") as mock_make_request,
+        ):
+            mock_get_client.return_value = MagicMock()
+            mock_make_request.return_value = bare_object
+
+            results = list(cfp_bracket_resource(years=[2025]))
+
+            assert len(results) == 1
+            assert results[0]["season"] == 2024  # API-provided value preserved
+            assert "participants" in results[0]
+            assert "rounds" in results[0]
+
+    def test_bare_dict_response_stamps_season_when_missing(self):
+        from src.pipelines.sources.playoffs import cfp_bracket_resource
+
+        fixture = _load("playoffs_cfp.json")
+        bare_object = dict(fixture[0])
+        del bare_object["season"]
+
+        with (
+            patch("src.pipelines.sources.playoffs.get_client") as mock_get_client,
+            patch("src.pipelines.sources.playoffs.make_request") as mock_make_request,
+        ):
+            mock_get_client.return_value = MagicMock()
+            mock_make_request.return_value = bare_object
+
+            results = list(cfp_bracket_resource(years=[2025]))
+
+            assert len(results) == 1
+            assert results[0]["season"] == 2025
+
     def test_keeps_api_provided_season(self):
         """When the response does carry `season` (the 2024 shape), the API
         value wins over the request year -- the stamp is defensive only."""

--- a/tests/test_sources/test_playoffs.py
+++ b/tests/test_sources/test_playoffs.py
@@ -103,6 +103,50 @@ class TestCfpBracketResource:
 
             assert results == []
 
+    def test_stamps_season_when_missing_from_response(self):
+        """The 2025 /playoffs/cfp response evidently omits the top-level
+        `season` field the 2024 fixture carries -- this is what broke the
+        live 2025 backfill (UnboundColumnException on the `season` PK).
+        Stamp it from the request year when absent."""
+        from src.pipelines.sources.playoffs import cfp_bracket_resource
+
+        fixture = _load("playoffs_cfp.json")
+        record_without_season = dict(fixture[0])
+        del record_without_season["season"]
+
+        with (
+            patch("src.pipelines.sources.playoffs.get_client") as mock_get_client,
+            patch("src.pipelines.sources.playoffs.make_request") as mock_make_request,
+        ):
+            mock_get_client.return_value = MagicMock()
+            mock_make_request.return_value = [record_without_season]
+
+            results = list(cfp_bracket_resource(years=[2025]))
+
+            assert len(results) == 1
+            assert results[0]["season"] == 2025
+
+    def test_keeps_api_provided_season(self):
+        """When the response does carry `season` (the 2024 shape), the API
+        value wins over the request year -- the stamp is defensive only."""
+        from src.pipelines.sources.playoffs import cfp_bracket_resource
+
+        fixture = _load("playoffs_cfp.json")
+        assert fixture[0]["season"] == 2024
+
+        with (
+            patch("src.pipelines.sources.playoffs.get_client") as mock_get_client,
+            patch("src.pipelines.sources.playoffs.make_request") as mock_make_request,
+        ):
+            mock_get_client.return_value = MagicMock()
+            mock_make_request.return_value = fixture
+
+            # Request year deliberately differs from the fixture's own season
+            # to prove the API-provided value is preserved, not overwritten.
+            results = list(cfp_bracket_resource(years=[2025]))
+
+            assert results[0]["season"] == 2024
+
 
 class TestCfpGamesResource:
     def test_skips_pre_2014_years(self):


### PR DESCRIPTION
## Summary

Five small fixes found by actually running the #75 rollout against live data today. All are verified against the failures that surfaced them; the full 22-season endpoint backfill, the flat-file loads (20/20 sources), and the refresh campaign's first two runs (2,000 games drained + finalize green) completed on this branch's code.

- **CFP bracket response shape** (`playoffs.py`, 2 commits): `/playoffs/cfp` returns a one-element array for 2024 but a **bare object** for 2025 — `yield from data` iterated the dict's string keys, which is what actually produced the unbound-`season` normalize failure. The resource now normalizes dict→[dict], stamps `season` from the request year when absent, and skips non-dict records with a warning.
- **NCAA numeric coercion** (`flatfile_parsers/ncaa.py`, 2 commits): the real `ncaa_mfb_rosters_2025.parquet` carries blank-string numerics and malformed heights whose *split parts* are blank (`"6-"`, `"-11"`, `"-"`) — `float('')` crashed the load. All three coercion helpers now treat blank/whitespace as NULL (blank PK components follow the existing drop-and-count convention); verified against the full live file: all 29,206 rows parse.
- **Pooler statement timeout** (`refresh_marts.py`): the script's `statement_timeout=0` was passed as an `options=` **startup parameter**, which Supabase's session pooler (Supavisor) silently ignores — the role-default 2-minute timeout still applied, and `marts.play_epa`'s concurrent refresh was cancelled at exactly ~120s in two runs today, failing the backfill's trailing refresh and the campaign's first finalize. It's now issued as a real `SET statement_timeout = 0` after connecting, which survives the pooler. **This is the operationally urgent one**: the campaign's daily 12:00 UTC cron runs from main, and without it every scheduled run fails its finalize (drained calls are preserved by the ledger, but the run goes red).
- **Probe workflow trigger cleanup** (`probe-endpoints.yml`): removes the temporary branch-scoped `push:` trigger now that the workflow exists on main and `workflow_dispatch` resolves (rollout runbook step 9).

## Test plan
- `ruff check` / `ruff format --check` clean; targeted suites green (13 playoffs tests incl. bare-dict shape, 62 NCAA parser tests incl. the height split-part cases, backfill-refresh suite).
- Live validation: backfill run [#4](https://github.com/rstover-fo/cfb-database/actions/runs/33310031223) loaded all 22 seasons; Flat File Load [#41](https://github.com/rstover-fo/cfb-database/actions/runs/33310531265) green (first success in a month); Historical Refresh [#2](https://github.com/rstover-fo/cfb-database/actions/runs/33314035040) green end-to-end (drain → EPA refit → full mart refresh incl. `play_epa` → watermark advanced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193d5pxRWHPe1nxMtb8WPm5

---
_Generated by [Claude Code](https://claude.ai/code/session_0193d5pxRWHPe1nxMtb8WPm5)_



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The mart-refresh command now protects session timeout setup with connection cleanup. An isolated execution injected failures in both the timeout statement and commit paths and confirmed that the connection is closed exactly once in either case.

<h3>Confidence Score: 5/5</h3>

Safe to merge.

No blocking failure remains.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran an isolated mock harness against refresh\_marts(dry\_run=False) with independent failures in SET statement\_timeout = 0 and in conn.commit().
- Validated that the exception propagated only after the connection recorded exactly one close() call, confirming the cleanup block covers both failure paths.
- Uploaded artifact references for the isolated connection-cleanup validation source and its observed output to document the test setup and results.
- Recorded exact execution traces and a successful process exit (exit code 0) for both the setup and commit failure paths, confirming the cleanup behavior.

<a href="https://app.greptile.com/trex/runs/21482193/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["Move session-timeout setup inside the co..."](https://github.com/rstover-fo/cfb-database/commit/b4bfd6ade4ea7d214b79f50159742f102854c50d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58386580)</sub>

<!-- /greptile_comment -->