### PR TITLE
Wepa id repair, cfb-app expansion views, backfill levers + handoffs

### DIFF
--- a/.github/workflows/backfill-sources.yml
+++ b/.github/workflows/backfill-sources.yml
@@ -47,6 +47,17 @@ on:
         options:
           - load_season
           - pipeline_run
+      player_overview_max:
+        description: >-
+          Optional cap override for the player_overview drainer (raises
+          MAX_PLAYER_OVERVIEW_PER_RUN via PLAYER_OVERVIEW_MAX_PER_RUN), e.g.
+          9000. Only takes effect when sources includes player_overview via
+          runner=load_season; pipeline_run's allowlist excludes
+          player_overview (it has a SOURCE_ORDER slot and belongs on the
+          default runner), so this input has no effect there. Leave blank
+          to keep the drainer's default cap (250).
+        required: false
+        type: string
 
 # Shares the daily load's concurrency group so a backfill never merges into
 # the same tables while the scheduled load is mid-run; it queues instead.
@@ -66,7 +77,10 @@ jobs:
   backfill:
     name: Backfill ${{ inputs.sources }} for ${{ inputs.seasons || 'no seasons' }} (${{ inputs.runner || 'load_season' }})
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    # A multi-thousand-call drainer dispatch (player_overview at a raised
+    # player_overview_max, e.g. ~9k calls) runs ~2.5-3h; 300 leaves headroom
+    # under GitHub-hosted runners' 360-minute ceiling.
+    timeout-minutes: 300
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -86,6 +100,11 @@ jobs:
         env:
           SEASONS_INPUT: ${{ inputs.seasons }}
           SOURCES_INPUT: ${{ inputs.sources }}
+          # Only load_season.py reads this (its player_overview runner
+          # lambda); the pipeline_run path below never sets it -- its
+          # allowlist excludes player_overview entirely, so there is
+          # nothing there for the cap to raise.
+          PLAYER_OVERVIEW_MAX_PER_RUN: ${{ inputs.player_overview_max }}
         run: |
           # runner=load_season always needs seasons -- fail fast with a
           # clear message rather than let the (empty) for-loop below

--- a/.github/workflows/flat-files.yml
+++ b/.github/workflows/flat-files.yml
@@ -25,9 +25,11 @@ on:
           once with no --season, today's behavior. Non-empty loops the load
           once per season, appending --season "$season" to the same
           --source-flags-or---due invocation each time. Combining this with
