### PR TITLE
Scope PFF crosswalk candidates by season, tiebreak on first name

### DIFF
--- a/docs/handoffs/2026-09-04-pff-backfill-deploy.md
+++ b/docs/handoffs/2026-09-04-pff-backfill-deploy.md
@@ -50,10 +50,15 @@ full parse path; a large deviation means the wrong file was fed:
 
 - Re-running a load with an unchanged file → `skipped_hash` (ledger:
   `meta.flat_file_loads`, source key `pff_<family>:<season>`).
-- Xwalk: expect **~96–99% matched** (validated on QB and CB/S/LB/DI/ED
-  samples). Unmatched + ambiguous players print to stdout — review, don't
-  force; known residual cases are nicknames (e.g. PFF "Trey" vs a legal
-  first name). Distinct `player_id` across all families ≈ 12–13k.
+- Xwalk: **98.6% matched** on the 2023–2025 backfill (2026-09-04 rebuild:
+  18,117 of 18,375 distinct `player_id`s; 121 ambiguous, 137 unmatched).
+  The first run scored 88.3% because candidates spanned every roster
+  season since 2004 — the matcher now scopes by PFF season and tiebreaks on
+  first name (17,517 same-season, 548 first-name tiebreaks, 42 season±1,
+  10 any-season). Unmatched + ambiguous players print to stdout — review,
+  don't force; the residual is West Georgia (D-II, no CFBD roster), PFF
+  "Unknown <team> <number>" placeholders, nicknames (PFF "Pickle"/"Trey"
+  vs a legal first name), and true same-name-same-season collisions.
 
 ## Post-load verification (any SQL client)
 
@@ -63,7 +68,7 @@ UNION ALL SELECT 'defense', season, count(*) FROM pff.defense_summary GROUP BY s
 ORDER BY 1, 2;                                   -- matches the table above
 SELECT count(*) FROM pff.team_map;               -- 137 (136 FBS map + W GEORGIA, a D-II
                                                  -- team PFF graded in 2023)
