### PR TITLE
Schema-review fixes for migration 057 (passing unit)

### DIFF
--- a/docs/SCHEMA_CONTRACT.md
+++ b/docs/SCHEMA_CONTRACT.md
@@ -861,7 +861,7 @@ These objects are implementation details. Do not depend on them from downstream 
 | Schema | Tables |
 |--------|--------|
 | `core` | `games`, `drives`, `plays` (partitioned: `plays_y2004`..`plays_y2026`), `roster`, `roster__recruit_ids`, `records`, `rankings`, `game_media`, `game_weather`, `game_player_stats` (+ nested `__teams`, `__categories`, `__types`, `__athletes`), `game_team_stats` (+ nested `__teams`, `__stats`), `games__home_line_scores`, `games__away_line_scores` |
-| `stats` | `team_season_stats`, `player_season_stats`, `advanced_team_stats`, `advanced_game_stats`, `game_havoc`, `play_stats`, `player_usage`, `player_returning` |
+| `stats` | `team_season_stats`, `player_season_stats`, `advanced_team_stats`, `advanced_game_stats`, `game_havoc`, `play_stats`, `player_usage`, `player_returning`, `passing_plays`, `passing_player_games`, `passing_team_games`, `passing_player_season`, `passing_team_season` |
 | `ratings` | `sp_ratings`, `sp_conference_ratings`, `elo_ratings`, `fpi_ratings`, `srs_ratings`, `core_ratings` |
 | `recruiting` | `recruits`, `team_recruiting`, `team_talent`, `transfer_portal`, `recruiting_groups` |
 | `betting` | `lines`, `team_ats`, `line_snapshots` (append-only line movement snapshots, no PK, `captured_at` stamped per run) |

--- a/src/schemas/migrations/057_passing_grants_indexes.sql
+++ b/src/schemas/migrations/057_passing_grants_indexes.sql
@@ -30,12 +30,26 @@
 -- dlt snake_cases camelCase fields and flattens nested dicts with "__"
 -- (e.g. `offense.totalAirYards` -> `offense__total_air_yards`). Verify
 -- actual column names via pg_attribute before applying, and adjust below
