### PR TITLE
F01: Fail incomplete box-score and roster loads with request context

### DIFF
--- a/docs/plans/2026-09-04-main-codebase-audit.md
+++ b/docs/plans/2026-09-04-main-codebase-audit.md
@@ -69,6 +69,8 @@ Evidence: [box-score loaders](https://github.com/rstover-fo/cfb-database/blob/4a
 
 **Acceptance:** inject 401, 403, exhausted 429, 5xx, timeout, malformed payload, and local quota exhaustion. None may produce an unqualified successful load. Expected no-data fixtures remain nonfatal and visible.
 
+**Implementation prepared — September 5, 2026:** the three affected resources now validate each response and propagate failures with endpoint/scope, original cause, and invocation-level request outcomes. The season summary and single/weekly/all-source CLI paths preserve failure status after earlier successes. Regression coverage includes the failure matrix, valid empty responses, request limits, client cleanup, and dlt wrapping; independent review also exercised actual offline `pipeline.extract`. Full offline validation passed (2,257 root tests, 447 skipped; 59 MCP tests). See [operational failure reporting](../warehouse-operations.md#box-score-and-roster-request-failures). Live rollout, historical gap detection, and corrective backfills remain unverified; this update does not claim those are complete.
+
 ### F02 — Weekly EPA omits the snapshot needed for upcoming games
 
 **P1 · Confirmed and reproduced · M**

--- a/docs/warehouse-operations.md
+++ b/docs/warehouse-operations.md
@@ -41,6 +41,31 @@ Secrets belong in ignored config or the host's credential mechanism, never docs.
 The request budget is configured in `.dlt/config.toml`; historical estimates do
 not establish the cost of today's source/resource selection.
 
+## Box-score and roster request failures
+
+The `/games/teams`, `/games/players`, and `/roster` loaders stop their resource
+when a request fails after the shared client's retries. A successful empty list
+is `expected_no_data`; HTTP errors (including 400/404), invalid JSON, invalid
+record lists, missing provider IDs, and local budget exhaustion are failures.
+These resources do not add a second retry loop.
+
+Each request logs a receipt with its endpoint, season/week or team/season,
+outcome, and fetched row count when available. A failure reports `succeeded`,
+`expected_no_data`, `failed`, and `deferred` request counts. `deferred` means
+requests left unattempted when this resource invocation stops. These are fetch
+outcomes for one invocation, not counts of committed rows or the entire job;
+weekly/year-batch loads may already have completed earlier invocations.
+
+`load_season()` retains this context in the failed source's `request_failure`
+summary field even when dlt wraps the original error. Both season and pipeline
+CLIs exit nonzero on source failure. An all-source run can continue independent
+sources, but its final status remains failed. Existing mart-refresh policy is
+unchanged; a failed load does not establish downstream freshness.
+
+Inspect the failed request and earlier load results before selecting a retry
+scope. Existing rows and an older successful run do not prove completeness.
+Historical gap detection and correction-aware backfills require separate work.
+
 ## Incident notes preserved from CLAUDE.md on 2026-09-04
 
 The following is a dated account of previous fixes and the behavior believed to

--- a/scripts/load_season.py
+++ b/scripts/load_season.py
@@ -19,6 +19,8 @@ import os
 import sys
 import time
 
+from src.pipelines.utils.request_outcomes import request_failure_summary
+
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
 
@@ -392,6 +394,15 @@ def _count_failures(results: dict) -> int:
     return sum(1 for r in results.values() if r["status"] != "ok")
 
 
+def _failure_result(error: Exception, elapsed: float) -> dict:
+    """Keep request context when dlt wraps a failed resource extraction."""
+    result = {"status": "error", "duration_s": round(elapsed, 1), "error": str(error)}
+    request_failure = request_failure_summary(error)
+    if request_failure is not None:
+        result["request_failure"] = request_failure
+    return result
+
+
 def load_season(
     season: int,
     sources: list[str] | None = None,
@@ -619,7 +630,7 @@ def load_season(
             logger.info(f"  {src} completed in {elapsed:.1f}s")
         except Exception as e:
             elapsed = time.time() - src_start
-            results[src] = {"status": "error", "duration_s": round(elapsed, 1), "error": str(e)}
+            results[src] = _failure_result(e, elapsed)
             logger.error(f"  {src} failed after {elapsed:.1f}s: {e}")
 
     # Off-season: keep the upcoming season's published schedule and betting
@@ -658,11 +669,7 @@ def load_season(
                 }
             except Exception as e:
                 elapsed = time.time() - src_start
-                results[name] = {
-                    "status": "error",
-                    "duration_s": round(elapsed, 1),
-                    "error": str(e),
-                }
+                results[name] = _failure_result(e, elapsed)
                 logger.error(f"  {name} failed after {elapsed:.1f}s: {e}")
 
     # Refresh marts

--- a/src/pipelines/run.py
+++ b/src/pipelines/run.py
@@ -1,6 +1,7 @@
 """CLI entry point for CFB database pipelines."""
 
 import argparse
+import json
 import logging
 import sys
 from typing import NoReturn
@@ -27,6 +28,7 @@ from .sources.rushing import rushing_source
 from .sources.stats import stats_source
 from .sources.wepa import wepa_source
 from .utils.rate_limiter import get_rate_limiter
+from .utils.request_outcomes import request_failure_summary
 
 logger = logging.getLogger(__name__)
 
@@ -1586,6 +1588,14 @@ def run_wepa_pipeline(years: list[int] | None = None, mode: str = "incremental")
     return info
 
 
+def _report_load_failure(name: str, error: Exception) -> None:
+    """Print the source failure and any contextual request receipt."""
+    print(f"ERROR in {name}: {error}")
+    request_failure = request_failure_summary(error)
+    if request_failure is not None:
+        print(f"  Request failure: {json.dumps(request_failure, sort_keys=True)}")
+
+
 def main() -> NoReturn:
     """Main entry point."""
     parser = create_parser()
@@ -1637,7 +1647,11 @@ def main() -> NoReturn:
         if not args.years:
             print("ERROR: --weekly requires --years")
             sys.exit(1)
-        run_game_stats_weekly(args.years, use_replace=args.replace)
+        try:
+            run_game_stats_weekly(args.years, use_replace=args.replace)
+        except Exception as e:
+            _report_load_failure("game_stats", e)
+            sys.exit(1)
         show_status()
         sys.exit(0)
 
@@ -1681,7 +1695,7 @@ def main() -> NoReturn:
             try:
                 runner()
             except Exception as e:
-                print(f"ERROR in {name}: {e}")
+                _report_load_failure(name, e)
                 failed.append(name)
                 continue
         if failed:
@@ -1691,7 +1705,11 @@ def main() -> NoReturn:
     else:
         runner = source_runners.get(args.source)
         if runner:
-            runner()
+            try:
+                runner()
+            except Exception as e:
+                _report_load_failure(args.source, e)
+                sys.exit(1)
         else:
             print(f"Unknown source: {args.source}")
             sys.exit(1)

--- a/src/pipelines/sources/base.py
+++ b/src/pipelines/sources/base.py
@@ -7,6 +7,10 @@ from ..utils.api_client import CFBDClient, get_client
 from ..utils.rate_limiter import get_rate_limiter
 
 
+class RequestBudgetExhausted(RuntimeError):
+    """The local monthly request budget cannot admit another API call."""
+
+
 def make_request(
     client: CFBDClient,
     endpoint: str,
@@ -25,7 +29,7 @@ def make_request(
     rate_limiter = get_rate_limiter()
 
     if not rate_limiter.check_budget():
-        raise RuntimeError(
+        raise RequestBudgetExhausted(
             f"API budget exhausted. {rate_limiter.calls_used} calls used this month. "
             "Wait for next month or upgrade tier."
         )

--- a/src/pipelines/sources/game_stats.py
+++ b/src/pipelines/sources/game_stats.py
@@ -12,7 +12,8 @@ import dlt
 from dlt.sources import DltSource
 
 from ..config.years import YEAR_RANGES, get_current_season
-from ..utils.api_client import RATE_LIMIT_ERRORS, get_client
+from ..utils.api_client import get_client
+from ..utils.request_outcomes import RequestOutcomeTracker, validate_record_list
 from .base import make_request
 
 logger = logging.getLogger(__name__)
@@ -75,37 +76,29 @@ def game_team_stats_resource(
     def _inner() -> Iterator[dict]:
         client = get_client()
         season_types = [season_type] if season_type else ["regular", "postseason"]
+        requests = []
+        for year in years:
+            for st in season_types:
+                week_range = weeks if weeks else range(1, (15 if st == "regular" else 5) + 1)
+                requests.extend(
+                    {"year": year, "seasonType": st, "week": week} for week in week_range
+                )
+        tracker = RequestOutcomeTracker("/games/teams", len(requests), logger)
         try:
-            for year in years:
-                for st in season_types:
-                    if weeks:
-                        week_range = weeks
-                    else:
-                        max_week = 15 if st == "regular" else 5
-                        week_range = list(range(1, max_week + 1))
-
-                    for week in week_range:
-                        logger.info(f"Loading game team stats: {year} {st} week {week}")
-                        try:
-                            data = make_request(
-                                client,
-                                "/games/teams",
-                                params={
-                                    "year": year,
-                                    "seasonType": st,
-                                    "week": week,
-                                },
-                            )
-                            yield from data
-                        except RATE_LIMIT_ERRORS:
-                            # A 429 is not "this week has no games". Swallowing
-                            # it here would complete the resource with silently
-                            # missing weeks -- the exact failure the rate-limit
-                            # exceptions exist to make loud.
-                            raise
-                        except Exception:
-                            # Some weeks may not have games (esp postseason)
-                            continue
+            for params in requests:
+                logger.info(
+                    "Loading game team stats: %s %s week %s",
+                    params["year"],
+                    params["seasonType"],
+                    params["week"],
+                )
+                try:
+                    data = make_request(client, "/games/teams", params=params)
+                    records = validate_record_list(data)
+                except Exception as error:
+                    raise tracker.failure(params, error) from error
+                tracker.record_response(params, records)
+                yield from records
         finally:
             client.close()
 
@@ -135,37 +128,29 @@ def game_player_stats_resource(
     def _inner() -> Iterator[dict]:
         client = get_client()
         season_types = [season_type] if season_type else ["regular", "postseason"]
+        requests = []
+        for year in years:
+            for st in season_types:
+                week_range = weeks if weeks else range(1, (15 if st == "regular" else 5) + 1)
+                requests.extend(
+                    {"year": year, "seasonType": st, "week": week} for week in week_range
+                )
+        tracker = RequestOutcomeTracker("/games/players", len(requests), logger)
         try:
-            for year in years:
-                for st in season_types:
-                    if weeks:
-                        week_range = weeks
-                    else:
-                        max_week = 15 if st == "regular" else 5
-                        week_range = list(range(1, max_week + 1))
-
-                    for week in week_range:
-                        logger.info(f"Loading game player stats: {year} {st} week {week}")
-                        try:
-                            data = make_request(
-                                client,
-                                "/games/players",
-                                params={
-                                    "year": year,
-                                    "seasonType": st,
-                                    "week": week,
-                                },
-                            )
-                            yield from data
-                        except RATE_LIMIT_ERRORS:
-                            # A 429 is not "this week has no games". Swallowing
-                            # it here would complete the resource with silently
-                            # missing weeks -- the exact failure the rate-limit
-                            # exceptions exist to make loud.
-                            raise
-                        except Exception:
-                            # Some weeks may not have games (esp postseason)
-                            continue
+            for params in requests:
+                logger.info(
+                    "Loading game player stats: %s %s week %s",
+                    params["year"],
+                    params["seasonType"],
+                    params["week"],
+                )
+                try:
+                    data = make_request(client, "/games/players", params=params)
+                    records = validate_record_list(data)
+                except Exception as error:
+                    raise tracker.failure(params, error) from error
+                tracker.record_response(params, records)
+                yield from records
         finally:
             client.close()
 

--- a/src/pipelines/sources/rosters.py
+++ b/src/pipelines/sources/rosters.py
@@ -10,7 +10,8 @@ import dlt
 from dlt.sources import DltSource
 
 from ..config.years import YEAR_RANGES, get_current_season
-from ..utils.api_client import RATE_LIMIT_ERRORS, get_client
+from ..utils.api_client import get_client
+from ..utils.request_outcomes import RequestOutcomeTracker, validate_record_list
 from .base import make_request
 
 logger = logging.getLogger(__name__)
@@ -72,29 +73,23 @@ def rosters_resource(
         Player roster records with team/year context added
     """
     client = get_client()
+    requests = [{"team": team, "year": year} for team in teams for year in years]
+    tracker = RequestOutcomeTracker("/roster", len(requests), logger)
     try:
-        for team in teams:
-            for year in years:
-                logger.info(f"Loading roster for {team} {year}...")
+        for params in requests:
+            logger.info("Loading roster for %s %s...", params["team"], params["year"])
+            try:
+                players = make_request(client, "/roster", params=params)
+                records = validate_record_list(players)
+            except Exception as error:
+                raise tracker.failure(params, error) from error
 
-                try:
-                    players = make_request(client, "/roster", params={"team": team, "year": year})
-
-                    for player in players:
-                        # Add context fields for PK and querying
-                        player["team"] = team
-                        player["year"] = year
-                        yield player
-
-                except RATE_LIMIT_ERRORS:
-                    # Demoting a 429 to a warning here yields a roster that is
-                    # quietly missing teams, which poisons every roster-derived
-                    # feature (continuity, trench counts) without any signal
-                    # that it happened. Fail the load instead.
-                    raise
-                except Exception as e:
-                    logger.warning(f"Error fetching roster for {team} {year}: {e}")
-                    continue
+            tracker.record_response(params, records)
+            for player in records:
+                # Add context fields for PK and querying
+                player["team"] = params["team"]
+                player["year"] = params["year"]
+                yield player
 
     finally:
         client.close()

--- a/src/pipelines/utils/request_outcomes.py
+++ b/src/pipelines/utils/request_outcomes.py
@@ -1,0 +1,144 @@
+"""Request-level outcomes for bounded CFBD resource invocations."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+
+class ResponseValidationError(ValueError):
+    """A successful HTTP response did not contain the resource's required shape."""
+
+
+class SourceRequestError(Exception):
+    """A failed request with the progress of its current resource invocation."""
+
+    def __init__(
+        self,
+        endpoint: str,
+        params: Mapping[str, Any],
+        error: BaseException,
+        counts: Mapping[str, int],
+    ) -> None:
+        self.endpoint = endpoint
+        self.params = dict(params)
+        self.error_type = type(error).__name__
+        self.counts = dict(counts)
+        counts_text = ", ".join(f"{name}={count}" for name, count in self.counts.items())
+        super().__init__(
+            f"CFBD request failed for endpoint={endpoint} params={self.params}; "
+            "fetched request outcomes for this resource invocation: "
+            f"{counts_text}; error_type={self.error_type}: {error}"
+        )
+
+    def to_summary(self) -> dict[str, Any]:
+        """Return a JSON-serializable failure summary for the job boundary."""
+        return {
+            "endpoint": self.endpoint,
+            "params": dict(self.params),
+            "outcome": "failed",
+            "error_type": self.error_type,
+            "counts_scope": "resource_invocation",
+            "counts_unit": "requests",
+            "counts": dict(self.counts),
+        }
+
+
+def request_failure_summary(error: BaseException) -> dict[str, Any] | None:
+    """Find a request failure summary anywhere in an exception chain."""
+    pending: list[BaseException] = [error]
+    seen: set[int] = set()
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        if isinstance(current, SourceRequestError):
+            return current.to_summary()
+        if current.__context__ is not None:
+            pending.append(current.__context__)
+        if current.__cause__ is not None:
+            pending.append(current.__cause__)
+    return None
+
+
+class RequestOutcomeTracker:
+    """Track fetched request outcomes within one bounded resource invocation."""
+
+    def __init__(self, endpoint: str, planned_requests: int, logger: logging.Logger) -> None:
+        if planned_requests < 0:
+            raise ValueError("planned_requests must be non-negative")
+        self.endpoint = endpoint
+        self.planned_requests = planned_requests
+        self.logger = logger
+        self._succeeded = 0
+        self._expected_no_data = 0
+        self._failed = 0
+
+    def record_response(self, params: Mapping[str, Any], records: list[dict]) -> None:
+        """Record a validated response as successful data or expected no-data."""
+        if records:
+            self._succeeded += 1
+            outcome = "succeeded"
+        else:
+            self._expected_no_data += 1
+            outcome = "expected_no_data"
+        self.logger.info(
+            "CFBD request receipt outcome=%s endpoint=%s params=%s fetched_rows=%d "
+            "resource_invocation_progress=%s",
+            outcome,
+            self.endpoint,
+            dict(params),
+            len(records),
+            self._progress(),
+        )
+
+    def failure(self, params: Mapping[str, Any], error: BaseException) -> SourceRequestError:
+        """Record one failed request and return its contextual wrapper."""
+        self._failed += 1
+        counts = self._counts()
+        self.logger.error(
+            "CFBD request receipt outcome=failed endpoint=%s params=%s error_type=%s "
+            "resource_invocation_counts=%s; counts describe fetched requests, not loaded rows",
+            self.endpoint,
+            dict(params),
+            type(error).__name__,
+            counts,
+        )
+        return SourceRequestError(self.endpoint, params, error, counts)
+
+    def _counts(self) -> dict[str, int]:
+        attempted = self._succeeded + self._expected_no_data + self._failed
+        return {
+            "succeeded": self._succeeded,
+            "expected_no_data": self._expected_no_data,
+            "failed": self._failed,
+            "deferred": max(0, self.planned_requests - attempted),
+        }
+
+    def _progress(self) -> dict[str, int]:
+        attempted = self._succeeded + self._expected_no_data + self._failed
+        return {
+            "succeeded": self._succeeded,
+            "expected_no_data": self._expected_no_data,
+            "failed": self._failed,
+            "pending": max(0, self.planned_requests - attempted),
+        }
+
+
+def validate_record_list(data: object, required_id: str = "id") -> list[dict]:
+    """Validate a complete request payload before any of its rows are yielded."""
+    if not isinstance(data, list):
+        raise ResponseValidationError(f"expected a list of records, got {type(data).__name__}")
+
+    for index, record in enumerate(data):
+        if not isinstance(record, dict):
+            raise ResponseValidationError(
+                f"expected record {index} to be a dict, got {type(record).__name__}"
+            )
+        if required_id not in record or record[required_id] is None:
+            raise ResponseValidationError(
+                f"record {index} is missing required non-null provider id {required_id!r}"
+            )
+    return data

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -703,18 +703,8 @@ class TestCircuitIsTerminalButResettable:
         client.close()
 
 
-class TestBroadExceptHandlersDoNotSwallowRateLimits:
-    """Found by the pre-PR adversarial pass on the Codex fixes.
-
-    Three source loops caught bare `Exception` and continued -- game_stats'
-    two week loops (to skip weeks with no games) and rosters' per-team loop.
-    Those handlers swallowed RateLimitExhausted and RateLimitCircuitOpen too,
-    so a quota-exhausted load would spin through every remaining week/team and
-    complete "successfully" with silently missing data: the exact bug raising
-    instead of returning `[]` was meant to eliminate, reintroduced one layer
-    up. For rosters it is worse than lost rows -- a partial roster poisons
-    every roster-derived feature with no signal that it happened.
-    """
+class TestResourceHandlersPropagateFailures:
+    """Resource wrappers must preserve the client's explicit failure causes."""
 
     @staticmethod
     def _rate_limited_client():
@@ -783,10 +773,12 @@ class TestBroadExceptHandlersDoNotSwallowRateLimits:
             patcher.stop()
             client.close()
 
-    def test_non_rate_limit_errors_are_still_skipped(self):
-        """The skip behaviour these handlers exist for must survive: a week
-        with no games still yields nothing rather than failing the load."""
+    def test_non_rate_limit_errors_are_contextual_failures(self):
+        """A provider 400 is not evidence that a week has no games."""
+        from dlt.extract.exceptions import ResourceExtractionError
+
         from src.pipelines.sources.game_stats import game_team_stats_resource
+        from src.pipelines.utils.request_outcomes import request_failure_summary
 
         client = CFBDClient(api_key="test-key")
         boom = MagicMock()
@@ -796,6 +788,21 @@ class TestBroadExceptHandlersDoNotSwallowRateLimits:
             with patch.object(client._client, "get", side_effect=err):
                 with patch("src.pipelines.sources.game_stats.get_client", return_value=client):
                     res = game_team_stats_resource([2026], season_type="regular", weeks=[1, 2])
-                    assert list(res) == []
+                    with pytest.raises(ResourceExtractionError) as exc_info:
+                        list(res)
+            assert request_failure_summary(exc_info.value) == {
+                "endpoint": "/games/teams",
+                "params": {"year": 2026, "seasonType": "regular", "week": 1},
+                "outcome": "failed",
+                "error_type": "HTTPStatusError",
+                "counts_scope": "resource_invocation",
+                "counts_unit": "requests",
+                "counts": {
+                    "succeeded": 0,
+                    "expected_no_data": 0,
+                    "failed": 1,
+                    "deferred": 1,
+                },
+            }
         finally:
             client.close()

--- a/tests/test_loader_failure_reporting.py
+++ b/tests/test_loader_failure_reporting.py
@@ -1,0 +1,216 @@
+"""Exercise real dlt resource extraction through offline orchestration fakes."""
+
+import json
+from unittest.mock import Mock
+
+import httpx
+import pytest
+
+from scripts import load_season as season_loader
+from src.pipelines import run
+from src.pipelines.sources import game_stats, rosters
+
+
+class ExtractingPipeline:
+    """Run dlt resource iterators, without normalizing or writing a database."""
+
+    def __init__(self):
+        self.completed = []
+        self.failures = []
+
+    def run(self, source):
+        rows = []
+        try:
+            for resource in source.selected_resources.values():
+                rows.extend(list(resource))
+        except Exception as error:
+            self.failures.append(error)
+            raise RuntimeError("Pipeline extraction failed") from error
+        self.completed.append(rows)
+        return "extraction completed (test fake; no database writes)"
+
+
+@pytest.fixture
+def runtime(monkeypatch):
+    pipeline = ExtractingPipeline()
+    monkeypatch.setattr(run.dlt, "pipeline", Mock(return_value=pipeline))
+    limiter = Mock()
+    limiter.check_budget.return_value = True
+    limiter.get_status.return_value = {"remaining": 100_000}
+    monkeypatch.setattr(run, "get_rate_limiter", lambda: limiter)
+    monkeypatch.setattr("src.pipelines.utils.rate_limiter.get_rate_limiter", lambda: limiter)
+    monkeypatch.setattr(run, "show_status", Mock())
+    monkeypatch.setattr(game_stats, "get_client", Mock())
+    monkeypatch.setattr(rosters, "get_client", Mock())
+    return pipeline
+
+
+def failing_request(monkeypatch, source, *, year=None):
+    """One good request, then a 401; a third request must never be attempted."""
+    error = httpx.HTTPStatusError(
+        "Unauthorized",
+        request=httpx.Request("GET", "https://example.invalid/cfbd"),
+        response=httpx.Response(401),
+    )
+
+    def request(client, endpoint, params):
+        should_fail = (
+            params["year"] == year
+            if year is not None
+            else params.get("week") == 2 or params.get("team") == "Georgia"
+        )
+        if should_fail:
+            raise error
+        return [{"id": 123, "teams": []}]
+
+    fake = Mock(side_effect=request)
+    monkeypatch.setattr(source, "make_request", fake)
+    return fake
+
+
+@pytest.mark.parametrize("source_name", ["game_stats", "rosters"])
+def test_season_summary_keeps_failure_context_after_dlt_wraps_it(
+    source_name, runtime, monkeypatch, capsys
+):
+    source = game_stats if source_name == "game_stats" else rosters
+    request = failing_request(monkeypatch, source)
+    if source_name == "rosters":
+        actual_runner = run.run_rosters_pipeline
+        monkeypatch.setattr(
+            run,
+            "run_rosters_pipeline",
+            lambda years: actual_runner(teams=["Alabama", "Georgia", "Texas"], years=years),
+        )
+
+    summary = season_loader.load_season(2026, sources=[source_name], skip_refresh=True)
+
+    assert summary["successes"] == 0
+    assert summary["errors"] == 1
+    result = summary["results"][source_name]
+    assert result["status"] == "error"
+    receipt = result["request_failure"]
+    assert receipt["outcome"] == "failed"
+    assert receipt["error_type"] == "HTTPStatusError"
+    assert receipt["params"]["year"] == 2026
+    assert receipt["counts"] == {
+        "succeeded": 1,
+        "expected_no_data": 0,
+        "failed": 1,
+        "deferred": 18 if source_name == "game_stats" else 1,
+    }
+    assert receipt["endpoint"] == ("/games/teams" if source_name == "game_stats" else "/roster")
+    json.dumps(summary)  # The full summary remains suitable for a run artifact.
+    assert request.call_count == 2
+    assert runtime.completed == []
+    assert "ResourceExtractionError" == type(runtime.failures[0]).__name__
+    assert "[FAIL]" in capsys.readouterr().out
+
+
+def test_season_continues_independent_sources_but_exits_nonzero(runtime, monkeypatch, capsys):
+    failing_request(monkeypatch, game_stats)
+    ratings = Mock(return_value="ratings completed")
+    monkeypatch.setattr(run, "run_ratings_pipeline", ratings)
+    monkeypatch.setattr(
+        "sys.argv",
+        ["load_season.py", "--season", "2026", "--sources", "game_stats,ratings", "--skip-refresh"],
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        season_loader.main()
+
+    assert exit_info.value.code == 1
+    ratings.assert_called_once_with(years=[2026])
+    output = capsys.readouterr().out
+    assert "1 succeeded, 1 failed" in output
+    assert "[FAIL] game_stats" in output
+
+
+@pytest.mark.parametrize("weekly", [False, True])
+def test_pipeline_cli_returns_failure_with_request_context(runtime, monkeypatch, capsys, weekly):
+    failing_request(monkeypatch, game_stats)
+    args = ["cfb-pipeline", "--source", "game_stats", "--years", "2026"]
+    if weekly:
+        args.append("--weekly")
+    monkeypatch.setattr("sys.argv", args)
+
+    with pytest.raises(SystemExit) as exit_info:
+        run.main()
+
+    assert exit_info.value.code == 1
+    output = capsys.readouterr().out
+    assert "ERROR in game_stats" in output
+    assert '"endpoint": "/games/teams"' in output
+    assert '"week": 2' in output
+    if weekly:
+        # Week one finished both resources. Week two still fails the whole command.
+        assert len(runtime.completed) == 1
+        assert "Weekly loading complete" not in output
+
+
+def test_all_sources_cli_carries_one_resource_failure_to_exit(runtime, monkeypatch, capsys):
+    failing_request(monkeypatch, game_stats)
+    other_runners = []
+    for name in list(vars(run)):
+        if name.startswith("run_") and name not in {
+            "run_game_stats_pipeline",
+            "run_game_stats_weekly",
+        }:
+            fake = Mock(return_value="independent source completed")
+            monkeypatch.setattr(run, name, fake)
+            other_runners.append(fake)
+    monkeypatch.setattr("sys.argv", ["cfb-pipeline", "--source", "all", "--years", "2026"])
+
+    with pytest.raises(SystemExit) as exit_info:
+        run.main()
+
+    assert exit_info.value.code == 1
+    assert all(fake.called for fake in other_runners)
+    output = capsys.readouterr().out
+    assert "sources failed: game_stats" in output
+    assert '"outcome": "failed"' in output
+
+
+def test_batched_cli_cannot_hide_failure_after_an_earlier_batch(runtime, monkeypatch, capsys):
+    failing_request(monkeypatch, game_stats, year=2025)
+    monkeypatch.setattr(
+        "sys.argv",
+        ["cfb-pipeline", "--source", "game_stats", "--years", "2024", "2025", "--batch-size", "1"],
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        run.main()
+
+    assert exit_info.value.code == 1
+    assert len(runtime.completed) == 1
+    output = capsys.readouterr().out
+    assert '"year": 2025' in output
+    assert "All 2 batches complete" not in output
+
+
+def test_empty_responses_remain_successful_through_season_cli(runtime, monkeypatch, capsys):
+    empty = Mock(return_value=[])
+    monkeypatch.setattr(game_stats, "make_request", empty)
+    monkeypatch.setattr(
+        "sys.argv",
+        ["load_season.py", "--season", "2026", "--sources", "game_stats", "--skip-refresh"],
+    )
+
+    assert season_loader.main() is None
+
+    assert len(runtime.completed) == 1
+    assert empty.call_count == 40  # Two resources, each with 15 regular + 5 postseason weeks.
+    assert "1 succeeded, 0 failed" in capsys.readouterr().out
+
+
+def test_unrelated_runner_errors_keep_existing_summary_shape(runtime, monkeypatch):
+    monkeypatch.setattr(
+        run, "run_ratings_pipeline", Mock(side_effect=ValueError("bad configuration"))
+    )
+
+    summary = season_loader.load_season(2026, sources=["ratings"], skip_refresh=True)
+
+    result = summary["results"]["ratings"]
+    assert result["status"] == "error"
+    assert result["error"] == "bad configuration"
+    assert "request_failure" not in result
+    assert summary["errors"] == 1

--- a/tests/test_sources/test_request_failures.py
+++ b/tests/test_sources/test_request_failures.py
@@ -1,0 +1,314 @@
+"""Failure outcomes for bounded game-stat and roster request loops."""
+
+import json
+import logging
+from collections.abc import Callable
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from dlt.extract.exceptions import ResourceExtractionError
+
+from src.pipelines.sources.base import RequestBudgetExhausted, make_request
+from src.pipelines.sources.game_stats import (
+    game_player_stats_resource,
+    game_team_stats_resource,
+)
+from src.pipelines.sources.rosters import rosters_resource
+from src.pipelines.utils.api_client import RateLimitCircuitOpen, RateLimitExhausted
+from src.pipelines.utils.request_outcomes import (
+    ResponseValidationError,
+    SourceRequestError,
+    request_failure_summary,
+)
+
+ResourceFactory = Callable[[], object]
+
+
+def _game_team_resource():
+    return game_team_stats_resource([2026], season_type="regular", weeks=[1, 2, 3])
+
+
+def _game_player_resource():
+    return game_player_stats_resource([2026], season_type="regular", weeks=[1, 2, 3])
+
+
+def _roster_resource():
+    return rosters_resource(teams=["Alabama", "Georgia", "Texas"], years=[2026])
+
+
+RESOURCE_CASES = [
+    pytest.param(
+        "src.pipelines.sources.game_stats",
+        _game_team_resource,
+        "/games/teams",
+        {"year": 2026, "seasonType": "regular", "week": 1},
+        id="game-team-stats",
+    ),
+    pytest.param(
+        "src.pipelines.sources.game_stats",
+        _game_player_resource,
+        "/games/players",
+        {"year": 2026, "seasonType": "regular", "week": 1},
+        id="game-player-stats",
+    ),
+    pytest.param(
+        "src.pipelines.sources.rosters",
+        _roster_resource,
+        "/roster",
+        {"team": "Alabama", "year": 2026},
+        id="rosters",
+    ),
+]
+
+
+def _http_error(status_code: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("GET", "https://example.test/resource")
+    response = httpx.Response(status_code, request=request)
+    return httpx.HTTPStatusError(str(status_code), request=request, response=response)
+
+
+def _failure(kind: str) -> BaseException:
+    if kind.isdigit():
+        return _http_error(int(kind))
+    if kind == "exhausted-429":
+        return RateLimitExhausted("rate limited on every attempt")
+    if kind == "open-breaker":
+        return RateLimitCircuitOpen("rate limit circuit is open")
+    if kind == "timeout":
+        return httpx.ReadTimeout(
+            "read timed out",
+            request=httpx.Request("GET", "https://example.test/resource"),
+        )
+    if kind == "invalid-json":
+        return json.JSONDecodeError("invalid JSON", "<html>", 0)
+    if kind == "local-budget":
+        return RequestBudgetExhausted("API budget exhausted")
+    raise AssertionError(f"unknown failure kind: {kind}")
+
+
+def _chain(error: BaseException) -> list[BaseException]:
+    causes = []
+    seen = set()
+    current: BaseException | None = error
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        causes.append(current)
+        current = current.__cause__ or current.__context__
+    return causes
+
+
+@pytest.mark.parametrize("module,resource_factory,endpoint,params", RESOURCE_CASES)
+@pytest.mark.parametrize(
+    "failure_kind",
+    [
+        "400",
+        "401",
+        "403",
+        "404",
+        "500",
+        "exhausted-429",
+        "open-breaker",
+        "timeout",
+        "invalid-json",
+        "local-budget",
+    ],
+)
+def test_request_failures_stop_the_bounded_resource_and_preserve_the_cause(
+    module: str,
+    resource_factory: ResourceFactory,
+    endpoint: str,
+    params: dict,
+    failure_kind: str,
+):
+    client = MagicMock()
+    original = _failure(failure_kind)
+
+    with (
+        patch(f"{module}.get_client", return_value=client),
+        patch(f"{module}.make_request", side_effect=original) as request,
+        pytest.raises(ResourceExtractionError) as exc_info,
+    ):
+        list(resource_factory())
+
+    summary = request_failure_summary(exc_info.value)
+    assert summary == {
+        "endpoint": endpoint,
+        "params": params,
+        "outcome": "failed",
+        "error_type": type(original).__name__,
+        "counts_scope": "resource_invocation",
+        "counts_unit": "requests",
+        "counts": {"succeeded": 0, "expected_no_data": 0, "failed": 1, "deferred": 2},
+    }
+    assert original in _chain(exc_info.value)
+    assert request.call_count == 1
+    client.close.assert_called_once_with()
+    json.dumps(summary)
+
+
+@pytest.mark.parametrize("module,resource_factory,endpoint,_params", RESOURCE_CASES)
+def test_successful_empty_responses_are_visible_expected_no_data(
+    module: str,
+    resource_factory: ResourceFactory,
+    endpoint: str,
+    _params: dict,
+    caplog: pytest.LogCaptureFixture,
+):
+    client = MagicMock()
+    with (
+        patch(f"{module}.get_client", return_value=client),
+        patch(f"{module}.make_request", return_value=[]) as request,
+        caplog.at_level(logging.INFO),
+    ):
+        assert list(resource_factory()) == []
+
+    assert request.call_count == 3
+    assert caplog.text.count(f"outcome=expected_no_data endpoint={endpoint}") == 3
+    client.close.assert_called_once_with()
+
+
+@pytest.mark.parametrize("module,resource_factory,endpoint,_params", RESOURCE_CASES)
+def test_success_receipts_describe_fetched_requests(
+    module: str,
+    resource_factory: ResourceFactory,
+    endpoint: str,
+    _params: dict,
+    caplog: pytest.LogCaptureFixture,
+):
+    client = MagicMock()
+    with (
+        patch(f"{module}.get_client", return_value=client),
+        patch(f"{module}.make_request", return_value=[{"id": 0, "optional": None}]),
+        caplog.at_level(logging.INFO),
+    ):
+        rows = list(resource_factory())
+
+    assert len(rows) == 3
+    assert caplog.text.count(f"outcome=succeeded endpoint={endpoint}") == 3
+    assert "fetched_rows=1" in caplog.text
+    client.close.assert_called_once_with()
+
+
+@pytest.mark.parametrize("module,resource_factory,endpoint,first_params", RESOURCE_CASES)
+def test_success_then_failure_reports_prior_fetch_and_deferred_requests(
+    module: str,
+    resource_factory: ResourceFactory,
+    endpoint: str,
+    first_params: dict,
+):
+    client = MagicMock()
+    original = _http_error(503)
+    with (
+        patch(f"{module}.get_client", return_value=client),
+        patch(
+            f"{module}.make_request",
+            side_effect=[[{"id": 17, "extra": "accepted"}], original],
+        ) as request,
+    ):
+        iterator = iter(resource_factory())
+        assert next(iterator)["id"] == 17
+        with pytest.raises(ResourceExtractionError) as exc_info:
+            next(iterator)
+
+    summary = request_failure_summary(exc_info.value)
+    assert summary is not None
+    assert summary["endpoint"] == endpoint
+    assert summary["params"] != first_params
+    assert summary["counts"] == {
+        "succeeded": 1,
+        "expected_no_data": 0,
+        "failed": 1,
+        "deferred": 1,
+    }
+    assert request.call_count == 2
+    assert original in _chain(exc_info.value)
+    client.close.assert_called_once_with()
+
+
+@pytest.mark.parametrize("module,resource_factory,_endpoint,_params", RESOURCE_CASES)
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param({"id": 1}, id="object-instead-of-list"),
+        pytest.param([{"id": 1}, "bad record"], id="non-dict-record"),
+        pytest.param([{"name": "missing"}], id="missing-id"),
+        pytest.param([{"id": None}], id="null-id"),
+    ],
+)
+def test_invalid_response_is_rejected_before_any_row_is_yielded(
+    module: str,
+    resource_factory: ResourceFactory,
+    _endpoint: str,
+    _params: dict,
+    payload: object,
+):
+    client = MagicMock()
+    with (
+        patch(f"{module}.get_client", return_value=client),
+        patch(f"{module}.make_request", return_value=payload) as request,
+    ):
+        iterator = iter(resource_factory())
+        with pytest.raises(ResourceExtractionError) as exc_info:
+            next(iterator)
+
+    summary = request_failure_summary(exc_info.value)
+    assert summary is not None
+    assert summary["error_type"] == "ResponseValidationError"
+    assert summary["counts"] == {
+        "succeeded": 0,
+        "expected_no_data": 0,
+        "failed": 1,
+        "deferred": 2,
+    }
+    assert any(isinstance(error, ResponseValidationError) for error in _chain(exc_info.value))
+    assert request.call_count == 1
+    client.close.assert_called_once_with()
+
+
+def test_local_budget_exhaustion_has_a_stable_typed_classification():
+    limiter = MagicMock()
+    limiter.check_budget.return_value = False
+    limiter.calls_used = 125_000
+    with (
+        patch("src.pipelines.sources.base.get_rate_limiter", return_value=limiter),
+        pytest.raises(RequestBudgetExhausted, match="API budget exhausted"),
+    ):
+        make_request(MagicMock(), "/roster", {"team": "Alabama", "year": 2026})
+
+
+def test_request_failure_summary_traverses_wrappers_and_guards_cycles():
+    original = RateLimitExhausted("spent")
+    request_error = SourceRequestError(
+        "/roster",
+        {"team": "Alabama", "year": 2026},
+        original,
+        {"succeeded": 0, "expected_no_data": 0, "failed": 1, "deferred": 1},
+    )
+    request_error.__cause__ = original
+    outer = RuntimeError("dlt wrapper")
+    outer.__cause__ = request_error
+    assert request_failure_summary(outer) == request_error.to_summary()
+
+    cycle = RuntimeError("cycle")
+    cycle.__cause__ = cycle
+    assert request_failure_summary(cycle) is None
+
+
+def test_resource_contracts_keep_existing_merge_keys_and_roster_table():
+    game_team = game_team_stats_resource([2026], weeks=[1])
+    game_player = game_player_stats_resource([2026], weeks=[1])
+    game_team_schema = game_team.compute_table_schema()
+    game_player_schema = game_player.compute_table_schema()
+    roster_schema = rosters_resource.compute_table_schema()
+    assert game_team.write_disposition == "merge"
+    assert game_team_schema["columns"]["id"]["primary_key"] is True
+    assert game_player.write_disposition == "merge"
+    assert game_player_schema["columns"]["id"]["primary_key"] is True
+    assert rosters_resource.table_name == "roster"
+    assert rosters_resource.write_disposition == "merge"
+    assert {name for name, column in roster_schema["columns"].items() if column["primary_key"]} == {
+        "id",
+        "team",
+        "year",
+    }


### PR DESCRIPTION
## Problem and behavior

The team/player box-score and roster resources caught general exceptions and continued. For example, a successful first week followed by an exhausted timeout or HTTP 401 could finish as an apparently successful load with missing data. The previous regression test explicitly permitted silently skipping HTTP 400.

These resources now stop on request or payload failure and preserve the original cause through dlt. A valid empty list remains a visible, nonfatal `expected_no_data` outcome. The shared client's retry behavior, resource merge keys, and `core.roster` destination remain intact.

## Changes

- Validate the complete response as a list of records with non-null provider IDs before yielding any rows for that request. Add a typed local-budget exception compatible with RuntimeError.
- Record contextual request receipts and a failure summary containing endpoint, parameters, cause type, and succeeded/empty/failed/deferred counts. Counts cover fetch outcomes in the current resource invocation, not committed rows or the entire run.
- Retain request context in season results and print it in pipeline CLI errors. Single-source, weekly, batched, and all-source runs fail after an incomplete load even when earlier work succeeded; all-source runs can still complete independent sources.
- Document operational interpretation and record the F01 implementation checkpoint in the audit plan.

## Validation

- Full offline root suite: **2,257 passed / 447 skipped**. MCP suite: **59 passed**. Ruff lint and formatting passed across 165 Python files; Git whitespace checks passed.
- Regression matrix covers 400/401/403/404, exhausted 429/circuit breaker, 5xx, timeout, invalid JSON, invalid record shape/IDs, and local budget exhaustion; also verifies legitimate empty responses, bounded requests, client cleanup, and successful work followed by failure.
- Independent GPT-6 Astra review found no actionable defects. A separate actual offline dlt extraction verified `PipelineStepFailed → ResourceExtractionError → SourceRequestError → original failure`, diagnostic context, and client cleanup. Implementation used the configured GPT-5.6 Sol role with lead-owned runner integration.

## Operational limits

No live CFBD calls, database writes, or historical backfills were performed. Earlier weekly/year-batch invocations may already have loaded data before a later failure; request counts do not imply rollback or atomicity. Existing mart-refresh policy remains unchanged. Historical gap detection and correction-aware reloads remain separate follow-up work.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change makes box-score and roster loads report request failures with useful context while continuing to accept valid empty responses. The checked endpoint response shapes remain compatible with the added record validation, and no merge-blocking issues were found.

<h3>Confidence Score: 5/5</h3>

Safe to merge: no actionable issues were found in the reviewed change.

The checked request-validation behavior accepted documented non-empty records and valid empty responses for all three affected endpoints.

**Files Needing Attention:** None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- - The test harness is configured to run with import shims and patched get\_client and make\_request, so it performs no network calls or writes.
- - T-Rex verified that validate\_record\_list(data, required\_id='id') is invoked in src/pipelines/sources/game\_stats.py and src/pipelines/sources/rosters.py, and that it accepts lists while requiring a non-null top-level id for non-empty records.
- - The post-change execution capture shows all endpoints returning 200 OK with mocked documented responses accepted and mocked valid empty-list responses accepted.

<a href="https://app.greptile.com/trex/runs/22697842/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Fail incomplete box-score and roster loa..."](https://github.com/rstover-fo/cfb-database/commit/cd287463a7288b089379f432674aacc3246130b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60776424)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [College football data ingestion](https://app.greptile.com/formentera-operations/-/custom-context/knowledge-base/rstover-fo/cfb-database/-/docs/data-ingestion.md)
- Knowledge Base — [CFBD source loading](https://app.greptile.com/formentera-operations/-/custom-context/knowledge-base/rstover-fo/cfb-database/-/docs/cfbd-source-loading.md)
- Knowledge Base — [Fail loudly on rate limits](https://app.greptile.com/formentera-operations/-/custom-context/knowledge-base/rstover-fo/cfb-database/-/reverts/incident-mitigation_49-20260725-silent-rate-limit-data-loss-d3c69c3.md)
</details>


<!-- /greptile_comment -->