-SELECT count(*) FROM pff.player_xwalk;           -- ~12-13k after step 3
+SELECT count(*) FROM pff.player_xwalk;           -- ~18.1k after step 3
 SELECT school, count(*) FROM pff.defense_summary WHERE season=2025
 GROUP BY school ORDER BY 2 DESC LIMIT 5;         -- school column resolved, sane counts
 ```

--- a/scripts/build_pff_player_xwalk.py
+++ b/scripts/build_pff_player_xwalk.py
@@ -17,12 +17,22 @@ docs/brainstorms/2026-09-01-pff-plus-api.md sections 5a+: 96% raw at QB,
   the FINAL surname token on both sides, so CFBD's whole-surname last_name
   and PFF's space-split display name land on the same key.
 - School is the CFBD full name: pff.*.school (pre-resolved via
-  pff.team_map) against core.roster.team, matched over ANY roster season --
-  the roster spans seasons, and a transfer's multiple PFF school
+  pff.team_map) against core.roster.team. A transfer's multiple PFF school
   observations union to the same athlete id.
-- NEVER guess: a key with two or more candidate athletes is left unmatched
-  and reported (ambiguous), as is a key with none. Only unique matches are
-  written.
+- Roster candidates are SEASON-SCOPED: a PFF observation from season S is
+  matched against roster rows for S first, then S+-1 (roster gaps), then
+  any season -- each tier only widening when the tighter one found nobody.
+  The first cut of this script matched against every roster season since
+  2004, so "J. Smith @ Kentucky" collided with every J. Smith Kentucky ever
+  rostered: a flat ~12% ambiguous rate across all positions/families
+  (88.3% matched on the 2023-2025 backfill, 2026-09-04).
+- Within a tier, two or more candidates are narrowed on the full first-name
+  token (PFF "Tycoolhill Luman" vs "Tyclean Luman", both FAU); a unique
+  survivor matches, otherwise the id stays ambiguous.
+- NEVER guess beyond that: a key with two or more surviving candidates is
+  left unmatched and reported (ambiguous), as is a key with none. Only
+  unique matches are written; match_method records the tier that resolved
+  it.
 
 Writes: INSERT ... ON CONFLICT (pff_player_id) DO UPDATE into
 pff.player_xwalk (athlete_id, match_method, matched_at). Already-matched
@@ -42,7 +52,7 @@ is pure and unit-tested in tests/test_pff_player_xwalk.py.
 
 import argparse
 import sys
-from collections import defaultdict
+from collections import Counter, defaultdict
 from dataclasses import dataclass, field
 
 from src.pipelines.utils.load_ledger import get_db_url
@@ -52,6 +62,15 @@ from src.pipelines.utils.load_ledger import get_db_url
 SUFFIX_TOKENS = frozenset({"JR", "SR", "II", "III", "IV", "V"})
 
 MATCH_METHOD = "last_name+first_initial+school"
+
+# Candidate tiers, tightest first. Each is a predicate on (roster years for
+# the athlete at this key, PFF observation season); the matcher only widens
+# to the next tier when the current one yields no candidate at all.
+SEASON_TIERS: tuple[tuple[str, object], ...] = (
+    ("season", lambda years, season: season in years),
+    ("season+-1", lambda years, season: any(abs(y - season) <= 1 for y in years)),
+    ("any_season", lambda years, season: True),
+)
 
 PFF_FAMILY_TABLES = (
     "passing_summary",
@@ -117,42 +136,71 @@ def match_players(pff_players, roster_rows) -> MatchResult:
     """Pure matching core.
 
     Args:
-        pff_players: iterable of {"pff_player_id", "player", "school"} dicts
-            -- possibly several observations per id (transfers).
+        pff_players: iterable of {"pff_player_id", "player", "school",
+            "season"} dicts -- possibly several observations per id
+            (transfers, multiple seasons).
         roster_rows: iterable of {"athlete_id", "first_name", "last_name",
-            "team"} dicts spanning any/all roster seasons.
+            "team", "year"} dicts spanning any/all roster seasons.
     """
-    index: dict[tuple[str, str, str], set[str]] = defaultdict(set)
+    # key -> athlete_id -> roster years seen at that key
+    index: dict[tuple[str, str, str], dict[str, set[int]]] = defaultdict(lambda: defaultdict(set))
+    # athlete_id -> normalized first-name tokens seen on any roster row
+    first_tokens: dict[str, set[str]] = defaultdict(set)
     for row in roster_rows:
         key = roster_match_key(row["first_name"], row["last_name"], row["team"])
-        if key:
-            index[key].add(str(row["athlete_id"]))
+        if not key:
+            continue
+        athlete = str(row["athlete_id"])
+        index[key][athlete].add(int(row["year"]))
+        first_tokens[athlete].add(_name_tokens(row["first_name"])[0])
 
-    observations: dict[int, list[tuple[str, str]]] = defaultdict(list)
+    observations: dict[int, list[tuple[str, str, int]]] = defaultdict(list)
     for p in pff_players:
-        observations[int(p["pff_player_id"])].append((p["player"], p["school"]))
+        observations[int(p["pff_player_id"])].append((p["player"], p["school"], int(p["season"])))
 
     result = MatchResult(matches=[], ambiguous=[], unmatched=[])
     for pff_id in sorted(observations):
         obs = observations[pff_id]
-        candidates: set[str] = set()
-        for player, school in obs:
-            key = pff_match_key(player, school)
-            if key:
-                candidates |= index.get(key, set())
+        obs_pairs = tuple((name, school) for name, school, _ in dict.fromkeys(obs))
+        resolved = False
+        for tier_name, in_tier in SEASON_TIERS:
+            candidates: set[str] = set()
+            for player, school, season in obs:
+                key = pff_match_key(player, school)
+                if not key:
+                    continue
+                for athlete, years in index.get(key, {}).items():
+                    if in_tier(years, season):
+                        candidates.add(athlete)
+            if not candidates:
+                continue  # widen to the next tier
 
-        if len(candidates) == 1:
-            result.matches.append(
-                {
-                    "pff_player_id": pff_id,
-                    "athlete_id": next(iter(candidates)),
-                    "match_method": MATCH_METHOD,
-                }
-            )
-        elif candidates:
-            result.ambiguous.append(UnresolvedPlayer(pff_id, tuple(obs), sorted(candidates)))
-        else:
-            result.unmatched.append(UnresolvedPlayer(pff_id, tuple(obs)))
+            method = f"{MATCH_METHOD}+{tier_name}"
+            if len(candidates) > 1:
+                pff_firsts = {_name_tokens(name)[0] for name, _, _ in obs if _name_tokens(name)}
+                narrowed = {a for a in candidates if first_tokens[a] & pff_firsts}
+                # Report the first-name survivors when there are any (the
+                # useful list for hand review); an empty narrowing (nickname
+                # vs legal name) keeps the full set and never guesses.
+                if narrowed:
+                    candidates = narrowed
+                if len(narrowed) == 1:
+                    method += "+first_name"
+
+            if len(candidates) == 1:
+                result.matches.append(
+                    {
+                        "pff_player_id": pff_id,
+                        "athlete_id": next(iter(candidates)),
+                        "match_method": method,
+                    }
+                )
+            else:
+                result.ambiguous.append(UnresolvedPlayer(pff_id, obs_pairs, sorted(candidates)))
+            resolved = True
+            break
+        if not resolved:
+            result.unmatched.append(UnresolvedPlayer(pff_id, obs_pairs))
     return result
 
 
@@ -163,24 +211,30 @@ def match_players(pff_players, roster_rows) -> MatchResult:
 
 def _fetch_pff_players(cur, skip_ids: set[int]) -> list[dict]:
     union = "\nUNION\n".join(
-        f"SELECT player_id, player, school FROM pff.{t}" for t in PFF_FAMILY_TABLES
+        f"SELECT player_id, player, school, season FROM pff.{t}" for t in PFF_FAMILY_TABLES
     )
     cur.execute(union)
     return [
-        {"pff_player_id": pid, "player": player, "school": school}
-        for pid, player, school in cur.fetchall()
+        {"pff_player_id": pid, "player": player, "school": school, "season": season}
+        for pid, player, school, season in cur.fetchall()
         if int(pid) not in skip_ids
     ]
 
 
 def _fetch_roster(cur) -> list[dict]:
     cur.execute(
-        "SELECT DISTINCT id::text, first_name, last_name, team "
-        "FROM core.roster WHERE team IS NOT NULL"
+        "SELECT DISTINCT id::text, first_name, last_name, team, year "
+        "FROM core.roster WHERE team IS NOT NULL AND year IS NOT NULL"
     )
     return [
-        {"athlete_id": athlete_id, "first_name": first, "last_name": last, "team": team}
-        for athlete_id, first, last, team in cur.fetchall()
+        {
+            "athlete_id": athlete_id,
+            "first_name": first,
+            "last_name": last,
+            "team": team,
+            "year": year,
+        }
+        for athlete_id, first, last, team, year in cur.fetchall()
     ]
 
 
@@ -208,6 +262,9 @@ def _report(result: MatchResult, skipped: int) -> None:
     print(f"{'=' * 60}")
     print(f"  candidates considered: {total} (already matched, skipped: {skipped})")
     print(f"  matched:   {len(result.matches):6d}  ({rate:.1f}%)")
+    by_method = Counter(m["match_method"] for m in result.matches)
+    for method, n in sorted(by_method.items(), key=lambda kv: -kv[1]):
+        print(f"    {method:<52} {n:6d}")
     print(f"  ambiguous: {len(result.ambiguous):6d}  (left unmatched -- never guessed)")
     print(f"  unmatched: {len(result.unmatched):6d}")
 

--- a/scripts/build_pff_player_xwalk.py
+++ b/scripts/build_pff_player_xwalk.py
@@ -22,6 +22,10 @@ docs/brainstorms/2026-09-01-pff-plus-api.md sections 5a+: 96% raw at QB,
 - Roster candidates are SEASON-SCOPED: a PFF observation from season S is
   matched against roster rows for S first, then S+-1 (roster gaps), then
   any season -- each tier only widening when the tighter one found nobody.
+  The tier is resolved per observation and the candidate sets are then
+  unioned, so a transfer's second school contributes its own candidates
+  even when the first school hit at a tighter tier; match_method records
+  the widest tier any observation needed.
   The first cut of this script matched against every roster season since
   2004, so "J. Smith @ Kentucky" collided with every J. Smith Kentucky ever
   rostered: a flat ~12% ambiguous rate across all positions/families
@@ -162,45 +166,49 @@ def match_players(pff_players, roster_rows) -> MatchResult:
     for pff_id in sorted(observations):
         obs = observations[pff_id]
         obs_pairs = tuple((name, school) for name, school, _ in dict.fromkeys(obs))
-        resolved = False
-        for tier_name, in_tier in SEASON_TIERS:
-            candidates: set[str] = set()
-            for player, school, season in obs:
-                key = pff_match_key(player, school)
-                if not key:
-                    continue
-                for athlete, years in index.get(key, {}).items():
-                    if in_tier(years, season):
-                        candidates.add(athlete)
-            if not candidates:
-                continue  # widen to the next tier
 
-            method = f"{MATCH_METHOD}+{tier_name}"
-            if len(candidates) > 1:
-                pff_firsts = {_name_tokens(name)[0] for name, _, _ in obs if _name_tokens(name)}
-                narrowed = {a for a in candidates if first_tokens[a] & pff_firsts}
-                # Report the first-name survivors when there are any (the
-                # useful list for hand review); an empty narrowing (nickname
-                # vs legal name) keeps the full set and never guesses.
-                if narrowed:
-                    candidates = narrowed
-                if len(narrowed) == 1:
-                    method += "+first_name"
-
-            if len(candidates) == 1:
-                result.matches.append(
-                    {
-                        "pff_player_id": pff_id,
-                        "athlete_id": next(iter(candidates)),
-                        "match_method": method,
-                    }
-                )
-            else:
-                result.ambiguous.append(UnresolvedPlayer(pff_id, obs_pairs, sorted(candidates)))
-            resolved = True
-            break
-        if not resolved:
+        # Resolve the tier PER OBSERVATION, then union. A transfer seen at
+        # A/2024 (exact-season hit) and B/2023 (roster gap, +-1 hit) must
+        # contribute both candidate sets so a conflicting identity surfaces
+        # as ambiguous instead of the first observation winning silently.
+        candidates: set[str] = set()
+        widest_tier = -1
+        for player, school, season in obs:
+            key = pff_match_key(player, school)
+            if not key:
+                continue
+            for tier_idx, (_, in_tier) in enumerate(SEASON_TIERS):
+                found = {a for a, years in index.get(key, {}).items() if in_tier(years, season)}
+                if found:
+                    candidates |= found
+                    widest_tier = max(widest_tier, tier_idx)
+                    break
+        if not candidates:
             result.unmatched.append(UnresolvedPlayer(pff_id, obs_pairs))
+            continue
+
+        method = f"{MATCH_METHOD}+{SEASON_TIERS[widest_tier][0]}"
+        if len(candidates) > 1:
+            pff_firsts = {_name_tokens(name)[0] for name, _, _ in obs if _name_tokens(name)}
+            narrowed = {a for a in candidates if first_tokens[a] & pff_firsts}
+            # Report the first-name survivors when there are any (the
+            # useful list for hand review); an empty narrowing (nickname
+            # vs legal name) keeps the full set and never guesses.
+            if narrowed:
+                candidates = narrowed
+            if len(narrowed) == 1:
+                method += "+first_name"
+
+        if len(candidates) == 1:
+            result.matches.append(
+                {
+                    "pff_player_id": pff_id,
+                    "athlete_id": next(iter(candidates)),
+                    "match_method": method,
+                }
+            )
+        else:
+            result.ambiguous.append(UnresolvedPlayer(pff_id, obs_pairs, sorted(candidates)))
     return result
 
 

--- a/tests/test_pff_player_xwalk.py
+++ b/tests/test_pff_player_xwalk.py
@@ -1,7 +1,8 @@
 """Unit tests for scripts/build_pff_player_xwalk.py's pure matching core:
 suffix/particle normalization on both sides, last-name + first-initial +
-school matching, ambiguity handling (never guess), and transfer-observation
-union. No DB, no network -- the DB flow is exercised only by running the
+school matching, season-scoped candidate tiers, the first-name tiebreak,
+ambiguity handling (never guess), and transfer-observation union. No DB,
+no network -- the DB flow is exercised only by running the
 script for real against the warehouse.
 """
 
@@ -60,86 +61,138 @@ class TestNormalization:
         assert xwalk.roster_match_key("A", "", "Toledo") is None
 
 
+def _r(athlete_id, first, last, team, year=2024):
+    return {
+        "athlete_id": athlete_id,
+        "first_name": first,
+        "last_name": last,
+        "team": team,
+        "year": year,
+    }
+
+
+def _p(pff_id, player, school, season=2024):
+    return {"pff_player_id": pff_id, "player": player, "school": school, "season": season}
+
+
 class TestMatchPlayers:
     ROSTER = [
-        {"athlete_id": "1", "first_name": "Caden", "last_name": "Veltkamp", "team": "FAU-full"},
-        {"athlete_id": "2", "first_name": "Cameron", "last_name": "Fox Jr.", "team": "Toledo"},
-        {"athlete_id": "3", "first_name": "Chris", "last_name": "Smith", "team": "Duke"},
-        {"athlete_id": "4", "first_name": "Carl", "last_name": "Smith", "team": "Duke"},
+        _r("1", "Caden", "Veltkamp", "FAU-full"),
+        _r("2", "Cameron", "Fox Jr.", "Toledo"),
+        _r("3", "Chris", "Smith", "Duke"),
+        _r("4", "Carl", "Smith", "Duke"),
     ]
 
     def test_unique_match(self):
-        result = xwalk.match_players(
-            [{"pff_player_id": 10, "player": "Caden Veltkamp", "school": "FAU-full"}],
-            self.ROSTER,
-        )
+        result = xwalk.match_players([_p(10, "Caden Veltkamp", "FAU-full")], self.ROSTER)
         assert result.matches == [
             {
                 "pff_player_id": 10,
                 "athlete_id": "1",
-                "match_method": xwalk.MATCH_METHOD,
+                "match_method": f"{xwalk.MATCH_METHOD}+season",
             }
         ]
         assert result.ambiguous == [] and result.unmatched == []
 
     def test_suffix_mismatch_still_matches(self):
-        result = xwalk.match_players(
-            [{"pff_player_id": 11, "player": "Cameron Fox Jr.", "school": "Toledo"}],
-            self.ROSTER,
-        )
+        result = xwalk.match_players([_p(11, "Cameron Fox Jr.", "Toledo")], self.ROSTER)
         assert [m["athlete_id"] for m in result.matches] == ["2"]
 
-    def test_two_candidates_is_ambiguous_never_guessed(self):
-        # Chris Smith and Carl Smith, both Duke: same (school, C, SMITH) key.
-        result = xwalk.match_players(
-            [{"pff_player_id": 12, "player": "Chris Smith", "school": "Duke"}],
-            self.ROSTER,
-        )
+    def test_two_candidates_narrow_on_first_name(self):
+        # Chris Smith and Carl Smith, both Duke 2024: same (school, C, SMITH)
+        # key, but the full first-name token is unique.
+        result = xwalk.match_players([_p(12, "Chris Smith", "Duke")], self.ROSTER)
+        assert [m["athlete_id"] for m in result.matches] == ["3"]
+        assert result.matches[0]["match_method"] == f"{xwalk.MATCH_METHOD}+season+first_name"
+
+    def test_same_first_name_stays_ambiguous_never_guessed(self):
+        roster = self.ROSTER + [_r("5", "Chris", "Smith", "Duke")]
+        result = xwalk.match_players([_p(12, "Chris Smith", "Duke")], roster)
         assert result.matches == []
         assert len(result.ambiguous) == 1
+        assert result.ambiguous[0].candidates == ["3", "5"]
+
+    def test_nickname_first_name_keeps_all_candidates_ambiguous(self):
+        # PFF "Trey" vs legal first names: narrowing to zero survivors must
+        # not silently pick anyone.
+        result = xwalk.match_players([_p(12, "C.J. Smith", "Duke")], self.ROSTER)
+        assert result.matches == []
         assert result.ambiguous[0].candidates == ["3", "4"]
 
     def test_no_candidate_is_unmatched(self):
-        result = xwalk.match_players(
-            [{"pff_player_id": 13, "player": "Ghost Player", "school": "Toledo"}],
-            self.ROSTER,
-        )
+        result = xwalk.match_players([_p(13, "Ghost Player", "Toledo")], self.ROSTER)
         assert result.matches == [] and result.ambiguous == []
         assert result.unmatched[0].pff_player_id == 13
 
     def test_transfer_observations_union_to_one_athlete(self):
         # Same PFF id seen at two schools (transfer); the roster spans
         # seasons so the same athlete appears at both -> one candidate.
-        roster = self.ROSTER + [
-            {"athlete_id": "1", "first_name": "Caden", "last_name": "Veltkamp", "team": "WKU"},
-        ]
+        roster = self.ROSTER + [_r("1", "Caden", "Veltkamp", "WKU", 2025)]
         result = xwalk.match_players(
-            [
-                {"pff_player_id": 10, "player": "Caden Veltkamp", "school": "WKU"},
-                {"pff_player_id": 10, "player": "Caden Veltkamp", "school": "FAU-full"},
-            ],
+            [_p(10, "Caden Veltkamp", "WKU", 2025), _p(10, "Caden Veltkamp", "FAU-full", 2024)],
             roster,
         )
         assert [m["athlete_id"] for m in result.matches] == ["1"]
 
     def test_transfer_observations_with_conflicting_athletes_are_ambiguous(self):
-        roster = self.ROSTER + [
-            {"athlete_id": "9", "first_name": "Caden", "last_name": "Veltkamp", "team": "WKU"},
-        ]
+        roster = self.ROSTER + [_r("9", "Caden", "Veltkamp", "WKU")]
         result = xwalk.match_players(
-            [
-                {"pff_player_id": 10, "player": "Caden Veltkamp", "school": "WKU"},
-                {"pff_player_id": 10, "player": "Caden Veltkamp", "school": "FAU-full"},
-            ],
+            [_p(10, "Caden Veltkamp", "WKU"), _p(10, "Caden Veltkamp", "FAU-full")],
             roster,
         )
         assert result.matches == []
         assert result.ambiguous[0].candidates == ["1", "9"]
 
     def test_results_are_deterministically_ordered(self):
-        players = [
-            {"pff_player_id": 20, "player": "Ghost B", "school": "Toledo"},
-            {"pff_player_id": 13, "player": "Ghost A", "school": "Toledo"},
-        ]
+        players = [_p(20, "Ghost B", "Toledo"), _p(13, "Ghost A", "Toledo")]
         result = xwalk.match_players(players, self.ROSTER)
         assert [u.pff_player_id for u in result.unmatched] == [13, 20]
+
+
+class TestSeasonTiers:
+    """The 2026-09-04 finding: matching against every roster season since
+    2004 made 'J. Smith @ Kentucky' collide with two decades of J. Smiths.
+    Candidates are scoped to the PFF season first and only widen when the
+    tighter tier finds nobody."""
+
+    ROSTER = [
+        _r("old", "Jaden", "Smith", "Kentucky", 2009),
+        _r("new", "Jaden", "Smith", "Kentucky", 2024),
+    ]
+
+    def test_same_season_candidate_beats_a_decade_old_namesake(self):
+        result = xwalk.match_players([_p(1, "Jaden Smith", "Kentucky", 2024)], self.ROSTER)
+        assert [m["athlete_id"] for m in result.matches] == ["new"]
+        assert result.matches[0]["match_method"].endswith("+season")
+
+    def test_adjacent_season_fills_a_roster_gap(self):
+        # Rostered 2024 only, graded by PFF in 2023 (roster gap): +-1 tier.
+        result = xwalk.match_players([_p(1, "Jaden Smith", "Kentucky", 2023)], self.ROSTER)
+        assert [m["athlete_id"] for m in result.matches] == ["new"]
+        assert result.matches[0]["match_method"].endswith("+season+-1")
+
+    def test_any_season_is_the_last_resort(self):
+        roster = [_r("only", "Jaden", "Smith", "Kentucky", 2015)]
+        result = xwalk.match_players([_p(1, "Jaden Smith", "Kentucky", 2024)], roster)
+        assert [m["athlete_id"] for m in result.matches] == ["only"]
+        assert result.matches[0]["match_method"].endswith("+any_season")
+
+    def test_ambiguity_at_a_tight_tier_does_not_widen(self):
+        # Two same-season candidates with the same first name: stay
+        # ambiguous rather than pulling in more from wider tiers.
+        roster = self.ROSTER + [_r("new2", "Jaden", "Smith", "Kentucky", 2024)]
+        result = xwalk.match_players([_p(1, "Jaden Smith", "Kentucky", 2024)], roster)
+        assert result.matches == []
+        assert result.ambiguous[0].candidates == ["new", "new2"]
+
+    def test_multi_season_observations_scope_each_to_its_own_year(self):
+        roster = [
+            _r("a", "Jaden", "Smith", "Kentucky", 2023),
+            _r("a", "Jaden", "Smith", "Kentucky", 2024),
+        ]
+        result = xwalk.match_players(
+            [_p(1, "Jaden Smith", "Kentucky", 2023), _p(1, "Jaden Smith", "Kentucky", 2024)],
+            roster,
+        )
+        assert [m["athlete_id"] for m in result.matches] == ["a"]
+        assert len(result.matches[0]) == 3

--- a/tests/test_pff_player_xwalk.py
+++ b/tests/test_pff_player_xwalk.py
@@ -185,6 +185,33 @@ class TestSeasonTiers:
         assert result.matches == []
         assert result.ambiguous[0].candidates == ["new", "new2"]
 
+    def test_each_observation_resolves_its_own_tier_before_the_union(self):
+        # Codex/Greptile finding on PR #115: A/2024 hits athlete X at the
+        # exact season; B/2023 finds athlete Y only via the +-1 tier. The
+        # first observation's hit must not stop the second from looking, or
+        # X is written while a conflicting identity (Y) goes unreported.
+        roster = [
+            _r("X", "Jaden", "Smith", "A", 2024),
+            _r("Y", "Jaden", "Smith", "B", 2022),
+        ]
+        result = xwalk.match_players(
+            [_p(1, "Jaden Smith", "A", 2024), _p(1, "Jaden Smith", "B", 2023)], roster
+        )
+        assert result.matches == []
+        assert result.ambiguous[0].candidates == ["X", "Y"]
+
+    def test_transfer_with_one_gapped_roster_still_matches_when_same_athlete(self):
+        roster = [
+            _r("X", "Jaden", "Smith", "A", 2024),
+            _r("X", "Jaden", "Smith", "B", 2022),
+        ]
+        result = xwalk.match_players(
+            [_p(1, "Jaden Smith", "A", 2024), _p(1, "Jaden Smith", "B", 2023)], roster
+        )
+        assert [m["athlete_id"] for m in result.matches] == ["X"]
+        # The widest tier any observation needed is what gets recorded.
+        assert result.matches[0]["match_method"].endswith("+season+-1")
+
     def test_multi_season_observations_scope_each_to_its_own_year(self):
         roster = [
             _r("a", "Jaden", "Smith", "Kentucky", 2023),


### PR DESCRIPTION
## Summary
- Running the backfill handoff (2026-09-04) matched 16,218 of 18,375 distinct PFF players (88.3%) against the expected 96 to 99%. The misses were flat at 9 to 16% across every family, season, position, and team: the matcher indexed all roster seasons since 2004, so common surnames collided with decades of namesakes and were left ambiguous.
- `match_players` now tries roster candidates at the PFF season, then ±1 (roster gaps), then any season, widening only when a tier finds nobody. Within a tier, multiple candidates are narrowed on the full first-name token; a unique survivor matches, otherwise the id stays ambiguous (never guesses). `match_method` records the resolving tier.
- `_fetch_pff_players` carries `season`, `_fetch_roster` carries `year`; the report now breaks matches down by method.
- Tests rewritten for the new fixture shape plus a `TestSeasonTiers` class (same-season beats old namesake, ±1 fallback, any-season last resort, ambiguity does not widen, multi-season observations).

Targets the PFF branch, not main.

## Test plan
- [x] `ruff check`, `ruff format --check`, `pytest tests/test_pff_player_xwalk.py tests/test_flatfile_pff.py` (66 passed)
- [ ] `python scripts/build_pff_player_xwalk.py --rebuild` against production; expect mid-90s match rate with West Georgia and PFF "Unknown" placeholders as the residual

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The player crosswalk resolves season fallback tiers independently for each PFF observation before combining candidate identities. This prevents a same-season match for one observation from suppressing appropriate fallback matching for another observation of the same player.

<h3>Confidence Score: 5/5</h3>

Safe to merge.

The previously reported multi-observation fallback issue is fully addressed: each observation now resolves its tightest non-empty season tier independently before candidates are combined, matching the developer’s stated fix.

<sub>Reviews (2): Last reviewed commit: ["Resolve the crosswalk season tier per ob..."](https://github.com/rstover-fo/cfb-database/commit/7b5a66ebaceb95c5b6aa83ce9dd61e5ae1c4a0ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60603518)</sub>

<!-- /greptile_comment -->