--- if the live schema differs from what's assumed here. This applies to the
--- COMMENT ON COLUMN statements too, including the offense__*/defense__*
--- flattened names -- unlike the guarded dlt-child-table GRANT loop above,
--- a COMMENT ON COLUMN naming a column that doesn't exist errors the whole
--- file rather than failing safe, so a wrong guess there needs the same
--- pg_attribute check before applying.
+-- if the live schema differs from what's assumed here.
+--
+-- The 36 charting-aggregate COMMENT ON COLUMN statements (four metrics plus
+-- two coverage denominators, per grain-side) run through a guarded DO block
+-- rather than as plain statements (Codex review, PR #79): dlt omits a
+-- column from a table's schema entirely when every value loaded for it so
+-- far was NULL, so a fresh database whose first passing load happens to
+-- land on an all-uncharted week could genuinely be missing one of these
+-- columns on create. run_migrations.py --file executes a whole file as one
+-- implicit transaction (single cursor.execute + commit/rollback), so an
+-- unguarded COMMENT naming a column that doesn't exist would error the
+-- whole file and roll back the grants/indexes above too -- the opposite of
+-- "deliberately re-appliable". Did NOT fire live (deploy run 188 applied
+-- green post-backfill; every column existed), but the guard removes the
+-- dependency on having gotten lucky. See that block below. The remaining
+-- COMMENT ON COLUMN statements (join-spine columns, parse_status,
+-- offense_id/defense_id) stay unguarded, plain statements: they always
+-- carry a value on every row CFBD returns, so they always materialize on a
+-- table's first load -- for those, this header's pg_attribute check is
+-- still the only defense against a wrong name guess.
 --
 -- Apply via:
 --   python scripts/run_migrations.py --file src/schemas/migrations/057_passing_grants_indexes.sql
@@ -148,10 +162,11 @@ CREATE INDEX IF NOT EXISTS idx_passing_team_games_game_id
 -- write overhead -- deliberate, not an oversight.
 
 -- ---------------------------------------------------------------------------
--- Column comments -- player-grain join spine, charting-nullability
--- semantics on the aggregate columns, and preferred join columns, mirroring
--- how migrations 042/046/047/050/054 carry provenance/NULL-semantics notes
--- on the column itself rather than only in docs.
+-- Column comments -- player-grain join spine, parse_status, and preferred
+-- join columns. Left as plain, unguarded statements (unlike the
+-- charting-aggregate family below): these columns always carry a value on
+-- every row CFBD returns, so they always materialize on a table's first
+-- load regardless of what has or hasn't been charted yet.
 -- ---------------------------------------------------------------------------
 
 COMMENT ON COLUMN stats.passing_player_games.player_id IS
@@ -161,44 +176,12 @@ COMMENT ON COLUMN stats.passing_player_games.season IS
 COMMENT ON COLUMN stats.passing_player_games.team IS
     'Team full name for this game. Player-grain join spine alongside player_id/season.';
 
--- Charting-nullability semantics (representative set -- see passing.py's
--- module docstring for the full charting field list). NULL means the
--- play(s) behind this value were not charted; 0 is a real observed value;
--- the *_attempts_available column is the charting-coverage denominator.
-COMMENT ON COLUMN stats.passing_player_games.total_air_yards IS
-    'Sum of charted air yards across this player''s pass attempts in this game. NULL means none of the attempts have been charted for air yards yet; 0 is a real observed value. air_yards_attempts_available is the charting-coverage denominator.';
-COMMENT ON COLUMN stats.passing_player_games.average_depth_of_target IS
-    'Average charted air yards per attempt (aDOT) for this player in this game. NULL means none of the attempts have been charted for air yards yet. air_yards_attempts_available is the charting-coverage denominator.';
-COMMENT ON COLUMN stats.passing_player_games.air_yards_attempts_available IS
-    'Count of this player''s attempts in this game that have been charted for air yards -- the charting-coverage denominator for total_air_yards/average_depth_of_target. Never NULL; 0 means none of this game''s attempts are charted yet, in which case both aggregates read NULL.';
-COMMENT ON COLUMN stats.passing_player_games.total_yards_after_catch IS
-    'Sum of charted yards after the catch across this player''s completions in this game. NULL means none of the attempts have been charted for YAC yet; 0 is a real observed value. yards_after_catch_attempts_available is the charting-coverage denominator.';
-COMMENT ON COLUMN stats.passing_player_games.average_yards_after_catch IS
-    'Average charted yards after the catch per attempt for this player in this game. NULL means none of the attempts have been charted for YAC yet. yards_after_catch_attempts_available is the charting-coverage denominator.';
-COMMENT ON COLUMN stats.passing_player_games.yards_after_catch_attempts_available IS
-    'Count of this player''s attempts in this game that have been charted for yards after catch -- the charting-coverage denominator for total_yards_after_catch/average_yards_after_catch. Never NULL; 0 means none of this game''s attempts are charted yet, in which case both aggregates read NULL.';
-
 COMMENT ON COLUMN stats.passing_player_season.player_id IS
     'CFBD athlete id (string) -- verified property of this warehouse: CFBD athlete ids ARE ESPN ids. Player-grain join spine alongside season/team.';
 COMMENT ON COLUMN stats.passing_player_season.season IS
     'Season year. Player-grain join spine alongside player_id/team.';
 COMMENT ON COLUMN stats.passing_player_season.team IS
     'Team full name at time of record. Player-grain join spine alongside player_id/season -- included in the PK because a transferred player can appear under more than one team in a season (same reasoning as stats.player_success_season).';
-
--- Charting-nullability semantics -- same convention as passing_player_games
--- above, over the full season rather than one game.
-COMMENT ON COLUMN stats.passing_player_season.total_air_yards IS
-    'Sum of charted air yards across this player''s pass attempts this season. NULL means none of the attempts have been charted for air yards yet; 0 is a real observed value. air_yards_attempts_available is the charting-coverage denominator.';
-COMMENT ON COLUMN stats.passing_player_season.average_depth_of_target IS
-    'Average charted air yards per attempt (aDOT) for this player this season. NULL means none of the attempts have been charted for air yards yet. air_yards_attempts_available is the charting-coverage denominator.';
-COMMENT ON COLUMN stats.passing_player_season.air_yards_attempts_available IS
-    'Count of this player''s attempts this season that have been charted for air yards -- the charting-coverage denominator for total_air_yards/average_depth_of_target. Never NULL; 0 means none of this season''s attempts are charted yet, in which case both aggregates read NULL.';
-COMMENT ON COLUMN stats.passing_player_season.total_yards_after_catch IS
-    'Sum of charted yards after the catch across this player''s completions this season. NULL means none of the attempts have been charted for YAC yet; 0 is a real observed value. yards_after_catch_attempts_available is the charting-coverage denominator.';
-COMMENT ON COLUMN stats.passing_player_season.average_yards_after_catch IS
-    'Average charted yards after the catch per attempt for this player this season. NULL means none of the attempts have been charted for YAC yet. yards_after_catch_attempts_available is the charting-coverage denominator.';
-COMMENT ON COLUMN stats.passing_player_season.yards_after_catch_attempts_available IS
-    'Count of this player''s attempts this season that have been charted for yards after catch -- the charting-coverage denominator for total_yards_after_catch/average_yards_after_catch. Never NULL; 0 means none of this season''s attempts are charted yet, in which case both aggregates read NULL.';
 
 COMMENT ON COLUMN stats.passing_plays.passer_id IS
     'CFBD athlete id (string) -- verified property of this warehouse: CFBD athlete ids ARE ESPN ids. The passing side of the play-grain join spine alongside target_id.';
@@ -222,63 +205,139 @@ COMMENT ON COLUMN stats.passing_plays.defense_id IS
     'CFBD/ESPN numeric team id for the defense on this play. Prefer this over the `defense` name string when joining to ref.teams(id) -- ref.teams has 35 legitimate duplicate school names, so a name-string join needs DISTINCT ON (school) or accepts fanout; defense_id avoids that.';
 
 -- ---------------------------------------------------------------------------
--- Column comments -- team-grain charting-nullability semantics. `offense`/
--- `defense` are nested dicts that dlt flattens to offense__*/defense__*
--- (see the module-level note above); same NULL/0/*_attempts_available
--- convention as the player-grain comments, applied to both sides.
--- `defense__*` is this team's passing DEFENSE this game/season (i.e. what
--- the opponent's passing offense did against them), not the opponent's own
--- offensive columns on a separate row.
+-- Column comments -- charting-aggregate family (GUARDED). 36 statements:
+-- four metrics (total_air_yards, average_depth_of_target,
+-- total_yards_after_catch, average_yards_after_catch) plus their two
+-- coverage denominators (air_yards_attempts_available,
+-- yards_after_catch_attempts_available), per grain-side -- 6 on
+-- passing_player_games + 6 on passing_player_season + 12 on
+-- passing_team_games (offense__/defense__ x 6) + 12 on passing_team_season
+-- (offense__/defense__ x 6).
+--
+-- Why guarded (see header note): dlt omits a column from a table's schema
+-- entirely when every value loaded for it so far was NULL. The two
+-- denominator columns are plain integers that are 0 (not NULL) when
+-- nothing is charted yet, so they always materialize -- only the four
+-- metric columns are actually at risk on a fresh database's first,
+-- all-uncharted load. They are guarded together anyway: a guarded comment
+-- on a column that already exists behaves identically to the unguarded
+-- form, so treating all 36 uniformly is simpler than special-casing which
+-- six of the thirty-six are merely defensive.
+--
+-- Convention: NULL means the play(s) behind this value were not charted;
+-- 0 is a real observed value; the *_attempts_available column is the
+-- charting-coverage denominator (mirrors migrations 046/047's NULL-vs-0
+-- phrasing). `defense__*` is this team's passing DEFENSE (what the
+-- opponent's passing offense did against them), not the opponent's own
+-- offensive row.
+--
+-- Comment text below is byte-identical to what was live in the database
+-- before this guard was added (Codex review, PR #79) -- only the
+-- structure moved, not the wording.
 -- ---------------------------------------------------------------------------
 
-COMMENT ON COLUMN stats.passing_team_games.offense__total_air_yards IS
-    'Sum of charted air yards across this team''s passing offense attempts in this game. NULL means none of the attempts have been charted for air yards yet; 0 is a real observed value. offense__air_yards_attempts_available is the charting-coverage denominator.';
-COMMENT ON COLUMN stats.passing_team_games.offense__average_depth_of_target IS
-    'Average charted air yards per attempt (aDOT) for this team''s passing offense in this game. NULL means none of the attempts have been charted for air yards yet. offense__air_yards_attempts_available is the charting-coverage denominator.';
-COMMENT ON COLUMN stats.passing_team_games.offense__air_yards_attempts_available IS
-    'Count of this team''s offensive attempts in this game that have been charted for air yards -- the charting-coverage denominator for offense__total_air_yards/offense__average_depth_of_target. Never NULL; 0 means none of this game''s offensive attempts are charted yet, in which case both aggregates read NULL.';
-COMMENT ON COLUMN stats.passing_team_games.offense__total_yards_after_catch IS
-    'Sum of charted yards after the catch across this team''s passing offense completions in this game. NULL means none of the attempts have been charted for YAC yet; 0 is a real observed value. offense__yards_after_catch_attempts_available is the charting-coverage denominator.';
-COMMENT ON COLUMN stats.passing_team_games.offense__average_yards_after_catch IS
-    'Average charted yards after the catch per attempt for this team''s passing offense in this game. NULL means none of the attempts have been charted for YAC yet. offense__yards_after_catch_attempts_available is the charting-coverage denominator.';
-COMMENT ON COLUMN stats.passing_team_games.offense__yards_after_catch_attempts_available IS
-    'Count of this team''s offensive attempts in this game that have been charted for yards after catch -- the charting-coverage denominator for offense__total_yards_after_catch/offense__average_yards_after_catch. Never NULL; 0 means none of this game''s offensive attempts are charted yet, in which case both aggregates read NULL.';
+DO $comment$
+DECLARE
+    rec record;
+    n_commented integer := 0;
+    n_skipped integer := 0;
+BEGIN
+    FOR rec IN
+        SELECT * FROM (VALUES
+            ('stats', 'passing_player_games', 'total_air_yards',
+             'Sum of charted air yards across this player''s pass attempts in this game. NULL means none of the attempts have been charted for air yards yet; 0 is a real observed value. air_yards_attempts_available is the charting-coverage denominator.'),
+            ('stats', 'passing_player_games', 'average_depth_of_target',
+             'Average charted air yards per attempt (aDOT) for this player in this game. NULL means none of the attempts have been charted for air yards yet. air_yards_attempts_available is the charting-coverage denominator.'),
+            ('stats', 'passing_player_games', 'air_yards_attempts_available',
+             'Count of this player''s attempts in this game that have been charted for air yards -- the charting-coverage denominator for total_air_yards/average_depth_of_target. Never NULL; 0 means none of this game''s attempts are charted yet, in which case both aggregates read NULL.'),
+            ('stats', 'passing_player_games', 'total_yards_after_catch',
+             'Sum of charted yards after the catch across this player''s completions in this game. NULL means none of the attempts have been charted for YAC yet; 0 is a real observed value. yards_after_catch_attempts_available is the charting-coverage denominator.'),
+            ('stats', 'passing_player_games', 'average_yards_after_catch',
+             'Average charted yards after the catch per attempt for this player in this game. NULL means none of the attempts have been charted for YAC yet. yards_after_catch_attempts_available is the charting-coverage denominator.'),
+            ('stats', 'passing_player_games', 'yards_after_catch_attempts_available',
+             'Count of this player''s attempts in this game that have been charted for yards after catch -- the charting-coverage denominator for total_yards_after_catch/average_yards_after_catch. Never NULL; 0 means none of this game''s attempts are charted yet, in which case both aggregates read NULL.'),
 
-COMMENT ON COLUMN stats.passing_team_games.defense__total_air_yards IS
-    'Sum of charted air yards allowed by this team''s passing defense in this game (i.e. the opponent offense''s charted air yards against them). NULL means none of the attempts have been charted for air yards yet; 0 is a real observed value. defense__air_yards_attempts_available is the charting-coverage denominator.';
-COMMENT ON COLUMN stats.passing_team_games.defense__average_depth_of_target IS
-    'Average charted air yards per attempt (aDOT) allowed by this team''s passing defense in this game. NULL means none of the attempts have been charted for air yards yet. defense__air_yards_attempts_available is the charting-coverage denominator.';
-COMMENT ON COLUMN stats.passing_team_games.defense__air_yards_attempts_available IS
-    'Count of attempts against this team''s defense in this game that have been charted for air yards -- the charting-coverage denominator for defense__total_air_yards/defense__average_depth_of_target. Never NULL; 0 means none of this game''s attempts against this defense are charted yet, in which case both aggregates read NULL.';
-COMMENT ON COLUMN stats.passing_team_games.defense__total_yards_after_catch IS
-    'Sum of charted yards after the catch allowed by this team''s passing defense in this game. NULL means none of the attempts have been charted for YAC yet; 0 is a real observed value. defense__yards_after_catch_attempts_available is the charting-coverage denominator.';
-COMMENT ON COLUMN stats.passing_team_games.defense__average_yards_after_catch IS
-    'Average charted yards after the catch per attempt allowed by this team''s passing defense in this game. NULL means none of the attempts have been charted for YAC yet. defense__yards_after_catch_attempts_available is the charting-coverage denominator.';
-COMMENT ON COLUMN stats.passing_team_games.defense__yards_after_catch_attempts_available IS
-    'Count of attempts against this team''s defense in this game that have been charted for yards after catch -- the charting-coverage denominator for defense__total_yards_after_catch/defense__average_yards_after_catch. Never NULL; 0 means none of this game''s attempts against this defense are charted yet, in which case both aggregates read NULL.';
+            ('stats', 'passing_player_season', 'total_air_yards',
+             'Sum of charted air yards across this player''s pass attempts this season. NULL means none of the attempts have been charted for air yards yet; 0 is a real observed value. air_yards_attempts_available is the charting-coverage denominator.'),
+            ('stats', 'passing_player_season', 'average_depth_of_target',
+             'Average charted air yards per attempt (aDOT) for this player this season. NULL means none of the attempts have been charted for air yards yet. air_yards_attempts_available is the charting-coverage denominator.'),
+            ('stats', 'passing_player_season', 'air_yards_attempts_available',
+             'Count of this player''s attempts this season that have been charted for air yards -- the charting-coverage denominator for total_air_yards/average_depth_of_target. Never NULL; 0 means none of this season''s attempts are charted yet, in which case both aggregates read NULL.'),
+            ('stats', 'passing_player_season', 'total_yards_after_catch',
+             'Sum of charted yards after the catch across this player''s completions this season. NULL means none of the attempts have been charted for YAC yet; 0 is a real observed value. yards_after_catch_attempts_available is the charting-coverage denominator.'),
+            ('stats', 'passing_player_season', 'average_yards_after_catch',
+             'Average charted yards after the catch per attempt for this player this season. NULL means none of the attempts have been charted for YAC yet. yards_after_catch_attempts_available is the charting-coverage denominator.'),
+            ('stats', 'passing_player_season', 'yards_after_catch_attempts_available',
+             'Count of this player''s attempts this season that have been charted for yards after catch -- the charting-coverage denominator for total_yards_after_catch/average_yards_after_catch. Never NULL; 0 means none of this season''s attempts are charted yet, in which case both aggregates read NULL.'),
 
-COMMENT ON COLUMN stats.passing_team_season.offense__total_air_yards IS
-    'Sum of charted air yards across this team''s passing offense attempts this season. NULL means none of the attempts have been charted for air yards yet; 0 is a real observed value. offense__air_yards_attempts_available is the charting-coverage denominator.';
-COMMENT ON COLUMN stats.passing_team_season.offense__average_depth_of_target IS
-    'Average charted air yards per attempt (aDOT) for this team''s passing offense this season. NULL means none of the attempts have been charted for air yards yet. offense__air_yards_attempts_available is the charting-coverage denominator.';
-COMMENT ON COLUMN stats.passing_team_season.offense__air_yards_attempts_available IS
-    'Count of this team''s offensive attempts this season that have been charted for air yards -- the charting-coverage denominator for offense__total_air_yards/offense__average_depth_of_target. Never NULL; 0 means none of this season''s offensive attempts are charted yet, in which case both aggregates read NULL.';
-COMMENT ON COLUMN stats.passing_team_season.offense__total_yards_after_catch IS
-    'Sum of charted yards after the catch across this team''s passing offense completions this season. NULL means none of the attempts have been charted for YAC yet; 0 is a real observed value. offense__yards_after_catch_attempts_available is the charting-coverage denominator.';
-COMMENT ON COLUMN stats.passing_team_season.offense__average_yards_after_catch IS
-    'Average charted yards after the catch per attempt for this team''s passing offense this season. NULL means none of the attempts have been charted for YAC yet. offense__yards_after_catch_attempts_available is the charting-coverage denominator.';
-COMMENT ON COLUMN stats.passing_team_season.offense__yards_after_catch_attempts_available IS
-    'Count of this team''s offensive attempts this season that have been charted for yards after catch -- the charting-coverage denominator for offense__total_yards_after_catch/offense__average_yards_after_catch. Never NULL; 0 means none of this season''s offensive attempts are charted yet, in which case both aggregates read NULL.';
+            ('stats', 'passing_team_games', 'offense__total_air_yards',
+             'Sum of charted air yards across this team''s passing offense attempts in this game. NULL means none of the attempts have been charted for air yards yet; 0 is a real observed value. offense__air_yards_attempts_available is the charting-coverage denominator.'),
+            ('stats', 'passing_team_games', 'offense__average_depth_of_target',
+             'Average charted air yards per attempt (aDOT) for this team''s passing offense in this game. NULL means none of the attempts have been charted for air yards yet. offense__air_yards_attempts_available is the charting-coverage denominator.'),
+            ('stats', 'passing_team_games', 'offense__air_yards_attempts_available',
+             'Count of this team''s offensive attempts in this game that have been charted for air yards -- the charting-coverage denominator for offense__total_air_yards/offense__average_depth_of_target. Never NULL; 0 means none of this game''s offensive attempts are charted yet, in which case both aggregates read NULL.'),
+            ('stats', 'passing_team_games', 'offense__total_yards_after_catch',
+             'Sum of charted yards after the catch across this team''s passing offense completions in this game. NULL means none of the attempts have been charted for YAC yet; 0 is a real observed value. offense__yards_after_catch_attempts_available is the charting-coverage denominator.'),
+            ('stats', 'passing_team_games', 'offense__average_yards_after_catch',
+             'Average charted yards after the catch per attempt for this team''s passing offense in this game. NULL means none of the attempts have been charted for YAC yet. offense__yards_after_catch_attempts_available is the charting-coverage denominator.'),
+            ('stats', 'passing_team_games', 'offense__yards_after_catch_attempts_available',
+             'Count of this team''s offensive attempts in this game that have been charted for yards after catch -- the charting-coverage denominator for offense__total_yards_after_catch/offense__average_yards_after_catch. Never NULL; 0 means none of this game''s offensive attempts are charted yet, in which case both aggregates read NULL.'),
 
-COMMENT ON COLUMN stats.passing_team_season.defense__total_air_yards IS
-    'Sum of charted air yards allowed by this team''s passing defense this season. NULL means none of the attempts have been charted for air yards yet; 0 is a real observed value. defense__air_yards_attempts_available is the charting-coverage denominator.';
-COMMENT ON COLUMN stats.passing_team_season.defense__average_depth_of_target IS
-    'Average charted air yards per attempt (aDOT) allowed by this team''s passing defense this season. NULL means none of the attempts have been charted for air yards yet. defense__air_yards_attempts_available is the charting-coverage denominator.';
-COMMENT ON COLUMN stats.passing_team_season.defense__air_yards_attempts_available IS
-    'Count of attempts against this team''s defense this season that have been charted for air yards -- the charting-coverage denominator for defense__total_air_yards/defense__average_depth_of_target. Never NULL; 0 means none of this season''s attempts against this defense are charted yet, in which case both aggregates read NULL.';
-COMMENT ON COLUMN stats.passing_team_season.defense__total_yards_after_catch IS
-    'Sum of charted yards after the catch allowed by this team''s passing defense this season. NULL means none of the attempts have been charted for YAC yet; 0 is a real observed value. defense__yards_after_catch_attempts_available is the charting-coverage denominator.';
-COMMENT ON COLUMN stats.passing_team_season.defense__average_yards_after_catch IS
-    'Average charted yards after the catch per attempt allowed by this team''s passing defense this season. NULL means none of the attempts have been charted for YAC yet. defense__yards_after_catch_attempts_available is the charting-coverage denominator.';
-COMMENT ON COLUMN stats.passing_team_season.defense__yards_after_catch_attempts_available IS
-    'Count of attempts against this team''s defense this season that have been charted for yards after catch -- the charting-coverage denominator for defense__total_yards_after_catch/defense__average_yards_after_catch. Never NULL; 0 means none of this season''s attempts against this defense are charted yet, in which case both aggregates read NULL.';
+            ('stats', 'passing_team_games', 'defense__total_air_yards',
+             'Sum of charted air yards allowed by this team''s passing defense in this game (i.e. the opponent offense''s charted air yards against them). NULL means none of the attempts have been charted for air yards yet; 0 is a real observed value. defense__air_yards_attempts_available is the charting-coverage denominator.'),
+            ('stats', 'passing_team_games', 'defense__average_depth_of_target',
+             'Average charted air yards per attempt (aDOT) allowed by this team''s passing defense in this game. NULL means none of the attempts have been charted for air yards yet. defense__air_yards_attempts_available is the charting-coverage denominator.'),
+            ('stats', 'passing_team_games', 'defense__air_yards_attempts_available',
+             'Count of attempts against this team''s defense in this game that have been charted for air yards -- the charting-coverage denominator for defense__total_air_yards/defense__average_depth_of_target. Never NULL; 0 means none of this game''s attempts against this defense are charted yet, in which case both aggregates read NULL.'),
+            ('stats', 'passing_team_games', 'defense__total_yards_after_catch',
+             'Sum of charted yards after the catch allowed by this team''s passing defense in this game. NULL means none of the attempts have been charted for YAC yet; 0 is a real observed value. defense__yards_after_catch_attempts_available is the charting-coverage denominator.'),
+            ('stats', 'passing_team_games', 'defense__average_yards_after_catch',
+             'Average charted yards after the catch per attempt allowed by this team''s passing defense in this game. NULL means none of the attempts have been charted for YAC yet. defense__yards_after_catch_attempts_available is the charting-coverage denominator.'),
+            ('stats', 'passing_team_games', 'defense__yards_after_catch_attempts_available',
+             'Count of attempts against this team''s defense in this game that have been charted for yards after catch -- the charting-coverage denominator for defense__total_yards_after_catch/defense__average_yards_after_catch. Never NULL; 0 means none of this game''s attempts against this defense are charted yet, in which case both aggregates read NULL.'),
+
+            ('stats', 'passing_team_season', 'offense__total_air_yards',
+             'Sum of charted air yards across this team''s passing offense attempts this season. NULL means none of the attempts have been charted for air yards yet; 0 is a real observed value. offense__air_yards_attempts_available is the charting-coverage denominator.'),
+            ('stats', 'passing_team_season', 'offense__average_depth_of_target',
+             'Average charted air yards per attempt (aDOT) for this team''s passing offense this season. NULL means none of the attempts have been charted for air yards yet. offense__air_yards_attempts_available is the charting-coverage denominator.'),
+            ('stats', 'passing_team_season', 'offense__air_yards_attempts_available',
+             'Count of this team''s offensive attempts this season that have been charted for air yards -- the charting-coverage denominator for offense__total_air_yards/offense__average_depth_of_target. Never NULL; 0 means none of this season''s offensive attempts are charted yet, in which case both aggregates read NULL.'),
+            ('stats', 'passing_team_season', 'offense__total_yards_after_catch',
+             'Sum of charted yards after the catch across this team''s passing offense completions this season. NULL means none of the attempts have been charted for YAC yet; 0 is a real observed value. offense__yards_after_catch_attempts_available is the charting-coverage denominator.'),
+            ('stats', 'passing_team_season', 'offense__average_yards_after_catch',
+             'Average charted yards after the catch per attempt for this team''s passing offense this season. NULL means none of the attempts have been charted for YAC yet. offense__yards_after_catch_attempts_available is the charting-coverage denominator.'),
+            ('stats', 'passing_team_season', 'offense__yards_after_catch_attempts_available',
+             'Count of this team''s offensive attempts this season that have been charted for yards after catch -- the charting-coverage denominator for offense__total_yards_after_catch/offense__average_yards_after_catch. Never NULL; 0 means none of this season''s offensive attempts are charted yet, in which case both aggregates read NULL.'),
+
+            ('stats', 'passing_team_season', 'defense__total_air_yards',
+             'Sum of charted air yards allowed by this team''s passing defense this season. NULL means none of the attempts have been charted for air yards yet; 0 is a real observed value. defense__air_yards_attempts_available is the charting-coverage denominator.'),
+            ('stats', 'passing_team_season', 'defense__average_depth_of_target',
+             'Average charted air yards per attempt (aDOT) allowed by this team''s passing defense this season. NULL means none of the attempts have been charted for air yards yet. defense__air_yards_attempts_available is the charting-coverage denominator.'),
+            ('stats', 'passing_team_season', 'defense__air_yards_attempts_available',
+             'Count of attempts against this team''s defense this season that have been charted for air yards -- the charting-coverage denominator for defense__total_air_yards/defense__average_depth_of_target. Never NULL; 0 means none of this season''s attempts against this defense are charted yet, in which case both aggregates read NULL.'),
+            ('stats', 'passing_team_season', 'defense__total_yards_after_catch',
+             'Sum of charted yards after the catch allowed by this team''s passing defense this season. NULL means none of the attempts have been charted for YAC yet; 0 is a real observed value. defense__yards_after_catch_attempts_available is the charting-coverage denominator.'),
+            ('stats', 'passing_team_season', 'defense__average_yards_after_catch',
+             'Average charted yards after the catch per attempt allowed by this team''s passing defense this season. NULL means none of the attempts have been charted for YAC yet. defense__yards_after_catch_attempts_available is the charting-coverage denominator.'),
+            ('stats', 'passing_team_season', 'defense__yards_after_catch_attempts_available',
+             'Count of attempts against this team''s defense this season that have been charted for yards after catch -- the charting-coverage denominator for defense__total_yards_after_catch/defense__average_yards_after_catch. Never NULL; 0 means none of this season''s attempts against this defense are charted yet, in which case both aggregates read NULL.')
+        ) AS t(tbl_schema, tbl_name, col_name, comment_text)
+    LOOP
+        IF EXISTS (
+            SELECT 1 FROM information_schema.columns c
+            WHERE c.table_schema = rec.tbl_schema
+              AND c.table_name = rec.tbl_name
+              AND c.column_name = rec.col_name
+        ) THEN
+            EXECUTE format(
+                'COMMENT ON COLUMN %I.%I.%I IS %L',
+                rec.tbl_schema, rec.tbl_name, rec.col_name, rec.comment_text
+            );
+            n_commented := n_commented + 1;
+        ELSE
+            n_skipped := n_skipped + 1;
+        END IF;
+    END LOOP;
+    RAISE NOTICE '057_passing_grants_indexes: % charting-aggregate column comment(s) applied, % skipped (column not present on this load)',
+        n_commented, n_skipped;
+END $comment$;

--- a/src/schemas/migrations/057_passing_grants_indexes.sql
+++ b/src/schemas/migrations/057_passing_grants_indexes.sql
@@ -30,7 +30,12 @@
 -- dlt snake_cases camelCase fields and flattens nested dicts with "__"
 -- (e.g. `offense.totalAirYards` -> `offense__total_air_yards`). Verify
 -- actual column names via pg_attribute before applying, and adjust below
--- if the live schema differs from what's assumed here.
+-- if the live schema differs from what's assumed here. This applies to the
+-- COMMENT ON COLUMN statements too, including the offense__*/defense__*
+-- flattened names -- unlike the guarded dlt-child-table GRANT loop above,
+-- a COMMENT ON COLUMN naming a column that doesn't exist errors the whole
+-- file rather than failing safe, so a wrong guess there needs the same
+-- pg_attribute check before applying.
 --
 -- Apply via:
 --   python scripts/run_migrations.py --file src/schemas/migrations/057_passing_grants_indexes.sql
@@ -137,10 +142,16 @@ CREATE INDEX IF NOT EXISTS idx_passing_player_season_player_id_season
 CREATE INDEX IF NOT EXISTS idx_passing_team_games_game_id
     ON stats.passing_team_games (game_id);
 
+-- No index on `team` on either team-grain table, unlike player_id above on
+-- the player-grain tables: `team` is ~136-value low-cardinality (roughly
+-- FBS+), so a btree on it does little for selectivity and isn't worth the
+-- write overhead -- deliberate, not an oversight.
+
 -- ---------------------------------------------------------------------------
--- Column comments -- player-grain join spine, mirroring how migrations
--- 042/046/047/050/054 carry provenance/NULL-semantics notes on the column
--- itself rather than only in docs.
+-- Column comments -- player-grain join spine, charting-nullability
+-- semantics on the aggregate columns, and preferred join columns, mirroring
+-- how migrations 042/046/047/050/054 carry provenance/NULL-semantics notes
+-- on the column itself rather than only in docs.
 -- ---------------------------------------------------------------------------
 
 COMMENT ON COLUMN stats.passing_player_games.player_id IS
@@ -150,6 +161,23 @@ COMMENT ON COLUMN stats.passing_player_games.season IS
 COMMENT ON COLUMN stats.passing_player_games.team IS
     'Team full name for this game. Player-grain join spine alongside player_id/season.';
 
+-- Charting-nullability semantics (representative set -- see passing.py's
+-- module docstring for the full charting field list). NULL means the
+-- play(s) behind this value were not charted; 0 is a real observed value;
+-- the *_attempts_available column is the charting-coverage denominator.
+COMMENT ON COLUMN stats.passing_player_games.total_air_yards IS
+    'Sum of charted air yards across this player''s pass attempts in this game. NULL means none of the attempts have been charted for air yards yet; 0 is a real observed value. air_yards_attempts_available is the charting-coverage denominator.';
+COMMENT ON COLUMN stats.passing_player_games.average_depth_of_target IS
+    'Average charted air yards per attempt (aDOT) for this player in this game. NULL means none of the attempts have been charted for air yards yet. air_yards_attempts_available is the charting-coverage denominator.';
+COMMENT ON COLUMN stats.passing_player_games.air_yards_attempts_available IS
+    'Count of this player''s attempts in this game that have been charted for air yards -- the charting-coverage denominator for total_air_yards/average_depth_of_target. Never NULL; 0 means none of this game''s attempts are charted yet, in which case both aggregates read NULL.';
+COMMENT ON COLUMN stats.passing_player_games.total_yards_after_catch IS
+    'Sum of charted yards after the catch across this player''s completions in this game. NULL means none of the attempts have been charted for YAC yet; 0 is a real observed value. yards_after_catch_attempts_available is the charting-coverage denominator.';
+COMMENT ON COLUMN stats.passing_player_games.average_yards_after_catch IS
+    'Average charted yards after the catch per attempt for this player in this game. NULL means none of the attempts have been charted for YAC yet. yards_after_catch_attempts_available is the charting-coverage denominator.';
+COMMENT ON COLUMN stats.passing_player_games.yards_after_catch_attempts_available IS
+    'Count of this player''s attempts in this game that have been charted for yards after catch -- the charting-coverage denominator for total_yards_after_catch/average_yards_after_catch. Never NULL; 0 means none of this game''s attempts are charted yet, in which case both aggregates read NULL.';
+
 COMMENT ON COLUMN stats.passing_player_season.player_id IS
     'CFBD athlete id (string) -- verified property of this warehouse: CFBD athlete ids ARE ESPN ids. Player-grain join spine alongside season/team.';
 COMMENT ON COLUMN stats.passing_player_season.season IS
@@ -157,7 +185,100 @@ COMMENT ON COLUMN stats.passing_player_season.season IS
 COMMENT ON COLUMN stats.passing_player_season.team IS
     'Team full name at time of record. Player-grain join spine alongside player_id/season -- included in the PK because a transferred player can appear under more than one team in a season (same reasoning as stats.player_success_season).';
 
+-- Charting-nullability semantics -- same convention as passing_player_games
+-- above, over the full season rather than one game.
+COMMENT ON COLUMN stats.passing_player_season.total_air_yards IS
+    'Sum of charted air yards across this player''s pass attempts this season. NULL means none of the attempts have been charted for air yards yet; 0 is a real observed value. air_yards_attempts_available is the charting-coverage denominator.';
+COMMENT ON COLUMN stats.passing_player_season.average_depth_of_target IS
+    'Average charted air yards per attempt (aDOT) for this player this season. NULL means none of the attempts have been charted for air yards yet. air_yards_attempts_available is the charting-coverage denominator.';
+COMMENT ON COLUMN stats.passing_player_season.air_yards_attempts_available IS
+    'Count of this player''s attempts this season that have been charted for air yards -- the charting-coverage denominator for total_air_yards/average_depth_of_target. Never NULL; 0 means none of this season''s attempts are charted yet, in which case both aggregates read NULL.';
+COMMENT ON COLUMN stats.passing_player_season.total_yards_after_catch IS
+    'Sum of charted yards after the catch across this player''s completions this season. NULL means none of the attempts have been charted for YAC yet; 0 is a real observed value. yards_after_catch_attempts_available is the charting-coverage denominator.';
+COMMENT ON COLUMN stats.passing_player_season.average_yards_after_catch IS
+    'Average charted yards after the catch per attempt for this player this season. NULL means none of the attempts have been charted for YAC yet. yards_after_catch_attempts_available is the charting-coverage denominator.';
+COMMENT ON COLUMN stats.passing_player_season.yards_after_catch_attempts_available IS
+    'Count of this player''s attempts this season that have been charted for yards after catch -- the charting-coverage denominator for total_yards_after_catch/average_yards_after_catch. Never NULL; 0 means none of this season''s attempts are charted yet, in which case both aggregates read NULL.';
+
 COMMENT ON COLUMN stats.passing_plays.passer_id IS
     'CFBD athlete id (string) -- verified property of this warehouse: CFBD athlete ids ARE ESPN ids. The passing side of the play-grain join spine alongside target_id.';
 COMMENT ON COLUMN stats.passing_plays.target_id IS
     'CFBD athlete id (string) -- verified property of this warehouse: CFBD athlete ids ARE ESPN ids. The receiver (target) side of the play-grain join spine alongside passer_id -- the novel join surface this unit adds.';
+
+-- parseStatus (dlt: parse_status) -- CFBD's charting-completeness marker.
+-- Only "partial" was observed in probing; other values are unconfirmed but
+-- read as more/fully charted.
+COMMENT ON COLUMN stats.passing_plays.parse_status IS
+    'CFBD charting-completeness marker for this play. "partial" (the only value observed in probing) means this play''s air yards/pass depth/direction/location/YAC charting is incomplete, and those nullable columns may read NULL as a result.';
+
+-- Preferred join columns to ref.teams(id): numeric CFBD/ESPN team ids,
+-- unlike offense/defense (name strings). ref.teams has 35 legitimate
+-- duplicate school names, so joining on the name string requires
+-- DISTINCT ON (school) or accepting fanout -- offense_id/defense_id avoid
+-- that entirely. No new index: ref.teams(id) is already the primary key.
+COMMENT ON COLUMN stats.passing_plays.offense_id IS
+    'CFBD/ESPN numeric team id for the offense on this play. Prefer this over the `offense` name string when joining to ref.teams(id) -- ref.teams has 35 legitimate duplicate school names, so a name-string join needs DISTINCT ON (school) or accepts fanout; offense_id avoids that.';
+COMMENT ON COLUMN stats.passing_plays.defense_id IS
+    'CFBD/ESPN numeric team id for the defense on this play. Prefer this over the `defense` name string when joining to ref.teams(id) -- ref.teams has 35 legitimate duplicate school names, so a name-string join needs DISTINCT ON (school) or accepts fanout; defense_id avoids that.';
+
+-- ---------------------------------------------------------------------------
+-- Column comments -- team-grain charting-nullability semantics. `offense`/
+-- `defense` are nested dicts that dlt flattens to offense__*/defense__*
+-- (see the module-level note above); same NULL/0/*_attempts_available
+-- convention as the player-grain comments, applied to both sides.
+-- `defense__*` is this team's passing DEFENSE this game/season (i.e. what
+-- the opponent's passing offense did against them), not the opponent's own
+-- offensive columns on a separate row.
+-- ---------------------------------------------------------------------------
+
+COMMENT ON COLUMN stats.passing_team_games.offense__total_air_yards IS
+    'Sum of charted air yards across this team''s passing offense attempts in this game. NULL means none of the attempts have been charted for air yards yet; 0 is a real observed value. offense__air_yards_attempts_available is the charting-coverage denominator.';
+COMMENT ON COLUMN stats.passing_team_games.offense__average_depth_of_target IS
+    'Average charted air yards per attempt (aDOT) for this team''s passing offense in this game. NULL means none of the attempts have been charted for air yards yet. offense__air_yards_attempts_available is the charting-coverage denominator.';
+COMMENT ON COLUMN stats.passing_team_games.offense__air_yards_attempts_available IS
+    'Count of this team''s offensive attempts in this game that have been charted for air yards -- the charting-coverage denominator for offense__total_air_yards/offense__average_depth_of_target. Never NULL; 0 means none of this game''s offensive attempts are charted yet, in which case both aggregates read NULL.';
+COMMENT ON COLUMN stats.passing_team_games.offense__total_yards_after_catch IS
+    'Sum of charted yards after the catch across this team''s passing offense completions in this game. NULL means none of the attempts have been charted for YAC yet; 0 is a real observed value. offense__yards_after_catch_attempts_available is the charting-coverage denominator.';
+COMMENT ON COLUMN stats.passing_team_games.offense__average_yards_after_catch IS
+    'Average charted yards after the catch per attempt for this team''s passing offense in this game. NULL means none of the attempts have been charted for YAC yet. offense__yards_after_catch_attempts_available is the charting-coverage denominator.';
+COMMENT ON COLUMN stats.passing_team_games.offense__yards_after_catch_attempts_available IS
+    'Count of this team''s offensive attempts in this game that have been charted for yards after catch -- the charting-coverage denominator for offense__total_yards_after_catch/offense__average_yards_after_catch. Never NULL; 0 means none of this game''s offensive attempts are charted yet, in which case both aggregates read NULL.';
+
+COMMENT ON COLUMN stats.passing_team_games.defense__total_air_yards IS
+    'Sum of charted air yards allowed by this team''s passing defense in this game (i.e. the opponent offense''s charted air yards against them). NULL means none of the attempts have been charted for air yards yet; 0 is a real observed value. defense__air_yards_attempts_available is the charting-coverage denominator.';
+COMMENT ON COLUMN stats.passing_team_games.defense__average_depth_of_target IS
+    'Average charted air yards per attempt (aDOT) allowed by this team''s passing defense in this game. NULL means none of the attempts have been charted for air yards yet. defense__air_yards_attempts_available is the charting-coverage denominator.';
+COMMENT ON COLUMN stats.passing_team_games.defense__air_yards_attempts_available IS
+    'Count of attempts against this team''s defense in this game that have been charted for air yards -- the charting-coverage denominator for defense__total_air_yards/defense__average_depth_of_target. Never NULL; 0 means none of this game''s attempts against this defense are charted yet, in which case both aggregates read NULL.';
+COMMENT ON COLUMN stats.passing_team_games.defense__total_yards_after_catch IS
+    'Sum of charted yards after the catch allowed by this team''s passing defense in this game. NULL means none of the attempts have been charted for YAC yet; 0 is a real observed value. defense__yards_after_catch_attempts_available is the charting-coverage denominator.';
+COMMENT ON COLUMN stats.passing_team_games.defense__average_yards_after_catch IS
+    'Average charted yards after the catch per attempt allowed by this team''s passing defense in this game. NULL means none of the attempts have been charted for YAC yet. defense__yards_after_catch_attempts_available is the charting-coverage denominator.';
+COMMENT ON COLUMN stats.passing_team_games.defense__yards_after_catch_attempts_available IS
+    'Count of attempts against this team''s defense in this game that have been charted for yards after catch -- the charting-coverage denominator for defense__total_yards_after_catch/defense__average_yards_after_catch. Never NULL; 0 means none of this game''s attempts against this defense are charted yet, in which case both aggregates read NULL.';
+
+COMMENT ON COLUMN stats.passing_team_season.offense__total_air_yards IS
+    'Sum of charted air yards across this team''s passing offense attempts this season. NULL means none of the attempts have been charted for air yards yet; 0 is a real observed value. offense__air_yards_attempts_available is the charting-coverage denominator.';
+COMMENT ON COLUMN stats.passing_team_season.offense__average_depth_of_target IS
+    'Average charted air yards per attempt (aDOT) for this team''s passing offense this season. NULL means none of the attempts have been charted for air yards yet. offense__air_yards_attempts_available is the charting-coverage denominator.';
+COMMENT ON COLUMN stats.passing_team_season.offense__air_yards_attempts_available IS
+    'Count of this team''s offensive attempts this season that have been charted for air yards -- the charting-coverage denominator for offense__total_air_yards/offense__average_depth_of_target. Never NULL; 0 means none of this season''s offensive attempts are charted yet, in which case both aggregates read NULL.';
+COMMENT ON COLUMN stats.passing_team_season.offense__total_yards_after_catch IS
+    'Sum of charted yards after the catch across this team''s passing offense completions this season. NULL means none of the attempts have been charted for YAC yet; 0 is a real observed value. offense__yards_after_catch_attempts_available is the charting-coverage denominator.';
+COMMENT ON COLUMN stats.passing_team_season.offense__average_yards_after_catch IS
+    'Average charted yards after the catch per attempt for this team''s passing offense this season. NULL means none of the attempts have been charted for YAC yet. offense__yards_after_catch_attempts_available is the charting-coverage denominator.';
+COMMENT ON COLUMN stats.passing_team_season.offense__yards_after_catch_attempts_available IS
+    'Count of this team''s offensive attempts this season that have been charted for yards after catch -- the charting-coverage denominator for offense__total_yards_after_catch/offense__average_yards_after_catch. Never NULL; 0 means none of this season''s offensive attempts are charted yet, in which case both aggregates read NULL.';
+
+COMMENT ON COLUMN stats.passing_team_season.defense__total_air_yards IS
+    'Sum of charted air yards allowed by this team''s passing defense this season. NULL means none of the attempts have been charted for air yards yet; 0 is a real observed value. defense__air_yards_attempts_available is the charting-coverage denominator.';
+COMMENT ON COLUMN stats.passing_team_season.defense__average_depth_of_target IS
+    'Average charted air yards per attempt (aDOT) allowed by this team''s passing defense this season. NULL means none of the attempts have been charted for air yards yet. defense__air_yards_attempts_available is the charting-coverage denominator.';
+COMMENT ON COLUMN stats.passing_team_season.defense__air_yards_attempts_available IS
+    'Count of attempts against this team''s defense this season that have been charted for air yards -- the charting-coverage denominator for defense__total_air_yards/defense__average_depth_of_target. Never NULL; 0 means none of this season''s attempts against this defense are charted yet, in which case both aggregates read NULL.';
+COMMENT ON COLUMN stats.passing_team_season.defense__total_yards_after_catch IS
+    'Sum of charted yards after the catch allowed by this team''s passing defense this season. NULL means none of the attempts have been charted for YAC yet; 0 is a real observed value. defense__yards_after_catch_attempts_available is the charting-coverage denominator.';
+COMMENT ON COLUMN stats.passing_team_season.defense__average_yards_after_catch IS
+    'Average charted yards after the catch per attempt allowed by this team''s passing defense this season. NULL means none of the attempts have been charted for YAC yet. defense__yards_after_catch_attempts_available is the charting-coverage denominator.';
+COMMENT ON COLUMN stats.passing_team_season.defense__yards_after_catch_attempts_available IS
+    'Count of attempts against this team''s defense this season that have been charted for yards after catch -- the charting-coverage denominator for defense__total_yards_after_catch/defense__average_yards_after_catch. Never NULL; 0 means none of this season''s attempts against this defense are charted yet, in which case both aggregates read NULL.';


### PR DESCRIPTION
Small follow-up to #78: the schema-architect review of migration 057 finished after the merge — verdict was "fine to ship as-is, no blocking findings," with two P2 documentation gaps and two P3 nits, all applied here before 057 is deployed to the live DB:

- **`docs/SCHEMA_CONTRACT.md`**: the `stats` internal-raw-tables inventory now lists the five `passing_*` tables (the row claims to be the complete inventory and was stale).
- **Migration 057 — charting-null semantics on the columns**: `COMMENT ON COLUMN` for the aggregate charting fields (`total_air_yards`, `average_depth_of_target`, `total_yards_after_catch`, `average_yards_after_catch`, and their `*_attempts_available` coverage denominators) on both player-grain tables and the flattened `offense__*`/`defense__*` team-grain columns, plus `parse_status` on `passing_plays` — per the 046/047 convention that NULL-vs-zero semantics live on the column, not only in module docstrings. NULL means not-yet-charted, never zero.
- **Migration 057 — P3 nits**: a one-line rationale for the deliberate absence of a team-name index (~136-value low cardinality), and preferred-join-column comments on `passing_plays.offense_id`/`defense_id` (numeric ids avoid the documented 35-duplicate-school-name fanout of name-string joins to `ref.teams`).
- **057 header**: notes that `COMMENT ON COLUMN` errors on a missing column rather than failing safe, so the pre-apply `pg_attribute` check covers the flattened names too.

No code changes — SQL comments and one docs row. 057 still applies only after the first passing load creates the tables (the 2025+2026 backfill dispatched from #78's branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193d5pxRWHPe1nxMtb8WPm5

---
_Generated by [Claude Code](https://claude.ai/code/session_0193d5pxRWHPe1nxMtb8WPm5)_



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The passing schema documentation now lists all five internal passing tables, and migration 057 safely applies available column comments, indexes, and read grants after a partial first load.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

A disposable PostgreSQL 16 execution confirmed that migration 057 completes when nullable charting aggregate columns are absent, while preserving comments on existing columns, indexes, and read grants.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran the migration validation script trex-artifacts/migration-057-nullable-columns-validation.py against a disposable PostgreSQL 16 environment and observed that the unguarded control failed on total\_air\_yards and rolled back its indexes, while the migration completed successfully, applied 23 comments to existing columns, created six indexes, and left the omitted 24 nullable aggregate columns absent.
- The guarded migration path succeeded with absent nullable columns.
- The migration retained SELECT grants for anon and authenticated users as part of its successful application.
- Tests for passing-source scenarios and migration render checks were completed successfully.

<a href="https://app.greptile.com/trex/runs/21489643/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["Guard charting-aggregate column comments..."](https://github.com/rstover-fo/cfb-database/commit/ec4bb99d74c051fbde85387de9fba684ba30e17a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58395655)</sub>

<!-- /greptile_comment -->