### PR TITLE
Fail the daily verify on unknown dlt variant-twin columns

### DIFF
--- a/.claude/skills/schema-migrations/SKILL.md
+++ b/.claude/skills/schema-migrations/SKILL.md
@@ -20,6 +20,13 @@ description: Schema-change workflow for this repo — migrations, grants/RLS, ma
 3. **Verify current state from the catalog**, not docs: column names via
    `pg_attribute`, view type (matview vs view) before adding to test
    inventories. dlt renames columns on load.
+4. **Variant-twin allow-lists (KTD7).** When a mart COALESCEs a new dlt
+   `<col>__v_double` twin, extend `EXPECTED_VARIANT_TWINS` in
+   `src/pipelines/utils/variant_twins.py` AND the matching allow-list array
+   in `src/schemas/api/validation_rushing_views.sql` (group (e)) — the two
+   must stay equal (`tests/test_variant_twins.py` guards it). Miss either
+   one and either `verify_load.py` fails every daily run on a twin it
+   doesn't recognize, or the deploy-time SQL validation does.
 
 ## Writing the migration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,14 @@ Elo/adjusted EPA (including the as-of weekly EPA build), refits fitted_v1 when i
 model's upcoming scores, then runs post-load checks (`scripts/verify_load.py`). Failures
 open/update a rolling GitHub issue.
 
+- `verify_load.py` also runs the KTD7 variant-twin tripwire (`check_variant_twins`,
+  backed by `src/pipelines/utils/variant_twins.py`): dlt sometimes splits a
+  charting metric into a bigint base column plus a `<col>__v_double` twin, and
+  every mart reading `stats.rushing_*`/`stats.passing_player_season` COALESCEs
+  only the twins that existed when it was authored. A daily load that creates a
+  NEW twin now FAILs the run naming the column instead of silently going NULL
+  in the mart/api view/RPC until someone notices.
+
 **Finished-season skip:** on the unattended path (no `--season`, no `--sources`)
 `load_season.py` skips sources whose data cannot change once a season is complete
 (`IMMUTABLE_ONCE_FINAL` -- plays, game_stats, ratings, recruiting, draft, ...).

--- a/scripts/verify_load.py
+++ b/scripts/verify_load.py
@@ -406,34 +406,70 @@ def check_backtest_freshness(cur, report: Report) -> None:
     )
 
 
+def _safe_execute(cur, sql: str) -> None:
+    """Best-effort execute for a SAVEPOINT/ROLLBACK/RELEASE bracket
+    statement -- must never raise into the caller. If the statement itself
+    fails (e.g. cur has no real `.execute`, as in unit tests, or the
+    connection turns out not to support it), the caller just proceeds
+    without savepoint protection rather than crashing the tripwire."""
+    try:
+        cur.execute(sql)
+    except Exception:  # noqa: BLE001 - the savepoint bracket must never crash the check
+        pass
+
+
 def check_variant_twins(cur, report: Report) -> None:
     """KTD7 tripwire: no unexpected dlt VARIANT (__v_double) twin column.
 
     dlt types a metric column bigint on first load and creates a sibling
     `<col>__v_double` twin the first time a later load carries a fractional
     value; every value dlt can't fit in the bigint column from then on lands
-    in the twin instead. Marts 045/050/051/052 COALESCE exactly the twins
-    that existed live when they were authored (the allow-list in
-    src/pipelines/utils/variant_twins.py, which
-    src/schemas/api/validation_rushing_views.sql's deploy-time check mirrors).
-    A daily load that pushes a previously-clean column into VARIANT
-    territory creates a twin no mart's COALESCE accounts for -- the affected
-    metric goes silently NULL in the mart, its api view, and any RPC reading
-    the mart directly. This check is what catches that between deploys,
-    since the SQL validation file only runs at deploy time.
+    in the twin instead. The marts tracked in
+    src/pipelines/utils/variant_twins.py's EXPECTED_VARIANT_TWINS COALESCE
+    exactly the twins that existed live when they were authored (the
+    rushing/passing charting allow-list also mirrors
+    src/schemas/api/validation_rushing_views.sql's deploy-time check). A
+    daily load that pushes a previously-clean column into VARIANT territory
+    creates a twin no mart's COALESCE accounts for -- the affected metric
+    goes silently NULL in the mart, its api view, and any RPC reading the
+    mart directly. This check is what catches that between deploys, since
+    the SQL validation file only runs at deploy time.
 
     Query failure (e.g. a tracked table doesn't exist on this database yet)
     WARNs rather than crashing the daily run -- this check is a tripwire,
-    not a hard dependency of the load.
+    not a hard dependency of the load. But verify() runs every check on one
+    shared, non-autocommit connection (psycopg2.connect() defaults to
+    transactional mode), so a PostgreSQL-level error from the catalog
+    queries below (e.g. a genuinely malformed query, not just "table
+    missing" which information_schema tolerates as zero rows) would leave
+    that connection's transaction in the aborted state -- every check that
+    runs afterward would then fail with InFailedSqlTransaction, not just
+    this one. A SAVEPOINT around the two catalog queries contains that:
+    ROLLBACK TO SAVEPOINT on failure clears the abort without touching
+    whatever check_partition/check_game_counts/etc. already did earlier in
+    the same transaction, and RELEASE SAVEPOINT on success just drops the
+    bookkeeping. SAVEPOINT is only valid inside a transaction block, so an
+    autocommit connection (cur.connection.autocommit is True) skips the
+    dance entirely -- there every statement is already its own transaction
+    and a failure can't poison a later one.
     """
     from src.pipelines.utils.variant_twins import find_missing_twins, find_unexpected_twins
+
+    use_savepoint = not getattr(getattr(cur, "connection", None), "autocommit", False)
+    if use_savepoint:
+        _safe_execute(cur, "SAVEPOINT variant_twins")
 
     try:
         unexpected = find_unexpected_twins(cur)
         missing = find_missing_twins(cur)
     except Exception as exc:  # noqa: BLE001 - tripwire must never crash the run
+        if use_savepoint:
+            _safe_execute(cur, "ROLLBACK TO SAVEPOINT variant_twins")
         report.record(WARN, "variant_twins", f"check could not run: {exc}")
         return
+
+    if use_savepoint:
+        _safe_execute(cur, "RELEASE SAVEPOINT variant_twins")
 
     if unexpected:
         for table_key, columns in sorted(unexpected.items()):

