### PR TITLE
Load rosters into core.roster, not core.rosters

### DIFF
--- a/docs/pipeline-manifest.md
+++ b/docs/pipeline-manifest.md
@@ -132,7 +132,7 @@ Only 3 actual variant columns in user data tables. dlt internal tables also have
 
 | # | API Path | Table | Source File | Resource Function | Wired? | Disposition | Primary Key | Year Range | Status |
 |---|---|---|---|---|---|---|---|---|---|
-| 35 | `/player/search` | — | — | — | — | — | — | — | REMOVED (requires searchTerm; use core.rosters instead) |
+| 35 | `/player/search` | — | — | — | — | — | — | — | REMOVED (requires searchTerm; use core.roster instead) |
 | 36 | `/player/usage` | stats.player_usage | stats.py | player_usage_resource | YES | merge | season, id | 2014-2026 | WORKING |
 | 37 | `/player/returning` | stats.player_returning | stats.py | player_returning_resource | YES | merge | season, team | 2014-2026 | WORKING |
 
@@ -176,7 +176,7 @@ Only 3 actual variant columns in user data tables. dlt internal tables also have
 | 51 | `/teams/fbs` | ref.teams_fbs | reference.py | teams_fbs_resource | YES | replace | id | — | WORKING |
 | 52 | `/teams/matchup` | core.team_matchups | — | — | — | DEFERRED | team1, team2, season | — | Computed from games via matchup_history mart |
 | 53 | `/teams/ats` | betting.team_ats | betting.py | team_ats_resource | YES | merge | year, team_id | 2013-2026 | WORKING |
-| 54 | `/roster` | core.rosters | rosters.py | rosters_resource | YES | merge | id, team, year | 2004-2026 | WORKING (requires team list) |
+| 54 | `/roster` | core.roster | rosters.py | rosters_resource | YES | merge | id, team, year | 2004-2026 | WORKING (requires team list) |
 | 55 | `/talent` | recruiting.team_talent | recruiting.py | team_talent_resource | YES | merge | year, team | 2000-2026 | WORKING |
 
 ### Adjusted Metrics (WEPA)
