### PR TITLE
Sept-1 incident hardenings and expansion campaign closeout

### DIFF
--- a/docs/pipeline-manifest.md
+++ b/docs/pipeline-manifest.md
@@ -218,7 +218,7 @@ the A2 unit above -- see the summary note for why they needed a targeted loader 
 than a year-fetch-all.
 
 | 69 | `/coaches/profile` | ref.coach_profiles | coaches.py | coach_profiles_resource | YES (drainer -- `run.py::run_coach_profiles_pipeline`, in `SOURCE_ORDER`, capped at 200 coach ids/run) | merge | id | current | WORKING (drainer live -- 200 rows after its first capped run, draining daily) |
-| 70 | `/player/season/overview` | stats.player_season_overview | player_overview.py | player_season_overview_resource | YES (drainer -- `run.py::run_player_overview_pipeline`, in `SOURCE_ORDER`, capped at 250 player-seasons/run) | merge | season, id | finished seasons only (completed-season gate) | WORKING (drainer live -- 250 rows after its first capped run, draining daily) |
+| 70 | `/player/season/overview` | stats.player_season_overview | player_overview.py | player_season_overview_resource | YES (drainer -- `run.py::run_player_overview_pipeline`, in `SOURCE_ORDER`, capped at 250 player-seasons/run) | merge | season, id, team | finished seasons only (completed-season gate) | WORKING (drain complete 2026-09-02 -- 47,396 rows, seasons 2013-2025; 4 2014 player-seasons held in `meta.fanout_misses` as network-fault/502 skips, self-heal after 30 days) |
 
 ### Passing (spec v5.25.0, 2026-08-30)
 

--- a/docs/plans/2026-08-29-cfbd-expansion-rollout.md
+++ b/docs/plans/2026-08-29-cfbd-expansion-rollout.md
@@ -2,9 +2,9 @@
 
 **Date:** 2026-08-29
 **Branch:** `claude/cfbd-cfb-package-updates-7iabg2`
-**Status:** Built and reviewed. Steps 1-3, 6, 7 (launch) and 9 applied to the live
-database/workflows as of 2026-08-30; steps 4, 5 (historical dispatches), 7's
-"once fully drained" rerun, and 8 remain open — see checklist below.
+**Status:** Built and reviewed. Steps 1-6, 7 (launch), 8, and 9 applied to the live
+database/workflows as of 2026-09-02 (steps 4, 5, 8 completed 2026-09-01/02); only
+7's "once fully drained" rerun remains open — see checklist below.
 
 ## What shipped on the branch
 
@@ -74,16 +74,25 @@ load precondition.
        `stats.player_season_overview` (250 rows) after their first capped runs;
        column names verified live via `pg_attribute` (not from API docs).
        `050`/`054` applied 2026-08-30.
-4. [ ] **Cheap corrected-data re-runs** (~4,900 calls): backfill-sources.yml
+4. [x] **Cheap corrected-data re-runs** (~4,900 calls): backfill-sources.yml
        dispatches, seasons 2025→2014, sources
        `metrics,wepa,recruiting,rosters,stats:advanced_team_stats+game_havoc+player_usage+player_returning+game_advanced`,
        plus one `reference` run. Split 2-3 dispatches for the 120-min timeout.
-5. [ ] **Flat-file first loads**: `flat-files.yml` picks the 16 new sources up via
+       **Done 2026-09-01** — all listed sources re-ran across the 2014-2025
+       dispatches; `wepa` was the long pole (the CFBD player-id rename ->
+       migration 058 saga) and finished last, all 12 seasons re-ingested
+       post-058.
+5. [x] **Flat-file first loads**: `flat-files.yml` picks the 16 new sources up via
        `--due`; historical seasons via explicit `--season` dispatches
        (ncaa 2013-2025, espn adv 2004-2025, participants 2014-2025 — ~190 fetches,
-       no API budget). **Partial: the `--due` first loads ran** (16 new sources
-       picked up on schedule); the historical `--season` dispatches for ncaa/espn
-       adv/participants have not been made yet.
+       no API budget). **Done 2026-09-01** — the `--due` first loads ran (16 new
+       sources picked up on schedule); the historical `--season` dispatches
+       loaded ncaa 2013-2024 (incl. play-by-play, 1.34M rows, 2021-2024), ESPN
+       player splits (57.8k/369.9k rows, 23 seasons, at `stats.espn_player_*`;
+       2014-2020 un-parked and loaded), and participants (12 seasons, ~1.77M
+       rows). ESPN 2002-03 pbp closed by decision (not loaded -- ESPN pbp
+       starts 2004, see "Facts discovered en route" above). Zero API budget
+       throughout; August closed under the monthly cap.
 6. [x] Deploy mart `044_epa_crossvalidation.sql` (separate, later run than 052);
        refresh marts; confirm the `cfbd_fpi_season` anchor is NON-dark (it has
        data today — dark there means the team-name join broke). Snapshot the
@@ -118,12 +127,32 @@ load precondition.
        scope here). If it times out again, that edit — parameterizing the loop
        bounds so it can be dispatched per-season or in season chunks — is the
        follow-up, not a re-dispatch of the same file.