-          an empty `source` (so the invocation is --due) makes little
-          sense: --due's cadence gating is bypassed by an explicit --season
-          anyway, same as it is by an explicit --source. An explicit-season
+          an empty `source` (so the invocation is --due) is a full
+          backfill: an explicit --season disables --due's cadence gating
+          and plans every non-manual source for that season -- cadence
+          freshness only describes the current season's file, and the
+          ledger hash-skip keeps the over-planning cheap. An explicit-season
           request for a year a source hasn't published yet reports
           not_published (see probe_offseason_availability.py's distinction)
           and does not fail the run.

--- a/.github/workflows/flat-files.yml
+++ b/.github/workflows/flat-files.yml
@@ -19,6 +19,20 @@ on:
         description: "Registry source name(s), space-separated; empty = --due"
         required: false
         type: string
+      seasons:
+        description: >-
+          Season years, space-separated (e.g. 2013 2014 2015); empty = run
+          once with no --season, today's behavior. Non-empty loops the load
+          once per season, appending --season "$season" to the same
+          --source-flags-or---due invocation each time. Combining this with
+          an empty `source` (so the invocation is --due) makes little
+          sense: --due's cadence gating is bypassed by an explicit --season
+          anyway, same as it is by an explicit --source. An explicit-season
+          request for a year a source hasn't published yet reports
+          not_published (see probe_offseason_availability.py's distinction)
+          and does not fail the run.
+        required: false
+        type: string
 
 concurrency:
   group: flat-file-load
@@ -36,7 +50,12 @@ jobs:
   load:
     name: Load flat-file sources
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # 30 is enough for a single --due/--source invocation, but a multi-season
+    # `seasons` backfill of the 7-source NCAA bundle (ncaa_schedule,
+    # ncaa_teams, ncaa_rosters, ncaa_linescores, ncaa_player_stats,
+    # ncaa_team_stats, ncaa_pbp -- the last a multi-hundred-thousand-row
+    # parquet load) across e.g. 12 seasons needs real headroom.
+    timeout-minutes: 300
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -52,11 +71,29 @@ jobs:
         # `source` input through a step-level env: var (probe-endpoints.yml's
         # pattern) instead of interpolating ${{ inputs.source }} directly
         # into the run: shell -- see historical-refresh.yml's Drain backlog
-        # step for the rationale.
+        # step for the rationale. Same treatment for `seasons`.
         env:
           SOURCE_INPUT: ${{ inputs.source }}
+          SEASONS_INPUT: ${{ inputs.seasons }}
         run: |
-          if [ -n "$SOURCE_INPUT" ]; then
+          if [ -n "$SEASONS_INPUT" ]; then
+            # $SEASONS_INPUT is deliberately unquoted -- it is a
+            # space-separated list of years and this loop relies on the
+            # shell's word-splitting to iterate them individually (same
+            # pattern as backfill-sources.yml's per-season loop).
+            for season in $SEASONS_INPUT; do
+              echo "::group::Season $season"
+              if [ -n "$SOURCE_INPUT" ]; then
+                # Deliberately unquoted: SOURCE_INPUT is a space-separated
+                # list of registry names, and word-splitting is how each
+                # one becomes its own --source flag below.
+                python scripts/load_flat_files.py $(printf -- '--source %s ' $SOURCE_INPUT) --season "$season"
+              else
+                python scripts/load_flat_files.py --due --season "$season"
+              fi
+              echo "::endgroup::"
+            done
+          elif [ -n "$SOURCE_INPUT" ]; then
             # Deliberately unquoted: SOURCE_INPUT is a space-separated list
             # of registry names, and word-splitting is how each one becomes
             # its own --source flag below.

--- a/deploys/expansion_views-manifest.json
+++ b/deploys/expansion_views-manifest.json
@@ -1,0 +1,19 @@
+{
+  "action": "apply",
+  "files": [
+    "src/schemas/marts/023_coaching_tenure.sql",
+    "src/schemas/marts/045_passing_charting_player_season.sql",
+    "src/schemas/marts/046_passing_charting_target_season.sql",
+    "src/schemas/marts/047_passing_charting_team_season.sql",
+    "src/schemas/marts/048_coach_tenures.sql",
+    "src/schemas/api/009_player_detail.sql",
+    "src/schemas/api/015_coaching_history.sql",
+    "src/schemas/api/038_coach_records.sql",
+    "src/schemas/api/045_passing_charting_player_season.sql",
+    "src/schemas/api/046_passing_charting_target_season.sql",
+    "src/schemas/api/047_passing_charting_team_season.sql",
+    "src/schemas/api/048_coach_tenures.sql",
+    "src/schemas/api/049_refresh_campaign_status.sql",
+    "src/schemas/api/validation_expansion_views.sql"
+  ]
+}

--- a/deploys/expansion_views-manifest.json
+++ b/deploys/expansion_views-manifest.json
@@ -1,6 +1,7 @@
 {
   "action": "apply",
   "files": [
+    "src/schemas/migrations/058_wepa_player_id_column.sql",
     "src/schemas/marts/023_coaching_tenure.sql",
     "src/schemas/marts/045_passing_charting_player_season.sql",
     "src/schemas/marts/046_passing_charting_target_season.sql",

--- a/docs/SCHEMA_CONTRACT.md
+++ b/docs/SCHEMA_CONTRACT.md
@@ -4,7 +4,7 @@
 > only depend on objects listed here as **public**. Everything else is internal and may change
 > without notice.
 
-Last updated: 2026-08-29
+Last updated: 2026-08-30
 
 > **Note on cfb-analytics:** the retired OU-only app (rstover-fo/cfb-analytics) was never a
 > warehouse consumer -- it ran its own DuckDB ingestion. Its unique features (rivals page,
@@ -14,6 +14,84 @@ Last updated: 2026-08-29
 ---
 
 ## Recent Contract Changes
+
+- **2026-08-30 — `expansion_views` unit: five new `api.*` views, `api.player_detail`
+  bug fix, `coach_id` added to two existing views (all per cfb-app's
+  2026-08-30 work order).** `deploys/expansion_views-manifest.json`.
+  - **`api.player_detail` dedupe (BUG FIX, pre-existing surface).** The
+    recruiting join fanned out for players carrying more than one
+    `recruiting.recruits` row (reclassifications) -- verified live,
+    e.g. player_id 5079720/season 2025 returned 2 rows differing only in
+    stars/recruit_rating/national_ranking/recruit_class. Under 1% of
+    players per season but concentrated in blue-chip cases, and
+    `SUM()`-style aggregation over the view silently double-counted them.
+    Fixed by collapsing the recruiting side to one row per athlete via
+    `DISTINCT ON`, keeping the highest (most authoritative) recruit-class
+    year. `api.player_detail` is now guaranteed one row per
+    `(player_id, season, team)`.
+  - **`api.player_detail` additive extension.** Six new columns from
+    `stats.player_season_overview`, joined `LEFT JOIN LATERAL ... ORDER BY
+    (overview.team = player_detail.team) DESC LIMIT 1` (fanout-proof
+    regardless of that table's own primary key): `games`, `usage_overall`,
+    `usage_pass`, `usage_rush`, `ppa_overview_avg`, `ppa_overview_total`.
+  - **`api.passing_charting_player_season` (new, `045`).** Passing charting
+    by player-season, 2025+: air yards, aDOT, YAC, plus attempts/
+    completions/interceptions/completion_rate/conference/position. Carries
+    **two** separate coverage denominators
+    (`air_yards_attempts_available`, `yards_after_catch_attempts_available`)
+    -- never merge them into one; 2025 charted only 407/820 player-seasons,
+    so a leaderboard without both denominators ranks on charting coverage,
+    not skill. NULL = not charted, 0 is a real value (mirrors migration
+    057's phrasing).
+  - **`api.passing_charting_target_season` (new, `046`) -- the highest-value
+    item in this batch.** Receiver-grain (target) passing charting by
+    season, 2025+, aggregated from `stats.passing_plays`. cfb-app had zero
+    receiver-grain analysis before this (`api.player_wepa_leaders` covers
+    passing/rushing/kicking only). Columns: `target_id`, `target`, `season`,
+    `team_id`, `team`, `targets_charted`, `receptions`, `total_air_yards`,
+    `average_depth_of_target`, `air_yards_charted_plays`,
+    `total_yards_after_catch`, `average_yards_after_catch`,
+    `yards_after_catch_charted_plays`, `target_share_charted`,
+    `partial_share`. **`target_share_charted` is a share of CHARTED targets
+    only** (deliberately not named `target_share`) -- never present it as a
+    true target share over every offensive snap. `partial_share` flags
+    plays with `parse_status='partial'` (charting fields may read NULL on
+    those).
+  - **`api.passing_charting_team_season` (new, `047`).** Team-season passing
+    charting, offense and defense sides, 2025+. Flattens
+    `stats.passing_team_season`'s raw `offense__*`/`defense__*` dlt shape to
+    `offense_*`/`defense_*` (Contract Rule 4: raw dlt shapes never reach the
+    api layer). **`defense_*` is this team's passing DEFENSE** (what
+    opposing offenses did against them), not the opponent's own offensive
+    row.
+  - **`coach_id` added to `api.coaching_history` and `api.coach_records`
+    (additive).** Both views previously carried only `first_name`/
+    `last_name` for coach identity, so cfb-app was joining them to each
+    other on name alone (`cfb-app/src/lib/queries/coaches.ts:170-182`,
+    with an acknowledged same-name-collision risk). `coach_id` is
+    `ref.coach_seasons`' `coach__id`, matched per season by
+    `(first_name, last_name, team, year)` with a deterministic tie-break;
+    NULL where no single `coach__id` unambiguously covers every one of the
+    relevant seasons (name collision, or no matching `ref.coach_seasons`
+    row at all).
+  - **`api.coach_tenures` (new, `048`).** CFBD's own continuous coach-tenure
+    record (`ref.coach_tenures`), distinct from `api.coaching_history`
+    (gap-detected from `ref.coaches__seasons`). Grain:
+    `(coach_id, team_id, tenure_start)`. Adds `is_interim` and
+    `classification`, retiring two cfb-app heuristics: a `DEFAULT_MIN_GAMES
+    = 24` floor used only to keep an interim's one-game record off win%
+    leaderboards, and an FBS filter pushed through a ~130-entry hardcoded
+    team-name list. **May be empty** in an environment where the
+    `coach_tenures` backfill (`--source coach_tenures`, a per-team fan-out,
+    not part of the daily path) has not yet run.
+  - **`api.refresh_campaign_status` (new, `049`, plain view -- no mart).**
+    Per-`(campaign, season)` progress against `meta.refresh_campaigns` +
+    `meta.refresh_progress` (migration 051's refresh ledger): games
+    refreshed/no-data for that season, plus the campaign's
+    `completed_at`/`last_finalized_at`. Lets a downstream consumer
+    scope-invalidate a cached historical answer for one season instead of
+    distrusting an entire in-progress corrections campaign's range. May be
+    empty if no campaign row exists yet.
 
 - **2026-08-29 — `marts.epa_crossvalidation` added (INTERNAL, not a public
   surface).** Mart 044 (`src/schemas/marts/044_epa_crossvalidation.sql`) is the
@@ -612,14 +690,19 @@ These are the primary PostgREST-accessible views. Queries go through Supabase cl
 | `api.team_penalties` | **Deployed** | ~42K | Official box-score penalty counts per (game, team) from totalPenaltiesYards. Columns: game_id, season, week, season_type, team, opponent, home_away, penalties, penalty_yards, opponent_penalties, opponent_penalty_yards. |
 | `api.recruit_lookup` | **Deployed** | 67,179 | Stable recruiting view for recruit data |
 | `api.player_season_leaders` | **Deployed** | 152,966 | Season stat leaders by category (passing, rushing, receiving, defensive). Columns: season, category, player_id, player_name, team, yards, touchdowns, interceptions, pct, attempts, completions, carries, yards_per_carry, receptions, yards_per_reception, longest, total_tackles, solo_tackles, sacks, tackles_for_loss, passes_defended, yards_rank |
-| `api.player_detail` | **Deployed** | 340,878 | Single player page: bio, recruiting, season stats, PPA. Columns: player_id, name, team, position, season, height, weight, jersey, home_city, home_state, stars, recruit_rating, national_ranking, recruit_class, pass_att, pass_cmp, pass_yds, pass_td, pass_int, pass_pct, rush_car, rush_yds, rush_td, rush_ypc, rec, rec_yds, rec_td, rec_ypr, tackles, sacks, tfl, pass_def, ppa_avg, ppa_total |
+| `api.player_detail` | **Deployed** | 340,878 | Single player page: bio, recruiting, season stats, PPA, and a compact season-overview payload. One row per (player_id, season, team) -- recruiting join deduped 2026-08-30 (was fanning out for reclassified players; see 2026-08-30 changelog entry). Columns: player_id, name, team, position, season, height, weight, jersey, home_city, home_state, stars, recruit_rating, national_ranking, recruit_class, pass_att, pass_cmp, pass_yds, pass_td, pass_int, pass_pct, rush_car, rush_yds, rush_td, rush_ypc, rec, rec_yds, rec_td, rec_ypr, tackles, sacks, tfl, pass_def, ppa_avg, ppa_total, games, usage_overall, usage_pass, usage_rush, ppa_overview_avg, ppa_overview_total (last six added 2026-08-30, from stats.player_season_overview via a fanout-proof LATERAL join) |
 | `api.player_comparison` | **Deployed** | 127,333 | Player stats with positional percentiles, backed by matview. Columns: all player_detail columns PLUS position_group, pass_yds_pctl, pass_td_pctl, pass_pct_pctl, rush_yds_pctl, rush_td_pctl, rush_ypc_pctl, rec_yds_pctl, rec_td_pctl, tackles_pctl, sacks_pctl, tfl_pctl, ppa_avg_pctl |
 | `api.game_player_leaders` | **Deployed** | 4,194,621 | Per-game player stats flattened from dlt hierarchy. Columns: game_id, season, team, conference, home_away, category, stat_type, player_id, player_name, stat |
 | `api.game_box_score` | **Deployed** | 1,178,727 | Per-game team stats in EAV format. Columns: game_id, season, team, home_away, category, stat_value |
 | `api.game_line_scores` | **Deployed** | 45,897 | Game line scores pivoted into Q1-Q4 columns with OT periods summed. Columns: game_id, season, home_q1, home_q2, home_q3, home_q4, home_ot, away_q1, away_q2, away_q3, away_q4, away_ot |
 | `api.team_playcalling_profile` | **Deployed** | 4,627 | Team playcalling identity with situational tendencies and percentile rankings. One row per team-season. Columns: team, season, conference, games_played, overall_run_rate, early_down_run_rate, third_down_pass_rate, red_zone_run_rate, overall_success_rate, overall_avg_epa, third_down_success_rate, red_zone_success_rate, leading_run_rate, trailing_run_rate, run_rate_delta, pace_plays_per_game, overall_run_rate_pctl, early_down_run_rate_pctl, third_down_pass_rate_pctl, overall_epa_pctl, third_down_success_pctl, red_zone_success_pctl, run_rate_delta_pctl, pace_pctl |
-| `api.coaching_history` | **Deployed** | 2,752 | Coaching tenure analytics: career spans, W-L records, talent metrics. One row per coach-team-tenure. Columns: first_name, last_name, team, tenure_start, tenure_end, seasons_count, total_wins, total_losses, win_pct, conf_wins, conf_losses, conf_win_pct, bowl_games, bowl_wins, inherited_talent_rank, year3_talent_rank, talent_improvement, is_active |
-| `api.coach_records` | **Pending deploy** | -- | Coach career record by school, straight-up and against-the-spread, for ranking coaches by win percentage. One row per coach-team (career-at-school grain, unlike `api.coaching_history`'s per-tenure grain). Columns: coach_name, first_name, last_name, team, first_season, last_season, seasons_count, games, wins, losses, ties, win_pct, ats_games, ats_wins, ats_losses, ats_pushes, ats_win_pct, seasons_with_ats_data. Coach attribution is whole-season (no mid-season splits); `ats_*` coverage is partial pre-lines-era -- see `seasons_with_ats_data` and the 2026-07-22 changelog entry. |
+| `api.coaching_history` | **Deployed** | 2,752 | Coaching tenure analytics: career spans, W-L records, talent metrics. One row per coach-team-tenure. Columns: coach_id, first_name, last_name, team, tenure_start, tenure_end, seasons_count, total_wins, total_losses, win_pct, conf_wins, conf_losses, conf_win_pct, bowl_games, bowl_wins, inherited_talent_rank, year3_talent_rank, talent_improvement, is_active (`coach_id` added 2026-08-30, additive -- `ref.coach_seasons`' coach__id matched by name+team+year, NULL where ambiguous/unmatched) |
+| `api.coach_records` | **Pending deploy** | -- | Coach career record by school, straight-up and against-the-spread, for ranking coaches by win percentage. One row per coach-team (career-at-school grain, unlike `api.coaching_history`'s per-tenure grain). Columns: coach_id, coach_name, first_name, last_name, team, first_season, last_season, seasons_count, games, wins, losses, ties, win_pct, ats_games, ats_wins, ats_losses, ats_pushes, ats_win_pct, seasons_with_ats_data. Coach attribution is whole-season (no mid-season splits); `ats_*` coverage is partial pre-lines-era -- see `seasons_with_ats_data` and the 2026-07-22 changelog entry. `coach_id` added 2026-08-30 (additive, same matching rule as `api.coaching_history`). |
+| `api.passing_charting_player_season` | **Pending deploy** | -- | Passing charting by player-season, 2025+: air yards, aDOT, YAC plus box-score passing columns. Columns: season, player_id, player, team, conference, position, attempts, completions, interceptions, completion_rate, total_air_yards, average_depth_of_target, air_yards_attempts_available, total_yards_after_catch, average_yards_after_catch, yards_after_catch_attempts_available. Two separate coverage denominators -- never merge them. Added 2026-08-30, see changelog entry. |
+| `api.passing_charting_target_season` | **Pending deploy** | -- | Receiver-grain (target) passing charting by season, 2025+ -- cfb-app's first receiving-analysis surface. Columns: target_id, target, season, team_id, team, targets_charted, receptions, total_air_yards, average_depth_of_target, air_yards_charted_plays, total_yards_after_catch, average_yards_after_catch, yards_after_catch_charted_plays, target_share_charted, partial_share. `target_share_charted` is a share of CHARTED targets only. Added 2026-08-30, see changelog entry. |
+| `api.passing_charting_team_season` | **Pending deploy** | -- | Team-season passing charting, offense and defense sides, 2025+. Columns: season, team, conference, offense_total_air_yards, offense_average_depth_of_target, offense_air_yards_attempts_available, offense_total_yards_after_catch, offense_average_yards_after_catch, offense_yards_after_catch_attempts_available, and the defense_ equivalents. `defense_*` is this team's passing DEFENSE, not the opponent's offense. Added 2026-08-30, see changelog entry. |
+| `api.coach_tenures` | **Pending deploy** | -- | CFBD's own continuous coach-tenure record, distinct from `api.coaching_history`. Grain: (coach_id, team_id, tenure_start). Columns: coach_id, coach_name, team_id, team, tenure_start, tenure_end (NULL = active), hire_date, is_interim, record_games, record_wins, record_losses, record_ties, record_win_percentage, classification. May be empty until the `coach_tenures` backfill has run. Added 2026-08-30, see changelog entry. |
+| `api.refresh_campaign_status` | **Pending deploy** | -- | Per-(campaign, season) progress against the migration-051 refresh ledger (`meta.refresh_campaigns`/`meta.refresh_progress`) -- scope-invalidate a cached historical answer for one season instead of an entire in-progress corrections campaign. Plain view, no mart. Columns: campaign, season, games_refreshed, games_no_data, completed_at, last_finalized_at. Added 2026-08-30, see changelog entry. |
 | `api.recruiting_roi` | **Deployed** | 1,324 | Recruiting investment vs on-field outcomes. 4-year rolling BCR, wins over expected, draft production. One row per team-season. Columns: team, season, conference, blue_chip_ratio, avg_recruit_rating, total_wins, win_pct, epa_per_play, players_drafted, wins_over_expected, recruiting_efficiency, win_pct_pctl, epa_pctl, recruiting_efficiency_pctl |
 | `api.transfer_portal_impact` | **Deployed** | 1,374 | Transfer portal activity correlated with team performance changes. Portal era (2021+). One row per team-season. Columns: team, season, conference, transfers_in, transfers_out, net_transfers, avg_transfer_stars, portal_dependency, win_delta, net_transfers_pctl, win_delta_pctl, portal_dependency_pctl |
 | `api.conference_comparison` | **Deployed** | 347 | Conference-level season analytics with percentile rankings. One row per conference-season. Columns: conference, season, member_count, avg_wins, avg_sp_rating, avg_epa, avg_recruiting_rank, non_conf_win_pct, avg_sp_pctl, avg_epa_pctl, avg_recruiting_pctl, non_conf_win_pct_pctl |
@@ -722,7 +805,11 @@ cfb-app for advanced features.
 | `marts.player_comparison` | Deployed | Player stats pivoted from EAV with positional percentiles (PERCENT_RANK). Indexes: (player_id, season) unique, (season, position_group) |
 | `marts.team_playcalling_tendencies` | Deployed | Team play-calling mix (run/pass rates) by situation: down, distance, field position, score state. ~492K rows. Grain: team + season + situation. |
 | `marts.team_situational_success` | Deployed | Team situational effectiveness (success rate, EPA, explosiveness) by context. ~492K rows. Min 10-play threshold for rate metrics. |
-| `marts.coaching_tenure` | Deployed | Coaching tenure analytics with gap detection. One row per coach-team-tenure. Includes W-L, bowl record, inherited vs recruited talent. 2,752 rows. |
+| `marts.coaching_tenure` | Deployed | Coaching tenure analytics with gap detection. One row per coach-team-tenure. Includes W-L, bowl record, inherited vs recruited talent. 2,752 rows. `coach_id` added 2026-08-30 (additive). |
+| `marts.coach_tenures` | Pending deploy | CFBD's own continuous coach-tenure record, passthrough of `ref.coach_tenures` joined to `ref.teams` for classification. Grain: `(coach_id, team_id, tenure_start)`. May be empty until the `coach_tenures` backfill has run. Added 2026-08-30. |
+| `marts.passing_charting_player_season` | Pending deploy | Passing charting by player-season (2025+), passthrough of `stats.passing_player_season` plus `position` joined from `core.roster` on its own primary key. Grain: `(season, player_id, team)`. Added 2026-08-30. |
+| `marts.passing_charting_target_season` | Pending deploy | Receiver-grain (target) passing charting by season (2025+), aggregated from `stats.passing_plays`. Grain: `(season, target_id, team_id)`. Added 2026-08-30. |
+| `marts.passing_charting_team_season` | Pending deploy | Team-season passing charting, offense/defense flattened from `stats.passing_team_season`'s dunder columns. Grain: `(season, team)`. Added 2026-08-30. |
 | `marts.recruiting_roi` | Deployed | 4-year rolling recruiting investment vs outcomes. Blue chip ratio, wins over expected, draft production, recruiting efficiency. 1,324 rows. |
 | `marts.transfer_portal_impact` | Deployed | Portal activity correlated with team performance changes. Portal era only (2021+). 1,374 rows. |
 | `marts.conference_comparison` | Deployed | Per-conference per-season aggregates with PERCENT_RANK percentiles. 347 rows. |

--- a/docs/handoffs/2026-08-30-expansion-exposure-for-cfb-app.md
+++ b/docs/handoffs/2026-08-30-expansion-exposure-for-cfb-app.md
@@ -1,0 +1,148 @@
+# Handoff: 2026-08 warehouse expansion — exposure plan wanted from cfb-app
+
+**From:** cfb-database
+**Date:** 2026-08-30
+**Status:** all data live in the shared Supabase DB (or landing today — see
+"In flight" below). Nothing in `api`/`public` changed yet; that is the ask.
+**Deliverable requested:** a prioritized exposure plan from cfb-app covering
+(a) dashboard/UI features, (b) the MCP/agent tool surface (run_sql views list,
+curated tools), and (c) the list of new `api.*` views cfb-app wants
+cfb-database to build — returned as a handoff doc or issue.
+
+## Why
+
+CFBD shipped a major pre-season API update (spec v5.24.2 → v5.25.0, 79
+endpoints) and cfbfastR 3.0.0 exposed the sportsdataverse parquet releases.
+cfb-database ingested all of it over 2026-08-29/30. The warehouse now carries
+substantial player-grain, coaching, and charting data that neither the app nor
+the bot can see yet. Player-grain depth is the platform's stated strategic
+priority (future PFF/SIS joinability).
+
+## Ground rules (unchanged)
+
+- `docs/SCHEMA_CONTRACT.md` in cfb-database remains the contract. The stable
+  surface is `api.*` views + `public` views/RPCs. Everything below in `stats`/
+  `ref`/`core`/`ratings`/`metrics` schemas is **internal raw tables** — they
+  are SELECT-granted to anon/authenticated (PostgREST-reachable) and fine for
+  prototyping and `run_sql`, but a shipped app feature should sit on an
+  `api.*` view requested from cfb-database, not raw-table coupling.
+- Athlete ids are TEXT and **CFBD athlete/team/game ids ARE ESPN ids**
+  (verified live) — `espn.*` joins need no crosswalk.
+- Join teams by numeric id (`team_id`, `offense_id`, `defense_id`) wherever
+  one exists: `ref.teams` has 35 legitimate duplicate school names, so
+  name-string joins need `DISTINCT ON (school)` or accept fanout.
+- Player-season PKs include `team` (transfer safety) — a player can carry two
+  rows in one season.
+
+## What's new, by feature area
+
+### 1. Passing charting — the headline (data 2025+, live in-season)
+
+Five tables in `stats`, from CFBD's new /passing endpoints (air yards, aDOT,
+pass depth/direction/location, YAC — manually charted from film):
+
+| Table | Grain / PK | Rows now |
+|---|---|---|
+| `stats.passing_plays` | (game_id, play_id) — per pass attempt | 53.5k (2025) + live 2026 |
+| `stats.passing_player_games` | (game_id, player_id) | 3k+ |
+| `stats.passing_player_season` | (season, player_id, team) | 820 (2025) |
+| `stats.passing_team_games` | (game_id, team), offense__*/defense__* columns | 1.7k+ |
+| `stats.passing_team_season` | (season, team) | 136 (2025) |
+
+Key columns on `passing_plays`: `passer_id`, **`target_id`** (the warehouse's
+first receiver-grain join surface — indexed), `outcome`, `air_yards`,
+`pass_depth`, `pass_direction`, `pass_location`, `yards_after_catch`,
+`is_spike`/`is_throwaway`/`is_intentional_grounding`, `parse_status`,
+`offense_id`/`defense_id` (preferred team-join columns).
+
+**NULL semantics (on the columns as COMMENTs, honor them in every surface):**
+NULL charting value = not (yet) charted, never zero; 0 is a real observed
+value; `*_attempts_available` columns are the charting-coverage denominators
+(e.g. `total_air_yards IS NULL` when `air_yards_attempts_available = 0`).
+`parse_status='partial'` marks incompletely-charted plays; partial rows may be
+re-charted upstream later. Coverage is genuinely partial in 2025 (407 of 820
+player-seasons have air-yards aggregates) — leaderboards must show the
+denominator or filter on it, or they will rank on coverage, not skill.
+2026 charts land the SAME DAY as games — this is live-season data.
+
+Feature ideas worth planning: aDOT/air-yards leaderboards, receiver target
+share and target quality (via `target_id`), QB depth-of-target profiles,
+team pass-location tendencies, YAC-over-expected once modeled.
+
+### 2. Player-season overview hub (2014-2025, ~44k rows landing today)
+
+`stats.player_season_overview` — one row per (season, id, team): the CFBD
+/player/season/overview payload (usage, PPA, stat lines) for every player in
+`stats.player_usage` ∪ `metrics.ppa_players_season`. Currently draining ~44k
+player-seasons at full depth 2014-2025 (complete within ~a day). This plus
+passing charting plus `stats.player_success_season/game` (success rates,
+2014+) is the new player-grain core the bot's player tools should sit on.
+
+### 3. Coaching (new: real coach ids)
+
+- `ref.coach_seasons` (3,066 rows, 2014+-ish): per coach-season detail with
+  `coach__id` — CFBD's real coachId, ending name-string coach joins.
+- `ref.coach_tenures` (2,738 rows): per (coach, team) tenure spans with
+  `start_year`/`end_year`, `hire_date`, `is_interim`, `record__wins` etc.
+- `ref.coach_profiles` (drainer, 200+ rows growing 250/day): career profile
+  per coach id.
+Existing `api.coaching_history`/`api.coach_records` still run on the old
+name-keyed marts — a coach_id rekeying of those views is a natural ask.
+
+### 4. CFP + conference history
+
+- `core.cfp_bracket` / `cfp_games` / `cfp_participants` (2014+): structured
+  playoff brackets, rounds, matchups, seeds.
+- `ref.conference_affiliations` / `ref.conference_changes`: full realignment
+  history to 1869 — replaces games-derived conference inference.
+
+### 5. Ratings & metrics additions
+
+- `ratings.srs_expanded` (2004+): FCS-inclusive SRS.
+- `ratings.fpi_weekly` + `ratings.external_weekly` (2005+): **as-of weekly**
+  rating snapshots (leak-free backtest inputs, unlike end-of-season tables).
+- `ratings.massey_composite` (+ `massey_system_ratings` child): the Massey
+  composite table; populates weekly once masseyratings.com starts publishing
+  2026 (team names resolve via the now-seeded `ref.team_name_xwalk`).
+- `metrics.ppa_predicted` (10,140 rows): static expected-points lookup by
+  down/distance/yardline — useful as a reference layer in play views.
+- `stats.game_advanced_team_stats` (2014+): year-scoped per-game advanced
+  team stats with garbage-time-excluded variants.
+- `marts.epa_crossvalidation`: house adjusted-EPA vs external systems
+  (Spearman per season; baseline avg 0.881) — a data-quality panel candidate.
+
+### 6. ESPN player splits + id crosswalks (sportsdataverse parquet)
+
+New `espn` schema: `espn.player_passing/rushing/receiving/defense` (EPA-grain
+advanced player splits, 2004+ — historical seasons loading today) and
+`espn.play_participants` (2014+). Joins to CFBD players directly by id.
+`ref.player_id_xwalk` / `team_id_xwalk` / `game_id_xwalk` add Fox/Yahoo ids.
+
+### 7. Explicitly NOT for consumption
+
+- **`ncaa` schema (sub-FBS 2013+) is deliberately UNGRANTED** — stats.ncaa.org
+  re-issues player ids every season; it stays staging-only until an identity
+  strategy exists. Do not plan features on it yet.
+- `meta`, `raw`, dlt `_dlt_*` columns: internal.
+- SBR betting history: table exists, no data until real SBR files arrive.
+
+## Data-correctness context the bot should know
+
+A historical-corrections refresh campaign (upstream garbage-time
+reclassifications, 2014-2025 play stats + box scores, ~19k games) is draining
+at ≤1,000 calls/day through ~early October. EPA-family numbers for past
+seasons will shift slightly as it lands; `marts.epa_crossvalidation` is the
+plausibility harness. Year-keyed corrected sources (metrics, wepa, recruiting,
+rosters, advanced stats) were re-ingested 2026-08-30.
+
+## What cfb-app should return
+
+A prioritized plan (P1/P2/P3) with, per item: the consumer (dashboard page,
+bot tool, run_sql prompt-surface line), the data source (existing table/view
+or a requested new `api.*` view with its proposed columns and grain), and any
+semantics the UI must carry (charting NULLs, coverage denominators,
+transfer-split rows, partial parse_status). Send new-view requests back as a
+handoff doc or issue to cfb-database — do not build on raw tables for shipped
+features. Quick wins to consider first: add the new granted tables to the
+bot's run_sql available-views prompt list (zero code), then curated tools for
+air-yards leaderboards, target analysis, coach tenures, and CFP brackets.

--- a/docs/handoffs/2026-08-30-expansion-exposure-for-cfb-app.md
+++ b/docs/handoffs/2026-08-30-expansion-exposure-for-cfb-app.md
@@ -113,9 +113,12 @@ name-keyed marts — a coach_id rekeying of those views is a natural ask.
 
 ### 6. ESPN player splits + id crosswalks (sportsdataverse parquet)
 
-New `espn` schema: `espn.player_passing/rushing/receiving/defense` (EPA-grain
-advanced player splits, 2004+ — historical seasons loading today) and
-`espn.play_participants` (2014+). Joins to CFBD players directly by id.
+In the `stats` schema (correction 2026-08-31: an earlier draft said a
+separate `espn` schema — there is none): `stats.espn_player_passing/
+_rushing/_receiving/_defense` (EPA-grain advanced player splits, 2004+ —
+historical seasons loaded 2026-08-30, e.g. 57.8k passing / 369.9k receiving
+rows across 23 seasons) and `stats.espn_play_participants` (2014+, loading).
+Joins to CFBD players directly by id.
 `ref.player_id_xwalk` / `team_id_xwalk` / `game_id_xwalk` add Fox/Yahoo ids.
 
 ### 7. Explicitly NOT for consumption

--- a/docs/handoffs/2026-08-30-expansion-views-reply-to-cfb-app.md
+++ b/docs/handoffs/2026-08-30-expansion-views-reply-to-cfb-app.md
@@ -4,12 +4,14 @@
 **Date:** 2026-08-30
 **Re:** your `WAREHOUSE_EXPANSION_DB_WORKORDER.md` (all P1 tasks) — thank you,
 every claim in it checked out, including two you couldn't see from your side.
-**Status:** everything below is committed on the expansion branch and
-schema-architect-reviewed with live-DB verification; it deploys with the
-branch's merge to main (the `deploys/expansion_views-manifest.json` push-path
-applies marts → api → validation in order). New matviews populate on the
-deploy's refresh; `marts.coach_tenures` and view floors assume the backfills
-running today (see "data timing").
+**Status:** LIVE as of 2026-08-30 ~23:50 UTC. The full unit (marts → api →
+validation, per `deploys/expansion_views-manifest.json`) was applied to the
+live DB ahead of the merge; the merge-day push-path re-apply is idempotent.
+Validation passed live: 840 player-season / 2,659 target-season / 152
+team-season charting rows, coach_tenures 2,738 rows (99.96% classified),
+refresh_campaign_status returning 12 season rows, zero player_detail dupes
+(your repro returns exactly 1 row), shares in [0,1], all grants intact.
+You can build against every view below right now.
 
 ## What shipped, task by task
 

--- a/docs/handoffs/2026-08-30-expansion-views-reply-to-cfb-app.md
+++ b/docs/handoffs/2026-08-30-expansion-views-reply-to-cfb-app.md
@@ -1,0 +1,95 @@
+# Reply: expansion work order — built, reviewed, pending deploy
+
+**From:** cfb-database
+**Date:** 2026-08-30
+**Re:** your `WAREHOUSE_EXPANSION_DB_WORKORDER.md` (all P1 tasks) — thank you,
+every claim in it checked out, including two you couldn't see from your side.
+**Status:** everything below is committed on the expansion branch and
+schema-architect-reviewed with live-DB verification; it deploys with the
+branch's merge to main (the `deploys/expansion_views-manifest.json` push-path
+applies marts → api → validation in order). New matviews populate on the
+deploy's refresh; `marts.coach_tenures` and view floors assume the backfills
+running today (see "data timing").
+
+## What shipped, task by task
+
+- **Task 0 (player_detail fanout) — fixed.** The recruiting side collapses via
+  `DISTINCT ON (athlete_id) ORDER BY year DESC NULLS LAST` — pedigree is a
+  property of the person, so the reclassified (latest-class) row wins and every
+  roster-season row joins the same single recruiting row. Your repro
+  (player_id 5079720, season 2025) verified live: exactly 1 row, stars=5,
+  recruit_class=2024. Legitimate transfer rows (same player-season, different
+  team) are untouched. All pre-existing columns preserved.
+- **Task 1 (overview grain) — resolved by widening the key.** CFBD returns one
+  overview record per (year, playerId) with a single team attribution (probe
+  fixture), so the grains were identical in practice — but we changed
+  `stats.player_season_overview`'s merge key to `(season, id, team)` anyway,
+  BEFORE today's full-depth backfill, so a per-team split can never silently
+  drop a stint. On spelling: raw tables keep their dlt-derived `id`; the api
+  layer is the alias boundary (new views expose `player_id`/`target_id`/
+  `coach_id` uniformly).
+- **Task 2 — `api.passing_charting_player_season` (045).** Both coverage
+  denominators on every row, never merged; NULL semantics in the view COMMENT
+  verbatim from migration 057. `position` was deliberately omitted (no safe
+  numeric join path from that table; roster name-joins risk the 35-duplicate
+  trap) — conference ships. One catch your work order couldn't see:
+  `average_yards_after_catch` had 70% of its live values stranded in a dlt
+  `__v_double` variant column (bigint-typed base + later fractional values);
+  it now COALESCEs both, so NULL really does mean not-charted.
+- **Task 3 — `api.passing_charting_target_season` (046).** Grain
+  (season, target_id, team_id); season via core.games, team via numeric
+  offense_id; `target_share_charted` (named exactly that) and `partial_share`,
+  both live-verified in [0,1]; plus per-metric charted-plays denominators
+  mirroring task 2's coverage principle.
+- **Task 4 — `api.passing_charting_team_season` (047).** offense_*/defense_*
+  flattening (no dunder shapes), with the defense_*-is-your-defense warning in
+  the COMMENT. Those columns are natively double precision — no variant issue.
+- **Task 5 — coaching.** `coach_id` added additively to `api.coaching_history`
+  and `api.coach_records` (name+team+year match to ref.coach_seasons,
+  deterministic, NULL on ambiguity — live: 0 ambiguous collisions; match rate
+  is ~24% today only because coach_seasons isn't fully backfilled, and rises
+  as it fills). New `api.coach_tenures` (048), grain
+  (coach_id, team_id, tenure_start), with coach_name, tenure_start/end
+  (NULL=active), hire_date, `is_interim`, flattened record_*, and
+  `classification` — both of your code-side hacks (`DEFAULT_MIN_GAMES`, the
+  130-name `.in()` filter) can retire.
+- **Task 6 — player_detail extended additively.** games, usage_overall,
+  usage_pass, usage_rush (COALESCEd across its variant twin — 62% of live
+  values were stranded), ppa_overview_avg, ppa_overview_total, via a
+  fanout-proof LATERAL (team-matched stint preferred, deterministic
+  tiebreaker, LIMIT 1).
+
+## Your two "things to settle"
+
+1. **`marts.epa_crossvalidation` is INTERNAL** — the SCHEMA_CONTRACT entry is
+   authoritative; the handoff's "panel candidate" phrasing was an idea, not a
+   contract change. Design nothing against it. If you decide you want it
+   consumable, ask for an api view explicitly and it gets the same treatment
+   as everything here.
+2. **Campaign invalidation — solved concretely: `api.refresh_campaign_status`
+   (049).** One row per (campaign, season): games_refreshed, games_no_data,
+   completed_at, last_finalized_at, over the meta ledger you spotted in
+   migration 051. Poll it to scope-invalidate the bot's cached historical
+   answers per season as the corrections campaign drains (through ~early
+   October) instead of distrusting the whole 2014-2025 range.
+
+## Data timing (affects when the views read full)
+
+- `stats.player_season_overview`: full-depth 2014-2025 backfill (~44k
+  player-seasons) is draining today; until it completes, task-6 columns are
+  NULL for most players (matching NULL semantics).
+- Passing charting: 2025 complete, 2026 accumulates same-day in-season.
+- `ref.coach_seasons` continues backfilling; coach_id match rates rise with it.
+
+## P2s (CFP bracket, per-season conference_affiliations expansion,
+## game_advanced, ratings_weekly)
+
+Acknowledged, not in this unit. Your notes are good specs — especially the
+span→season expansion being the real work on affiliations and era-explicit
+CFP seeds; the CFP view will be scheduled to land before December.
+
+## One correction accepted
+
+Your dedupe-check grain note was right and we went further: the validation SQL
+checks (player_id, season, team) — the finer grain — plus your exact repro
+case, so a legitimate transfer never trips the check.

--- a/scripts/load_flat_files.py
+++ b/scripts/load_flat_files.py
@@ -13,7 +13,10 @@ Usage:
     python scripts/load_flat_files.py --due                      # run whatever cadence says is due
     python scripts/load_flat_files.py --source massey            # force one source
     python scripts/load_flat_files.py --source sbr --file odds.xlsx  # feed a local file
-    python scripts/load_flat_files.py --season 2025 --due         # override the season hint
+    python scripts/load_flat_files.py --season 2025 --due         # backfill that season: every
+                                                                  # non-manual source, cadence
+                                                                  # gating off (hash-skip keeps
+                                                                  # it cheap)
 
 Row counting (kind="dlt"): ``build_flat_file_source`` already materializes the
 parsed rows into in-memory list resources, so re-iterating those resources
@@ -463,10 +466,20 @@ def build_arg_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _planned_sources(args: argparse.Namespace, today: date, season: int) -> list[str]:
+def _planned_sources(
+    args: argparse.Namespace, today: date, season: int, *, season_explicit: bool
+) -> list[str]:
     if args.source:
         return list(args.source)
     if args.due:
+        if season_explicit:
+            # An explicit --season is a backfill request: cadence freshness
+            # describes only the current season's file, so gating a
+            # historical season on is_due would silently plan nothing (e.g.
+            # every weekly source off-season). Plan every non-manual source
+            # instead -- the ledger hash-skip makes over-planning free, and
+            # manual-cadence sources still need --file so they stay excluded.
+            return [name for name, spec in REGISTRY.items() if spec.cadence != "manual"]
         return [
             name
             for name, spec in REGISTRY.items()
@@ -496,7 +509,7 @@ def main(argv: list[str] | None = None) -> int:
     today = date.today()
     season_explicit = args.season is not None
     season = args.season if season_explicit else season_for_date(today)
-    names = _planned_sources(args, today, season)
+    names = _planned_sources(args, today, season, season_explicit=season_explicit)
 
     if args.dry_run:
         print(f"[DRY RUN] {len(names)} flat-file source(s) planned for season {season}")

--- a/scripts/load_season.py
+++ b/scripts/load_season.py
@@ -15,6 +15,7 @@ Usage:
 
 import argparse
 import logging
+import os
 import sys
 import time
 
@@ -549,8 +550,21 @@ def load_season(
         # Season-independent by design -- the completed-season gate inside
         # run_player_overview_pipeline decides which seasons are eligible,
         # not the season this load_season() call targets. See
-        # run_player_overview_pipeline and the IMMUTABLE_ONCE_FINAL comment above.
-        "player_overview": lambda: run_player_overview_pipeline(),
+        # run_player_overview_pipeline and the IMMUTABLE_ONCE_FINAL comment
+        # above. PLAYER_OVERVIEW_MAX_PER_RUN (set by backfill-sources.yml's
+        # player_overview_max input) raises the drainer's CAP only -- it
+        # never widens scope, which stays newest-completed-season-first
+        # across every eligible season regardless of the cap. Read inside
+        # the lambda (not bound as a default arg) so each call picks up the
+        # env as it stands at call time rather than freezing it at import.
+        # GitHub sets an empty-string env for an unset input, and
+        # int(os.environ.get(...)) on "" would crash, so fall back to 250
+        # (today's default) unless the value is actually digits.
+        "player_overview": lambda: run_player_overview_pipeline(
+            max_players=int(v)
+            if (v := os.environ.get("PLAYER_OVERVIEW_MAX_PER_RUN", "")).isdigit()
+            else 250
+        ),
         # Excluded from the default active set above (one call per team), so
         # this only runs when an operator asks for it by name:
         # --sources rosters. The team list resolves from the season's

--- a/scripts/refresh_marts.py
+++ b/scripts/refresh_marts.py
@@ -44,6 +44,13 @@ MARTS_VIEWS = [
     "marts.core_ratings",
     "marts.penalty_log",
     "marts.team_penalty_box",
+    # 2026-08-30 expansion_views unit: passing charting (stats.passing_*) and
+    # coach_tenures (ref.coach_tenures) -- all read base tables only, no
+    # mart dependencies.
+    "marts.passing_charting_player_season",
+    "marts.passing_charting_target_season",
+    "marts.passing_charting_team_season",
+    "marts.coach_tenures",
     # Layer 2: Depends on Layer 1
     "marts.team_epa_season",
     "marts.team_season_summary",

--- a/src/pipelines/config/endpoints.py
+++ b/src/pipelines/config/endpoints.py
@@ -232,7 +232,13 @@ STATS_ENDPOINTS = {
     "player_season_overview": EndpointConfig(
         path="/player/season/overview",
         table_name="player_season_overview",
-        primary_key=["season", "id"],
+        # team added 2026-08-30 pre-backfill for transfer safety and grain
+        # consistency with player_success_season/passing_player_season
+        # (cfb-app work-order task 1); see player_overview.py's resource
+        # decorator for the full rationale. CFBD normally returns one
+        # overview record per player-season with a single team
+        # attribution, so this is insurance, not an observed split.
+        primary_key=["season", "id", "team"],
         schema="stats",
         write_disposition="merge",
     ),

--- a/src/pipelines/sources/player_overview.py
+++ b/src/pipelines/sources/player_overview.py
@@ -68,7 +68,18 @@ def player_overview_source(
 @dlt.resource(
     name="player_season_overview",
     write_disposition="merge",
-    primary_key=["season", "id"],
+    # team added 2026-08-30 pre-backfill for transfer safety and grain
+    # consistency with player_success_season/passing_player_season
+    # (cfb-app work-order task 1). CFBD normally returns one overview
+    # record per player-season with a single top-level team attribution --
+    # this is insurance against a per-team split (e.g. a mid-season
+    # transfer reported as two rows for the same player-season), not an
+    # observed one: merging on (season, id) alone would silently drop a
+    # stint under last-write-wins if CFBD ever does split. The candidate
+    # set-difference in run.py (run_player_overview_pipeline) still keys on
+    # (season, id) only, which stays correct -- it drains a candidate once
+    # per season regardless of team.
+    primary_key=["season", "id", "team"],
 )
 def player_season_overview_resource(
     player_seasons: list[tuple[int, str]],

--- a/src/pipelines/sources/wepa.py
+++ b/src/pipelines/sources/wepa.py
@@ -17,6 +17,57 @@ from .base import make_request
 logger = logging.getLogger(__name__)
 
 
+def _stamp_player_id(player: dict, resource_name: str) -> dict | None:
+    """Ensure `player["id"]` is populated before dlt normalizes the row.
+
+    CFBD renamed the player-id field upstream on at least one of the
+    /wepa/players/* endpoints sometime after the existing 2014-2025 rows
+    were loaded (observed 2026-08-30, backfill run 33333482499: dlt raised
+    UnboundColumnException on wepa_players_passing -- "id ... did not
+    receive any data" -- even though the endpoint returned HTTP 200). We did
+    not probe the exact new field name before diagnosing this, so this
+    coalesces across the plausible candidates instead of guessing one:
+    `playerId`, `athleteId`, or a nested `athlete.id`. Coalescing (rather
+    than a straight rename) keeps primary-key continuity with the existing
+    `id` column, which is text, so the winning candidate is cast with
+    str() to keep the column type stable no matter which candidate it came
+    from. The original renamed field is left in the record too -- dlt just
+    adds it as a new column, and it tells us after the run what CFBD
+    actually renamed it to.
+
+    Returns the record with `id` populated, or None if no candidate exists
+    at all. A caller that gets None must skip the record (yield nothing for
+    it) rather than let dlt's normalize step raise on the non-nullable PK
+    column and kill the whole resource -- and, per the stats.py
+    play_stats lesson, its sibling resources' already-fetched packages too.
+    """
+    if player.get("id") is not None:
+        return player
+
+    athlete = player.get("athlete")
+    candidate = None
+    for value in (
+        player.get("playerId"),
+        player.get("athleteId"),
+        athlete.get("id") if isinstance(athlete, dict) else None,
+    ):
+        if value is not None:
+            candidate = value
+            break
+
+    if candidate is None:
+        logger.warning(
+            "%s: no player id found on record (checked id/playerId/athleteId/"
+            "athlete.id) -- skipping. keys=%s",
+            resource_name,
+            sorted(player.keys()),
+        )
+        return None
+
+    player["id"] = str(candidate)
+    return player
+
+
 @dlt.source(name="cfbd_wepa")
 def wepa_source(
     years: list[int] | None = None,
@@ -94,6 +145,9 @@ def wepa_players_passing_resource(years: list[int]) -> Iterator[dict]:
 
             for player in data:
                 player["year"] = year
+                player = _stamp_player_id(player, "wepa_players_passing")
+                if player is None:
+                    continue
                 yield player
 
     finally:
@@ -123,6 +177,9 @@ def wepa_players_rushing_resource(years: list[int]) -> Iterator[dict]:
 
             for player in data:
                 player["year"] = year
+                player = _stamp_player_id(player, "wepa_players_rushing")
+                if player is None:
+                    continue
                 yield player
 
     finally:
@@ -152,6 +209,9 @@ def wepa_players_kicking_resource(years: list[int]) -> Iterator[dict]:
 
             for player in data:
                 player["year"] = year
+                player = _stamp_player_id(player, "wepa_players_kicking")
+                if player is None:
+                    continue
                 yield player
 
     finally:

--- a/src/schemas/api/009_player_detail.sql
+++ b/src/schemas/api/009_player_detail.sql
@@ -2,6 +2,56 @@
 -- Comprehensive player profile: roster info, recruiting, season stats (pass/rush/rec/def), and PPA
 -- Exposed via PostgREST as /api/player_detail
 -- Extracted from deployed Supabase database on 2026-02-06
+--
+-- 2026-08-30 (expansion_views unit, task 0 -- BUG FIX): the recruiting join
+-- fanned out for players carrying more than one recruiting.recruits row for
+-- the same athlete_id (reclassifications: a player signed in one class year
+-- and re-ranked/re-classed into another keeps BOTH rows -- recruiting.recruits'
+-- primary key is its own `id`, not athlete_id, per src/pipelines/sources/
+-- recruiting.py). The original join (`rec.athlete_id::text = r.id::text`,
+-- no year filter) matched every one of a player's recruiting rows against
+-- every one of their roster-season rows, duplicating every stat column
+-- verbatim. Verified live by cfb-app (player_id 5079720, season 2025: 2 rows
+-- differing only in stars/recruit_rating/national_ranking/recruit_class).
+-- Under 1% of players per season (2020: 39/16,419 ... 2025: 14/30,004) but
+-- concentrated in blue-chip reclassification cases -- exactly who gets asked
+-- about most -- and SUM(rec_yds)-style aggregation over this view silently
+-- double-counts them.
+--
+-- Fix: `recruit_dedup` collapses recruiting.recruits to one row per
+-- athlete_id via DISTINCT ON, keeping the row with the HIGHEST recruit
+-- class year (a reclassification's later year is the authoritative,
+-- final-status entry -- CFBD does not retract the earlier row). A player's
+-- recruiting pedigree (stars/rating/ranking/class) is a property of the
+-- person, not of a given playing season, so every roster-season row for
+-- that player_id now joins to the SAME single recruiting row -- this is a
+-- deliberate 1-to-1-on-athlete_id dedupe, not a (player_id, season, team)
+-- key on the recruiting side (recruiting.recruits carries neither a
+-- matching `season` nor `team` column to key on), and it is what makes the
+-- final view exactly one row per (player_id, season, team) -- roster's own
+-- grain -- again.
+--
+-- 2026-08-30 (expansion_views unit, task 6 -- additive): LEFT JOIN LATERAL a
+-- compact stats.player_season_overview payload (games, usage, PPA-overview).
+-- Column names (season, id, team, usage__overall, usage__pass, usage__rush,
+-- ppa__average__all, ppa__total__all) are verified against the CFBD OpenAPI
+-- spec's PlayerSeasonOverview/PlayerUsage/PlayerSeasonOverviewPPA schemas
+-- (fetched 2026-08-30) and src/pipelines/sources/player_overview.py's own
+-- docstring -- NOT a live pg_attribute read (no DB access from this
+-- session). usage__overall/usage__pass/usage__rush are individually
+-- nullable but always-present keys per the spec's `required` list, so they
+-- materialize as columns on first load; ppa__average__all/ppa__total__all
+-- are required+non-nullable. VERIFY VIA pg_attribute AT DEPLOY TIME before
+-- applying, per this repo's column-contract convention.
+--
+-- The overview table's primary key is being changed to (season, id, team)
+-- in a parallel diff (src/pipelines/sources/player_overview.py, same day) --
+-- this join does not depend on which PK shape is live: LEFT JOIN LATERAL
+-- ... ORDER BY (overview.team = player_detail.team) DESC LIMIT 1 always
+-- returns at most one row (preferring a team-matched stint, falling back to
+-- any stint for that player-season if team doesn't match or is NULL), so it
+-- cannot fan out player_detail regardless of how many team-stints a given
+-- (season, id) has on the overview table.
 
 CREATE OR REPLACE VIEW api.player_detail AS
 WITH player_passing AS (
@@ -122,6 +172,19 @@ WITH player_passing AS (
     FROM stats.player_season_stats
     WHERE player_season_stats.category::text = 'defensive'::text
     GROUP BY player_season_stats.player_id, player_season_stats.season
+), recruit_dedup AS (
+    -- Task 0 fix: one row per athlete_id (recruiting.recruits' PK is its own
+    -- `id`, not athlete_id -- see file header). ORDER BY year DESC keeps the
+    -- reclassified/authoritative entry when an athlete has more than one
+    -- recruiting-class row.
+    SELECT DISTINCT ON (athlete_id)
+        athlete_id,
+        stars,
+        rating,
+        ranking,
+        year
+    FROM recruiting.recruits
+    ORDER BY athlete_id, year DESC
 )
 SELECT
     r.id AS player_id,
@@ -157,16 +220,38 @@ SELECT
     pd.tfl,
     pd.pass_def,
     ppa.average_ppa__all AS ppa_avg,
-    ppa.total_ppa__all AS ppa_total
+    ppa.total_ppa__all AS ppa_total,
+    -- Task 6 additions (additive; see file header for join-safety rationale)
+    ov.games,
+    ov.usage_overall,
+    ov.usage_pass,
+    ov.usage_rush,
+    ov.ppa_overview_avg,
+    ov.ppa_overview_total
 FROM core.roster r
-LEFT JOIN recruiting.recruits rec ON rec.athlete_id::text = r.id::text
+LEFT JOIN recruit_dedup rec ON rec.athlete_id::text = r.id::text
 LEFT JOIN player_passing pp ON pp.player_id::text = r.id::text AND pp.season = r.year
 LEFT JOIN player_rushing pr ON pr.player_id::text = r.id::text AND pr.season = r.year
 LEFT JOIN player_receiving prv ON prv.player_id::text = r.id::text AND prv.season = r.year
 LEFT JOIN player_defense pd ON pd.player_id::text = r.id::text AND pd.season = r.year
-LEFT JOIN metrics.ppa_players_season ppa ON ppa.id::text = r.id::text AND ppa.season = r.year;
+LEFT JOIN metrics.ppa_players_season ppa ON ppa.id::text = r.id::text AND ppa.season = r.year
+LEFT JOIN LATERAL (
+    SELECT
+        pso.games,
+        pso.usage__overall AS usage_overall,
+        pso.usage__pass AS usage_pass,
+        pso.usage__rush AS usage_rush,
+        pso.ppa__average__all AS ppa_overview_avg,
+        pso.ppa__total__all AS ppa_overview_total,
+        pso.team
+    FROM stats.player_season_overview pso
+    WHERE pso.id::text = r.id::text
+      AND pso.season = r.year
+    ORDER BY (pso.team = r.team) DESC
+    LIMIT 1
+) ov ON true;
 
-COMMENT ON VIEW api.player_detail IS 'Comprehensive player profile with roster info, recruiting data, season stats, and PPA metrics';
+COMMENT ON VIEW api.player_detail IS 'Comprehensive player profile with roster info, recruiting data, season stats, PPA metrics, and a compact season-overview payload (games/usage/ppa_overview_*). One row per (player_id, season, team) -- recruiting pedigree (stars/recruit_rating/national_ranking/recruit_class) is deduped to one row per player_id, keeping the highest (most authoritative) recruit_class year for a reclassified player (fixed 2026-08-30; was fanning out on players with 2+ recruiting.recruits rows). games/usage_overall/usage_pass/usage_rush/ppa_overview_avg/ppa_overview_total are from stats.player_season_overview via a fanout-proof LATERAL join (team-matched stint preferred, falls back to any stint for that player-season) -- NULL outside that table''s coverage.';
 
 -- Grants are part of the definition: an apply that DROPs/recreates the
 -- view would otherwise leave the PostgREST roles without read access

--- a/src/schemas/api/009_player_detail.sql
+++ b/src/schemas/api/009_player_detail.sql
@@ -33,16 +33,22 @@
 --
 -- 2026-08-30 (expansion_views unit, task 6 -- additive): LEFT JOIN LATERAL a
 -- compact stats.player_season_overview payload (games, usage, PPA-overview).
--- Column names (season, id, team, usage__overall, usage__pass, usage__rush,
--- ppa__average__all, ppa__total__all) are verified against the CFBD OpenAPI
--- spec's PlayerSeasonOverview/PlayerUsage/PlayerSeasonOverviewPPA schemas
--- (fetched 2026-08-30) and src/pipelines/sources/player_overview.py's own
--- docstring -- NOT a live pg_attribute read (no DB access from this
--- session). usage__overall/usage__pass/usage__rush are individually
--- nullable but always-present keys per the spec's `required` list, so they
--- materialize as columns on first load; ppa__average__all/ppa__total__all
--- are required+non-nullable. VERIFY VIA pg_attribute AT DEPLOY TIME before
--- applying, per this repo's column-contract convention.
+-- Column names LIVE-VERIFIED 2026-08-30 via information_schema.columns
+-- against stats.player_season_overview, including a check for dlt VARIANT
+-- (__v_double) twins on every bigint-typed column -- the same pattern
+-- codified in src/schemas/009_variant_columns.sql and marts/032_player_usage.sql
+-- (dlt creates a `<col>__v_double` sibling when the API returns a float for
+-- a column it first inferred as bigint from an earlier integer value; the
+-- float-typed rows land in the twin and the base column reads NULL for
+-- them unless the two are COALESCEd). Result:
+--   - games: integer by nature (a games-played count), no twin possible.
+--   - usage__overall, usage__pass, ppa__average__all, ppa__total__all: all
+--     natively double precision on this table -- no twin exists, read
+--     directly.
+--   - usage__rush: bigint base column WITH a __v_double twin -- live,
+--     155/249 non-null values are stranded in usage__rush__v_double alone.
+--     COALESCEd below; reading the base column alone would have silently
+--     NULLed out the majority of non-null values.
 --
 -- The overview table's primary key is being changed to (season, id, team)
 -- in a parallel diff (src/pipelines/sources/player_overview.py, same day) --
@@ -176,7 +182,9 @@ WITH player_passing AS (
     -- Task 0 fix: one row per athlete_id (recruiting.recruits' PK is its own
     -- `id`, not athlete_id -- see file header). ORDER BY year DESC keeps the
     -- reclassified/authoritative entry when an athlete has more than one
-    -- recruiting-class row.
+    -- recruiting-class row. NULLS LAST is required: Postgres defaults DESC
+    -- to NULLS FIRST, so without it a recruiting row with a NULL year would
+    -- outrank a real recruit_class year instead of losing to it.
     SELECT DISTINCT ON (athlete_id)
         athlete_id,
         stars,
@@ -184,7 +192,7 @@ WITH player_passing AS (
         ranking,
         year
     FROM recruiting.recruits
-    ORDER BY athlete_id, year DESC
+    ORDER BY athlete_id, year DESC NULLS LAST
 )
 SELECT
     r.id AS player_id,
@@ -240,14 +248,26 @@ LEFT JOIN LATERAL (
         pso.games,
         pso.usage__overall AS usage_overall,
         pso.usage__pass AS usage_pass,
-        pso.usage__rush AS usage_rush,
+        -- usage__rush is bigint with a dlt __v_double VARIANT twin on this
+        -- table (live-verified 2026-08-30: 155/249 non-null values are
+        -- stranded in the twin alone) -- COALESCE per the repo's codified
+        -- pattern (src/schemas/009_variant_columns.sql,
+        -- marts/032_player_usage.sql:56). games/usage__overall/usage__pass/
+        -- ppa__average__all/ppa__total__all have no twin (see file header)
+        -- and are read directly.
+        COALESCE(pso.usage__rush::double precision, pso.usage__rush__v_double) AS usage_rush,
         pso.ppa__average__all AS ppa_overview_avg,
         pso.ppa__total__all AS ppa_overview_total,
         pso.team
     FROM stats.player_season_overview pso
     WHERE pso.id::text = r.id::text
       AND pso.season = r.year
-    ORDER BY (pso.team = r.team) DESC
+    -- Secondary tiebreaker (pso.team) makes the pick deterministic even
+    -- when two stints share the same team-match outcome (both matched, or
+    -- both didn't) -- without it, LIMIT 1 could return either row from run
+    -- to run since ORDER BY on the boolean match alone leaves ties
+    -- unordered.
+    ORDER BY (pso.team = r.team) DESC, pso.team
     LIMIT 1
 ) ov ON true;
 

--- a/src/schemas/api/015_coaching_history.sql
+++ b/src/schemas/api/015_coaching_history.sql
@@ -42,10 +42,11 @@ COMMENT ON VIEW api.coaching_history IS
 'Filter by team, coach_name, last_name, is_active. '
 'talent_improvement = inherited_rank - year3_rank (positive = improved recruiting). '
 'coach_id (added 2026-08-30) is ref.coach_seasons'' coach__id, matched by (first_name, '
-'last_name, team, year) with a deterministic tie-break -- NULL when no unambiguous match '
-'was found across the tenure''s seasons (name collision or no matching ref.coach_seasons '
-'row); use it instead of first_name+last_name to join to api.coach_records or '
-'api.coach_tenures.';
+'last_name, team, year) -- the single id every MATCHED season of the tenure agrees on. '
+'NULL when a season''s match is ambiguous (more than one distinct coach__id), when matched '
+'seasons disagree, or when zero seasons matched; seasons outside ref.coach_seasons'' '
+'coverage (it has no pre-2014 depth) do NOT invalidate the match. Use it instead of '
+'first_name+last_name to join to api.coach_records or api.coach_tenures.';
 
 -- Grants are part of the definition: an apply that DROPs/recreates the
 -- view would otherwise leave the PostgREST roles without read access

--- a/src/schemas/api/015_coaching_history.sql
+++ b/src/schemas/api/015_coaching_history.sql
@@ -43,8 +43,9 @@ COMMENT ON VIEW api.coaching_history IS
 'talent_improvement = inherited_rank - year3_rank (positive = improved recruiting). '
 'coach_id (added 2026-08-30) is ref.coach_seasons'' coach__id, matched by (first_name, '
 'last_name, team, year) -- the single id every MATCHED season of the tenure agrees on. '
-'NULL when a season''s match is ambiguous (more than one distinct coach__id), when matched '
-'seasons disagree, or when zero seasons matched; seasons outside ref.coach_seasons'' '
+'NULL when any season''s match is ambiguous (more than one distinct coach__id -- one '
+'ambiguous season poisons the entire tenure''s coach_id), when matched seasons disagree, '
+'or when zero seasons matched; seasons outside ref.coach_seasons'' '
 'coverage (it has no pre-2014 depth) do NOT invalidate the match. Use it instead of '
 'first_name+last_name to join to api.coach_records or api.coach_tenures.';
 

--- a/src/schemas/api/015_coaching_history.sql
+++ b/src/schemas/api/015_coaching_history.sql
@@ -5,6 +5,7 @@
 
 CREATE OR REPLACE VIEW api.coaching_history AS
 SELECT
+    coach_id,
     coach_name,
     first_name,
     last_name,
@@ -39,7 +40,12 @@ FROM marts.coaching_tenure;
 COMMENT ON VIEW api.coaching_history IS
 'Coaching history with tenure performance summaries. One row per coach-team-tenure. '
 'Filter by team, coach_name, last_name, is_active. '
-'talent_improvement = inherited_rank - year3_rank (positive = improved recruiting).';
+'talent_improvement = inherited_rank - year3_rank (positive = improved recruiting). '
+'coach_id (added 2026-08-30) is ref.coach_seasons'' coach__id, matched by (first_name, '
+'last_name, team, year) with a deterministic tie-break -- NULL when no unambiguous match '
+'was found across the tenure''s seasons (name collision or no matching ref.coach_seasons '
+'row); use it instead of first_name+last_name to join to api.coach_records or '
+'api.coach_tenures.';
 
 -- Grants are part of the definition: an apply that DROPs/recreates the
 -- view would otherwise leave the PostgREST roles without read access

--- a/src/schemas/api/038_coach_records.sql
+++ b/src/schemas/api/038_coach_records.sql
@@ -31,6 +31,22 @@
 -- marts.team_ats_records.team + season -- there is no shared surrogate id
 -- between coaching data and betting data.
 --
+-- 2026-08-30 (expansion_views unit, task 5a -- additive): coach_id, matched
+-- per-season to ref.coach_seasons by (first_name, last_name, school, year)
+-- via LEFT JOIN LATERAL ... ORDER BY coach__id LIMIT 1 (deterministic
+-- tie-break, cannot fan out) -- same fix and same rationale as
+-- marts.coaching_tenure's coach_id (see that file's header): CFBD's older
+-- /coaches bio rows share no surrogate key with the newer, richer
+-- /coaches/seasons load, so cfb-app was joining coaching_history to
+-- coach_records on first_name+last_name alone
+-- (cfb-app/src/lib/queries/coaches.ts:170-182). Because this view's grain is
+-- a coach's WHOLE CAREER at a school (not a single tenure), the per-season
+-- matches are collapsed to one coach_id per (coach_name, team) only when
+-- every one of that coach's seasons at that school agrees on the same
+-- coach__id -- ambiguous (>1 distinct id, e.g. a same-named-coach
+-- collision) or unmatched (0) seasons yield NULL rather than a guessed
+-- value.
+--
 -- PostgREST usage:
 --   GET /api/coach_records?team=eq.Alabama&order=win_pct.desc
 --   GET /api/coach_records?coach_name=ilike.*saban*&order=ats_win_pct.desc
@@ -51,9 +67,20 @@ WITH coach_seasons AS (
         cs.games,
         cs.wins,
         cs.losses,
-        cs.ties
+        cs.ties,
+        match.coach_id AS season_coach_id
     FROM ref.coaches c
     JOIN ref.coaches__seasons cs ON cs._dlt_parent_id = c._dlt_id
+    LEFT JOIN LATERAL (
+        SELECT rcs.coach__id AS coach_id
+        FROM ref.coach_seasons rcs
+        WHERE rcs.coach__first_name = c.first_name
+          AND rcs.coach__last_name = c.last_name
+          AND rcs.team__school = cs.school
+          AND rcs.year = cs.year
+        ORDER BY rcs.coach__id
+        LIMIT 1
+    ) match ON true
     WHERE cs.school IS NOT NULL
       AND cs.year IS NOT NULL
 ),
@@ -72,6 +99,14 @@ coach_seasons_ats AS (
         AND tar.season = cse.season
 )
 SELECT
+    -- One coach_id for the coach's whole career at this school only when
+    -- every matched season agrees; ambiguous (>1 distinct id) or unmatched
+    -- (0) -> NULL. See coach_seasons CTE above for the per-season LATERAL
+    -- match.
+    CASE
+        WHEN COUNT(DISTINCT season_coach_id) FILTER (WHERE season_coach_id IS NOT NULL) = 1
+            THEN MIN(season_coach_id)
+    END AS coach_id,
     coach_name,
     first_name,
     last_name,
@@ -114,6 +149,6 @@ SELECT
 FROM coach_seasons_ats
 GROUP BY coach_name, first_name, last_name, team;
 
-COMMENT ON VIEW api.coach_records IS 'Coach career records at a school (coach x team grain), straight-up and against-the-spread. Columns: coach_name, first_name, last_name, team, first_season, last_season, seasons_count, games, wins, losses, ties, win_pct, ats_games, ats_wins, ats_losses, ats_pushes, ats_win_pct, seasons_with_ats_data. Coach attribution is whole-season (mid-season coaching changes not splittable -- see ref.coaches__seasons). ATS columns are partial pre-lines-era coverage (LEFT JOIN to marts.team_ats_records); use seasons_with_ats_data to gauge coverage. Backed by ref.coaches / ref.coaches__seasons and marts.team_ats_records.';
+COMMENT ON VIEW api.coach_records IS 'Coach career records at a school (coach x team grain), straight-up and against-the-spread. Columns: coach_id, coach_name, first_name, last_name, team, first_season, last_season, seasons_count, games, wins, losses, ties, win_pct, ats_games, ats_wins, ats_losses, ats_pushes, ats_win_pct, seasons_with_ats_data. Coach attribution is whole-season (mid-season coaching changes not splittable -- see ref.coaches__seasons). ATS columns are partial pre-lines-era coverage (LEFT JOIN to marts.team_ats_records); use seasons_with_ats_data to gauge coverage. coach_id (added 2026-08-30) is ref.coach_seasons'' coach__id, matched by (first_name, last_name, team, year) with a deterministic tie-break -- NULL when no unambiguous match was found across every one of the coach''s seasons at this school. Backed by ref.coaches / ref.coaches__seasons and marts.team_ats_records.';
 
 GRANT SELECT ON api.coach_records TO anon, authenticated;

--- a/src/schemas/api/038_coach_records.sql
+++ b/src/schemas/api/038_coach_records.sql
@@ -51,7 +51,10 @@
 -- collision) or unmatched (0) seasons yield NULL rather than a guessed
 -- value. Seasons outside ref.coach_seasons' coverage (it has no pre-2014
 -- depth) do NOT invalidate the match -- requiring full-span matches would
--- NULL nearly every long career.
+-- NULL nearly every long career. An ambiguous season poisons the entire
+-- career's coach_id (NULL), while unmatched coverage-gap seasons still do
+-- not -- the two NULL causes are distinguished via an explicit per-season
+-- ambiguity flag (PR #81 Greptile round-2).
 --
 -- PostgREST usage:
 --   GET /api/coach_records?team=eq.Alabama&order=win_pct.desc
@@ -74,13 +77,16 @@ WITH coach_seasons AS (
         cs.wins,
         cs.losses,
         cs.ties,
-        match.coach_id AS season_coach_id
+        match.coach_id AS season_coach_id,
+        match.ambiguous AS season_match_ambiguous
     FROM ref.coaches c
     JOIN ref.coaches__seasons cs ON cs._dlt_parent_id = c._dlt_id
     LEFT JOIN LATERAL (
-        SELECT CASE
-            WHEN COUNT(DISTINCT rcs.coach__id) = 1 THEN MIN(rcs.coach__id)
-        END AS coach_id
+        SELECT
+            CASE
+                WHEN COUNT(DISTINCT rcs.coach__id) = 1 THEN MIN(rcs.coach__id)
+            END AS coach_id,
+            COUNT(DISTINCT rcs.coach__id) > 1 AS ambiguous
         FROM ref.coach_seasons rcs
         WHERE rcs.coach__first_name = c.first_name
           AND rcs.coach__last_name = c.last_name
@@ -106,11 +112,13 @@ coach_seasons_ats AS (
 )
 SELECT
     -- One coach_id for the coach's whole career at this school only when
-    -- every matched season agrees; ambiguous (>1 distinct id) or unmatched
-    -- (0) -> NULL. See coach_seasons CTE above for the per-season LATERAL
-    -- match.
+    -- every matched season agrees AND no season's match was ambiguous; any
+    -- ambiguous season poisons the whole career (NULL), while unmatched
+    -- coverage-gap seasons do not. See coach_seasons CTE above for the
+    -- per-season LATERAL match and its explicit ambiguity flag.
     CASE
         WHEN COUNT(DISTINCT season_coach_id) FILTER (WHERE season_coach_id IS NOT NULL) = 1
+         AND NOT BOOL_OR(season_match_ambiguous)
             THEN MIN(season_coach_id)
     END AS coach_id,
     coach_name,
@@ -155,6 +163,6 @@ SELECT
 FROM coach_seasons_ats
 GROUP BY coach_name, first_name, last_name, team;
 
-COMMENT ON VIEW api.coach_records IS 'Coach career records at a school (coach x team grain), straight-up and against-the-spread. Columns: coach_id, coach_name, first_name, last_name, team, first_season, last_season, seasons_count, games, wins, losses, ties, win_pct, ats_games, ats_wins, ats_losses, ats_pushes, ats_win_pct, seasons_with_ats_data. Coach attribution is whole-season (mid-season coaching changes not splittable -- see ref.coaches__seasons). ATS columns are partial pre-lines-era coverage (LEFT JOIN to marts.team_ats_records); use seasons_with_ats_data to gauge coverage. coach_id (added 2026-08-30) is ref.coach_seasons'' coach__id, matched by (first_name, last_name, team, year) -- the single id every MATCHED season of the coach''s career at this school agrees on; NULL when any season''s match is ambiguous (more than one distinct coach__id), when matched seasons disagree, or when zero seasons matched. Seasons outside ref.coach_seasons'' coverage (it has no pre-2014 depth) do NOT invalidate the match. Backed by ref.coaches / ref.coaches__seasons and marts.team_ats_records.';
+COMMENT ON VIEW api.coach_records IS 'Coach career records at a school (coach x team grain), straight-up and against-the-spread. Columns: coach_id, coach_name, first_name, last_name, team, first_season, last_season, seasons_count, games, wins, losses, ties, win_pct, ats_games, ats_wins, ats_losses, ats_pushes, ats_win_pct, seasons_with_ats_data. Coach attribution is whole-season (mid-season coaching changes not splittable -- see ref.coaches__seasons). ATS columns are partial pre-lines-era coverage (LEFT JOIN to marts.team_ats_records); use seasons_with_ats_data to gauge coverage. coach_id (added 2026-08-30) is ref.coach_seasons'' coach__id, matched by (first_name, last_name, team, year) -- the single id every MATCHED season of the coach''s career at this school agrees on; NULL when any season''s match is ambiguous (more than one distinct coach__id -- one ambiguous season poisons the entire career''s coach_id), when matched seasons disagree, or when zero seasons matched. Seasons outside ref.coach_seasons'' coverage (it has no pre-2014 depth) do NOT invalidate the match. Backed by ref.coaches / ref.coaches__seasons and marts.team_ats_records.';
 
 GRANT SELECT ON api.coach_records TO anon, authenticated;

--- a/src/schemas/api/038_coach_records.sql
+++ b/src/schemas/api/038_coach_records.sql
@@ -33,19 +33,25 @@
 --
 -- 2026-08-30 (expansion_views unit, task 5a -- additive): coach_id, matched
 -- per-season to ref.coach_seasons by (first_name, last_name, school, year)
--- via LEFT JOIN LATERAL ... ORDER BY coach__id LIMIT 1 (deterministic
--- tie-break, cannot fan out) -- same fix and same rationale as
--- marts.coaching_tenure's coach_id (see that file's header): CFBD's older
--- /coaches bio rows share no surrogate key with the newer, richer
--- /coaches/seasons load, so cfb-app was joining coaching_history to
--- coach_records on first_name+last_name alone
+-- via an aggregate LEFT JOIN LATERAL (an aggregate LATERAL always returns
+-- exactly one row, so ON true cannot fan out) that yields the season's
+-- coach__id only when exactly one distinct id matches -- a season whose
+-- (name, school, year) matches MORE than one distinct coach__id
+-- contributes NULL (ambiguity is never guessed away -- PR #81 Greptile P1;
+-- zero such groups exist live today, this is contract hardening). Same fix
+-- and same rationale as marts.coaching_tenure's coach_id (see that file's
+-- header): CFBD's older /coaches bio rows share no surrogate key with the
+-- newer, richer /coaches/seasons load, so cfb-app was joining
+-- coaching_history to coach_records on first_name+last_name alone
 -- (cfb-app/src/lib/queries/coaches.ts:170-182). Because this view's grain is
 -- a coach's WHOLE CAREER at a school (not a single tenure), the per-season
 -- matches are collapsed to one coach_id per (coach_name, team) only when
--- every one of that coach's seasons at that school agrees on the same
--- coach__id -- ambiguous (>1 distinct id, e.g. a same-named-coach
+-- every one of that coach's MATCHED seasons at that school agrees on the
+-- same coach__id -- ambiguous (>1 distinct id, e.g. a same-named-coach
 -- collision) or unmatched (0) seasons yield NULL rather than a guessed
--- value.
+-- value. Seasons outside ref.coach_seasons' coverage (it has no pre-2014
+-- depth) do NOT invalidate the match -- requiring full-span matches would
+-- NULL nearly every long career.
 --
 -- PostgREST usage:
 --   GET /api/coach_records?team=eq.Alabama&order=win_pct.desc
@@ -72,14 +78,14 @@ WITH coach_seasons AS (
     FROM ref.coaches c
     JOIN ref.coaches__seasons cs ON cs._dlt_parent_id = c._dlt_id
     LEFT JOIN LATERAL (
-        SELECT rcs.coach__id AS coach_id
+        SELECT CASE
+            WHEN COUNT(DISTINCT rcs.coach__id) = 1 THEN MIN(rcs.coach__id)
+        END AS coach_id
         FROM ref.coach_seasons rcs
         WHERE rcs.coach__first_name = c.first_name
           AND rcs.coach__last_name = c.last_name
           AND rcs.team__school = cs.school
           AND rcs.year = cs.year
-        ORDER BY rcs.coach__id
-        LIMIT 1
     ) match ON true
     WHERE cs.school IS NOT NULL
       AND cs.year IS NOT NULL
@@ -149,6 +155,6 @@ SELECT
 FROM coach_seasons_ats
 GROUP BY coach_name, first_name, last_name, team;
 
-COMMENT ON VIEW api.coach_records IS 'Coach career records at a school (coach x team grain), straight-up and against-the-spread. Columns: coach_id, coach_name, first_name, last_name, team, first_season, last_season, seasons_count, games, wins, losses, ties, win_pct, ats_games, ats_wins, ats_losses, ats_pushes, ats_win_pct, seasons_with_ats_data. Coach attribution is whole-season (mid-season coaching changes not splittable -- see ref.coaches__seasons). ATS columns are partial pre-lines-era coverage (LEFT JOIN to marts.team_ats_records); use seasons_with_ats_data to gauge coverage. coach_id (added 2026-08-30) is ref.coach_seasons'' coach__id, matched by (first_name, last_name, team, year) with a deterministic tie-break -- NULL when no unambiguous match was found across every one of the coach''s seasons at this school. Backed by ref.coaches / ref.coaches__seasons and marts.team_ats_records.';
+COMMENT ON VIEW api.coach_records IS 'Coach career records at a school (coach x team grain), straight-up and against-the-spread. Columns: coach_id, coach_name, first_name, last_name, team, first_season, last_season, seasons_count, games, wins, losses, ties, win_pct, ats_games, ats_wins, ats_losses, ats_pushes, ats_win_pct, seasons_with_ats_data. Coach attribution is whole-season (mid-season coaching changes not splittable -- see ref.coaches__seasons). ATS columns are partial pre-lines-era coverage (LEFT JOIN to marts.team_ats_records); use seasons_with_ats_data to gauge coverage. coach_id (added 2026-08-30) is ref.coach_seasons'' coach__id, matched by (first_name, last_name, team, year) -- the single id every MATCHED season of the coach''s career at this school agrees on; NULL when any season''s match is ambiguous (more than one distinct coach__id), when matched seasons disagree, or when zero seasons matched. Seasons outside ref.coach_seasons'' coverage (it has no pre-2014 depth) do NOT invalidate the match. Backed by ref.coaches / ref.coaches__seasons and marts.team_ats_records.';
 
 GRANT SELECT ON api.coach_records TO anon, authenticated;

--- a/src/schemas/api/045_passing_charting_player_season.sql
+++ b/src/schemas/api/045_passing_charting_player_season.sql
@@ -1,0 +1,30 @@
+-- api.passing_charting_player_season
+-- Passing charting by player-season (2025+): air yards, aDOT, YAC. Thin
+-- passthrough of marts.passing_charting_player_season.
+--
+-- NULL means the play(s) behind that value were not charted; 0 is a real
+-- observed value. air_yards_attempts_available and
+-- yards_after_catch_attempts_available are the two charting-coverage
+-- denominators for the air-yards and YAC metric pairs respectively -- they
+-- are DIFFERENT counts and must never be merged/aliased into one: a
+-- leaderboard on the metrics alone, without both denominators alongside,
+-- ranks on charting coverage rather than skill (2025: 407/820
+-- player-seasons charted). Data starts 2025.
+--
+-- position is joined from core.roster on its own primary key (id, team,
+-- year) -- never a name-string join -- so it can be legitimately NULL for a
+-- player-season with no matching roster row; conference comes straight off
+-- stats.passing_player_season, no join.
+--
+-- PostgREST usage:
+--   GET /api/passing_charting_player_season?season=eq.2025&order=total_air_yards.desc
+
+DROP VIEW IF EXISTS api.passing_charting_player_season;
+
+CREATE VIEW api.passing_charting_player_season AS
+SELECT *
+FROM marts.passing_charting_player_season;
+
+COMMENT ON VIEW api.passing_charting_player_season IS 'Passing charting by player-season (2025+): season, player_id, player, team, conference, position, attempts, completions, interceptions, completion_rate, total_air_yards, average_depth_of_target, air_yards_attempts_available, total_yards_after_catch, average_yards_after_catch, yards_after_catch_attempts_available. NULL on a charting metric means those plays were not charted (0 is a real value); air_yards_attempts_available/yards_after_catch_attempts_available are the two charting-coverage denominators and are never interchangeable. Backed by marts.passing_charting_player_season.';
+
+GRANT SELECT ON api.passing_charting_player_season TO anon, authenticated;

--- a/src/schemas/api/046_passing_charting_target_season.sql
+++ b/src/schemas/api/046_passing_charting_target_season.sql
@@ -1,0 +1,28 @@
+-- api.passing_charting_target_season
+-- Receiver-grain (target) passing charting by season (2025+): the highest-
+-- value unit in the 2026-08-30 expansion -- cfb-app has no receiver-grain
+-- analysis today (api.player_wepa_leaders covers passing/rushing/kicking,
+-- no receiving). Thin passthrough of marts.passing_charting_target_season.
+--
+-- target_share_charted is a share of CHARTED targets only (this target's
+-- targets_charted / the team-season's total targets_charted) -- it is NOT a
+-- true target share over every offensive snap and must never be presented
+-- as one. partial_share is the fraction of this target's plays with
+-- parse_status = 'partial' (charting fields on those plays may read NULL).
+-- air_yards_charted_plays / yards_after_catch_charted_plays are the
+-- charting-coverage denominators for the air-yards and YAC metric pairs
+-- respectively -- NULL on a metric means those plays were not charted, 0 is
+-- a real observed value. Data starts 2025.
+--
+-- PostgREST usage:
+--   GET /api/passing_charting_target_season?season=eq.2025&order=receptions.desc
+
+DROP VIEW IF EXISTS api.passing_charting_target_season;
+
+CREATE VIEW api.passing_charting_target_season AS
+SELECT *
+FROM marts.passing_charting_target_season;
+
+COMMENT ON VIEW api.passing_charting_target_season IS 'Receiver-grain (target) passing charting by season (2025+): target_id, target, season, team_id, team, targets_charted, receptions, total_air_yards, average_depth_of_target, air_yards_charted_plays, total_yards_after_catch, average_yards_after_catch, yards_after_catch_charted_plays, target_share_charted, partial_share. target_share_charted is a share of CHARTED targets only -- never present as a true target share. partial_share flags plays whose charting is incomplete (parse_status=''partial''); charting metrics read NULL when not charted, 0 is a real value. Backed by marts.passing_charting_target_season.';
+
+GRANT SELECT ON api.passing_charting_target_season TO anon, authenticated;

--- a/src/schemas/api/047_passing_charting_team_season.sql
+++ b/src/schemas/api/047_passing_charting_team_season.sql
@@ -1,0 +1,27 @@
+-- api.passing_charting_team_season
+-- Team-season passing charting, offense and defense sides (2025+). Thin
+-- passthrough of marts.passing_charting_team_season, which flattens the raw
+-- dlt offense__*/defense__* dunder shape to offense_*/defense_* -- per this
+-- repo's Contract Rule 4, raw dlt column shapes must never reach the api
+-- layer.
+--
+-- CRITICAL: defense_* is THIS TEAM'S PASSING DEFENSE -- what opposing
+-- offenses did against them -- NOT the opponent's own offensive row.
+-- NULL on a metric means those plays were not charted; 0 is a real observed
+-- value. offense_air_yards_attempts_available/
+-- offense_yards_after_catch_attempts_available (and the defense_
+-- equivalents) are the charting-coverage denominators for their respective
+-- metric pairs and must never be merged/aliased together. Data starts 2025.
+--
+-- PostgREST usage:
+--   GET /api/passing_charting_team_season?season=eq.2025&order=offense_total_air_yards.desc
+
+DROP VIEW IF EXISTS api.passing_charting_team_season;
+
+CREATE VIEW api.passing_charting_team_season AS
+SELECT *
+FROM marts.passing_charting_team_season;
+
+COMMENT ON VIEW api.passing_charting_team_season IS 'Team-season passing charting, offense and defense sides (2025+): season, team, conference, offense_total_air_yards, offense_average_depth_of_target, offense_air_yards_attempts_available, offense_total_yards_after_catch, offense_average_yards_after_catch, offense_yards_after_catch_attempts_available, and the defense_ equivalents. defense_* is this team''s passing DEFENSE (what opposing offenses did against them), not the opponent''s offensive row. NULL on a metric means those plays were not charted, 0 is a real observed value; the two *_attempts_available columns per side are the charting-coverage denominators. Backed by marts.passing_charting_team_season.';
+
+GRANT SELECT ON api.passing_charting_team_season TO anon, authenticated;

--- a/src/schemas/api/048_coach_tenures.sql
+++ b/src/schemas/api/048_coach_tenures.sql
@@ -1,0 +1,25 @@
+-- api.coach_tenures
+-- CFBD's own continuous coach-tenure record (2026-08-30 expansion_views
+-- unit, task 5b). Grain: one row per (coach_id, team_id, tenure_start).
+-- Thin passthrough of marts.coach_tenures.
+--
+-- Distinct from api.coaching_history (marts.coaching_tenure, gap-detected
+-- from ref.coaches__seasons): this view is CFBD's own pre-computed tenure
+-- record and is the one that carries is_interim and classification.
+-- tenure_end IS NULL for an active tenure. May be empty until the
+-- coach_tenures backfill (`--source coach_tenures`) has run for a given
+-- environment -- see marts.coach_tenures' header.
+--
+-- PostgREST usage:
+--   GET /api/coach_tenures?team_id=eq.333&order=tenure_start.desc
+--   GET /api/coach_tenures?is_interim=eq.false&order=record_win_percentage.desc
+
+DROP VIEW IF EXISTS api.coach_tenures;
+
+CREATE VIEW api.coach_tenures AS
+SELECT *
+FROM marts.coach_tenures;
+
+COMMENT ON VIEW api.coach_tenures IS 'CFBD''s own continuous coach-tenure record. One row per (coach_id, team_id, tenure_start). Columns: coach_id, coach_name, team_id, team, tenure_start, tenure_end (NULL = active), hire_date, is_interim, record_games, record_wins, record_losses, record_ties, record_win_percentage, classification. is_interim and classification retire cfb-app heuristics that previously stood in for them (a min-games floor and a hardcoded FBS team-name list respectively). May be empty until the coach_tenures backfill has run for this environment. Backed by marts.coach_tenures.';
+
+GRANT SELECT ON api.coach_tenures TO anon, authenticated;

--- a/src/schemas/api/049_refresh_campaign_status.sql
+++ b/src/schemas/api/049_refresh_campaign_status.sql
@@ -1,0 +1,77 @@
+-- api.refresh_campaign_status
+-- Owner-rights view over meta.refresh_campaigns + meta.refresh_progress
+-- (2026-08-30 expansion_views unit, task 7). Lets downstream consumers
+-- (the cfb-app Discord bot's long-term memory / prediction ledger)
+-- scope-invalidate cached historical answers while a corrections campaign
+-- (e.g. the 2014-2025 upstream play-stats/advanced-box-score refresh,
+-- src/schemas/migrations/051_refresh_ledger.sql) is still draining --
+-- rather than distrusting an entire season range, a consumer can check
+-- whether the specific season it already answered a question about has
+-- finished refreshing.
+--
+-- Grain: (campaign, season) -- meta.refresh_campaigns.seasons is an int[]
+-- (the campaign's declared scope), unnested one row per season here.
+-- games_refreshed/games_no_data count DISTINCT game_ids from
+-- meta.refresh_progress with status='refreshed'/'no_data' respectively,
+-- summed ACROSS every task the campaign declared (meta.refresh_campaigns.tasks)
+-- -- not broken out per task. A game can appear in both counts if different
+-- tasks landed different statuses for it (e.g. play_stats refreshed but
+-- advanced_game_stats came back no_data for the same game) -- query
+-- meta.refresh_progress directly (it is also granted SELECT to
+-- anon/authenticated) for a per-task breakdown.
+--
+-- meta.refresh_progress has no season column of its own (its grain is
+-- game_id); season comes from a join to core.games on game_id, same
+-- join-to-core.games-for-season idiom used elsewhere in this unit
+-- (marts.passing_charting_target_season) and in marts.penalty_log/
+-- team_penalty_box.
+--
+-- completed_at / last_finalized_at are passed through from
+-- meta.refresh_campaigns as-is: completed_at is set once every declared
+-- task's backlog has drained to empty across all declared seasons;
+-- last_finalized_at is the watermark of the last successful post-drain
+-- finalize (adjusted-EPA refit + mart refresh) and is NULL if the campaign
+-- has never been finalized.
+--
+-- Plain (non-materialized) view by design -- this is queried rarely and
+-- meta.refresh_progress is small, so no mart is warranted.
+--
+-- PostgREST usage:
+--   GET /api/refresh_campaign_status?campaign=eq.2026-08-upstream-corrections&season=eq.2024
+
+DROP VIEW IF EXISTS api.refresh_campaign_status;
+
+CREATE VIEW api.refresh_campaign_status AS
+WITH campaign_seasons AS (
+    SELECT
+        c.campaign,
+        c.completed_at,
+        c.last_finalized_at,
+        unnest(c.seasons) AS season
+    FROM meta.refresh_campaigns c
+),
+progress_seasoned AS (
+    SELECT
+        rp.campaign,
+        rp.game_id,
+        rp.status,
+        g.season
+    FROM meta.refresh_progress rp
+    JOIN core.games g ON g.id = rp.game_id
+)
+SELECT
+    cs.campaign,
+    cs.season,
+    COUNT(DISTINCT ps.game_id) FILTER (WHERE ps.status = 'refreshed') AS games_refreshed,
+    COUNT(DISTINCT ps.game_id) FILTER (WHERE ps.status = 'no_data') AS games_no_data,
+    cs.completed_at,
+    cs.last_finalized_at
+FROM campaign_seasons cs
+LEFT JOIN progress_seasoned ps
+    ON ps.campaign = cs.campaign
+    AND ps.season = cs.season
+GROUP BY cs.campaign, cs.season, cs.completed_at, cs.last_finalized_at;
+
+COMMENT ON VIEW api.refresh_campaign_status IS 'Per (campaign, season) progress against meta.refresh_campaigns'' declared scope: games_refreshed/games_no_data are distinct game counts from meta.refresh_progress (status=''refreshed''/''no_data'' respectively), summed across every task the campaign declared -- not a per-task breakdown (query meta.refresh_progress directly for that). completed_at is set once the campaign''s full backlog has drained; last_finalized_at is the watermark of the last successful post-drain finalize (NULL = never finalized). Lets a downstream consumer scope-invalidate a cached historical answer for one season instead of distrusting an entire in-progress correction campaign''s range. Backed by meta.refresh_campaigns + meta.refresh_progress joined to core.games for season.';
+
+GRANT SELECT ON api.refresh_campaign_status TO anon, authenticated;

--- a/src/schemas/api/validation_expansion_views.sql
+++ b/src/schemas/api/validation_expansion_views.sql
@@ -1,0 +1,153 @@
+-- Behavioral validation for the 2026-08-30 expansion_views unit (cfb-app
+-- work order P1 items: passing charting, coaching, player_detail dedupe/
+-- extension, refresh-campaign status). Applied as its OWN file/transaction
+-- (after the marts + api files listed in
+-- deploys/expansion_views-manifest.json) so a failed assertion reports
+-- without rolling back the DDL. Read-only; safe to re-run any time as a
+-- health check. Style follows src/schemas/api/validation_penalties.sql.
+--
+-- Five assertion groups:
+--   (a) each new view exists and returns rows, EXCEPT api.coach_tenures and
+--       api.refresh_campaign_status, which are legitimately empty until
+--       their respective backfills/campaigns exist (NOTICE only, no
+--       failure -- see each view's own header for why).
+--   (b) api.player_detail has zero (player_id, season, team) dupes for
+--       season 2025 -- the view's own declared grain, checked at the finer
+--       grain than the work order's literal (player_id, season) phrasing
+--       because a mid-season transfer legitimately produces two
+--       (player_id, season) rows under different team values; that is not
+--       the reclassification bug task 0 fixed. A targeted spot-check on the
+--       specific reported case (player_id 5079720) is included alongside.
+--   (c) api.passing_charting_target_season's target_share_charted and
+--       partial_share are both within [0, 1] (NULLs ignored).
+--   (d) api.coach_tenures' classification non-null rate is sane, SKIPPED
+--       (not failed) if the table is empty (backfill-gated -- see (a)).
+--   (e) grant tripwire: anon/authenticated/analyst_ro kept SELECT on every
+--       new/changed view in this unit.
+
+DO $$
+DECLARE
+    n_player_season BIGINT;
+    n_target_season BIGINT;
+    n_team_season BIGINT;
+    n_coach_tenures BIGINT;
+    n_refresh_status BIGINT;
+    n_dupes BIGINT;
+    n_smith_rows BIGINT;
+    min_target_share NUMERIC;
+    max_target_share NUMERIC;
+    min_partial_share NUMERIC;
+    max_partial_share NUMERIC;
+    n_tenures_total BIGINT;
+    n_tenures_classified BIGINT;
+    classified_rate NUMERIC;
+    role_name TEXT;
+    view_name TEXT;
+BEGIN
+    -- (a) existence + rows (or legitimately-empty)
+    SELECT COUNT(*) INTO n_player_season FROM api.passing_charting_player_season;
+    SELECT COUNT(*) INTO n_target_season FROM api.passing_charting_target_season;
+    SELECT COUNT(*) INTO n_team_season FROM api.passing_charting_team_season;
+    SELECT COUNT(*) INTO n_coach_tenures FROM api.coach_tenures;
+    SELECT COUNT(*) INTO n_refresh_status FROM api.refresh_campaign_status;
+
+    RAISE NOTICE 'passing_charting_player_season: % rows', n_player_season;
+    RAISE NOTICE 'passing_charting_target_season: % rows', n_target_season;
+    RAISE NOTICE 'passing_charting_team_season: % rows', n_team_season;
+    RAISE NOTICE 'coach_tenures: % rows (0 is OK -- backfill-gated, see view header)', n_coach_tenures;
+    RAISE NOTICE 'refresh_campaign_status: % rows (0 is OK -- no active correction campaign row yet)', n_refresh_status;
+
+    IF n_player_season = 0 THEN
+        RAISE EXCEPTION 'passing_charting_player_season: empty -- expected 2025+ passing charting rows (source stats.passing_player_season reported ~820 player-seasons for 2025 per src/pipelines/sources/passing.py)';
+    END IF;
+    IF n_target_season = 0 THEN
+        RAISE EXCEPTION 'passing_charting_target_season: empty -- expected rows aggregated from stats.passing_plays for 2025+';
+    END IF;
+    IF n_team_season = 0 THEN
+        RAISE EXCEPTION 'passing_charting_team_season: empty -- expected ~136 team-seasons for 2025 per src/pipelines/sources/passing.py';
+    END IF;
+
+    -- (b) player_detail dedupe (task 0). Finer grain than the work order's
+    -- literal (player_id, season) -- see header note.
+    SELECT COUNT(*) INTO n_dupes
+    FROM (
+        SELECT player_id, season, team
+        FROM api.player_detail
+        WHERE season = 2025
+        GROUP BY player_id, season, team
+        HAVING COUNT(*) > 1
+    ) dupes;
+
+    RAISE NOTICE 'player_detail 2025: % (player_id, season, team) dupe group(s)', n_dupes;
+    IF n_dupes > 0 THEN
+        RAISE EXCEPTION 'player_detail: % (player_id, season, team) dupe group(s) found for season 2025 -- task 0 dedupe regressed', n_dupes;
+    END IF;
+
+    -- Targeted spot-check: the reported reclassification case
+    -- (player_id 5079720, season 2025, two recruiting.recruits rows
+    -- pre-fix) must now return exactly one row.
+    SELECT COUNT(*) INTO n_smith_rows
+    FROM api.player_detail
+    WHERE player_id::text = '5079720' AND season = 2025;
+
+    RAISE NOTICE 'player_detail 5079720/2025: % row(s) (expected 1)', n_smith_rows;
+    IF n_smith_rows <> 1 THEN
+        RAISE EXCEPTION 'player_detail: expected exactly 1 row for player_id 5079720, season 2025, got % -- reclassification dedupe regressed or roster/recruiting data changed shape', n_smith_rows;
+    END IF;
+
+    -- (c) target-season shares in [0, 1] (NULLs ignored by MIN/MAX)
+    SELECT MIN(target_share_charted), MAX(target_share_charted),
+           MIN(partial_share), MAX(partial_share)
+    INTO min_target_share, max_target_share, min_partial_share, max_partial_share
+    FROM api.passing_charting_target_season;
+
+    RAISE NOTICE 'target_share_charted range: [%, %]; partial_share range: [%, %]',
+        min_target_share, max_target_share, min_partial_share, max_partial_share;
+
+    IF min_target_share IS NOT NULL AND (min_target_share < 0 OR max_target_share > 1) THEN
+        RAISE EXCEPTION 'passing_charting_target_season: target_share_charted out of [0,1] range (min=%, max=%)',
+            min_target_share, max_target_share;
+    END IF;
+    IF min_partial_share IS NOT NULL AND (min_partial_share < 0 OR max_partial_share > 1) THEN
+        RAISE EXCEPTION 'passing_charting_target_season: partial_share out of [0,1] range (min=%, max=%)',
+            min_partial_share, max_partial_share;
+    END IF;
+
+    -- (d) coach_tenures classification non-null rate, skipped if empty
+    SELECT COUNT(*), COUNT(*) FILTER (WHERE classification IS NOT NULL)
+    INTO n_tenures_total, n_tenures_classified
+    FROM api.coach_tenures;
+
+    IF n_tenures_total = 0 THEN
+        RAISE NOTICE 'coach_tenures: 0 rows, skipping classification-coverage check (backfill has not run)';
+    ELSE
+        classified_rate := n_tenures_classified::numeric / n_tenures_total;
+        RAISE NOTICE 'coach_tenures classification coverage: %/% (% pct)',
+            n_tenures_classified, n_tenures_total, round(100.0 * classified_rate, 1);
+        IF classified_rate < 0.5 THEN
+            RAISE EXCEPTION 'coach_tenures: classification non-null rate below 50%% (%/%) -- team_id join to ref.teams likely broken',
+                n_tenures_classified, n_tenures_total;
+        END IF;
+    END IF;
+
+    -- (e) grant tripwire: anon/authenticated/analyst_ro kept SELECT on
+    -- every new/changed view in this unit
+    FOREACH view_name IN ARRAY ARRAY[
+        'api.passing_charting_player_season',
+        'api.passing_charting_target_season',
+        'api.passing_charting_team_season',
+        'api.coach_tenures',
+        'api.refresh_campaign_status',
+        'api.player_detail',
+        'api.coaching_history',
+        'api.coach_records'
+    ] LOOP
+        FOREACH role_name IN ARRAY ARRAY['anon', 'authenticated', 'analyst_ro'] LOOP
+            IF NOT has_table_privilege(role_name, view_name, 'SELECT') THEN
+                RAISE EXCEPTION '%: role % lost SELECT', view_name, role_name;
+            END IF;
+        END LOOP;
+    END LOOP;
+
+    RAISE NOTICE 'expansion_views validation passed';
+END $$;

--- a/src/schemas/functions/refresh_all_marts.sql
+++ b/src/schemas/functions/refresh_all_marts.sql
@@ -3,7 +3,9 @@
 -- Layers:
 --   1: _game_epa_calc, play_epa, player_comparison, conference_head_to_head, team_wepa_season,
 --      player_wepa_season, returning_production, player_usage, team_ats_records, core_ratings,
---      penalty_log, team_penalty_box (no mart dependencies)
+--      penalty_log, team_penalty_box, passing_charting_player_season,
+--      passing_charting_target_season, passing_charting_team_season, coach_tenures
+--      (no mart dependencies)
 --   2: team_epa_season, team_season_summary, player_game_epa, defensive_havoc, scoring_opportunities,
 --      team_playcalling_tendencies, team_situational_success
 --   3: situational_splits, player_season_epa, coach_record, matchup_history, recruiting_class,
@@ -45,7 +47,15 @@ BEGIN
         -- penalty_log/team_penalty_box were in scripts/refresh_marts.py but
         -- missing here (drift); repaired alongside the core_ratings addition.
         'penalty_log',
-        'team_penalty_box'
+        'team_penalty_box',
+        -- 2026-08-30 expansion_views unit: passing charting (stats.passing_*)
+        -- and coach_tenures (ref.coach_tenures) -- all read base tables only,
+        -- no mart dependencies. Registered in the same Layer-1 slot as
+        -- scripts/refresh_marts.py.
+        'passing_charting_player_season',
+        'passing_charting_target_season',
+        'passing_charting_team_season',
+        'coach_tenures'
     ];
     v_layer := 1;
 
@@ -242,5 +252,5 @@ END;
 $$;
 
 COMMENT ON FUNCTION marts.refresh_all IS
-'Refreshes all 43 materialized views in the marts schema in dependency order (7 layers). '
+'Refreshes all 47 materialized views in the marts schema in dependency order (7 layers). '
 'Returns timing and status for each view. Errors are caught per-view so one failure does not abort the rest.';

--- a/src/schemas/marts/023_coaching_tenure.sql
+++ b/src/schemas/marts/023_coaching_tenure.sql
@@ -12,13 +12,20 @@
 -- (cfb-app/src/lib/queries/coaches.ts:170-182), with a comment
 -- acknowledging that two same-named coaches would collide. Fix: match each
 -- coach-season row to ref.coach_seasons by (first_name, last_name, school,
--- year) via LEFT JOIN LATERAL ... ORDER BY coach__id LIMIT 1 (deterministic
--- tie-break, cannot fan out), then in tenure_agg collapse a tenure's
--- per-season matches to ONE coach_id only when every matched season agrees
--- on the same coach__id -- if two different ids appear across a tenure's
--- seasons (a same-named-coach collision) or zero seasons matched, coach_id
--- is NULL rather than a guessed value. Additive only -- no existing column
--- changed.
+-- year) via an aggregate LEFT JOIN LATERAL (an aggregate LATERAL always
+-- returns exactly one row, so ON true cannot fan out) that yields the
+-- season's coach__id only when exactly one distinct id matches -- a season
+-- whose (name, school, year) matches MORE than one distinct coach__id
+-- contributes NULL (ambiguity is never guessed away -- PR #81 Greptile P1;
+-- zero such groups exist live today, this is contract hardening). Then in
+-- tenure_agg collapse a tenure's per-season matches to ONE coach_id only
+-- when every matched season agrees on the same coach__id -- if two
+-- different ids appear across a tenure's seasons (a same-named-coach
+-- collision) or zero seasons matched, coach_id is NULL rather than a
+-- guessed value. coach_id is the single id every MATCHED season agrees on:
+-- seasons outside ref.coach_seasons' coverage (it has no pre-2014 depth)
+-- do NOT invalidate the match -- requiring full-span matches would NULL
+-- nearly every long tenure. Additive only -- no existing column changed.
 
 DROP MATERIALIZED VIEW IF EXISTS marts.coaching_tenure CASCADE;
 
@@ -41,14 +48,14 @@ WITH coach_seasons AS (
     FROM ref.coaches c
     JOIN ref.coaches__seasons cs ON cs._dlt_parent_id = c._dlt_id
     LEFT JOIN LATERAL (
-        SELECT rcs.coach__id AS coach_id
+        SELECT CASE
+            WHEN COUNT(DISTINCT rcs.coach__id) = 1 THEN MIN(rcs.coach__id)
+        END AS coach_id
         FROM ref.coach_seasons rcs
         WHERE rcs.coach__first_name = c.first_name
           AND rcs.coach__last_name = c.last_name
           AND rcs.team__school = cs.school
           AND rcs.year = cs.year
-        ORDER BY rcs.coach__id
-        LIMIT 1
     ) match ON true
     WHERE cs.school IS NOT NULL
 ),

--- a/src/schemas/marts/023_coaching_tenure.sql
+++ b/src/schemas/marts/023_coaching_tenure.sql
@@ -2,6 +2,23 @@
 -- Grain: Coach × Team × Tenure (contiguous seasons)
 -- Uses gap detection on ref.coaches__seasons to identify separate stints
 -- Includes inherited vs recruited talent comparison
+--
+-- 2026-08-30 (expansion_views unit, task 5a -- additive): coach_id.
+-- ref.coaches (bio: first_name/last_name only, no id) and ref.coaches__seasons
+-- (this mart's source) predate ref.coach_seasons (coaches.py's newer,
+-- richer /coaches/seasons load, PK coach__id/year/team__id) and share no
+-- surrogate key -- cfb-app was joining coaching_history to coach_records on
+-- first_name+last_name for lack of anything better
+-- (cfb-app/src/lib/queries/coaches.ts:170-182), with a comment
+-- acknowledging that two same-named coaches would collide. Fix: match each
+-- coach-season row to ref.coach_seasons by (first_name, last_name, school,
+-- year) via LEFT JOIN LATERAL ... ORDER BY coach__id LIMIT 1 (deterministic
+-- tie-break, cannot fan out), then in tenure_agg collapse a tenure's
+-- per-season matches to ONE coach_id only when every matched season agrees
+-- on the same coach__id -- if two different ids appear across a tenure's
+-- seasons (a same-named-coach collision) or zero seasons matched, coach_id
+-- is NULL rather than a guessed value. Additive only -- no existing column
+-- changed.
 
 DROP MATERIALIZED VIEW IF EXISTS marts.coaching_tenure CASCADE;
 
@@ -19,9 +36,20 @@ WITH coach_seasons AS (
         cs.ties,
         cs.preseason_rank,
         cs.postseason_rank,
-        cs.sp_overall
+        cs.sp_overall,
+        match.coach_id AS season_coach_id
     FROM ref.coaches c
     JOIN ref.coaches__seasons cs ON cs._dlt_parent_id = c._dlt_id
+    LEFT JOIN LATERAL (
+        SELECT rcs.coach__id AS coach_id
+        FROM ref.coach_seasons rcs
+        WHERE rcs.coach__first_name = c.first_name
+          AND rcs.coach__last_name = c.last_name
+          AND rcs.team__school = cs.school
+          AND rcs.year = cs.year
+        ORDER BY rcs.coach__id
+        LIMIT 1
+    ) match ON true
     WHERE cs.school IS NOT NULL
 ),
 gap_detect AS (
@@ -49,6 +77,13 @@ tenure_agg AS (
         MIN(season) AS tenure_start,
         MAX(season) AS tenure_end,
         COUNT(DISTINCT season) AS seasons_count,
+        -- One coach_id for the whole tenure only when every matched season
+        -- agrees; ambiguous (>1 distinct id) or unmatched (0) -> NULL.
+        -- See coach_seasons CTE above for the per-season LATERAL match.
+        CASE
+            WHEN COUNT(DISTINCT season_coach_id) FILTER (WHERE season_coach_id IS NOT NULL) = 1
+                THEN MIN(season_coach_id)
+        END AS coach_id,
         SUM(COALESCE(games, 0))::int AS total_games,
         SUM(COALESCE(wins, 0))::int AS total_wins,
         SUM(COALESCE(losses, 0))::int AS total_losses,
@@ -108,6 +143,7 @@ year3 AS (
     WHERE ta.seasons_count >= 3
 )
 SELECT
+    ta.coach_id,
     ta.coach_name,
     ta.first_name,
     ta.last_name,
@@ -191,7 +227,7 @@ LEFT JOIN year3 y3
     AND y3.last_name = ta.last_name
     AND y3.tenure_start = ta.tenure_start
 GROUP BY
-    ta.coach_name, ta.first_name, ta.last_name, ta.team,
+    ta.coach_id, ta.coach_name, ta.first_name, ta.last_name, ta.team,
     ta.tenure_id, ta.tenure_start, ta.tenure_end, ta.seasons_count,
     ta.total_games, ta.total_wins, ta.total_losses, ta.total_ties,
     ta.best_season_wins, ta.worst_season_wins,

--- a/src/schemas/marts/023_coaching_tenure.sql
+++ b/src/schemas/marts/023_coaching_tenure.sql
@@ -25,7 +25,11 @@
 -- guessed value. coach_id is the single id every MATCHED season agrees on:
 -- seasons outside ref.coach_seasons' coverage (it has no pre-2014 depth)
 -- do NOT invalidate the match -- requiring full-span matches would NULL
--- nearly every long tenure. Additive only -- no existing column changed.
+-- nearly every long tenure. An ambiguous season poisons the entire
+-- tenure's coach_id (NULL), while unmatched coverage-gap seasons still do
+-- not -- the two NULL causes are distinguished via an explicit per-season
+-- ambiguity flag (PR #81 Greptile round-2). Additive only -- no existing
+-- column changed.
 
 DROP MATERIALIZED VIEW IF EXISTS marts.coaching_tenure CASCADE;
 
@@ -44,13 +48,16 @@ WITH coach_seasons AS (
         cs.preseason_rank,
         cs.postseason_rank,
         cs.sp_overall,
-        match.coach_id AS season_coach_id
+        match.coach_id AS season_coach_id,
+        match.ambiguous AS season_match_ambiguous
     FROM ref.coaches c
     JOIN ref.coaches__seasons cs ON cs._dlt_parent_id = c._dlt_id
     LEFT JOIN LATERAL (
-        SELECT CASE
-            WHEN COUNT(DISTINCT rcs.coach__id) = 1 THEN MIN(rcs.coach__id)
-        END AS coach_id
+        SELECT
+            CASE
+                WHEN COUNT(DISTINCT rcs.coach__id) = 1 THEN MIN(rcs.coach__id)
+            END AS coach_id,
+            COUNT(DISTINCT rcs.coach__id) > 1 AS ambiguous
         FROM ref.coach_seasons rcs
         WHERE rcs.coach__first_name = c.first_name
           AND rcs.coach__last_name = c.last_name
@@ -85,10 +92,13 @@ tenure_agg AS (
         MAX(season) AS tenure_end,
         COUNT(DISTINCT season) AS seasons_count,
         -- One coach_id for the whole tenure only when every matched season
-        -- agrees; ambiguous (>1 distinct id) or unmatched (0) -> NULL.
-        -- See coach_seasons CTE above for the per-season LATERAL match.
+        -- agrees AND no season's match was ambiguous; any ambiguous season
+        -- poisons the whole tenure (NULL), while unmatched coverage-gap
+        -- seasons do not. See coach_seasons CTE above for the per-season
+        -- LATERAL match and its explicit ambiguity flag.
         CASE
             WHEN COUNT(DISTINCT season_coach_id) FILTER (WHERE season_coach_id IS NOT NULL) = 1
+             AND NOT BOOL_OR(season_match_ambiguous)
                 THEN MIN(season_coach_id)
         END AS coach_id,
         SUM(COALESCE(games, 0))::int AS total_games,

--- a/src/schemas/marts/045_passing_charting_player_season.sql
+++ b/src/schemas/marts/045_passing_charting_player_season.sql
@@ -1,0 +1,74 @@
+-- marts.passing_charting_player_season
+-- =============================================================================
+-- Passing charting (spec v5.25.0, 2026-08-30 expansion_views unit, task 2).
+-- Thin per-row mart over stats.passing_player_season (PK season, player_id,
+-- team) -- charting is player-season-grain already; nothing to aggregate.
+--
+-- Column names verified against src/schemas/migrations/057_passing_grants_indexes.sql
+-- (applied, column comments already live) and the 2026-08-30 probe fixture
+-- tests/fixtures/cfbd_2026/passing_players_season.json -- NOT a fresh
+-- pg_attribute read from this session (no DB access here). Re-verify at
+-- deploy time per this repo's column-contract convention.
+--
+-- NULL/denominator semantics (mirrors migration 057's phrasing verbatim):
+-- NULL on total_air_yards/average_depth_of_target/total_yards_after_catch/
+-- average_yards_after_catch means the play(s) behind that value were not
+-- charted; 0 is a real observed value. air_yards_attempts_available and
+-- yards_after_catch_attempts_available are the two charting-coverage
+-- denominators -- they are DIFFERENT counts (air-yards and YAC charting can
+-- cover different play sets for the same player-season) and must never be
+-- merged or aliased into one "attempts_available" column: a leaderboard
+-- built on the metrics alone, without both denominators alongside, ranks on
+-- charting coverage rather than skill (2025: 407/820 player-seasons
+-- charted). Data starts 2025 (PASSING_DATA_START in
+-- src/pipelines/sources/passing.py).
+--
+-- `position` is joined from core.roster on (id, team, year) -- ALL THREE of
+-- core.roster's own primary-key columns (src/pipelines/sources/rosters.py),
+-- matched against passing_player_season's player_id/team/season -- so this
+-- is a join to roster's exact PK, not a name-string join, and cannot fan
+-- out: at most one roster row can match. `conference` needs no join at all
+-- -- it is already a column on stats.passing_player_season itself (per the
+-- probe fixture).
+--
+-- DEPLOY-ORDER CAVEAT (same shape as migration 057's guarded COMMENT
+-- block): dlt omits a column entirely from a table's schema when every
+-- value loaded for it so far was NULL. total_air_yards/
+-- average_depth_of_target/total_yards_after_catch/average_yards_after_catch
+-- are the ones actually at risk of this (the two *_attempts_available
+-- denominators are plain integers that are 0, not NULL, when nothing is
+-- charted, so they always materialize). Per 057's header, deploy run 188
+-- (post-backfill) already had all of these columns live, so apply this file
+-- after that same passing-source load, not before.
+DROP MATERIALIZED VIEW IF EXISTS marts.passing_charting_player_season CASCADE;
+
+CREATE MATERIALIZED VIEW marts.passing_charting_player_season AS
+SELECT
+    pps.season,
+    pps.player_id,
+    pps.player,
+    pps.team,
+    pps.conference,
+    r.position,
+    pps.attempts,
+    pps.completions,
+    pps.interceptions,
+    pps.completion_rate,
+    pps.total_air_yards,
+    pps.average_depth_of_target,
+    pps.air_yards_attempts_available,
+    pps.total_yards_after_catch,
+    pps.average_yards_after_catch,
+    pps.yards_after_catch_attempts_available
+FROM stats.passing_player_season pps
+LEFT JOIN core.roster r
+    ON r.id::text = pps.player_id::text
+    AND r.team = pps.team
+    AND r.year = pps.season;
+
+-- Required for REFRESH CONCURRENTLY
+CREATE UNIQUE INDEX ON marts.passing_charting_player_season (season, player_id, team);
+
+-- Query indexes
+CREATE INDEX ON marts.passing_charting_player_season (season, team);
+CREATE INDEX ON marts.passing_charting_player_season (player_id);

--- a/src/schemas/marts/045_passing_charting_player_season.sql
+++ b/src/schemas/marts/045_passing_charting_player_season.sql
@@ -4,11 +4,21 @@
 -- Thin per-row mart over stats.passing_player_season (PK season, player_id,
 -- team) -- charting is player-season-grain already; nothing to aggregate.
 --
--- Column names verified against src/schemas/migrations/057_passing_grants_indexes.sql
--- (applied, column comments already live) and the 2026-08-30 probe fixture
--- tests/fixtures/cfbd_2026/passing_players_season.json -- NOT a fresh
--- pg_attribute read from this session (no DB access here). Re-verify at
--- deploy time per this repo's column-contract convention.
+-- Column names LIVE-VERIFIED 2026-08-30 via information_schema.columns
+-- against stats.passing_player_season (supersedes the prior
+-- migration-057/fixture-only check), including a check for dlt VARIANT
+-- (__v_double) twins on every bigint-typed column -- same pattern as
+-- src/schemas/009_variant_columns.sql / marts/032_player_usage.sql. Result:
+--   - total_air_yards, total_yards_after_catch: bigint, but integer-BY-NATURE
+--     (sums of whole charted yards) -- no twin is possible for these, and
+--     none exists live.
+--   - average_depth_of_target, completion_rate: natively double precision --
+--     no twin, read directly.
+--   - average_yards_after_catch: bigint base column WITH a __v_double twin
+--     -- live, 254/365 real (non-null) values are stranded in
+--     average_yards_after_catch__v_double alone. COALESCEd below; this
+--     mart's own NULL-means-"not charted" semantics (next paragraph) made
+--     the miss actively misreport charted plays as uncharted.
 --
 -- NULL/denominator semantics (mirrors migration 057's phrasing verbatim):
 -- NULL on total_air_yards/average_depth_of_target/total_yards_after_catch/
@@ -23,6 +33,14 @@
 -- charted). Data starts 2025 (PASSING_DATA_START in
 -- src/pipelines/sources/passing.py).
 --
+-- Sibling marts unaffected (reviewer-confirmed 2026-08-30):
+-- marts.passing_charting_target_season (046) computes its air-yards/YAC
+-- aggregates fresh via SUM()/AVG() over stats.passing_plays' plain bigint
+-- columns, which have no twin to miss; marts.passing_charting_team_season
+-- (047) flattens stats.passing_team_season's offense__/defense__ metric
+-- family, which are natively double precision on that table, same as this
+-- table's average_depth_of_target/completion_rate above.
+--
 -- `position` is joined from core.roster on (id, team, year) -- ALL THREE of
 -- core.roster's own primary-key columns (src/pipelines/sources/rosters.py),
 -- matched against passing_player_season's player_id/team/season -- so this
@@ -32,14 +50,16 @@
 -- probe fixture).
 --
 -- DEPLOY-ORDER CAVEAT (same shape as migration 057's guarded COMMENT
--- block): dlt omits a column entirely from a table's schema when every
--- value loaded for it so far was NULL. total_air_yards/
+-- block, kept for a future fresh/re-provisioned database, not a live
+-- concern today): dlt omits a column entirely from a table's schema when
+-- every value loaded for it so far was NULL. total_air_yards/
 -- average_depth_of_target/total_yards_after_catch/average_yards_after_catch
--- are the ones actually at risk of this (the two *_attempts_available
--- denominators are plain integers that are 0, not NULL, when nothing is
--- charted, so they always materialize). Per 057's header, deploy run 188
--- (post-backfill) already had all of these columns live, so apply this file
--- after that same passing-source load, not before.
+-- (plus average_yards_after_catch__v_double) are the ones that would be at
+-- risk of this (the two *_attempts_available denominators are plain
+-- integers that are 0, not NULL, when nothing is charted, so they always
+-- materialize). The 2026-08-30 live check above confirms every column this
+-- file reads already exists today; a fresh database must still apply this
+-- file after the passing source's first load, not before.
 DROP MATERIALIZED VIEW IF EXISTS marts.passing_charting_player_season CASCADE;
 
 CREATE MATERIALIZED VIEW marts.passing_charting_player_season AS
@@ -58,7 +78,12 @@ SELECT
     pps.average_depth_of_target,
     pps.air_yards_attempts_available,
     pps.total_yards_after_catch,
-    pps.average_yards_after_catch,
+    -- bigint base column WITH a dlt __v_double VARIANT twin on this table
+    -- (live-verified 2026-08-30: 254/365 real values stranded in the twin
+    -- alone) -- COALESCE per src/schemas/009_variant_columns.sql /
+    -- marts/032_player_usage.sql:56's codified pattern. See file header.
+    COALESCE(pps.average_yards_after_catch::double precision, pps.average_yards_after_catch__v_double)
+        AS average_yards_after_catch,
     pps.yards_after_catch_attempts_available
 FROM stats.passing_player_season pps
 LEFT JOIN core.roster r

--- a/src/schemas/marts/046_passing_charting_target_season.sql
+++ b/src/schemas/marts/046_passing_charting_target_season.sql
@@ -1,0 +1,118 @@
+-- marts.passing_charting_target_season
+-- =============================================================================
+-- Passing charting (spec v5.25.0, 2026-08-30 expansion_views unit, task 3).
+-- THE HIGHEST-VALUE UNIT IN THIS BATCH: cfb-app has no receiver-grain
+-- analysis at all today (api.player_wepa_leaders carries passing/rushing/
+-- kicking, no receiving category), so "who is the best receiver" is
+-- currently unanswerable from the contracted surface.
+--
+-- Built from stats.passing_plays (PK game_id, play_id -- play-grain, not
+-- pre-aggregated), aggregated here to (season, target_id, team_id).
+-- passing_plays has no `season` column IN ITS PRIMARY KEY, so season is
+-- derived via a join to core.games on game_id -- the same
+-- join-to-core.games-for-season idiom marts.penalty_log/team_penalty_box
+-- already use for a play-grain source. offense_id (renamed team_id here)
+-- is the numeric CFBD/ESPN team id per stats.passing_plays.offense_id's own
+-- column COMMENT (migration 057): "Prefer this over the `offense` name
+-- string when joining to ref.teams(id) -- ref.teams has 35 legitimate
+-- duplicate school names, so a name-string join needs DISTINCT ON (school)
+-- or accepts fanout; offense_id avoids that." ref.teams.id is that table's
+-- primary key, so the LEFT JOIN below cannot fan out regardless of the
+-- duplicate-school-name issue (id joins never hit it; only name joins do).
+--
+-- Column names (gameId/playId/targetId/target/outcome/airYards/
+-- yardsAfterCatch/parseStatus/offenseId) verified against
+-- src/schemas/migrations/057_passing_grants_indexes.sql and the 2026-08-30
+-- probe fixture tests/fixtures/cfbd_2026/passing_plays.json -- NOT a fresh
+-- pg_attribute read from this session (no DB access here). Re-verify at
+-- deploy time.
+--
+-- Semantics:
+--  - targets_charted: total charted plays where this player was the target,
+--    regardless of whether air-yards/YAC charting is complete for the play
+--    (i.e. this dataset's own denominator, distinct from the two finer
+--    denominators below). receptions: targets_charted plays with
+--    outcome = 'completion'.
+--  - total_air_yards/average_depth_of_target are computed only over plays
+--    where air_yards IS NOT NULL (charted); air_yards_charted_plays is that
+--    count -- added beyond the literal column list cfb-app's work order
+--    named, for the same charting-transparency reason task 2 required two
+--    separate denominators on the player-season mart: without it, a
+--    leaderboard here would rank on charting coverage, not receiving
+--    volume. Same construction for total_yards_after_catch/
+--    average_yards_after_catch/yards_after_catch_charted_plays. NULL means
+--    not charted; 0 is a real observed value (mirrors migration 057's
+--    phrasing).
+--  - target_share_charted = this target's targets_charted / the SUM of
+--    targets_charted across every target on that (season, team_id) --
+--    i.e. a share of CHARTED attempts only, named target_share_charted (not
+--    target_share) so it is never misread as a true target-share metric
+--    computed from the full, uncharted play population.
+--  - partial_share = fraction of this target's contributing plays with
+--    parse_status = 'partial' -- per migration 057's COMMENT, 'partial' is
+--    the only value observed in probing and means a play's air yards/pass
+--    depth/direction/location/YAC charting fields may read NULL.
+--
+-- Data starts 2025 (PASSING_DATA_START in src/pipelines/sources/passing.py).
+DROP MATERIALIZED VIEW IF EXISTS marts.passing_charting_target_season CASCADE;
+
+CREATE MATERIALIZED VIEW marts.passing_charting_target_season AS
+WITH plays_seasoned AS (
+    SELECT
+        pp.target_id,
+        pp.target,
+        pp.offense_id AS team_id,
+        g.season,
+        pp.outcome,
+        pp.parse_status,
+        pp.air_yards,
+        pp.yards_after_catch
+    FROM stats.passing_plays pp
+    JOIN core.games g ON g.id = pp.game_id
+    WHERE pp.target_id IS NOT NULL
+),
+target_agg AS (
+    SELECT
+        season,
+        target_id,
+        team_id,
+        mode() WITHIN GROUP (ORDER BY target) AS target,
+        COUNT(*) AS targets_charted,
+        COUNT(*) FILTER (WHERE outcome = 'completion') AS receptions,
+        SUM(air_yards) AS total_air_yards,
+        AVG(air_yards) AS average_depth_of_target,
+        COUNT(*) FILTER (WHERE air_yards IS NOT NULL) AS air_yards_charted_plays,
+        SUM(yards_after_catch) AS total_yards_after_catch,
+        AVG(yards_after_catch) AS average_yards_after_catch,
+        COUNT(*) FILTER (WHERE yards_after_catch IS NOT NULL) AS yards_after_catch_charted_plays,
+        (COUNT(*) FILTER (WHERE parse_status = 'partial'))::numeric / COUNT(*) AS partial_share
+    FROM plays_seasoned
+    GROUP BY season, target_id, team_id
+)
+SELECT
+    ta.target_id,
+    ta.target,
+    ta.season,
+    ta.team_id,
+    t.school AS team,
+    ta.targets_charted,
+    ta.receptions,
+    ta.total_air_yards,
+    ta.average_depth_of_target,
+    ta.air_yards_charted_plays,
+    ta.total_yards_after_catch,
+    ta.average_yards_after_catch,
+    ta.yards_after_catch_charted_plays,
+    ta.targets_charted::numeric
+        / NULLIF(SUM(ta.targets_charted) OVER (PARTITION BY ta.season, ta.team_id), 0)
+        AS target_share_charted,
+    ta.partial_share
+FROM target_agg ta
+LEFT JOIN ref.teams t ON t.id = ta.team_id;
+
+-- Required for REFRESH CONCURRENTLY
+CREATE UNIQUE INDEX ON marts.passing_charting_target_season (season, target_id, team_id);
+
+-- Query indexes
+CREATE INDEX ON marts.passing_charting_target_season (season, team_id);
+CREATE INDEX ON marts.passing_charting_target_season (target_id);

--- a/src/schemas/marts/046_passing_charting_target_season.sql
+++ b/src/schemas/marts/046_passing_charting_target_season.sql
@@ -8,10 +8,12 @@
 --
 -- Built from stats.passing_plays (PK game_id, play_id -- play-grain, not
 -- pre-aggregated), aggregated here to (season, target_id, team_id).
--- passing_plays has no `season` column IN ITS PRIMARY KEY, so season is
--- derived via a join to core.games on game_id -- the same
--- join-to-core.games-for-season idiom marts.penalty_log/team_penalty_box
--- already use for a play-grain source. offense_id (renamed team_id here)
+-- season is stamped on every stats.passing_plays row by
+-- passing_plays_resource (`row.setdefault("season", year)`; live-verified
+-- zero NULLs 2026-08-31) and is read directly here, so charted plays never
+-- depend on core.games having loaded that game -- the previous join to
+-- core.games for g.season silently DROPPED any charted play whose game was
+-- missing there (PR #81 review finding). offense_id (renamed team_id here)
 -- is the numeric CFBD/ESPN team id per stats.passing_plays.offense_id's own
 -- column COMMENT (migration 057): "Prefer this over the `offense` name
 -- string when joining to ref.teams(id) -- ref.teams has 35 legitimate
@@ -62,13 +64,12 @@ WITH plays_seasoned AS (
         pp.target_id,
         pp.target,
         pp.offense_id AS team_id,
-        g.season,
+        pp.season,
         pp.outcome,
         pp.parse_status,
         pp.air_yards,
         pp.yards_after_catch
     FROM stats.passing_plays pp
-    JOIN core.games g ON g.id = pp.game_id
     WHERE pp.target_id IS NOT NULL
 ),
 target_agg AS (

--- a/src/schemas/marts/047_passing_charting_team_season.sql
+++ b/src/schemas/marts/047_passing_charting_team_season.sql
@@ -1,0 +1,73 @@
+-- marts.passing_charting_team_season
+-- =============================================================================
+-- Passing charting (spec v5.25.0, 2026-08-30 expansion_views unit, task 4).
+-- Thin per-row mart over stats.passing_team_season (PK season, team).
+-- Flattens the raw dlt dunder shape (offense__*/defense__*) to
+-- offense_*/defense_* -- per this repo's Contract Rule 4, raw dlt column
+-- shapes must never reach the api layer.
+--
+-- Only the SIX charting-family columns per side are flattened here (4
+-- metrics + 2 coverage denominators -- the same six as task 2's player-
+-- season mart), not the full attempts/completions/interceptions/
+-- completion_rate/totalYards family: stats.passing_team_season nests those
+-- under offense__/defense__ too, but they are plain box-score counts, not
+-- charting-derived, so they carry no NULL-vs-not-charted ambiguity and were
+-- not called out in the work order for this unit. conference is included
+-- (already a plain column on stats.passing_team_season, no join, no fanout
+-- risk) for parity with task 2's player-season mart.
+--
+-- Column names verified against
+-- src/schemas/migrations/057_passing_grants_indexes.sql (applied, column
+-- comments already live) and the 2026-08-30 probe fixture
+-- tests/fixtures/cfbd_2026/passing_teams_season.json -- NOT a fresh
+-- pg_attribute read from this session (no DB access here). Re-verify at
+-- deploy time.
+--
+-- CRITICAL semantic note (migration 057's phrasing, verbatim): defense_* is
+-- THIS TEAM'S PASSING DEFENSE -- what opposing offenses did against them --
+-- NOT the opponent's own offensive row. NULL on a metric means the play(s)
+-- behind it were not charted; 0 is a real observed value.
+-- offense_air_yards_attempts_available / offense_yards_after_catch_attempts_available
+-- (and the defense_ equivalents) are the charting-coverage denominators for
+-- their respective metric pairs and must never be merged/aliased together.
+-- Data starts 2025.
+--
+-- DEPLOY-ORDER CAVEAT (same shape as migration 057's guarded COMMENT
+-- block): dlt omits a column entirely from a table's schema when every
+-- value loaded for it so far was NULL. The four *_total_air_yards/
+-- *_average_depth_of_target/*_total_yards_after_catch/
+-- *_average_yards_after_catch columns per side are the ones actually at
+-- risk of this (the two *_attempts_available denominators are plain
+-- integers that are 0, not NULL, when nothing is charted, so they always
+-- materialize). A plain CREATE MATERIALIZED VIEW AS SELECT cannot guard a
+-- possibly-absent column the way migration 057's DO block guards a COMMENT,
+-- so this file must be applied AFTER the passing source's first successful
+-- load, same precondition as 057 itself -- per that migration's header,
+-- deploy run 188 (post-backfill) already had all 36 charting-family columns
+-- live, so this is a which-order-was-this-applied-in check, not a design
+-- gap. If a fresh/unbackfilled database ever applies this file first, it
+-- will fail with "column does not exist" on whichever metric column dlt
+-- has not yet created -- reapply after the next passing load completes.
+DROP MATERIALIZED VIEW IF EXISTS marts.passing_charting_team_season CASCADE;
+
+CREATE MATERIALIZED VIEW marts.passing_charting_team_season AS
+SELECT
+    pts.season,
+    pts.team,
+    pts.conference,
+    pts.offense__total_air_yards AS offense_total_air_yards,
+    pts.offense__average_depth_of_target AS offense_average_depth_of_target,
+    pts.offense__air_yards_attempts_available AS offense_air_yards_attempts_available,
+    pts.offense__total_yards_after_catch AS offense_total_yards_after_catch,
+    pts.offense__average_yards_after_catch AS offense_average_yards_after_catch,
+    pts.offense__yards_after_catch_attempts_available AS offense_yards_after_catch_attempts_available,
+    pts.defense__total_air_yards AS defense_total_air_yards,
+    pts.defense__average_depth_of_target AS defense_average_depth_of_target,
+    pts.defense__air_yards_attempts_available AS defense_air_yards_attempts_available,
+    pts.defense__total_yards_after_catch AS defense_total_yards_after_catch,
+    pts.defense__average_yards_after_catch AS defense_average_yards_after_catch,
+    pts.defense__yards_after_catch_attempts_available AS defense_yards_after_catch_attempts_available
+FROM stats.passing_team_season pts;
+
+-- Required for REFRESH CONCURRENTLY
+CREATE UNIQUE INDEX ON marts.passing_charting_team_season (season, team);

--- a/src/schemas/marts/048_coach_tenures.sql
+++ b/src/schemas/marts/048_coach_tenures.sql
@@ -1,0 +1,88 @@
+-- marts.coach_tenures
+-- =============================================================================
+-- Coach tenure history from CFBD's /coaches/tenures (2026-08-30
+-- expansion_views unit, task 5b). Grain: one row per (coach_id, team_id,
+-- tenure_start). Distinct from the EXISTING marts.coaching_tenure (gap-
+-- detected from ref.coaches__seasons, no is_interim/classification): this
+-- mart is CFBD's own pre-computed continuous-tenure record from
+-- ref.coach_tenures, and retires two hacks documented in the cfb-app work
+-- order:
+--   - is_interim replaces cfb-app's DEFAULT_MIN_GAMES = 24 heuristic
+--     (coaches.ts:59-61), which exists only to keep an interim's one-game
+--     record off win% leaderboards and also silently drops legitimate short
+--     tenures.
+--   - classification replaces pushing the FBS filter through
+--     .in('team', <~130 name strings>) (coaches.ts:56-58), needed only
+--     because api.coach_records has no classification column.
+--
+-- Column names verified against the CFBD OpenAPI spec's CoachTenure /
+-- CoachReference / CoachTeamReference / CoachRecord schemas (fetched
+-- 2026-08-30 from api.collegefootballdata.com/api-docs.json) -- NOT a live
+-- pg_attribute read from this session (no DB access here). dlt flattens:
+-- coach {id, firstName, lastName} -> coach__id/coach__first_name/
+-- coach__last_name; team {id, school} -> team__id/team__school; record
+-- {games, wins, losses, ties, winPercentage} -> record__games/record__wins/
+-- record__losses/record__ties/record__win_percentage; hireDate -> hire_date
+-- (nullable string, not a real date type per the spec); startYear/endYear ->
+-- start_year/end_year (endYear nullable = active tenure); isInterim ->
+-- is_interim. Re-verify at deploy time per this repo's column-contract
+-- convention.
+--
+-- ref.coach_tenures is populated by a PER-TEAM FAN-OUT resource
+-- (coaches.py's coach_tenures_resource, source cfbd_coach_tenures) that is
+-- deliberately NOT part of the daily/incremental path -- it requires an
+-- explicit backfill (`--source coach_tenures`, run.py::run_coach_tenures_pipeline).
+-- If that backfill has not run yet in a given environment, this mart is
+-- legitimately empty -- see the row-count guard note below (no hard
+-- empty-guard here, unlike marts/041_penalty_log.sql and
+-- marts/042_team_penalty_box.sql, whose sources are always-populated
+-- 2004+ tables; this source is backfill-gated and empty-until-run is an
+-- expected state, not a break).
+--
+-- team_id (team__id) is joined to ref.teams(id) -- that table's own primary
+-- key -- for classification, so this cannot fan out on ref.teams' 35
+-- duplicate school-name rows (id joins never hit that; only name-string
+-- joins do).
+DROP MATERIALIZED VIEW IF EXISTS marts.coach_tenures CASCADE;
+
+CREATE MATERIALIZED VIEW marts.coach_tenures AS
+SELECT
+    ct.coach__id AS coach_id,
+    (ct.coach__first_name || ' ' || ct.coach__last_name) AS coach_name,
+    ct.team__id AS team_id,
+    ct.team__school AS team,
+    ct.start_year AS tenure_start,
+    ct.end_year AS tenure_end,
+    ct.hire_date,
+    ct.is_interim,
+    ct.record__games AS record_games,
+    ct.record__wins AS record_wins,
+    ct.record__losses AS record_losses,
+    ct.record__ties AS record_ties,
+    ct.record__win_percentage AS record_win_percentage,
+    t.classification
+FROM ref.coach_tenures ct
+LEFT JOIN ref.teams t ON t.id = ct.team__id;
+
+-- Required for REFRESH CONCURRENTLY
+CREATE UNIQUE INDEX ON marts.coach_tenures (coach_id, team_id, tenure_start);
+
+-- Query indexes
+CREATE INDEX ON marts.coach_tenures (team_id);
+CREATE INDEX ON marts.coach_tenures (coach_id);
+
+-- Soft row-count notice, deliberately NOT a hard RAISE EXCEPTION: unlike
+-- marts/041/042's always-populated core.plays/core.game_team_stats sources,
+-- ref.coach_tenures depends on an explicit, currently-optional per-team
+-- backfill (see header). A hard empty-guard here would fail this file's
+-- very first apply in any environment where that backfill has not yet run,
+-- which is the expected state right after this file is authored. Flag for
+-- the orchestrator: confirm the coach_tenures backfill has actually run
+-- before relying on this mart being non-empty.
+DO $$
+DECLARE
+    n bigint;
+BEGIN
+    SELECT count(*) INTO n FROM marts.coach_tenures;
+    RAISE NOTICE 'marts.coach_tenures: % row(s) after build (0 is expected if the coach_tenures backfill has not run yet -- see file header)', n;
+END $$;

--- a/src/schemas/migrations/058_wepa_player_id_column.sql
+++ b/src/schemas/migrations/058_wepa_player_id_column.sql
@@ -37,8 +37,25 @@ BEGIN
             RAISE NOTICE '058: metrics.% does not exist -- skipping (a fresh load creates it with id already present)', t;
             CONTINUE;
         END IF;
+        IF NOT EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_schema = 'metrics' AND table_name = t AND column_name = 'athlete_id'
+        ) THEN
+            -- A table the post-fix loader created after another upstream
+            -- rename would have id but no athlete_id -- nothing to backfill.
+            RAISE NOTICE '058: metrics.% has no athlete_id column -- skipping (loader-created shape)', t;
+            CONTINUE;
+        END IF;
         EXECUTE format('ALTER TABLE metrics.%I ADD COLUMN IF NOT EXISTS id text', t);
         EXECUTE format('UPDATE metrics.%I SET id = athlete_id WHERE id IS NULL', t);
         EXECUTE format('ALTER TABLE metrics.%I ALTER COLUMN id SET NOT NULL', t);
+        -- athlete_id's NOT NULL is a relic of the table's original merge key
+        -- (pre-rename era); the key is id now and athlete_id is a plain
+        -- passthrough payload column. CFBD's current payload still populates
+        -- it (verified live: 12 seasons re-ingested post-fix, zero NULLs),
+        -- but _stamp_player_id is deliberately shape-agnostic about the NEXT
+        -- upstream rename -- and a payload that stops carrying athleteId
+        -- must not be rejected on a stale constraint (PR #81 review).
+        EXECUTE format('ALTER TABLE metrics.%I ALTER COLUMN athlete_id DROP NOT NULL', t);
     END LOOP;
 END $$;

--- a/src/schemas/migrations/058_wepa_player_id_column.sql
+++ b/src/schemas/migrations/058_wepa_player_id_column.sql
@@ -1,0 +1,31 @@
+-- 058: Pre-add the id column dlt now expects on metrics.wepa_players_*.
+--
+-- CFBD renamed the player-id field on the /wepa/players/* endpoints before
+-- these tables were ever first loaded, so they were created carrying
+-- athlete_id (text, zero NULLs -- verified live 2026-08-30) and never had
+-- the id column that wepa.py declares as primary key ["id", "year"].
+-- _stamp_player_id (src/pipelines/sources/wepa.py) now stamps
+-- id = str(<athlete id>) on every record, which made dlt try to
+-- ADD COLUMN id NOT NULL onto the populated tables and fail with
+-- SchemaUpdateTerminalError ("column id ... contains null values";
+-- backfill runs 33337866929 / 33337870220).
+--
+-- Pre-adding the column and copying athlete_id keeps merge-key
+-- continuity: re-ingested rows carry the same stamped ids, so the
+-- corrected-data re-runs replace these rows season by season instead of
+-- duplicating them.
+--
+-- Applied live 2026-08-30 (mcp migration wepa_player_id_column_backfill).
+-- Idempotent: re-running is a no-op.
+
+alter table metrics.wepa_players_passing add column if not exists id text;
+update metrics.wepa_players_passing set id = athlete_id where id is null;
+alter table metrics.wepa_players_passing alter column id set not null;
+
+alter table metrics.wepa_players_rushing add column if not exists id text;
+update metrics.wepa_players_rushing set id = athlete_id where id is null;
+alter table metrics.wepa_players_rushing alter column id set not null;
+
+alter table metrics.wepa_players_kicking add column if not exists id text;
+update metrics.wepa_players_kicking set id = athlete_id where id is null;
+alter table metrics.wepa_players_kicking alter column id set not null;

--- a/src/schemas/migrations/058_wepa_player_id_column.sql
+++ b/src/schemas/migrations/058_wepa_player_id_column.sql
@@ -16,16 +16,29 @@
 -- duplicating them.
 --
 -- Applied live 2026-08-30 (mcp migration wepa_player_id_column_backfill).
--- Idempotent: re-running is a no-op.
+-- Idempotent: re-running is a no-op. Guarded per table (PR #81 review:
+-- this file rides deploys/expansion_views-manifest.json so the unit is
+-- self-contained): on a fresh database the wepa player tables do not
+-- exist yet -- the first load creates them WITH id, so a missing table
+-- is skipped with a NOTICE rather than failing the manifest apply.
+-- A SET NOT NULL failure (athlete_id NULLs in some other environment)
+-- stays loud by design.
 
-alter table metrics.wepa_players_passing add column if not exists id text;
-update metrics.wepa_players_passing set id = athlete_id where id is null;
-alter table metrics.wepa_players_passing alter column id set not null;
-
-alter table metrics.wepa_players_rushing add column if not exists id text;
-update metrics.wepa_players_rushing set id = athlete_id where id is null;
-alter table metrics.wepa_players_rushing alter column id set not null;
-
-alter table metrics.wepa_players_kicking add column if not exists id text;
-update metrics.wepa_players_kicking set id = athlete_id where id is null;
-alter table metrics.wepa_players_kicking alter column id set not null;
+DO $$
+DECLARE
+    t text;
+BEGIN
+    FOREACH t IN ARRAY ARRAY[
+        'wepa_players_passing',
+        'wepa_players_rushing',
+        'wepa_players_kicking'
+    ] LOOP
+        IF to_regclass(format('metrics.%I', t)) IS NULL THEN
+            RAISE NOTICE '058: metrics.% does not exist -- skipping (a fresh load creates it with id already present)', t;
+            CONTINUE;
+        END IF;
+        EXECUTE format('ALTER TABLE metrics.%I ADD COLUMN IF NOT EXISTS id text', t);
+        EXECUTE format('UPDATE metrics.%I SET id = athlete_id WHERE id IS NULL', t);
+        EXECUTE format('ALTER TABLE metrics.%I ALTER COLUMN id SET NOT NULL', t);
+    END LOOP;
+END $$;

--- a/tests/test_api_views.py
+++ b/tests/test_api_views.py
@@ -567,6 +567,11 @@ GAME_RECAPS_COLUMNS = {
 }
 
 COACH_RECORDS_COLUMNS = {
+    # Added 2026-08-30 (expansion_views unit, task 5a) -- ref.coach_seasons'
+    # coach__id matched by (first_name, last_name, team, year); NULL where
+    # ambiguous/unmatched. A subset check, so this makes the column
+    # load-bearing in CI (a regression that dropped it would fail here).
+    "coach_id",
     "coach_name",
     "first_name",
     "last_name",
@@ -628,6 +633,95 @@ TEAM_PENALTIES_COLUMNS = {
     "opponent_penalty_yards",
 }
 
+# expansion_views unit (2026-08-30): passing charting, coach tenures, and the
+# refresh-campaign status view.
+
+PASSING_CHARTING_PLAYER_SEASON_COLUMNS = {
+    "season",
+    "player_id",
+    "player",
+    "team",
+    "conference",
+    "position",
+    "attempts",
+    "completions",
+    "interceptions",
+    "completion_rate",
+    "total_air_yards",
+    "average_depth_of_target",
+    "air_yards_attempts_available",
+    "total_yards_after_catch",
+    "average_yards_after_catch",
+    "yards_after_catch_attempts_available",
+}
+
+PASSING_CHARTING_TARGET_SEASON_COLUMNS = {
+    "target_id",
+    "target",
+    "season",
+    "team_id",
+    "team",
+    "targets_charted",
+    "receptions",
+    "total_air_yards",
+    "average_depth_of_target",
+    "air_yards_charted_plays",
+    "total_yards_after_catch",
+    "average_yards_after_catch",
+    "yards_after_catch_charted_plays",
+    "target_share_charted",
+    "partial_share",
+}
+
+PASSING_CHARTING_TEAM_SEASON_COLUMNS = {
+    "season",
+    "team",
+    "conference",
+    "offense_total_air_yards",
+    "offense_average_depth_of_target",
+    "offense_air_yards_attempts_available",
+    "offense_total_yards_after_catch",
+    "offense_average_yards_after_catch",
+    "offense_yards_after_catch_attempts_available",
+    "defense_total_air_yards",
+    "defense_average_depth_of_target",
+    "defense_air_yards_attempts_available",
+    "defense_total_yards_after_catch",
+    "defense_average_yards_after_catch",
+    "defense_yards_after_catch_attempts_available",
+}
+
+# CFBD's own continuous coach-tenure record (distinct from api.coaching_history's
+# gap-detected marts.coaching_tenure). May be empty pre-backfill -- see
+# TestViewsExistAndReturnRows below, column check only.
+COACH_TENURES_COLUMNS = {
+    "coach_id",
+    "coach_name",
+    "team_id",
+    "team",
+    "tenure_start",
+    "tenure_end",
+    "hire_date",
+    "is_interim",
+    "record_games",
+    "record_wins",
+    "record_losses",
+    "record_ties",
+    "record_win_percentage",
+    "classification",
+}
+
+# Per-(campaign, season) progress against meta.refresh_campaigns/refresh_progress
+# (migration 051). May be empty until a correction campaign row exists.
+REFRESH_CAMPAIGN_STATUS_COLUMNS = {
+    "campaign",
+    "season",
+    "games_refreshed",
+    "games_no_data",
+    "completed_at",
+    "last_finalized_at",
+}
+
 # ---------------------------------------------------------------------------
 # Test: views exist and return rows
 # ---------------------------------------------------------------------------
@@ -685,6 +779,15 @@ class TestViewsExistAndReturnRows:
             # (2016-2025) = ~1,300+; conservative floor below the backfill,
             # 2026 in-season rows are upside.
             ("api.core_ratings", 1000),
+            # Passing charting (2025+ only). Floors are conservative fractions
+            # of src/pipelines/sources/passing.py's documented 2025 probe
+            # counts (820 player-seasons, 136 team-seasons, roughly FBS);
+            # target-season is aggregated per-receiver from stats.passing_plays,
+            # so it has more rows than either grain (many receivers per team).
+            # 2026 in-season rows are upside; not re-verified live this run.
+            ("api.passing_charting_player_season", 500),
+            ("api.passing_charting_target_season", 1000),
+            ("api.passing_charting_team_season", 100),
         ],
         ids=[
             "team_detail",
@@ -709,6 +812,9 @@ class TestViewsExistAndReturnRows:
             "season_outlook",
             "expected_points",
             "core_ratings",
+            "passing_charting_player_season",
+            "passing_charting_target_season",
+            "passing_charting_team_season",
         ],
     )
     def test_view_returns_rows(self, db_conn, view_name, min_rows):
@@ -756,6 +862,14 @@ class TestViewColumns:
             ("api.season_outlook", SEASON_OUTLOOK_COLUMNS),
             ("api.expected_points", EXPECTED_POINTS_COLUMNS),
             ("api.core_ratings", CORE_RATINGS_COLUMNS),
+            ("api.passing_charting_player_season", PASSING_CHARTING_PLAYER_SEASON_COLUMNS),
+            ("api.passing_charting_target_season", PASSING_CHARTING_TARGET_SEASON_COLUMNS),
+            ("api.passing_charting_team_season", PASSING_CHARTING_TEAM_SEASON_COLUMNS),
+            # coach_tenures/refresh_campaign_status may be empty pre-backfill /
+            # pre-campaign -- column check only, no row-count entry above
+            # (same treatment as game_recaps/scored_matchup_edges).
+            ("api.coach_tenures", COACH_TENURES_COLUMNS),
+            ("api.refresh_campaign_status", REFRESH_CAMPAIGN_STATUS_COLUMNS),
         ],
         ids=[
             "team_detail",
@@ -784,6 +898,11 @@ class TestViewColumns:
             "season_outlook",
             "expected_points",
             "core_ratings",
+            "passing_charting_player_season",
+            "passing_charting_target_season",
+            "passing_charting_team_season",
+            "coach_tenures",
+            "refresh_campaign_status",
         ],
     )
     def test_columns_present(self, db_conn, view_name, expected_columns):

--- a/tests/test_endpoints_config.py
+++ b/tests/test_endpoints_config.py
@@ -178,11 +178,14 @@ class TestSyncedEndpointPKs:
         assert config.path == "/coaches/profile"
 
     def test_player_season_overview_pk(self):
-        """player_season_overview keyed by season + id, the player-grain
-        join spine shared with stats.player_usage / metrics.ppa_players_season
-        (A4 unit, 2026-08-29)."""
+        """player_season_overview keyed by season + id + team (team added
+        2026-08-30 pre-backfill for transfer safety and grain consistency
+        with player_success_season/passing_player_season -- cfb-app
+        work-order task 1; CFBD normally returns one overview record per
+        player-season with a single team attribution, so this is insurance
+        against a per-team split, not an observed one)."""
         config = STATS_ENDPOINTS["player_season_overview"]
-        assert config.primary_key == ["season", "id"]
+        assert config.primary_key == ["season", "id", "team"]
         assert config.path == "/player/season/overview"
 
 

--- a/tests/test_load_flat_files.py
+++ b/tests/test_load_flat_files.py
@@ -159,6 +159,69 @@ class TestDryRun:
 
 
 # ---------------------------------------------------------------------------
+# _planned_sources: explicit-season backfills must not be cadence-gated
+# (PR #81 review finding -- an off-season `--due --season 2016` used to plan
+# nothing weekly and exit 0)
+# ---------------------------------------------------------------------------
+
+
+def _parse(argv: list[str]):
+    return load_flat_files.build_arg_parser().parse_args(argv)
+
+
+class TestPlannedSources:
+    def test_explicit_season_with_due_plans_all_non_manual_sources(self, monkeypatch):
+        # Cadence must not even be consulted: an explicit season is a
+        # backfill request, and is_due describes only the current season.
+        def boom(*a, **k):
+            raise AssertionError("explicit-season --due must not consult cadence")
+
+        monkeypatch.setattr(load_flat_files, "is_due", boom)
+        monkeypatch.setattr(load_flat_files, "_cadence_last_checked", boom)
+
+        args = _parse(["--due", "--season", "2016"])
+        names = load_flat_files._planned_sources(args, OFF_SEASON_DAY, 2016, season_explicit=True)
+
+        expected = [name for name, spec in REGISTRY.items() if spec.cadence != "manual"]
+        assert names == expected
+        assert all(REGISTRY[name].cadence != "manual" for name in names)
+        # The registry has at least one manual source, so the exclusion is
+        # actually exercised, and the plan is never empty.
+        assert 0 < len(names) < len(REGISTRY)
+
+    def test_due_without_explicit_season_keeps_cadence_filter(self, monkeypatch):
+        consulted: list[str] = []
+
+        def fake_is_due(spec, last, today):
+            consulted.append(spec.name)
+            return spec.name == "massey"
+
+        monkeypatch.setattr(load_flat_files, "is_due", fake_is_due)
+        monkeypatch.setattr(load_flat_files, "_cadence_last_checked", lambda spec, season: None)
+
+        args = _parse(["--due"])
+        names = load_flat_files._planned_sources(args, IN_SEASON_DAY, 2025, season_explicit=False)
+
+        assert names == ["massey"]
+        assert set(consulted) == set(REGISTRY)
+
+    def test_explicit_source_wins_unchanged(self, monkeypatch):
+        def boom(*a, **k):
+            raise AssertionError("--source selection must not consult cadence")
+
+        monkeypatch.setattr(load_flat_files, "is_due", boom)
+        monkeypatch.setattr(load_flat_files, "_cadence_last_checked", boom)
+
+        args = _parse(["--source", "massey", "--season", "2016"])
+        names = load_flat_files._planned_sources(args, OFF_SEASON_DAY, 2016, season_explicit=True)
+        assert names == ["massey"]
+
+        args = _parse(["--source", "massey", "--source", "sbr"])
+        names = load_flat_files._planned_sources(args, IN_SEASON_DAY, 2025, season_explicit=False)
+        assert names == ["massey", "sbr"]
+
+
+# ---------------------------------------------------------------------------
 # run_source
 # ---------------------------------------------------------------------------
 

--- a/tests/test_load_season.py
+++ b/tests/test_load_season.py
@@ -1,6 +1,9 @@
 """Unit tests for load_season's season-selection helpers (no DB, no API)."""
 
+from pathlib import Path
+
 import pytest
+import yaml
 
 from scripts.load_season import (
     ESTIMATED_CALLS,
@@ -18,6 +21,9 @@ from scripts.load_season import (
     upcoming_schedule_season,
     validate_resource_filters,
 )
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOWS_DIR = PROJECT_ROOT / ".github" / "workflows"
 
 
 class TestUpcomingScheduleSeason:
@@ -316,6 +322,67 @@ class TestFanoutDrainerWiring:
         assert "coach_profiles" in out
         assert "player_overview" in out
 
+    def test_player_overview_max_env_var_is_forwarded(self, monkeypatch):
+        """PLAYER_OVERVIEW_MAX_PER_RUN (wired from backfill-sources.yml's
+        player_overview_max input) raises the drainer's CAP only -- the
+        runner lambda must read it at call time (not bind a stale default
+        at import time) and forward it as max_players."""
+        captured = {}
+
+        def fake_run_player_overview_pipeline(**kwargs):
+            captured.update(kwargs)
+            return {"missing": 0}
+
+        monkeypatch.setattr(
+            "src.pipelines.run.run_player_overview_pipeline",
+            fake_run_player_overview_pipeline,
+        )
+        monkeypatch.setenv("PLAYER_OVERVIEW_MAX_PER_RUN", "9000")
+
+        load_season(season=2024, sources=["player_overview"], dry_run=False, skip_refresh=True)
+
+        assert captured == {"max_players": 9000}
+
+    def test_player_overview_max_defaults_when_env_absent(self, monkeypatch):
+        """No env var (the daily path) must stay byte-identical to today:
+        max_players=250."""
+        captured = {}
+
+        def fake_run_player_overview_pipeline(**kwargs):
+            captured.update(kwargs)
+            return {"missing": 0}
+
+        monkeypatch.setattr(
+            "src.pipelines.run.run_player_overview_pipeline",
+            fake_run_player_overview_pipeline,
+        )
+        monkeypatch.delenv("PLAYER_OVERVIEW_MAX_PER_RUN", raising=False)
+
+        load_season(season=2024, sources=["player_overview"], dry_run=False, skip_refresh=True)
+
+        assert captured == {"max_players": 250}
+
+    def test_player_overview_max_defaults_when_env_empty(self, monkeypatch):
+        """GitHub sets an empty-string env var for an unset workflow input
+        (backfill-sources.yml's player_overview_max defaults to ""), and
+        int("") would crash -- the empty case must fall back to 250 exactly
+        like the absent case, not raise."""
+        captured = {}
+
+        def fake_run_player_overview_pipeline(**kwargs):
+            captured.update(kwargs)
+            return {"missing": 0}
+
+        monkeypatch.setattr(
+            "src.pipelines.run.run_player_overview_pipeline",
+            fake_run_player_overview_pipeline,
+        )
+        monkeypatch.setenv("PLAYER_OVERVIEW_MAX_PER_RUN", "")
+
+        load_season(season=2024, sources=["player_overview"], dry_run=False, skip_refresh=True)
+
+        assert captured == {"max_players": 250}
+
 
 class TestPassingWiring:
     """Passing unit (spec v5.25.0, 2026-08-30): the five /passing charting
@@ -610,3 +677,26 @@ class TestMainExitCode:
             ["load_season.py", "--season", "2026", "--sources", "games", "--dry-run"],
         )
         assert main() is None
+
+
+class TestWorkflowYaml:
+    """Sanity checks on the two workflow files touched alongside the
+    player_overview cap override -- catches a YAML syntax error (bad
+    indentation, an unescaped `:` in a description) before it reaches CI,
+    where a broken workflow file fails silently until dispatched."""
+
+    def test_flat_files_workflow_parses(self):
+        doc = yaml.safe_load((WORKFLOWS_DIR / "flat-files.yml").read_text())
+
+        dispatch_inputs = doc[True]["workflow_dispatch"]["inputs"]
+        assert "seasons" in dispatch_inputs
+        assert dispatch_inputs["seasons"]["required"] is False
+        assert doc["jobs"]["load"]["timeout-minutes"] == 300
+
+    def test_backfill_sources_workflow_parses(self):
+        doc = yaml.safe_load((WORKFLOWS_DIR / "backfill-sources.yml").read_text())
+
+        dispatch_inputs = doc[True]["workflow_dispatch"]["inputs"]
+        assert "player_overview_max" in dispatch_inputs
+        assert dispatch_inputs["player_overview_max"]["required"] is False
+        assert doc["jobs"]["backfill"]["timeout-minutes"] == 300

--- a/tests/test_marts.py
+++ b/tests/test_marts.py
@@ -14,6 +14,7 @@ MARTS_VIEWS = [
     "_game_epa_calc",
     "adjusted_epa_week",
     "coach_record",
+    "coach_tenures",
     "coaching_tenure",
     "conference_comparison",
     "conference_era_summary",
@@ -24,6 +25,9 @@ MARTS_VIEWS = [
     "epa_crossvalidation",
     "matchup_edges",
     "matchup_history",
+    "passing_charting_player_season",
+    "passing_charting_target_season",
+    "passing_charting_team_season",
     "penalty_log",
     "play_epa",
     "player_comparison",
@@ -124,6 +128,12 @@ class TestMartViewsHaveData:
     EMPTY_OK = {
         ("marts", "scored_matchup_edges"),
         ("marts", "epa_crossvalidation"),
+        # ref.coach_tenures is a per-team fan-out resource, deliberately
+        # excluded from the daily/incremental path (coaches.py's
+        # cfbd_coach_tenures source) -- an environment that hasn't yet run
+        # the backfill (`--source coach_tenures`) legitimately has zero rows
+        # here. See marts/048_coach_tenures.sql's header.
+        ("marts", "coach_tenures"),
     }
 
     @pytest.mark.parametrize(

--- a/tests/test_sources/test_player_overview.py
+++ b/tests/test_sources/test_player_overview.py
@@ -295,6 +295,11 @@ class TestPlayerSeasonOverviewResource:
             assert results == []
 
     def test_merge_write_disposition_and_compound_primary_key(self):
+        """team added 2026-08-30 pre-backfill for transfer safety and grain
+        consistency with player_success_season/passing_player_season
+        (cfb-app work-order task 1) -- CFBD normally returns one overview
+        record per player-season with a single team attribution, so this is
+        insurance against a per-team split, not an observed one."""
         from src.pipelines.sources.player_overview import player_season_overview_resource
 
         with patch("src.pipelines.sources.player_overview.get_client") as mock_get_client:
@@ -305,7 +310,7 @@ class TestPlayerSeasonOverviewResource:
             assert resource.write_disposition == "merge"
             schema = resource.compute_table_schema()
             pk_columns = {name for name, col in schema["columns"].items() if col.get("primary_key")}
-            assert pk_columns == {"season", "id"}
+            assert pk_columns == {"season", "id", "team"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sources/test_wepa.py
+++ b/tests/test_sources/test_wepa.py
@@ -2,6 +2,14 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from src.pipelines.sources.wepa import (
+    wepa_players_kicking_resource,
+    wepa_players_passing_resource,
+    wepa_players_rushing_resource,
+)
+
 
 def test_wepa_team_season_resource_yields_data():
     """WEPA endpoint should yield opponent-adjusted EPA by team/season."""
@@ -80,6 +88,109 @@ def test_wepa_players_passing_resource_yields_data():
 
         assert len(results) == 1
         assert results[0]["id"] == 12345
+
+
+PLAYER_RESOURCES = [
+    wepa_players_passing_resource,
+    wepa_players_rushing_resource,
+    wepa_players_kicking_resource,
+]
+
+
+@pytest.mark.parametrize("resource_fn", PLAYER_RESOURCES, ids=lambda fn: fn.__name__)
+class TestPlayerIdCoalesce:
+    """CFBD renamed the player-id field on at least one /wepa/players/*
+    endpoint sometime after the existing 2014-2025 rows were loaded
+    (observed 2026-08-30, backfill run 33333482499: dlt's
+    UnboundColumnException on wepa_players_passing -- "id ... did not
+    receive any data" -- despite an HTTP 200 response). All three player
+    resources share the same fix, so these run against all three."""
+
+    def test_id_already_present_is_unchanged(self, resource_fn):
+        mock_response = [{"id": 12345, "name": "Player A"}]
+
+        with (
+            patch("src.pipelines.sources.wepa.get_client") as mock_get_client,
+            patch("src.pipelines.sources.wepa.make_request") as mock_make_request,
+        ):
+            mock_get_client.return_value = MagicMock()
+            mock_make_request.return_value = mock_response
+
+            results = list(resource_fn(years=[2024]))
+
+        assert len(results) == 1
+        assert results[0]["id"] == 12345  # untouched -- still the original int
+
+    def test_player_id_field_is_coalesced_and_stamped_as_string(self, resource_fn):
+        mock_response = [{"playerId": 777, "name": "Player B"}]
+
+        with (
+            patch("src.pipelines.sources.wepa.get_client") as mock_get_client,
+            patch("src.pipelines.sources.wepa.make_request") as mock_make_request,
+        ):
+            mock_get_client.return_value = MagicMock()
+            mock_make_request.return_value = mock_response
+
+            results = list(resource_fn(years=[2024]))
+
+        assert len(results) == 1
+        assert results[0]["id"] == "777"
+        assert isinstance(results[0]["id"], str)
+        assert results[0]["playerId"] == 777  # original renamed field kept too
+
+    def test_athlete_id_field_is_coalesced_and_stamped_as_string(self, resource_fn):
+        mock_response = [{"athleteId": 888, "name": "Player C"}]
+
+        with (
+            patch("src.pipelines.sources.wepa.get_client") as mock_get_client,
+            patch("src.pipelines.sources.wepa.make_request") as mock_make_request,
+        ):
+            mock_get_client.return_value = MagicMock()
+            mock_make_request.return_value = mock_response
+
+            results = list(resource_fn(years=[2024]))
+
+        assert len(results) == 1
+        assert results[0]["id"] == "888"
+        assert isinstance(results[0]["id"], str)
+        assert results[0]["athleteId"] == 888
+
+    def test_nested_athlete_id_is_coalesced_and_stamped_as_string(self, resource_fn):
+        mock_response = [{"athlete": {"id": 999, "name": "Player D"}, "name": "Player D"}]
+
+        with (
+            patch("src.pipelines.sources.wepa.get_client") as mock_get_client,
+            patch("src.pipelines.sources.wepa.make_request") as mock_make_request,
+        ):
+            mock_get_client.return_value = MagicMock()
+            mock_make_request.return_value = mock_response
+
+            results = list(resource_fn(years=[2024]))
+
+        assert len(results) == 1
+        assert results[0]["id"] == "999"
+        assert isinstance(results[0]["id"], str)
+        assert results[0]["athlete"] == {"id": 999, "name": "Player D"}  # preserved
+
+    def test_no_id_candidate_is_skipped_but_siblings_still_yielded(self, resource_fn, caplog):
+        mock_response = [
+            {"name": "No Id Player"},
+            {"playerId": 42, "name": "Has Id Player"},
+        ]
+
+        with (
+            patch("src.pipelines.sources.wepa.get_client") as mock_get_client,
+            patch("src.pipelines.sources.wepa.make_request") as mock_make_request,
+        ):
+            mock_get_client.return_value = MagicMock()
+            mock_make_request.return_value = mock_response
+
+            with caplog.at_level("WARNING"):
+                results = list(resource_fn(years=[2024]))
+
+        assert len(results) == 1
+        assert results[0]["id"] == "42"
+        assert any("id" in record.message.lower() for record in caplog.records)
 
 
 def test_wepa_source_returns_all_resources():


### PR DESCRIPTION
## What this carries

Four related units from the 2026-08-30 expansion push. Everything DB-facing is already **applied to the live database and verified** — merging makes main's code agree with production and puts the daily load on the fixed path.

### 1. wepa player-id repair (urgent for the daily load)
- `src/pipelines/sources/wepa.py`: CFBD renamed the player-id field on `/wepa/players/*`; each player resource now stamps `id` by coalescing `id`/`playerId`/`athleteId`/`athlete.id` (str-cast for text-PK stability) and skips-with-warning records with no candidate, so one bad record can no longer kill the source's sibling packages.
- `src/schemas/migrations/058_wepa_player_id_column.sql`: the live tables were first created after the rename (`athlete_id` only, no `id`), so dlt's `ADD COLUMN id NOT NULL` died on populated tables. 058 pre-adds `id text`, copies `athlete_id` (text, zero NULLs), sets NOT NULL. Applied live; idempotent; all 12 seasons re-ingested green afterward.
- Why urgent: main's daily load is safe only while CFBD has no 2026 wepa data. Season play has started — without this, the first 2026 wepa publish crashes the daily load.

### 2. cfb-app work order P1 (expansion views) — live since 2026-08-30 ~23:50 UTC
- New marts 045–048 (passing charting player/target/team season, coach_tenures) + additive `coach_id` on marts/023; api views 045–049 plus `player_detail` dedupe fix (reclassification fanout) and overview payload, `coaching_history`/`coach_records` coach_id; `refresh_marts.py` registrations; `deploys/expansion_views-manifest.json` (idempotent re-apply on merge); validation SQL — passed live (840/2,659/152 charting rows, 2,738 tenures @ 99.96% classified, zero player_detail dupes, grants intact).
- `player_overview.py` PK widened to `(season, id, team)` before the full-depth backfill (transfer-stint safety).
- Until merged, main's refresh script doesn't know the four new matviews — they'd go stale daily.

### 3. Backfill levers (used tonight for the runbook items)
- `flat-files.yml`: optional space-separated `seasons` loop input; timeout 30→300.
- `backfill-sources.yml`: timeout 120→300; `player_overview_max` input → `PLAYER_OVERVIEW_MAX_PER_RUN`, read at call time in `load_season.py` with an empty-string guard (unset workflow inputs arrive as `""`). Cap raise only — drain scope/order unchanged.

### 4. Cross-repo handoffs
- `docs/handoffs/2026-08-30-expansion-exposure-for-cfb-app.md` (catalog + exposure-plan ask; corrected: ESPN tables live at `stats.espn_player_*`, not an `espn` schema).
- `docs/handoffs/2026-08-30-expansion-views-reply-to-cfb-app.md` (work-order reply, marked live-deployed).

## Validation
- ruff + pytest green (pre-push hook) on every commit; workflow YAML asserted in tests.
- Live: migration 058 verified (9,020 rows id=athlete_id, 0 mismatches); wepa re-ingest green across 2014–2025; expansion validation suite passed against production.

## Still in flight (doesn't block merge)
player_overview drain dispatches (~4 more), stats/2014 timeout patch, espn play participants load — all run from this branch ref and survive the merge. Final runbook checkoffs follow as a small docs change once the drain lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193d5pxRWHPe1nxMtb8WPm5

---
_Generated by [Claude Code](https://claude.ai/code/session_0193d5pxRWHPe1nxMtb8WPm5)_









<!-- greptile_comment -->

<h3>Greptile Summary</h3>

WEPA player identity migration now deploys before dependent database views, preserves the required `id` key for legacy tables, and no longer requires the retired `athlete_id` field on new source rows. Executed checks also confirmed that coach identity matching returns no identity for duplicate matches and that any ambiguous season prevents a tenure-level identity from being published.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

There are no accepted blocking findings. The executed identity harness exercised the previously reported duplicate-match, mixed-ambiguity, historical-coverage-gap, and legacy WEPA insert paths against the current SQL behavior.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the Offline PR 81 database identity validation harness in three modes, and all runs completed successfully.
- Compared the before and after results to identify the corrected behavior: prior runs showed arbitrary coach-ID selection, a tenure with an ambiguous season, and rejection of a WEPA insert without athlete\_id, while the current runs show NULLs for duplicate/ambiguous identities, a stable ID across an unmatched historical season, and acceptance of inserts after id backfill with id NOT NULL.
- Captured a separate before-and-after verification snapshot that confirms the same fixtures now exhibit corrected behavior and notes that no repository edits were made; only required test artifacts were created in trex-artifacts.

<a href="https://app.greptile.com/trex/runs/21532235/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (5): Last reviewed commit: ["Relax legacy athlete\_id NOT NULL in wepa..."](https://github.com/rstover-fo/cfb-database/commit/af477433cec1c52c9a1d4be6d8f6b718277dbb2d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58476803)</sub>

<!-- /greptile_comment -->