@@ -294,7 +294,7 @@ and PKs above now reflect the code. `/plays/stats/types` was loaded (26 rows in
 (`games.py` no longer yields them), whose week-by-week path avoids Supabase merge
 timeouts — `run.py --source game_stats --weekly` or `scripts/load_season.py --weekly`.
 
-**Sprint 4 Progress:** Promoted 15 endpoints from UNMAPPED/CONFIG_ONLY to WORKING: `/game/box/advanced`, `/plays/stats`, `/stats/season/advanced`, `/stats/game/havoc`, `/ratings/sp/conferences`, `/player/usage`, `/player/returning`, `/teams/ats`, `/ppa/games`, `/ppa/players/games`, `/metrics/fg/ep`, `/wepa/players/passing`, `/wepa/players/rushing`, `/wepa/team/season`, `/wepa/players/kicking`. Removed `/player/search` (requires searchTerm; use core.rosters instead). Deleted dead code: `adjusted_metrics.py` (duplicate of `wepa.py`), `players.py` (broken source).
+**Sprint 4 Progress:** Promoted 15 endpoints from UNMAPPED/CONFIG_ONLY to WORKING: `/game/box/advanced`, `/plays/stats`, `/stats/season/advanced`, `/stats/game/havoc`, `/ratings/sp/conferences`, `/player/usage`, `/player/returning`, `/teams/ats`, `/ppa/games`, `/ppa/players/games`, `/metrics/fg/ep`, `/wepa/players/passing`, `/wepa/players/rushing`, `/wepa/team/season`, `/wepa/players/kicking`. Removed `/player/search` (requires searchTerm; use core.roster instead). Deleted dead code: `adjusted_metrics.py` (duplicate of `wepa.py`), `players.py` (broken source).
 
 **2026-08-29 update:** `/metrics/wp` (row 47) verified against the live database
 (`SELECT COUNT(*) FROM metrics.win_probability` -> 1,971,363) and promoted

--- a/docs/solutions/database-issues/dlt-resource-name-vs-table-name.md
+++ b/docs/solutions/database-issues/dlt-resource-name-vs-table-name.md
@@ -1,0 +1,29 @@
+# dlt resource name vs. destination table name (core.roster / core.rosters)
+
+**Symptom (2026-09-03):** `api.roster_lookup` had no 2026 rows the week of
+Week 1, even though the `rosters` backfill ran green: 716 `/roster` calls,
+all 200, dlt package LOADED, zero warnings.
+
+**Cause:** dlt names the destination table after the resource unless
+`table_name` is set. `rosters_resource` is named `rosters`, so it wrote
+`core.rosters`. Every consumer -- `api.roster_lookup`, marts 011/017/020/
+025/045/050, `public.player_search`, `scouting.player_mart`,
+`check_presence.py` -- reads `core.roster` (singular), a dlt-shaped table
+from an earlier load path that stopped at 2025. Both tables had the same 17
+columns and a `*__recruit_ids` child, so nothing failed; the data simply
+landed where nobody looked. Presence-check recon showed core.roster at
+2025 / 315 teams and core.rosters at 2026 / 31,076 rows / 284 teams.
+
+**Fix:** `table_name="roster"` on the resource
+(`src/pipelines/sources/rosters.py`), plus a unit test pinning it. The
+merge then lands in the existing `core.roster` / `core.roster__recruit_ids`
+(dlt reconciles an existing table by column name; identical columns, no
+ALTERs). `core.rosters` / `core.rosters__recruit_ids` are now orphans and
+can be dropped in a later migration once a load has been verified against
+`core.roster`.
+
+**Lesson:** when a load reports success but a view stays stale, compare the
+resource/table name dlt actually wrote (`Job for <table>.<hash>.insert_values`
+in the load log) against the table the view reads before suspecting the
+API. A row-count floor on the consumer view (`verify_load.py`) would have
+caught this the day it happened; a green load log never will.

--- a/src/pipelines/run.py
+++ b/src/pipelines/run.py
@@ -1539,8 +1539,9 @@ def run_rosters_pipeline(
             # successful roster load that made zero /roster requests -- the
             # same silent-no-op shape as the finished-season skip turning a
             # backfill into nothing, and as `--sources rosters` logging "No
-            # runner for source" and exiting 0, which is why core.roster had
-            # no 2026 rows in the first place.
+            # runner for source" and exiting 0. (The 2026-09-03 "no 2026
+            # rosters" incident itself was a different silent no-op: the
+            # resource lacked table_name="roster" and loaded core.rosters.)
             raise RuntimeError(
                 f"No teams with scheduled games in {years}: core.games has no rows for "
                 f"{'that season' if len(years) == 1 else 'those seasons'}. /roster is "

--- a/src/pipelines/sources/rosters.py
+++ b/src/pipelines/sources/rosters.py
@@ -48,6 +48,13 @@ def rosters_source(
 
 @dlt.resource(
     name="rosters",
+    # Every consumer (api.roster_lookup, marts 011/017/020/025/045/050, the
+    # scouting player mart, public.player_search) reads core.roster
+    # (singular). Without this, dlt derives the table from the resource
+    # name and writes core.rosters -- a parallel table nobody reads, which
+    # is where the 2026 rosters landed on 2026-09-03 while core.roster
+    # stopped at 2025. Same 17 columns + roster__recruit_ids child.
+    table_name="roster",
     write_disposition="merge",
     primary_key=["id", "team", "year"],
 )

--- a/tests/test_sources/test_rosters.py
+++ b/tests/test_sources/test_rosters.py
@@ -28,6 +28,19 @@ def test_rosters_resource_yields_players():
         assert results[0]["year"] == 2024
 
 
+def test_rosters_resource_writes_core_roster():
+    """The consumers (api.roster_lookup, the charting marts' position join,
+    the scouting player mart) all read core.roster, singular. dlt names the
+    table after the resource unless told otherwise, so without an explicit
+    table_name the load lands in core.rosters and every downstream view
+    silently stops at the last season loaded the old way (2025, as of the
+    2026-09-03 incident)."""
+    from src.pipelines.sources.rosters import rosters_resource
+
+    assert rosters_resource.table_name == "roster"
+    assert rosters_resource.write_disposition == "merge"
+
+
 def test_rosters_resource_iterates_teams_and_years():
     """Should call API for each team/year combination."""
     from src.pipelines.sources.rosters import rosters_resource
@@ -106,8 +119,9 @@ class TestScheduledTeamResolution:
     def test_an_unloaded_schedule_fails_loudly(self):
         """load_season reports a returning runner as [OK]. An empty team list
         would therefore print a successful roster load that made zero /roster
-        requests -- the same silent no-op that left core.roster with no 2026
-        rows to begin with."""
+        requests -- a silent no-op of the same shape as the resource
+        loading core.rosters instead of core.roster (see
+        test_rosters_resource_writes_core_roster)."""
         from unittest.mock import patch
 
         import pytest


### PR DESCRIPTION
## Summary
- `rosters_resource` had no `table_name`, so dlt wrote `core.rosters` (plural). Every consumer (`api.roster_lookup`, marts 011/017/020/025/045/050, `public.player_search`, `scouting.player_mart`) reads `core.roster` (singular), which stopped at 2025.
- Recon via presence check: `core.roster` 2025 / 315 teams; `core.rosters` 2026 / 31,076 rows / 284 teams. Identical 17 columns and `__recruit_ids` child on both.
- Fix: `table_name="roster"` on the resource + a unit test pinning it; corrected the run.py comment and test docstring that misattributed the missing 2026 rows; manifest row 54 now says `core.roster`; solution doc under `docs/solutions/database-issues/`.

## Follow-ups (not in this PR)
- Drop orphaned `core.rosters` / `core.rosters__recruit_ids` in a migration once a load is verified against `core.roster`.
- Add a `core.roster` current-season row-count floor to `verify_load.py`; a green load log never catches this.

## Test plan
- [x] `ruff check`, `ruff format --check`, `pytest tests/test_sources/test_rosters.py` (14 passed)
- [ ] `backfill-sources` dispatched from this branch: seasons `2026`, sources `rosters` -> `api.roster_lookup` gains year 2026 rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

## Summary
This change directs roster loads to the singular `core.roster` table used by roster lookups and downstream marts, while preserving the existing merge behavior and composite key. It also adds focused coverage for the resource metadata and corrects related documentation.

The previously possible plural-table destination was explicitly checked and does not remain in this change: dlt metadata resolves the decorated resource, bound resource, computed schema, and source resource to `roster`. The same executable assertion reproduces `rosters` on the parent revision and passes on this revision. No review comments are required.

<h3>Confidence Score: 5/5</h3>

Safe to merge based on the verified destination metadata and focused regression coverage.

The runtime check reproduced the old plural destination on the parent revision, then confirmed that every inspected dlt metadata path resolves to the required singular destination in this revision. The focused roster destination test also passed.

**Files Needing Attention:** No files need follow-up attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a review-owned Python assertion that imports rosters\_resource and rosters\_source, binds the resource, computes its table schema, and checks decorated, bound, computed, and source metadata.
- Compared outcomes across revisions: the parent revision failed the roster metadata assertion, while the PR revision reported roster for all four metadata paths.
- Observed the PR revision assertion printed the success message ASSERTION PASSED: dlt destination table resolves to roster.
- Ran the focused pytest regression test test\_rosters.py::test\_rosters\_resource\_writes\_core\_roster; the test passed.

<a href="https://app.greptile.com/trex/runs/22414739/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Load rosters into core.roster, not core...."](https://github.com/rstover-fo/cfb-database/commit/eed392db23ec90c63171e1993f2ebf34b75c4eb0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60211450)</sub>

<!-- /greptile_comment -->