-8. [ ] **player_overview backfill 2021-2025** (~23k calls — live counts run
+8. [x] **player_overview backfill 2021-2025** (~23k calls — live counts run
        4-5.5k players/season, higher than the ~3k planning estimate): dispatch
        `backfill-sources.yml --sources player_overview` per season, or let the
        daily drainer work at 250/day. Pace against the campaign so combined
-       spend stays under ~30k/month of headroom. **2014-2020 (~30k more) is
-       parked pending an explicit go-ahead.**
+       spend stays under ~30k/month of headroom.
+       **Complete 2026-09-02** — `stats.player_season_overview` holds **47,396
+       rows across seasons 2013-2025** (grain season/id/team; 2013 was pulled
+       into scope by the `metrics.ppa_players_season` candidate union, the
+       original scope said 2014-2025 -- the 2014-2020 parked range above is
+       included). Per-season: 2013: 2,984 | 2014: 3,048 | 2015: 3,096 | 2016:
+       3,238 | 2017: 3,214 | 2018: 3,473 | 2019: 3,489 | 2020: 2,370 (COVID) |
+       2021: 3,290 | 2022: 4,969 | 2023: 4,560 | 2024: 4,104 | 2025: 5,561.
+       Nine drain rounds Aug 30-Sep 2 drained the measured 43,788-pair backlog
+       (~43.8k calls; ~3.6k rows predated the campaign from the daily 250-cap
+       drip; the September share ≈21k against the fresh 125k monthly budget)
+       -- well above the ~23k estimate above because the full 2013-2020 range
+       was included. Round 7 died at batch 149/180 on a post-retries
+       ReadTimeout (fixed: network-fault skip-with-miss, commit `b046571`,
+       proven in production in round 8); round 8 was externally cancelled at
+       ~5h; the final round (run `33575474184`, 2026-09-02, green, 28 min)
+       finished the tail. Residual backlog: exactly 4 player-seasons, all
+       2014, all in `meta.fanout_misses` (3 network-fault skips -- sentinel
+       `status_code` 0 -- and 1 post-retries 502, recorded during CFBD's
+       unstable evening of 2026-09-01); they age back into eligibility after
+       30 days and self-heal on a later run. Zero 400/404 misses and zero
+       empty-200 residual across the whole population.
 9. [x] On merge to main: remove the temporary `push:` trigger from
        `probe-endpoints.yml` (workflow_dispatch works once it's on main).
        **Done** — commit `d14823f`.
@@ -136,7 +165,7 @@ load precondition.
 | A2 endpoint backfills + one-times | ~1,300 | step 2 |
 | Cheap corrected-data re-runs | ~4,900 | step 4 |
 | Refresh campaign (both per-game tasks) | ~38,000 | step 7, paced |
-| player_overview 2021-2025 | ~23,000 | step 8, paced |
+| player_overview 2021-2025 | ~23,000 (actual: ~43.8k for 2013-2025, split ~22.8k Aug / ~21k Sep) | step 8, paced |
 | Flat-file sources | 0 (GitHub fetches) | steps 5+ |
 
 Worst-case months stay ≈100k of the 125k Tier-4 budget with both paced streams
@@ -149,7 +178,8 @@ referenced in step 5's flat-file notes is now partially seeded — `massey` seed
 2026-08-30 (131 mappings, reviewed); `sbr` remains unseeded, pending a
 user-supplied Excel file.
 
-- player_overview 2014-2020 (~30k calls) — explicit user go-ahead required.
+- player_overview 2014-2020 (~30k calls) — **done, see step 8** (complete
+  2026-09-02, full 2013-2025 range drained; go-ahead was given).
 - `ncaa` schema exposure — deliberately ungranted until a crosswalk exists;
   revisit when an FCS join path is built on the `espn_game_id` bridge columns.
 - `ref.conference_affiliations` replacing the games-derived

--- a/scripts/load_season.py
+++ b/scripts/load_season.py
@@ -365,6 +365,19 @@ def upcoming_schedule_season(season: int, month: int) -> int | None:
     return season + 1 if month < 8 else None
 
 
+def _count_failures(results: dict) -> int:
+    """Count every non-"ok" result as a failure for the summary tally.
+
+    Must stay in lockstep with the row icon's predicate (anything but "ok"
+    prints FAIL) and with main()'s exit-code check. _mart_refresh can report
+    status "partial" (some matviews failed to refresh, others didn't) --
+    that is not "ok" and must fail the run, or a stale mart layer behind N
+    failed refreshes prints "0 failed" and exits 0. Counting only
+    status == "error" was exactly that bug.
+    """
+    return sum(1 for r in results.values() if r["status"] != "ok")
+
+
 def load_season(
     season: int,
     sources: list[str] | None = None,
@@ -657,12 +670,12 @@ def load_season(
     print(f"Season {season} Load Summary")
     print(f"{'=' * 60}")
     successes = sum(1 for r in results.values() if r["status"] == "ok")
-    errors = sum(1 for r in results.values() if r["status"] == "error")
+    errors = _count_failures(results)
     for name, res in results.items():
         status_icon = "OK" if res["status"] == "ok" else "FAIL"
         print(f"  [{status_icon:4s}] {name:25s} {res['duration_s']:>8.1f}s")
     print(f"{'=' * 60}")
-    print(f"  Total: {total_elapsed:.1f}s | {successes} succeeded, {errors} failed")
+    print(f"  Total: {total_elapsed:.1f}s | {successes} succeeded, {errors} failed (incl. partial)")
 
     return {
         "season": season,
@@ -740,8 +753,11 @@ def main() -> None:
     )
 
     # Validation failures return {"error": str} (singular) before any source
-    # runs; per-source failures count up {"errors": int}. Both must exit
-    # nonzero or a mistyped --sources reports success having loaded nothing.
+    # runs; per-source failures count up {"errors": int} via _count_failures,
+    # which counts any non-"ok" status -- including _mart_refresh's "partial"
+    # -- not just literal status == "error". Both must exit nonzero, or a
+    # mistyped --sources (or a partially-failed mart refresh) reports success
+    # having loaded/refreshed nothing.
     if summary.get("error") or summary.get("errors", 0) > 0:
         sys.exit(1)
 

--- a/src/pipelines/run.py
+++ b/src/pipelines/run.py
@@ -1266,14 +1266,15 @@ def run_player_overview_pipeline(
         Summary dict: `seasons` considered, `eligible_seasons` (post-gate),
         `missing` (the FULL backlog, not the capped slice),
         `excluded_misses` (candidates skipped because meta.fanout_misses
-        recorded a 400/404/5xx for them within FANOUT_MISS_RETRY_DAYS --
-        PR #75 review finding A), `loaded_this_run`,
+        recorded a 400/404/5xx/network-fault for them within
+        FANOUT_MISS_RETRY_DAYS -- PR #75 review finding A), `loaded_this_run`,
         `skipped_misses_this_run` (player-seasons attempted this run that
         ended in a recorded miss instead of rows -- terminal 400/404s plus
-        5xxs that survived api_client's retries, which skip the one player
-        rather than killing the dispatch: backfill run 33351198599),
-        `deferred`, batches, and the list of dlt LoadInfo objects (one per
-        batch).
+        5xxs and network faults (timeouts/connect errors, recorded with
+        sentinel status_code 0) that survived api_client's retries, which
+        skip the one player rather than killing the dispatch: backfill run
+        33351198599, drain #7 run 33515429442), `deferred`, batches, and the
+        list of dlt LoadInfo objects (one per batch).
     """
     import psycopg2
 

--- a/src/pipelines/sources/player_overview.py
+++ b/src/pipelines/sources/player_overview.py
@@ -48,9 +48,11 @@ def player_overview_source(
         player_seasons: List of (year, player_id) pairs to fetch.
         misses: When given, a list the resource appends
             (f"{year}:{player_id}", status_code) to for every 400/404 hit
-            and every 5xx that survives api_client's retries -- forwarded
-            straight through to `player_season_overview_resource`.
-            The caller persists it to `meta.fanout_misses` via
+            and every 5xx or network fault (read/connect timeout, connection
+            error -- recorded with sentinel status_code 0) that survives
+            api_client's retries -- forwarded straight through to
+            `player_season_overview_resource`. The caller persists it to
+            `meta.fanout_misses` via
             `run.py::_record_fanout_misses` (PR #75 review finding A) so
             the next run's candidate query can exclude a terminal miss
             instead of re-spending the call forever.
@@ -106,16 +108,22 @@ def player_season_overview_resource(
     A 400 or 404 for a given (year, playerId) is logged and skipped rather
     than aborting the whole batch -- candidates come from a UNION of
     stats.player_usage and metrics.ppa_players_season, either of which may
-    include a player-season CFBD has no overview computed for. A 5xx that
-    exhausts api_client's per-request retries is skipped the same way: one
-    player's transient gateway failure must not kill a multi-thousand-call
-    dispatch (backfill run 33351198599, 2026-08-30). When `misses` is
-    given, the "{year}:{player_id}" key (matching
+    include a player-season CFBD has no overview computed for. A 5xx, or a
+    network fault (read/connect timeout, connection error), that exhausts
+    api_client's transient-fault retries is skipped the same way: one
+    player's flaky gateway or a passing CFBD instability window must not
+    kill a multi-thousand-call dispatch (backfill run 33351198599,
+    2026-08-30; drain #7 run 33515429442, 2026-09-01, where the failure
+    arrived as a post-retries httpx.ReadTimeout instead of a 5xx). When
+    `misses` is given, the "{year}:{player_id}" key (matching
     `meta.fanout_misses.key`'s format for this source) and status code are
     appended to it so the caller can persist the miss (PR #75 review
     finding A: without this, a terminal 400/404 was re-requested every run
-    forever); the ledger's FANOUT_MISS_RETRY_DAYS window ages a 5xx skip
-    back into eligibility rather than blacklisting it.
+    forever); a network fault is recorded with the sentinel status_code 0
+    (meta.fanout_misses.status_code is `int NOT NULL`, so there is no real
+    HTTP status to store). The ledger's FANOUT_MISS_RETRY_DAYS window ages
+    a 5xx or network-fault skip back into eligibility rather than
+    blacklisting it.
 
     Args:
         player_seasons: List of (year, player_id) pairs to fetch.
@@ -145,9 +153,10 @@ def player_season_overview_resource(
                     continue
                 if e.response.status_code >= 500:
                     # Already retried: a 5xx HTTPStatusError only reaches here
-                    # after api_client.get() has burned its full retry budget
-                    # (MAX_RETRIES backoff attempts) on this one call. One
-                    # player's flaky gateway must not kill the whole dispatch
+                    # after api_client.get() has burned its full transient-fault
+                    # retry budget (TRANSIENT_MAX_RETRIES backoff attempts) on
+                    # this one call. One player's flaky gateway must not kill
+                    # the whole dispatch
                     # -- backfill run 33351198599 (2026-08-30) lost ~5,600
                     # planned calls when a single transient 502 for
                     # (2024, 4879928) raised through dlt at batch 68/180.
@@ -166,6 +175,34 @@ def player_season_overview_resource(
                         misses.append((f"{year}:{player_id}", e.response.status_code))
                     continue
                 raise
+            except httpx.RequestError as e:
+                # Already retried: api_client.get() burns its full transient
+                # budget (TRANSIENT_MAX_RETRIES retries, ~120s of backoff) on
+                # 5xx responses AND connect/read timeouts alike before either
+                # can reach here. Drain #7 (run 33515429442, 2026-09-01) hit a
+                # ~4.5-minute CFBD instability window where 5xx and timeout
+                # retries alternated through the whole budget, and the final
+                # attempt ALSO timed out -- so this arrived as
+                # httpx.ReadTimeout (a RequestError), not HTTPStatusError. The
+                # 5xx-only skip above didn't catch it, the timeout escaped,
+                # and dlt discarded the remaining ~31 planned batches (~1,600
+                # calls) -- the same blast radius the 5xx hardening (batch
+                # 68/180, run 33351198599) was built to stop. Recorded in the
+                # same meta.fanout_misses ledger with status_code=0 -- the
+                # documented sentinel for "network fault, no HTTP status"
+                # (the column is `int NOT NULL`, so there is no real status to
+                # store) -- and FANOUT_MISS_RETRY_DAYS ages it back into
+                # eligibility exactly like a 5xx skip. RateLimitExhausted/
+                # RateLimitCircuitOpen are custom exceptions raised by
+                # api_client directly, never httpx.RequestError, so a spent
+                # quota still propagates and aborts the run.
+                logger.warning(
+                    f"Request failed for player season overview {player_id} ({year}) "
+                    f"after client retries ({e}); recording miss and continuing"
+                )
+                if misses is not None:
+                    misses.append((f"{year}:{player_id}", 0))
+                continue
 
             if isinstance(data, list):
                 rows = data

--- a/src/schemas/marts/028_data_freshness.sql
+++ b/src/schemas/marts/028_data_freshness.sql
@@ -1,6 +1,29 @@
 -- Data freshness: track when each key table was last loaded and whether it's stale
 -- Grain: schema_name + table_name (one row per tracked table)
 -- Sources: pg_stat_user_tables activity timestamps + reltuples estimates
+--
+-- Two failure modes this guards against (2026-08-31/09-01 incident):
+--   1. Stats-reset blindness. A Postgres crash-restart (2026-08-31 00:26 UTC)
+--      zeroes pg_stat_user_tables: last_vacuum/autovacuum/analyze/autoanalyze
+--      all go NULL even though the table is being written to right now (e.g.
+--      betting.lines took 616 inserts on 2026-09-01 with no recorded activity
+--      timestamp). Naive GREATEST-of-four-timestamps reports these as stale
+--      indefinitely, even fresh, until the next natural VACUUM/ANALYZE lands.
+--      Fix: when a table has recorded writes (n_tup_ins/upd/del > 0) but no
+--      activity timestamp, fall back to pg_postmaster_start_time() -- the
+--      table cannot have been idle any longer than the server has been up.
+--   2. Partitioned-parent blindness. core.plays is a partitioned parent
+--      (relkind 'p'). All real writes and autovacuum/autoanalyze activity
+--      land on its partitions (core.plays_y2026, etc); the parent's OWN
+--      pg_stat_user_tables row never gets a timestamp from autovacuum in
+--      practice (autovacuum analyzes the parent only after accumulated
+--      cross-partition changes clear a threshold, which a stats reset also
+--      zeroes out). Fix: aggregate by pg_partition_root() so a partition's
+--      autoanalyze rolls up to its parent. Note the parent's OWN
+--      pg_stat_user_tables row (PG14+) already carries a rolled-up
+--      reltuples estimate independent of its children's -- it is excluded
+--      from the source set below so its reltuples/writes aren't double
+--      counted on top of the children's.
 
 DROP MATERIALIZED VIEW IF EXISTS marts.data_freshness CASCADE;
 
@@ -29,47 +52,81 @@ WITH tracked_tables AS (
         ('recruiting', 'transfer_portal', 'seasonal'),
         ('betting', 'lines', 'weekly'),
         ('draft', 'draft_picks', 'seasonal'),
-        ('metrics', 'predicted_points', 'weekly'),
+        -- Was ('metrics', 'predicted_points', 'weekly') -- that table never
+        -- existed; aspirational name for what shipped as metrics.ppa_predicted,
+        -- the /ppa/predicted static model grid loaded once by the run.py-only
+        -- metrics_ppa_predicted source, not refreshed weekly. Every apply of
+        -- this file with the old entry made daily verify_load.py fail
+        -- unconditionally (LEFT JOIN miss -> last_activity NULL -> stale).
+        ('metrics', 'ppa_predicted', 'static'),
         ('metrics', 'win_probability', 'weekly')
     ) AS t(schema_name, table_name, expected_refresh_frequency)
 ),
 table_stats AS (
+    -- relkind <> 'p': exclude partitioned-parent shell rows. A partitioned
+    -- parent (e.g. core.plays) gets its own pg_stat_user_tables row on
+    -- PG14+, but it's a rollup pg_class.reltuples estimate maintained
+    -- independently of the children -- summing it alongside the children
+    -- would roughly double-count row_count. The parent carries no write
+    -- counters of its own (n_tup_ins/upd/del stay 0; all DML is attributed
+    -- to the partition actually written) and no activity timestamp of its
+    -- own in practice, so excluding it loses nothing.
     SELECT
-        s.schemaname AS schema_name,
-        s.relname AS table_name,
-        c.reltuples::bigint AS row_count,
-        GREATEST(
+        root.relnamespace::regnamespace::text AS schema_name,
+        root.relname AS table_name,
+        SUM(GREATEST(c.reltuples, 0))::bigint AS row_count,
+        MAX(GREATEST(
             s.last_vacuum, s.last_autovacuum,
             s.last_analyze, s.last_autoanalyze
-        ) AS last_activity
+        )) AS last_activity_recorded,
+        SUM(s.n_tup_ins + s.n_tup_upd + s.n_tup_del) AS writes_since_reset
     FROM pg_stat_user_tables s
     JOIN pg_class c ON s.relid = c.oid
+    JOIN pg_class root
+        ON root.oid = COALESCE(pg_partition_root(s.relid::regclass), s.relid::regclass)::oid
+    WHERE c.relkind <> 'p'
+    GROUP BY root.relnamespace, root.relname
+),
+freshness AS (
+    SELECT
+        tt.schema_name,
+        tt.table_name,
+        COALESCE(ts.row_count, 0) AS row_count,
+        -- A table with recorded writes since the last stats reset was active
+        -- no earlier than the restart, so pg_postmaster_start_time() is an
+        -- honest floor when the reset wiped the real timestamp.
+        COALESCE(
+            ts.last_activity_recorded,
+            CASE WHEN ts.writes_since_reset > 0 THEN pg_postmaster_start_time() END
+        ) AS last_activity,
+        tt.expected_refresh_frequency
+    FROM tracked_tables tt
+    LEFT JOIN table_stats ts
+        ON ts.schema_name = tt.schema_name
+        AND ts.table_name = tt.table_name
 )
 SELECT
-    tt.schema_name,
-    tt.table_name,
-    COALESCE(ts.row_count, 0) AS row_count,
-    ts.last_activity,
-    tt.expected_refresh_frequency,
+    schema_name,
+    table_name,
+    row_count,
+    last_activity,
+    expected_refresh_frequency,
     CASE
-        WHEN ts.last_activity IS NOT NULL
-        THEN ROUND(EXTRACT(EPOCH FROM (now() - ts.last_activity)) / 86400.0, 1)
+        WHEN last_activity IS NOT NULL
+        THEN ROUND(EXTRACT(EPOCH FROM (now() - last_activity)) / 86400.0, 1)
     END AS days_since_activity,
     CASE
-        WHEN tt.expected_refresh_frequency = 'static' THEN false
-        WHEN tt.expected_refresh_frequency = 'weekly'
-            AND (ts.last_activity IS NULL
-                 OR ts.last_activity < now() - interval '14 days') THEN true
-        WHEN tt.expected_refresh_frequency = 'seasonal'
-            AND (ts.last_activity IS NULL
-                 OR ts.last_activity < now() - interval '90 days') THEN true
+        WHEN expected_refresh_frequency = 'static' THEN false
+        WHEN expected_refresh_frequency = 'weekly'
+            AND (last_activity IS NULL
+                 OR last_activity < now() - interval '14 days') THEN true
+        WHEN expected_refresh_frequency = 'seasonal'
+            AND (last_activity IS NULL
+                 OR last_activity < now() - interval '90 days') THEN true
         ELSE false
     END AS is_stale
-FROM tracked_tables tt
-LEFT JOIN table_stats ts
-    ON ts.schema_name = tt.schema_name
-    AND ts.table_name = tt.table_name
-ORDER BY tt.schema_name, tt.table_name;
+FROM freshness
+ORDER BY schema_name, table_name;
 
 -- Required for REFRESH CONCURRENTLY
 CREATE UNIQUE INDEX ON marts.data_freshness (schema_name, table_name);

--- a/src/schemas/migrations/056_fanout_miss_ledger.sql
+++ b/src/schemas/migrations/056_fanout_miss_ledger.sql
@@ -1,13 +1,15 @@
 -- Migration: 056_fanout_miss_ledger
 --
 -- meta.fanout_misses: shared ledger of fan-out misses -- terminal (400/404)
--- responses, plus 5xx failures that survived api_client's full retry budget
--- (recorded by player_overview.py so one flaky gateway response cannot kill a
--- multi-thousand-call dispatch) -- from the per-entity fan-out drainers in
--- coaches.py (coach_profiles_resource) and player_overview.py
--- (player_season_overview_resource) -- PR #75 review finding A (P1 x2, unit
--- R2, 2026-08-30). The shared 30-day window means a 5xx skip is deferred,
--- never blacklisted: it ages back into eligibility like a late-published id.
+-- responses, plus 5xx failures and network faults (timeouts/connect errors,
+-- status_code 0) that survived api_client's full retry budget (recorded by
+-- player_overview.py so one flaky gateway response or transient CFBD
+-- instability window cannot kill a multi-thousand-call dispatch) -- from the
+-- per-entity fan-out drainers in coaches.py (coach_profiles_resource) and
+-- player_overview.py (player_season_overview_resource) -- PR #75 review
+-- finding A (P1 x2, unit R2, 2026-08-30). The shared 30-day window means a
+-- 5xx or network-fault skip is deferred, never blacklisted: it ages back
+-- into eligibility like a late-published id.
 --
 -- Without this, run.py's set-difference drainers (run_coach_profiles_pipeline
 -- ~line 661, run_player_overview_pipeline ~line 1193) re-select the SAME ids
@@ -57,23 +59,33 @@ CREATE TABLE IF NOT EXISTS meta.fanout_misses (
 
 COMMENT ON TABLE meta.fanout_misses IS
     'Misses from per-entity fan-out drainers: terminal (400/404) responses, '
-    'plus 5xx failures that survived api_client''s full retry budget '
-    '(player_overview.py records these so one flaky gateway response cannot '
-    'kill a multi-thousand-call dispatch). Keyed by (source, key) so a '
-    'set-difference drainer (src/pipelines/run.py) can exclude a '
-    'recently-attempted miss instead of re-spending its API call every run. '
+    'plus 5xx failures and network faults (timeouts/connect errors, '
+    'status_code 0) that survived api_client''s full retry budget '
+    '(player_overview.py records these so one flaky gateway response or '
+    'transient CFBD instability window cannot kill a multi-thousand-call '
+    'dispatch). Keyed by (source, key) so a set-difference drainer '
+    '(src/pipelines/run.py) can exclude a recently-attempted miss instead of '
+    're-spending its API call every run. '
     'source: ''coach_profiles'' | ''player_season_overview''. '
     'key: str(coach_id) for coach_profiles, ''{season}:{player_id}'' for '
     'player_season_overview. 30-day re-eligibility is enforced in run.py '
     '(FANOUT_MISS_RETRY_DAYS), not here, so late-published CFBD data -- and '
-    'a transient 5xx skip -- self-heals instead of being excluded forever. '
-    'PR #75 review finding A.';
+    'a transient 5xx or network-fault skip -- self-heals instead of being '
+    'excluded forever. PR #75 review finding A.';
+
+COMMENT ON COLUMN meta.fanout_misses.status_code IS
+    'HTTP status code of the miss (400/404/5xx), or the sentinel 0 for a '
+    'network fault (read/connect timeout, connection error) that survived '
+    'api_client''s full retry budget with no HTTP response to report -- this '
+    'column is NOT NULL, so 0 documents "no HTTP status" rather than a real '
+    'server response.';
 
 COMMENT ON COLUMN meta.fanout_misses.attempts IS
     'Incremented (not overwritten) on every re-encountered miss via the '
     'ON CONFLICT (source, key) DO UPDATE upsert in '
     'run.py::_record_fanout_misses -- a rising count is the operator signal '
-    'that a given id keeps 400/404ing rather than having been hit once.';
+    'that a given id keeps missing (400/404, 5xx, or network fault) rather '
+    'than having been hit once.';
 
 GRANT USAGE ON SCHEMA meta TO anon, authenticated;
 GRANT SELECT ON meta.fanout_misses TO anon, authenticated;

--- a/tests/test_load_season.py
+++ b/tests/test_load_season.py
@@ -679,6 +679,55 @@ class TestMainExitCode:
         assert main() is None
 
 
+class TestCountFailures:
+    """_count_failures backs the summary tally, the row icon, and (via
+    summary["errors"]) main()'s exit code -- all three must agree. Mart
+    refresh reports status "partial" when some matviews refresh and others
+    don't; that is not "ok" and must fail the run. Counting only
+    status == "error" let a run with every source "ok" and a partial mart
+    refresh print "[FAIL] _mart_refresh" plus "0 failed" and exit 0 -- a
+    green run hiding a stale mart layer (found by review, 2026-09-01)."""
+
+    def test_all_ok_is_zero_failures(self):
+        from scripts.load_season import _count_failures
+
+        results = {"games": {"status": "ok"}, "stats": {"status": "ok"}}
+
+        assert _count_failures(results) == 0
+
+    def test_partial_mart_refresh_counts_as_a_failure(self):
+        from scripts.load_season import _count_failures
+
+        results = {
+            "games": {"status": "ok"},
+            "_mart_refresh": {"status": "partial", "failures": 3},
+        }
+
+        assert _count_failures(results) == 1
+
+    def test_literal_error_status_still_counts(self):
+        from scripts.load_season import _count_failures
+
+        results = {"games": {"status": "ok"}, "stats": {"status": "error"}}
+
+        assert _count_failures(results) == 1
+
+    def test_matches_the_row_icons_fail_predicate(self):
+        """The tally and the printed [FAIL] icon must never disagree --
+        anything counted as a failure here must also print FAIL, and vice
+        versa."""
+        from scripts.load_season import _count_failures
+
+        results = {
+            "a": {"status": "ok"},
+            "b": {"status": "partial"},
+            "c": {"status": "error"},
+        }
+        icon_fail_count = sum(1 for r in results.values() if r["status"] != "ok")
+
+        assert _count_failures(results) == icon_fail_count == 2
+
+
 class TestWorkflowYaml:
     """Sanity checks on the two workflow files touched alongside the
     player_overview cap override -- catches a YAML syntax error (bad

--- a/tests/test_sources/test_player_overview.py
+++ b/tests/test_sources/test_player_overview.py
@@ -258,6 +258,74 @@ class TestPlayerSeasonOverviewResource:
             assert len(results) == 1
             assert results[0]["id"] == "5083552"
 
+    def test_timeout_after_retries_records_miss_and_continues(self):
+        """Drain #7 (run 33515429442, 2026-09-01) died at batch 149/180: one
+        player's request hit a ~4.5-minute CFBD instability window (5xx and
+        read-timeout retries alternating through the full transient budget),
+        and the 7th attempt ALSO timed out -- so api_client.get() raised
+        httpx.ReadTimeout (an httpx.RequestError), not HTTPStatusError. The
+        5xx-only skip caught nothing, the timeout escaped, and dlt discarded
+        the remaining ~31 batches (~1,600 planned calls) -- the same blast
+        radius the 5xx hardening was built to stop. A post-retries
+        httpx.RequestError is now recorded as a miss with the network-fault
+        sentinel status_code 0 (meta.fanout_misses.status_code is NOT NULL,
+        so there is no HTTP status to record), same ledger, same key format,
+        same FANOUT_MISS_RETRY_DAYS re-eligibility as a 5xx skip, and the
+        loop moves to the next player."""
+        from src.pipelines.sources.player_overview import player_season_overview_resource
+
+        fixture = _load_fixture("player_season_overview.json")
+        timeout = httpx.ReadTimeout(
+            "The read operation timed out",
+            request=httpx.Request(
+                "GET", "https://api.collegefootballdata.com/player/season/overview"
+            ),
+        )
+
+        with (
+            patch("src.pipelines.sources.player_overview.get_client") as mock_get_client,
+            patch("src.pipelines.sources.player_overview.make_request") as mock_make_request,
+        ):
+            mock_get_client.return_value = MagicMock()
+            mock_make_request.side_effect = [timeout, fixture]
+
+            misses: list[tuple[str, int]] = []
+            results = list(
+                player_season_overview_resource(
+                    player_seasons=[(2024, "4879928"), (2024, "5083552")], misses=misses
+                )
+            )
+
+            assert misses == [("2024:4879928", 0)]
+            # The healthy player AFTER the timed-out one still loads.
+            assert len(results) == 1
+            assert results[0]["id"] == "5083552"
+
+    def test_rate_limit_errors_are_not_recorded_as_network_fault_misses(self):
+        """RateLimitExhausted/RateLimitCircuitOpen are custom exceptions, not
+        httpx.RequestError subclasses -- api_client raises them directly
+        rather than letting a 429 surface as a request/response error -- so
+        the network-fault skip must not catch them either: a spent quota
+        aborting the run stays correct."""
+        from dlt.extract.exceptions import ResourceExtractionError
+
+        from src.pipelines.sources.player_overview import player_season_overview_resource
+        from src.pipelines.utils.api_client import RateLimitExhausted
+
+        with (
+            patch("src.pipelines.sources.player_overview.get_client") as mock_get_client,
+            patch("src.pipelines.sources.player_overview.make_request") as mock_make_request,
+        ):
+            mock_get_client.return_value = MagicMock()
+            mock_make_request.side_effect = RateLimitExhausted("rate limited on all attempts")
+
+            misses: list[tuple[str, int]] = []
+            with pytest.raises(ResourceExtractionError) as exc_info:
+                list(player_season_overview_resource(player_seasons=[(2024, "1")], misses=misses))
+
+            assert isinstance(exc_info.value.__cause__, RateLimitExhausted)
+            assert misses == []
+
     def test_500_after_retries_with_no_collector_still_continues(self):
         """The skip must not depend on a misses collector being passed --
         misses=None (the default) loses only the ledger benefit, never the


### PR DESCRIPTION
## What this carries

Fixes for the two failures the Sept 1 operations day surfaced — both root-caused, both **already applied to the live database and proven in production** — plus the wrap of the 2026-08 CFBD expansion campaign, which is now data-complete.

### 1. `marts.data_freshness` hardening (3aa92a3)
Daily run 33515417737 failed ONLY on verify's freshness check while the load and full compute chain were green. Three defects, all fixed and applied live:
- **Stats-reset blindness** — the Aug 31 crash-restart wiped `pg_stat_user_tables`, so actively-written tables graded "stale, None days since activity". Fix: when timestamps are gone but write counters show post-restart activity, fall back to `pg_postmaster_start_time()` as an honest floor.
- **Partitioned-parent blindness** — `core.plays`' activity lands on partitions; the parent row never self-heals after a reset. Fix: aggregate by `pg_partition_root()` (excluding parent shell rows, whose PG14+ rolled-up reltuples would double-count row_count).
- **Phantom entry** — the tracked `metrics.predicted_points` never existed (the real table is `metrics.ppa_predicted`, a static model grid); every apply of the old entry made daily verify fail unconditionally.

Live-validated: 24 rows, zero stale, `core.plays` rolls up 3.6M rows from its partition's autoanalyze, grants + `get_data_freshness()` RPC intact.

### 2. `load_season` exit-code honesty (8005ba1)
A partial mart refresh printed `[FAIL] _mart_refresh` but counted as 0 failures and **exited 0** — a green workflow hiding a stale mart layer. New `_count_failures` keys the tally, the row icon, and the exit code off one predicate (any non-"ok" fails). Four red-first tests.

### 3. Network-fault skip-with-miss (b046571)
Drain #7 died at batch 149/180: a ~4.5-minute CFBD instability window ran out even the 120s retry budget and the final failure arrived as `httpx.ReadTimeout` — which the 5xx-only skip didn't catch, discarding ~31 planned batches. The drainer now records post-retries network faults as `meta.fanout_misses` entries (documented `status_code 0` sentinel, 30-day re-eligibility) and continues; rate-limit aborts still propagate (pinned by test). **Proven in production the same evening**: drain #8 recorded 3 such misses and kept going through conditions that would have killed it three times over. Migration 056's ledger comments updated (applied live, text-only).

### 4. Campaign closeout docs (5952174)
Runbook items 4/5/8 checked off with final tallies; manifest row 70 → drain complete (and its PK cell corrected to the live `(season, id, team)`).

## Campaign final state (verified live 2026-09-02)

- `stats.player_season_overview`: **47,396 rows, seasons 2013–2025**, drained in nine rounds (~43.8k calls against the measured 43,788-pair backlog; Sept share ≈21k of the fresh 125k budget).
- Residual: **exactly 4 player-seasons**, all 2014, all in `meta.fanout_misses` as transient skips (3 network-fault, 1 × 502) that self-heal within 30 days. Zero 400/404s, zero empty-200 residual — every candidate CFBD was asked about returned data.
- Spot checks: real 2014/2025 rows; `api.player_detail` serves games/usage/PPA overview columns for a current player.

## Validation
- ruff + format clean; full suite 2,010 passed / 426 DB-gated skips (the one `test_seed_team_xwalk` failure is the known missing-`openpyxl` env gap in this runner, unrelated).
- All DB changes applied live and verified before this PR; merging brings main in sync with production. Today's 10:00 UTC daily cron is the green-run proof for the freshness fix (the daily only refreshes the matview, so the live fix applies regardless of merge timing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193d5pxRWHPe1nxMtb8WPm5

---
_Generated by [Claude Code](https://claude.ai/code/session_0193d5pxRWHPe1nxMtb8WPm5)_

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change makes operational failures visible to scheduled season loads, lets player-overview processing continue past exhausted transient network faults without treating quota exhaustion as a recoverable per-player miss, and improves freshness reporting after PostgreSQL restarts and for partitioned tables.

The following failure hypotheses were disproved by executed checks:
- A mocked partial materialized-view refresh produced a failing refresh row, one reported failure, and exit code 1 from the command-line entry point.
- Seven exhausted timeout attempts recorded the affected player as a temporary miss, continued to a healthy player, and handed the miss to the ledger. Four HTTP 429 responses still raised `RateLimitExhausted` and did not create a miss.
- The exact freshness-view SQL applied successfully on PostgreSQL 14.24. The exercised fixtures reported the expected ordinary-table count and partition-root count, including the NULL timestamp aggregation path.

No actionable defects were found. The change is safe to merge.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the changed failure-reporting, request-recovery, and database freshness paths behaved as intended under direct execution.

No final findings remain after exercising the relevant partial-refresh, timeout, rate-limit, partitioned-table, and ordinary-table paths.

**Files Needing Attention:** No files require follow-up changes.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Started an isolated PostgreSQL 14.24 instance and ran the exact data freshness SQL harness; the materialized view was created and the assertions showed core.games with three rows and core.plays leaf partitions with four rows, and the NULL timestamp aggregation passed.
- Ran the authored runtime harness using CFBDClient, player-overview resource, and httpx.MockTransport; the seven-attempt timeout produced ("2024:timed-out", 0) and, with four mocked HTTP 429 responses, RateLimitExhausted was observed, while regression tests for timeout continuation and rate-limit propagation passed (2 passed, 48 deselected).
- Executed the in-process harness with deterministic fakes for the mart refresh; the run loaded games successfully but reported two failures after the refresh and caused main to exit with code 1.
- Bootstrapped the environment with a PostgreSQL 14.24 container and applied the exact SQL harness; after-capture the run showed SELECT 24, index creation, GRANT, and both assertion blocks succeeding, with the expected core.games and core.plays rows visible before rollback.
- Compared pre-change and current implementations; observed identical seven-attempt timeouts and rate-limit propagation, and focused tests for timeout collection/continuation and rate-limit non-swallowing passed: 2 passed, 48 deselected.

<a href="https://app.greptile.com/trex/runs/21957841/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Close out expansion runbook items 4, 5, ..."](https://github.com/rstover-fo/cfb-database/commit/5952174f25e924611d528d035e205684352a08dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59316795)</sub>

<!-- /greptile_comment -->