--- a/scripts/verify_load.py
+++ b/scripts/verify_load.py
@@ -24,6 +24,12 @@ Checks:
        season (in-season only; WARNs if migration 041 isn't applied yet)
     7. meta.flat_file_loads has a recent successful 'availability' load
        (in-season only; never FAILs -- external conference sites are flaky)
+    8. no unexpected dlt VARIANT (__v_double) twin has appeared on a
+       charting source table since the mart(s) reading it were authored
+       (KTD7 tripwire; see src/pipelines/utils/variant_twins.py) -- FAILs
+       naming the column, since it means a metric is silently reading NULL
+       downstream; a query failure (e.g. the table doesn't exist yet) WARNs
+       instead of crashing the run
 
 Pre-season semantics: with no completed games, checks 3-4 pass vacuously and
 check 2 is the meaningful one (schedules publish in July, so core.games must
@@ -400,6 +406,58 @@ def check_backtest_freshness(cur, report: Report) -> None:
     )
 
 
+def check_variant_twins(cur, report: Report) -> None:
+    """KTD7 tripwire: no unexpected dlt VARIANT (__v_double) twin column.
+
+    dlt types a metric column bigint on first load and creates a sibling
+    `<col>__v_double` twin the first time a later load carries a fractional
+    value; every value dlt can't fit in the bigint column from then on lands
+    in the twin instead. Marts 045/050/051/052 COALESCE exactly the twins
+    that existed live when they were authored (the allow-list in
+    src/pipelines/utils/variant_twins.py, which
+    src/schemas/api/validation_rushing_views.sql's deploy-time check mirrors).
+    A daily load that pushes a previously-clean column into VARIANT
+    territory creates a twin no mart's COALESCE accounts for -- the affected
+    metric goes silently NULL in the mart, its api view, and any RPC reading
+    the mart directly. This check is what catches that between deploys,
+    since the SQL validation file only runs at deploy time.
+
+    Query failure (e.g. a tracked table doesn't exist on this database yet)
+    WARNs rather than crashing the daily run -- this check is a tripwire,
+    not a hard dependency of the load.
+    """
+    from src.pipelines.utils.variant_twins import find_missing_twins, find_unexpected_twins
+
+    try:
+        unexpected = find_unexpected_twins(cur)
+        missing = find_missing_twins(cur)
+    except Exception as exc:  # noqa: BLE001 - tripwire must never crash the run
+        report.record(WARN, "variant_twins", f"check could not run: {exc}")
+        return
+
+    if unexpected:
+        for table_key, columns in sorted(unexpected.items()):
+            report.record(
+                FAIL,
+                "variant_twins",
+                f"{table_key}: unexpected __v_double twin(s) {columns} -- add the COALESCE to "
+                "the affected mart, extend EXPECTED_VARIANT_TWINS and the matching "
+                "validation_rushing_views.sql allow-list, then re-apply the mart",
+            )
+    else:
+        report.record(PASS, "variant_twins", "no unexpected __v_double twins")
+
+    if missing:
+        for table_key, columns in sorted(missing.items()):
+            report.record(
+                WARN,
+                "variant_twins_missing",
+                f"{table_key}: expected __v_double twin(s) {columns} not present "
+                "(informational -- OK if the table was recreated or hasn't loaded a "
+                "fractional value for that metric yet)",
+            )
+
+
 def check_freshness(cur, in_season: bool, strict: bool, report: Report) -> None:
     cur.execute(
         """
@@ -443,6 +501,7 @@ def verify(season: int, strict: bool) -> int:
             check_fitted_coverage(cur, report)
             check_backtest_freshness(cur, report)
             check_freshness(cur, in_season, strict, report)
+            check_variant_twins(cur, report)
             check_massey_composite(cur, season, report)
             check_availability_archive(cur, season, report)
     finally:

--- a/src/pipelines/utils/variant_twins.py
+++ b/src/pipelines/utils/variant_twins.py
@@ -37,14 +37,24 @@ Remediation when `find_unexpected_twins` reports a new column:
     3. Re-apply the affected mart(s) (python scripts/run_marts.py or the
        migration workflow -- see the schema-migrations skill).
 
-Scope: only tables a mart actually reads. The rushing GAME-grain tables
-(stats.rushing_player_games, stats.rushing_team_games) carry far more twins
-(39 and 68 respectively, as of 2026-09-03) than the season-grain tables --
-new ones appear routinely as data lands -- but no mart COALESCEs any of
-them today, so a new twin there hurts nothing and would just be alert
-noise. They are deliberately left out of EXPECTED_VARIANT_TWINS; add them
-(with their own allow-list) the day a mart starts reading game-grain
-rushing data.
+Scope: only tables a mart actually reads. As of 2026-09-03 that is six
+tables: stats.rushing_player_season, stats.rushing_team_season,
+stats.passing_player_season (the rushing/passing charting family above),
+plus stats.player_returning (marts/031_returning_production.sql),
+stats.player_usage (marts/032_player_usage.sql), and stats.game_havoc
+(marts/005_defensive_havoc.sql) -- three more marts that already COALESCE
+a twin on a source table outside the charting family. A new twin appearing
+on any of those three would pass this tripwire silently (the affected
+metric going NULL in returning-production / player-usage / defensive-havoc
+outputs) if they weren't tracked here too.
+
+The rushing GAME-grain tables (stats.rushing_player_games,
+stats.rushing_team_games) carry far more twins (39 and 68 respectively, as
+of 2026-09-03) than the season-grain tables -- new ones appear routinely as
+data lands -- but no mart COALESCEs any of them today, so a new twin there
+hurts nothing and would just be alert noise. They are deliberately left out
+of EXPECTED_VARIANT_TWINS; add them (with their own allow-list) the day a
+mart starts reading game-grain rushing data.
 """
 
 from __future__ import annotations
@@ -64,6 +74,26 @@ from __future__ import annotations
 # and marts/047 (passing_charting_team_season) reads stats.passing_team_
 # season's natively-double offense_/defense_ columns -- neither has a twin
 # to track, so passing_plays and passing_team_season are not keys here.
+#
+# stats.player_returning: the single twin marts/031_returning_production.sql
+# COALESCEs (total_receiving_ppa__v_double). Live-verified 2026-09-03
+# presence check found exactly this one twin on the table -- if a future
+# check reports it as a day-one FAIL (i.e. some *other* twin exists live
+# that no mart COALESCEs), that is a real pre-existing gap to fix, not
+# tripwire noise: go add the COALESCE, don't just widen the allow-list.
+#
+# stats.player_usage: the two twins marts/032_player_usage.sql COALESCEs on
+# the nested "usage" object (usage__pass__v_double,
+# usage__third_down__v_double). Seeded from the mart's own COALESCE calls;
+# not independently re-verified against a live presence check the way
+# player_returning was on 2026-09-03.
+#
+# stats.game_havoc: the two twins marts/005_defensive_havoc.sql COALESCEs
+# in its game_havoc_season CTE (defense__total_havoc_events__v_double,
+# defense__front_seven_havoc_events__v_double; defense__db_havoc_events has
+# no variant column). Seeded from the mart's own COALESCE calls; not
+# independently re-verified against a live presence check the way
+# player_returning was on 2026-09-03.
 EXPECTED_VARIANT_TWINS: dict[str, frozenset[str]] = {
     "stats.rushing_player_season": frozenset(
         {
@@ -101,6 +131,23 @@ EXPECTED_VARIANT_TWINS: dict[str, frozenset[str]] = {
     "stats.passing_player_season": frozenset(
         {
             "average_yards_after_catch__v_double",
+        }
+    ),
+    "stats.player_returning": frozenset(
+        {
+            "total_receiving_ppa__v_double",
+        }
+    ),
+    "stats.player_usage": frozenset(
+        {
+            "usage__pass__v_double",
+            "usage__third_down__v_double",
+        }
+    ),
+    "stats.game_havoc": frozenset(
+        {
+            "defense__total_havoc_events__v_double",
+            "defense__front_seven_havoc_events__v_double",
         }
     ),
 }

--- a/src/pipelines/utils/variant_twins.py
+++ b/src/pipelines/utils/variant_twins.py
@@ -1,0 +1,175 @@
+"""Tripwire for dlt's bigint/double VARIANT twin columns (KTD7).
+
+dlt types a metric column `bigint` on first load. The first time a later
+load carries a fractional value for that column, dlt cannot widen the
+already-materialized bigint column in place -- instead it creates a sibling
+`<col>__v_double` column and routes every value it cannot fit into the
+bigint (i.e. every fractional value, going forward) into the twin instead.
+The base column keeps collecting whole-number values; the twin silently
+becomes the only place a large share of that metric's real values live.
+
+Every mart that reads one of these charting tables must therefore
+`COALESCE(col::double precision, col__v_double)` for each twin that exists
+on its source table at the time the mart is authored (see
+src/schemas/009_variant_columns.sql and marts/032, 045, 050-052 for worked
+examples). That COALESCE set is frozen into the mart's SQL. If a later
+daily load pushes a previously-clean column into VARIANT territory --
+creating a NEW twin the mart's author never saw -- the mart keeps reading
+only the (now partially empty) base column: the affected metric goes
+silently NULL in the mart, the api view built on it, and any RPC
+(get_player_detail) that reads the mart directly. Nothing about this
+produces an error; it just produces wrong numbers that look like missing
+charting coverage.
+
+This module holds the one place both the Python daily check
+(scripts/verify_load.py) and the deploy-time SQL validation
+(src/schemas/api/validation_rushing_views.sql, group (e)) should agree on
+which twins are expected, so the two allow-lists cannot drift
+independently of each other -- tests/test_variant_twins.py asserts the SQL
+literal and this dict stay equal.
+
+Remediation when `find_unexpected_twins` reports a new column:
+    1. Add `COALESCE(<col>::double precision, <col>__v_double)` to every
+       mart that reads the affected table and metric.
+    2. Add the new `<col>__v_double` entry to EXPECTED_VARIANT_TWINS below
+       AND to the matching allow-list array in
+       src/schemas/api/validation_rushing_views.sql (group (e)).
+    3. Re-apply the affected mart(s) (python scripts/run_marts.py or the
+       migration workflow -- see the schema-migrations skill).
+
+Scope: only tables a mart actually reads. The rushing GAME-grain tables
+(stats.rushing_player_games, stats.rushing_team_games) carry far more twins
+(39 and 68 respectively, as of 2026-09-03) than the season-grain tables --
+new ones appear routinely as data lands -- but no mart COALESCEs any of
+them today, so a new twin there hurts nothing and would just be alert
+noise. They are deliberately left out of EXPECTED_VARIANT_TWINS; add them
+(with their own allow-list) the day a mart starts reading game-grain
+rushing data.
+"""
+
+from __future__ import annotations
+
+# "schema.table" -> frozenset of expected "<col>__v_double" column names.
+#
+# stats.rushing_player_season / stats.rushing_team_season: the exact
+# allow-lists from src/schemas/api/validation_rushing_views.sql group (e)
+# (allowed_player_twins / allowed_team_twins), live-verified 2026-09-03.
+# Read by marts/050 (2 of the 17 player twins), marts/051 (3 of the 8 team
+# twins), and marts/052 (the remaining 15 player + 5 team twins, across its
+# direction-season breakdown).
+#
+# stats.passing_player_season: the single twin marts/045 COALESCEs
+# (average_yards_after_catch__v_double). marts/046 (passing_charting_target_
+# season) aggregates fresh from stats.passing_plays' plain bigint columns
+# and marts/047 (passing_charting_team_season) reads stats.passing_team_
+# season's natively-double offense_/defense_ columns -- neither has a twin
+# to track, so passing_plays and passing_team_season are not keys here.
+EXPECTED_VARIANT_TWINS: dict[str, frozenset[str]] = {
+    "stats.rushing_player_season": frozenset(
+        {
+            "open_field_yards__v_double",
+            "power_success__v_double",
+            "directions__unknown__power_success__v_double",
+            "directions__middle__yards_per_carry__v_double",
+            "directions__middle__success_rate__v_double",
+            "directions__middle__ppa__v_double",
+            "directions__middle__total_ppa__v_double",
+            "directions__middle__line_yards__v_double",
+            "directions__middle__line_yards_total__v_double",
+            "directions__middle__second_level_yards__v_double",
+            "directions__middle__open_field_yards__v_double",
+            "directions__middle__stuff_rate__v_double",
+            "directions__middle__explosiveness__v_double",
+            "directions__left__line_yards_total__v_double",
+            "directions__right__power_success__v_double",
+            "directions__middle__power_success__v_double",
+            "directions__left__power_success__v_double",
+        }
+    ),
+    "stats.rushing_team_season": frozenset(
+        {
+            "defense__directions__right__line_yards_total__v_double",
+            "defense__directions__middle__second_level_yards__v_double",
+            "defense__directions__middle__power_success__v_double",
+            "defense__directions__left__line_yards__v_double",
+            "offense__line_yards_total__v_double",
+            "offense__second_level_yards__v_double",
+            "offense__open_field_yards__v_double",
+            "defense__directions__right__power_success__v_double",
+        }
+    ),
+    "stats.passing_player_season": frozenset(
+        {
+            "average_yards_after_catch__v_double",
+        }
+    ),
+}
+
+
+def _split_table_key(table_key: str) -> tuple[str, str]:
+    schema, _, table = table_key.partition(".")
+    return schema, table
+
+
+def _fetch_actual_twins(cur) -> dict[str, set[str]]:
+    """Query information_schema.columns once for every tracked table.
+
+    Returns {"schema.table": {actual __v_double column names}}. A table
+    that does not exist (or has no twins) simply contributes an empty set --
+    information_schema returns zero rows for it, not an error.
+    """
+    table_keys = list(EXPECTED_VARIANT_TWINS)
+    pairs = [_split_table_key(key) for key in table_keys]
+
+    actual: dict[str, set[str]] = {key: set() for key in table_keys}
+    if not pairs:
+        return actual
+
+    cur.execute(
+        """
+        SELECT table_schema, table_name, column_name
+        FROM information_schema.columns
+        WHERE (table_schema, table_name) IN %s
+          AND column_name LIKE '%%\\_\\_v\\_double' ESCAPE '\\'
+        """,
+        (tuple(pairs),),
+    )
+    for table_schema, table_name, column_name in cur.fetchall():
+        actual[f"{table_schema}.{table_name}"].add(column_name)
+
+    return actual
+
+
+def find_unexpected_twins(cur) -> dict[str, list[str]]:
+    """Return {"schema.table": [unexpected __v_double columns]} for any twin
+    that exists live but is not in EXPECTED_VARIANT_TWINS.
+
+    A non-empty result means a daily load created a NEW variant twin that no
+    mart's COALESCE set accounts for -- see the module docstring for the
+    remediation. Tables with no unexpected columns are omitted from the
+    result entirely (an empty dict means everything is accounted for).
+    """
+    actual = _fetch_actual_twins(cur)
+    unexpected: dict[str, list[str]] = {}
+    for table_key, expected_cols in EXPECTED_VARIANT_TWINS.items():
+        extra = actual.get(table_key, set()) - expected_cols
+        if extra:
+            unexpected[table_key] = sorted(extra)
+    return unexpected
+
+
+def find_missing_twins(cur) -> dict[str, list[str]]:
+    """Return {"schema.table": [expected __v_double columns not present]}.
+
+    Informational only -- a table recreated from scratch (or one that has
+    not yet received a load carrying a fractional value for that metric)
+    can legitimately lack a twin that existed at allow-list authoring time.
+    Callers should WARN on a non-empty result, never FAIL.
+    """
+    actual = _fetch_actual_twins(cur)
+    missing: dict[str, list[str]] = {}
+    for table_key, expected_cols in EXPECTED_VARIANT_TWINS.items():
+        gone = expected_cols - actual.get(table_key, set())
+        if gone:
+            missing[table_key] = sorted(gone)
+    return missing

--- a/tests/test_variant_twins.py
+++ b/tests/test_variant_twins.py
@@ -113,20 +113,23 @@ class TestAllowListsMatchMarts:
     by a mart but missing from EXPECTED_VARIANT_TWINS would mean the daily
     check doesn't actually cover it."""
 
-    def test_every_v_double_token_in_marts_is_expected_and_vice_versa(self):
-        found: set[str] = set()
-        for path in MART_TABLE_MAP:
-            found |= _v_double_tokens(path)
-
-        expected_union: set[str] = set()
-        for cols in EXPECTED_VARIANT_TWINS.values():
-            expected_union |= cols
-
-        assert found == expected_union, (
-            f"mart files and EXPECTED_VARIANT_TWINS disagree -- "
-            f"in marts but not expected: {found - expected_union}; "
-            f"expected but not in any mart: {expected_union - found}"
-        )
+    def test_each_marts_v_double_tokens_belong_to_a_table_it_reads(self):
+        """Attribution direction of the drift guard: every twin a mart
+        COALESCEs must be an expected twin of one of the source tables that
+        mart reads (per MART_TABLE_MAP). A global union of all marts against
+        all tables would still pass if a twin's COALESCE moved from the mart
+        that needs it to a mart that never reads that table; comparing per
+        mart, against only that mart's own tables, catches the move."""
+        for path, tables in MART_TABLE_MAP.items():
+            allowed: set[str] = set()
+            for table_key in tables:
+                allowed |= EXPECTED_VARIANT_TWINS[table_key]
+            found = _v_double_tokens(path)
+            assert found <= allowed, (
+                f"{path.name} COALESCEs twin(s) that are not expected on any table it "
+                f"reads ({tables}): {found - allowed} -- either the twin belongs to a "
+                f"different mart, or EXPECTED_VARIANT_TWINS is missing it"
+            )
 
     def test_every_expected_table_is_covered_by_a_mapped_mart(self):
         """MART_TABLE_MAP itself must not silently drop a tracked table --

--- a/tests/test_variant_twins.py
+++ b/tests/test_variant_twins.py
@@ -1,0 +1,193 @@
+"""Drift guard + unit tests for src/pipelines/utils/variant_twins.py (KTD7).
+
+Three independent places encode "which __v_double twins are expected":
+Python (EXPECTED_VARIANT_TWINS), the deploy-time SQL validation
+(src/schemas/api/validation_rushing_views.sql group (e)), and the marts'
+own COALESCE calls (045/050/051/052). This file asserts all three agree, so
+a change to one that isn't mirrored in the others fails a fast, DB-free
+unit test instead of surfacing as a silent NULL in production. Plus unit
+tests for find_unexpected_twins/find_missing_twins against a fake cursor.
+No DB, no network -- pure text parsing and in-memory fakes.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from src.pipelines.utils.variant_twins import (
+    EXPECTED_VARIANT_TWINS,
+    find_missing_twins,
+    find_unexpected_twins,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+VALIDATION_SQL = (
+    PROJECT_ROOT / "src" / "schemas" / "api" / "validation_rushing_views.sql"
+).read_text()
+
+MART_FILES = [
+    PROJECT_ROOT / "src" / "schemas" / "marts" / "045_passing_charting_player_season.sql",
+    PROJECT_ROOT / "src" / "schemas" / "marts" / "050_rushing_charting_player_season.sql",
+    PROJECT_ROOT / "src" / "schemas" / "marts" / "051_rushing_charting_team_season.sql",
+    PROJECT_ROOT / "src" / "schemas" / "marts" / "052_rushing_charting_direction_season.sql",
+]
+
+
+def _parse_sql_array(var_name: str) -> set[str]:
+    """Extract the quoted string literals out of `<var_name> := ARRAY[...]`."""
+    match = re.search(rf"{var_name}\s*:=\s*ARRAY\[(.*?)\];", VALIDATION_SQL, re.S)
+    assert match, f"could not find `{var_name} := ARRAY[...]` in validation_rushing_views.sql"
+    return set(re.findall(r"'([^']+)'", match.group(1)))
+
+
+class TestAllowListsMatchSql:
+    """Python and the deploy-time SQL validation must carry the identical
+    allow-list for each rushing table -- KTD7's whole point is that these
+    cannot drift apart silently."""
+
+    def test_player_season_matches(self):
+        sql_twins = _parse_sql_array("allowed_player_twins")
+        assert sql_twins == EXPECTED_VARIANT_TWINS["stats.rushing_player_season"]
+
+    def test_team_season_matches(self):
+        sql_twins = _parse_sql_array("allowed_team_twins")
+        assert sql_twins == EXPECTED_VARIANT_TWINS["stats.rushing_team_season"]
+
+    def test_player_season_count_is_17(self):
+        assert len(EXPECTED_VARIANT_TWINS["stats.rushing_player_season"]) == 17
+
+    def test_team_season_count_is_8(self):
+        assert len(EXPECTED_VARIANT_TWINS["stats.rushing_team_season"]) == 8
+
+
+class TestAllowListsMatchMarts:
+    """Every twin the Python allow-lists know about must actually be
+    COALESCEd by one of marts 045/050/051/052, and vice versa -- a twin
+    referenced by a mart but missing from EXPECTED_VARIANT_TWINS would mean
+    the daily check doesn't actually cover it."""
+
+    def test_every_v_double_token_in_marts_is_expected_and_vice_versa(self):
+        found: set[str] = set()
+        for path in MART_FILES:
+            found |= set(re.findall(r"\b[a-z][a-z_]*__v_double\b", path.read_text()))
+
+        expected_union: set[str] = set()
+        for cols in EXPECTED_VARIANT_TWINS.values():
+            expected_union |= cols
+
+        assert found == expected_union, (
+            f"mart files and EXPECTED_VARIANT_TWINS disagree -- "
+            f"in marts but not expected: {found - expected_union}; "
+            f"expected but not in any mart: {expected_union - found}"
+        )
+
+
+class _FakeCursor:
+    """Cursor stub for find_unexpected_twins/find_missing_twins: records the
+    single query issued and returns canned (schema, table, column) rows for
+    fetchall(), the shape information_schema.columns yields."""
+
+    def __init__(self, rows: list[tuple[str, str, str]]):
+        self._rows = rows
+        self.queries: list[tuple[str, tuple]] = []
+
+    def execute(self, sql, params=None):
+        self.queries.append((sql, params))
+
+    def fetchall(self):
+        return self._rows
+
+
+def _all_expected_rows() -> list[tuple[str, str, str]]:
+    rows = []
+    for table_key, cols in EXPECTED_VARIANT_TWINS.items():
+        schema, table = table_key.split(".")
+        for col in cols:
+            rows.append((schema, table, col))
+    return rows
+
+
+class TestFindUnexpectedTwins:
+    def test_all_expected_returns_empty(self):
+        cur = _FakeCursor(_all_expected_rows())
+        assert find_unexpected_twins(cur) == {}
+
+    def test_one_extra_column_is_reported_under_its_table(self):
+        rows = _all_expected_rows()
+        rows.append(("stats", "rushing_player_season", "totally_new__v_double"))
+        cur = _FakeCursor(rows)
+
+        result = find_unexpected_twins(cur)
+
+        assert result == {"stats.rushing_player_season": ["totally_new__v_double"]}
+
+    def test_extra_on_a_table_with_no_prior_twins_is_still_reported(self):
+        rows = _all_expected_rows()
+        rows.append(("stats", "passing_player_season", "some_other_metric__v_double"))
+        cur = _FakeCursor(rows)
+
+        result = find_unexpected_twins(cur)
+
+        assert result == {"stats.passing_player_season": ["some_other_metric__v_double"]}
+
+    def test_single_query_issued(self):
+        cur = _FakeCursor(_all_expected_rows())
+        find_unexpected_twins(cur)
+        assert len(cur.queries) == 1
+        sql, params = cur.queries[0]
+        assert "information_schema.columns" in sql
+        assert "v\\_double" in sql
+        assert "ESCAPE" in sql
+        assert len(params[0]) == len(EXPECTED_VARIANT_TWINS)
+
+
+class TestFindMissingTwins:
+    def test_nothing_missing_returns_empty(self):
+        cur = _FakeCursor(_all_expected_rows())
+        assert find_missing_twins(cur) == {}
+
+    def test_expected_but_absent_column_is_reported(self):
+        rows = [
+            row
+            for row in _all_expected_rows()
+            if row != ("stats", "passing_player_season", "average_yards_after_catch__v_double")
+        ]
+        cur = _FakeCursor(rows)
+
+        result = find_missing_twins(cur)
+
+        assert result == {"stats.passing_player_season": ["average_yards_after_catch__v_double"]}
+
+    def test_unexpected_and_missing_are_independent(self):
+        """A table can simultaneously have an unexpected twin AND be missing
+        a different expected one -- e.g. after a partial re-load."""
+        rows = [
+            row
+            for row in _all_expected_rows()
+            if row != ("stats", "rushing_player_season", "power_success__v_double")
+        ]
+        rows.append(("stats", "rushing_player_season", "brand_new__v_double"))
+        cur = _FakeCursor(rows)
+
+        assert find_unexpected_twins(cur) == {
+            "stats.rushing_player_season": ["brand_new__v_double"]
+        }
+        assert find_missing_twins(cur) == {
+            "stats.rushing_player_season": ["power_success__v_double"]
+        }
+
+
+class TestNoGameGrainTables:
+    """The game-grain rushing tables carry far more twins than the season
+    tables but no mart reads them -- they must stay out of
+    EXPECTED_VARIANT_TWINS (module docstring explains why)."""
+
+    def test_game_grain_tables_are_not_tracked(self):
+        tracked = set(EXPECTED_VARIANT_TWINS)
+        assert "stats.rushing_player_games" not in tracked
+        assert "stats.rushing_team_games" not in tracked
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_variant_twins.py
+++ b/tests/test_variant_twins.py
@@ -3,11 +3,21 @@
 Three independent places encode "which __v_double twins are expected":
 Python (EXPECTED_VARIANT_TWINS), the deploy-time SQL validation
 (src/schemas/api/validation_rushing_views.sql group (e)), and the marts'
-own COALESCE calls (045/050/051/052). This file asserts all three agree, so
-a change to one that isn't mirrored in the others fails a fast, DB-free
-unit test instead of surfacing as a silent NULL in production. Plus unit
-tests for find_unexpected_twins/find_missing_twins against a fake cursor.
-No DB, no network -- pure text parsing and in-memory fakes.
+own COALESCE calls (005/031/032/045/050/051/052 -- the rushing/passing
+charting family plus the three non-charting marts that also COALESCE a
+twin: defensive_havoc, returning_production, player_usage). This file
+asserts all three agree, so a change to one that isn't mirrored in the
+others fails a fast, DB-free unit test instead of surfacing as a silent
+NULL in production. Plus unit tests for find_unexpected_twins/
+find_missing_twins against a fake cursor. No DB, no network -- pure text
+parsing and in-memory fakes.
+
+Only 045/050/051/052 are cross-checked against validation_rushing_views.sql
+(TestAllowListsMatchSql) -- that SQL file's allow-lists only cover the
+rushing/passing charting tables. 005/031/032 have no deploy-time SQL
+counterpart, so they're covered only by the marts-vs-Python drift guard
+below (TestAllowListsMatchMarts) and by MART_TABLE_MAP's exhaustiveness
+check against EXPECTED_VARIANT_TWINS.
 """
 
 import re
@@ -26,12 +36,42 @@ VALIDATION_SQL = (
     PROJECT_ROOT / "src" / "schemas" / "api" / "validation_rushing_views.sql"
 ).read_text()
 
+# Rushing/passing charting family -- cross-checked against the deploy-time
+# SQL validation allow-lists (TestAllowListsMatchSql) as well as the
+# marts-vs-Python drift guard below.
 MART_FILES = [
     PROJECT_ROOT / "src" / "schemas" / "marts" / "045_passing_charting_player_season.sql",
     PROJECT_ROOT / "src" / "schemas" / "marts" / "050_rushing_charting_player_season.sql",
     PROJECT_ROOT / "src" / "schemas" / "marts" / "051_rushing_charting_team_season.sql",
     PROJECT_ROOT / "src" / "schemas" / "marts" / "052_rushing_charting_direction_season.sql",
 ]
+
+# Every mart that COALESCEs a __v_double twin, mapped to the source table(s)
+# it reads -- the full set the marts-vs-Python drift guard walks. Includes
+# MART_FILES (the charting family) plus the three non-charting marts Finding
+# 1 (KTD7 follow-up, 2026-09-03) added: defensive_havoc reads
+# stats.game_havoc, returning_production reads stats.player_returning,
+# player_usage reads stats.player_usage.
+MART_TABLE_MAP: dict[Path, list[str]] = {
+    PROJECT_ROOT / "src" / "schemas" / "marts" / "045_passing_charting_player_season.sql": [
+        "stats.passing_player_season"
+    ],
+    PROJECT_ROOT / "src" / "schemas" / "marts" / "050_rushing_charting_player_season.sql": [
+        "stats.rushing_player_season"
+    ],
+    PROJECT_ROOT / "src" / "schemas" / "marts" / "051_rushing_charting_team_season.sql": [
+        "stats.rushing_team_season"
+    ],
+    PROJECT_ROOT / "src" / "schemas" / "marts" / "052_rushing_charting_direction_season.sql": [
+        "stats.rushing_player_season",
+        "stats.rushing_team_season",
+    ],
+    PROJECT_ROOT / "src" / "schemas" / "marts" / "005_defensive_havoc.sql": ["stats.game_havoc"],
+    PROJECT_ROOT / "src" / "schemas" / "marts" / "031_returning_production.sql": [
+        "stats.player_returning"
+    ],
+    PROJECT_ROOT / "src" / "schemas" / "marts" / "032_player_usage.sql": ["stats.player_usage"],
+}
 
 
 def _parse_sql_array(var_name: str) -> set[str]:
@@ -61,16 +101,22 @@ class TestAllowListsMatchSql:
         assert len(EXPECTED_VARIANT_TWINS["stats.rushing_team_season"]) == 8
 
 
+def _v_double_tokens(path: Path) -> set[str]:
+    return set(re.findall(r"\b[a-z][a-z_]*__v_double\b", path.read_text()))
+
+
 class TestAllowListsMatchMarts:
     """Every twin the Python allow-lists know about must actually be
-    COALESCEd by one of marts 045/050/051/052, and vice versa -- a twin
-    referenced by a mart but missing from EXPECTED_VARIANT_TWINS would mean
-    the daily check doesn't actually cover it."""
+    COALESCEd by one of the seven marts in MART_TABLE_MAP (the
+    rushing/passing charting family plus defensive_havoc/
+    returning_production/player_usage), and vice versa -- a twin referenced
+    by a mart but missing from EXPECTED_VARIANT_TWINS would mean the daily
+    check doesn't actually cover it."""
 
     def test_every_v_double_token_in_marts_is_expected_and_vice_versa(self):
         found: set[str] = set()
-        for path in MART_FILES:
-            found |= set(re.findall(r"\b[a-z][a-z_]*__v_double\b", path.read_text()))
+        for path in MART_TABLE_MAP:
+            found |= _v_double_tokens(path)
 
         expected_union: set[str] = set()
         for cols in EXPECTED_VARIANT_TWINS.values():
@@ -81,6 +127,43 @@ class TestAllowListsMatchMarts:
             f"in marts but not expected: {found - expected_union}; "
             f"expected but not in any mart: {expected_union - found}"
         )
+
+    def test_every_expected_table_is_covered_by_a_mapped_mart(self):
+        """MART_TABLE_MAP itself must not silently drop a tracked table --
+        every key in EXPECTED_VARIANT_TWINS must appear as a value somewhere
+        in the map, or the per-table check below would vacuously pass it."""
+        mapped_tables: set[str] = set()
+        for tables in MART_TABLE_MAP.values():
+            mapped_tables |= set(tables)
+
+        assert mapped_tables == set(EXPECTED_VARIANT_TWINS), (
+            f"MART_TABLE_MAP and EXPECTED_VARIANT_TWINS track different tables -- "
+            f"mapped but not expected: {mapped_tables - set(EXPECTED_VARIANT_TWINS)}; "
+            f"expected but not mapped: {set(EXPECTED_VARIANT_TWINS) - mapped_tables}"
+        )
+
+    def test_each_tables_twins_come_from_its_own_mapped_marts(self):
+        """Per-table version of the drift guard: the tokens found in the
+        mart(s) mapped to a given source table must exactly match that
+        table's entry in EXPECTED_VARIANT_TWINS -- catches a twin correctly
+        spelled but attributed to the wrong table (e.g. copy-paste between
+        005/031/032), which the pooled union check above cannot see."""
+        tokens_by_table: dict[str, set[str]] = {key: set() for key in EXPECTED_VARIANT_TWINS}
+        for path, tables in MART_TABLE_MAP.items():
+            tokens = _v_double_tokens(path)
+            for table_key in tables:
+                tokens_by_table[table_key] |= tokens
+
+        for table_key, expected_cols in EXPECTED_VARIANT_TWINS.items():
+            found = tokens_by_table[table_key]
+            # 052 shares its file (and hence its token pool) between two
+            # tables (player-season and team-season), so require the
+            # table's expected columns to be a subset of what its mapped
+            # mart(s) contain rather than an exact match.
+            assert expected_cols <= found, (
+                f"{table_key}: EXPECTED_VARIANT_TWINS has columns not found in its "
+                f"mapped mart(s): {expected_cols - found}"
+            )
 
 
 class _FakeCursor:

--- a/tests/test_verify_load.py
+++ b/tests/test_verify_load.py
@@ -474,6 +474,11 @@ class TestCheckVariantTwins:
         assert "[WARN] variant_twins:" in out
         assert "could not run" in out
 
+    def test_docstring_explains_the_savepoint(self):
+        from scripts.verify_load import check_variant_twins
+
+        assert "SAVEPOINT" in (check_variant_twins.__doc__ or "")
+
     def test_the_check_is_wired_into_the_run_after_freshness(self):
         """A check that is never called is a comment -- and this one must run
         after check_freshness per the module docstring's numbered list."""
@@ -492,3 +497,94 @@ class TestCheckVariantTwins:
         import scripts.verify_load as vl
 
         assert "variant" in vl.__doc__.lower()
+
+
+class _FakeConnection:
+    """Bare psycopg2-connection stand-in: check_variant_twins only reads
+    `.autocommit` off of `cur.connection`."""
+
+    def __init__(self, autocommit: bool = False):
+        self.autocommit = autocommit
+
+
+class _SavepointCursor:
+    """Fake cursor exercising the real (non-monkeypatched)
+    find_unexpected_twins/find_missing_twins against a real EXPECTED_
+    VARIANT_TWINS -- unlike the tests above, which stub the finder
+    functions out entirely. Records every SQL statement issued so the
+    SAVEPOINT/ROLLBACK TO SAVEPOINT/RELEASE SAVEPOINT bracket around the
+    two catalog queries can be asserted on directly. `fail_catalog=True`
+    raises the first time an information_schema catalog query runs,
+    simulating the PostgreSQL-level failure (e.g. a malformed query) that
+    would otherwise leave the shared connection's transaction aborted."""
+
+    def __init__(self, fail_catalog: bool, autocommit: bool = False):
+        self.connection = _FakeConnection(autocommit=autocommit)
+        self.statements: list[str] = []
+        self._fail_catalog = fail_catalog
+
+    def execute(self, sql, params=None):
+        self.statements.append(sql)
+        if "information_schema" in sql and self._fail_catalog:
+            raise RuntimeError("relation does not exist")
+
+    def fetchall(self):
+        return []
+
+
+class TestCheckVariantTwinsSavepoint:
+    """Finding 2 (P2, post-#110 review): the two catalog queries run inside
+    a SAVEPOINT so a PostgreSQL-level failure there can't leave verify()'s
+    shared, non-autocommit connection in InFailedSqlTransaction for every
+    check that runs afterward."""
+
+    def test_catalog_failure_rolls_back_to_savepoint_and_warns(self, capsys):
+        from scripts.verify_load import Report, check_variant_twins
+
+        cur = _SavepointCursor(fail_catalog=True)
+        report = Report()
+
+        check_variant_twins(cur, report)  # must not raise
+
+        assert "SAVEPOINT variant_twins" in cur.statements
+        assert "ROLLBACK TO SAVEPOINT variant_twins" in cur.statements
+        assert "RELEASE SAVEPOINT variant_twins" not in cur.statements
+        assert report.failures == 0
+        out = capsys.readouterr().out
+        assert "[WARN] variant_twins:" in out
+        assert "could not run" in out
+
+    def test_catalog_success_releases_savepoint(self):
+        from scripts.verify_load import Report, check_variant_twins
+
+        cur = _SavepointCursor(fail_catalog=False)
+        report = Report()
+
+        check_variant_twins(cur, report)
+
+        assert "SAVEPOINT variant_twins" in cur.statements
+        assert "RELEASE SAVEPOINT variant_twins" in cur.statements
+        assert not any(s.startswith("ROLLBACK TO SAVEPOINT") for s in cur.statements)
+
+    def test_autocommit_connection_skips_the_savepoint_dance(self):
+        from scripts.verify_load import Report, check_variant_twins
+
+        cur = _SavepointCursor(fail_catalog=False, autocommit=True)
+        report = Report()
+
+        check_variant_twins(cur, report)
+
+        assert not any("SAVEPOINT" in s for s in cur.statements)
+
+    def test_autocommit_connection_still_warns_not_crashes_on_catalog_failure(self, capsys):
+        from scripts.verify_load import Report, check_variant_twins
+
+        cur = _SavepointCursor(fail_catalog=True, autocommit=True)
+        report = Report()
+
+        check_variant_twins(cur, report)  # must not raise
+
+        assert not any("SAVEPOINT" in s for s in cur.statements)
+        assert report.failures == 0
+        out = capsys.readouterr().out
+        assert "[WARN] variant_twins:" in out

--- a/tests/test_verify_load.py
+++ b/tests/test_verify_load.py
@@ -401,3 +401,94 @@ class TestBacktestFreshnessGate:
             "the daily backtest must run BARE so the script defaults stay "
             f"canonical; found: {invoked.strip()!r}"
         )
+
+
+class TestCheckVariantTwins:
+    """KTD7 tripwire wired into the daily verifier: check_variant_twins must
+    FAIL on an unexpected __v_double twin, WARN (never FAIL) on a missing
+    expected twin, and WARN (never crash) if the finder itself errors."""
+
+    def test_no_unexpected_no_missing_passes(self, monkeypatch):
+        from scripts.verify_load import Report, check_variant_twins
+
+        monkeypatch.setattr(
+            "src.pipelines.utils.variant_twins.find_unexpected_twins", lambda cur: {}
+        )
+        monkeypatch.setattr("src.pipelines.utils.variant_twins.find_missing_twins", lambda cur: {})
+
+        report = Report()
+        check_variant_twins(cur=object(), report=report)
+
+        assert report.failures == 0
+
+    def test_unexpected_twin_fails(self, monkeypatch, capsys):
+        from scripts.verify_load import Report, check_variant_twins
+
+        monkeypatch.setattr(
+            "src.pipelines.utils.variant_twins.find_unexpected_twins",
+            lambda cur: {"stats.rushing_player_season": ["new_metric__v_double"]},
+        )
+        monkeypatch.setattr("src.pipelines.utils.variant_twins.find_missing_twins", lambda cur: {})
+
+        report = Report()
+        check_variant_twins(cur=object(), report=report)
+
+        assert report.failures == 1
+        out = capsys.readouterr().out
+        assert "[FAIL] variant_twins:" in out
+        assert "stats.rushing_player_season" in out
+        assert "new_metric__v_double" in out
+
+    def test_missing_twin_warns_not_fails(self, monkeypatch, capsys):
+        from scripts.verify_load import Report, check_variant_twins
+
+        monkeypatch.setattr(
+            "src.pipelines.utils.variant_twins.find_unexpected_twins", lambda cur: {}
+        )
+        monkeypatch.setattr(
+            "src.pipelines.utils.variant_twins.find_missing_twins",
+            lambda cur: {"stats.passing_player_season": ["average_yards_after_catch__v_double"]},
+        )
+
+        report = Report()
+        check_variant_twins(cur=object(), report=report)
+
+        assert report.failures == 0
+        out = capsys.readouterr().out
+        assert "[WARN] variant_twins_missing:" in out
+        assert "stats.passing_player_season" in out
+
+    def test_finder_exception_warns_never_crashes(self, monkeypatch, capsys):
+        from scripts.verify_load import Report, check_variant_twins
+
+        def _boom(cur):
+            raise RuntimeError("relation does not exist")
+
+        monkeypatch.setattr("src.pipelines.utils.variant_twins.find_unexpected_twins", _boom)
+
+        report = Report()
+        check_variant_twins(cur=object(), report=report)  # must not raise
+
+        assert report.failures == 0
+        out = capsys.readouterr().out
+        assert "[WARN] variant_twins:" in out
+        assert "could not run" in out
+
+    def test_the_check_is_wired_into_the_run_after_freshness(self):
+        """A check that is never called is a comment -- and this one must run
+        after check_freshness per the module docstring's numbered list."""
+        import inspect
+
+        import scripts.verify_load as vl
+
+        src = inspect.getsource(vl.verify)
+        assert "check_freshness(cur, in_season, strict, report)" in src
+        assert "check_variant_twins(cur, report)" in src
+        assert src.index("check_freshness(cur, in_season, strict, report)") < src.index(
+            "check_variant_twins(cur, report)"
+        )
+
+    def test_docstring_lists_the_check(self):
+        import scripts.verify_load as vl
+
+        assert "variant" in vl.__doc__.lower()


### PR DESCRIPTION
## Summary

The daily load now fails loudly when dlt creates a `__v_double` variant twin that no mart accounts for, instead of letting the affected metric go silently NULL in the mart, its api view, and `get_player_detail` until the next deploy-time validation. Before this, the only twin check was the allow-list in `validation_rushing_views.sql`, which runs only when the rushing manifest is applied.

Fixes #109

## Design

- `src/pipelines/utils/variant_twins.py` holds `EXPECTED_VARIANT_TWINS`, the per-table allow-list of twins the charting marts COALESCE: 17 on `stats.rushing_player_season`, 8 on `stats.rushing_team_season`, 1 on `stats.passing_player_season`. It scopes to tables a mart reads; the game-grain rushing tables carry dozens of twins nothing consumes, so they are deliberately excluded and would only page for no reason.
- `verify_load.py` check 8 (`check_variant_twins`) runs one `information_schema.columns` query inside the existing connection: an unexpected twin FAILs the run with the table, columns, and the remediation (add the COALESCE, extend both allow-lists, re-apply the mart); an expected twin that is absent only WARNs; a query error WARNs rather than crashing the run.
- Drift guard: `tests/test_variant_twins.py` parses the two `ARRAY[...]` allow-lists in `validation_rushing_views.sql` and greps the twin tokens in marts 045/050/051/052, asserting all three agree with the Python set in both directions. Python, SQL validation, and marts can no longer drift independently.

## Testing

- `pytest`: 2105 passed, 447 skipped (DB-gated); `ruff check` and `ruff format --check` clean.
- New tests: fake-cursor cases for all-expected, one extra, and expected-missing; `check_variant_twins` FAIL / WARN / exception-safety / wiring into `verify()`; the SQL-and-marts drift guard.
- Not run live: no database is reachable from this session, so the query itself (`(table_schema, table_name) IN %s` with a tuple of tuples, `LIKE '%\_\_v\_double' ESCAPE '\'`) has only been exercised against fake cursors. The next daily load at 10:00 UTC runs `verify_load.py` against production and is the first live execution.

## Post-Deploy Monitoring & Validation

1. Next daily run: the log shows `variant_twins` PASS with "no unexpected __v_double twins"; `verify_load.py` exits 0.
2. Failure signal: a `variant_twins` FAIL naming a column means a real new twin (follow the remediation in the message) or, on the first run only, a query-syntax problem (the log line will show the psycopg2 error inside a WARN instead, since the check never raises).
3. No API calls added; no schema change. Rollback: revert this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds post-load checks for unexpected variant columns and keeps the expected-variant definitions synchronized with deployment validation and reporting marts.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

No accepted blocking findings remain.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated that after applying the temporary wrong-alias mutation, both targeted assertions for the rps fallback still pass.
- Diagnosed the root cause as lines 155-158 assign the complete file-level token set to every table in MART\_TABLE\_MAP, causing the same unqualified token pool on 052.
- Observed that existing tests improve a global guard but cannot distinguish rps from rts within 052, so alias-level attribution remains unaddressed.
- Uploaded and linked supporting artifacts, including a Python proof script and multiple external test-run logs to aid review.

<a href="https://app.greptile.com/trex/runs/22360480/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["Check twin attribution per mart, not as ..."](https://github.com/rstover-fo/cfb-database/commit/db33cc16bf8afa262433b1e8af1cd601422acb45) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60094095)</sub>

<!-- /greptile_comment -->