### PR TITLE
F01: Preserve HTTP status in request failure summaries

### DIFF
--- a/docs/warehouse-operations.md
+++ b/docs/warehouse-operations.md
@@ -57,9 +57,12 @@ outcomes for one invocation, not counts of committed rows or the entire job;
 weekly/year-batch loads may already have completed earlier invocations.
 
 `load_season()` retains this context in the failed source's `request_failure`
-summary field even when dlt wraps the original error. Both season and pipeline
-CLIs exit nonzero on source failure. An all-source run can continue independent
-sources, but its final status remains failed. Existing mart-refresh policy is
+summary field even when dlt wraps the original error. The summary's `http_status`
+is the response code for `HTTPStatusError`, or `null` for other error types.
+Rate-limit exhaustion and circuit-open failures retain their distinct `error_type`.
+Both season and pipeline CLIs exit nonzero on source failure. An all-source run
+can continue independent sources, but its final status remains failed. Existing
+mart-refresh policy is
 unchanged; a failed load does not establish downstream freshness.
 
 Inspect the failed request and earlier load results before selecting a retry

--- a/src/pipelines/utils/request_outcomes.py
+++ b/src/pipelines/utils/request_outcomes.py
@@ -6,6 +6,8 @@ import logging
 from collections.abc import Mapping
 from typing import Any
 
+import httpx
+
 
 class ResponseValidationError(ValueError):
     """A successful HTTP response did not contain the resource's required shape."""
@@ -24,6 +26,9 @@ class SourceRequestError(Exception):
         self.endpoint = endpoint
         self.params = dict(params)
         self.error_type = type(error).__name__
+        self.http_status = (
+            error.response.status_code if isinstance(error, httpx.HTTPStatusError) else None
+        )
         self.counts = dict(counts)
         counts_text = ", ".join(f"{name}={count}" for name, count in self.counts.items())
         super().__init__(
@@ -39,6 +44,7 @@ class SourceRequestError(Exception):
             "params": dict(self.params),
             "outcome": "failed",
             "error_type": self.error_type,
+            "http_status": self.http_status,
             "counts_scope": "resource_invocation",
             "counts_unit": "requests",
             "counts": dict(self.counts),

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -795,6 +795,7 @@ class TestResourceHandlersPropagateFailures:
                 "params": {"year": 2026, "seasonType": "regular", "week": 1},
                 "outcome": "failed",
                 "error_type": "HTTPStatusError",
+                "http_status": 400,
                 "counts_scope": "resource_invocation",
                 "counts_unit": "requests",
                 "counts": {

--- a/tests/test_loader_failure_reporting.py
+++ b/tests/test_loader_failure_reporting.py
@@ -91,6 +91,7 @@ def test_season_summary_keeps_failure_context_after_dlt_wraps_it(
     receipt = result["request_failure"]
     assert receipt["outcome"] == "failed"
     assert receipt["error_type"] == "HTTPStatusError"
+    assert receipt["http_status"] == 401
     assert receipt["params"]["year"] == 2026
     assert receipt["counts"] == {
         "succeeded": 1,
@@ -141,6 +142,7 @@ def test_pipeline_cli_returns_failure_with_request_context(runtime, monkeypatch,
     assert "ERROR in game_stats" in output
     assert '"endpoint": "/games/teams"' in output
     assert '"week": 2' in output
+    assert '"http_status": 401' in output
     if weekly:
         # Week one finished both resources. Week two still fails the whole command.
         assert len(runtime.completed) == 1
@@ -168,6 +170,7 @@ def test_all_sources_cli_carries_one_resource_failure_to_exit(runtime, monkeypat
     output = capsys.readouterr().out
     assert "sources failed: game_stats" in output
     assert '"outcome": "failed"' in output
+    assert '"http_status": 401' in output
 
 
 def test_batched_cli_cannot_hide_failure_after_an_earlier_batch(runtime, monkeypatch, capsys):
@@ -184,6 +187,7 @@ def test_batched_cli_cannot_hide_failure_after_an_earlier_batch(runtime, monkeyp
     assert len(runtime.completed) == 1
     output = capsys.readouterr().out
     assert '"year": 2025' in output
+    assert '"http_status": 401' in output
     assert "All 2 batches complete" not in output
 
 

--- a/tests/test_sources/test_request_failures.py
+++ b/tests/test_sources/test_request_failures.py
@@ -107,6 +107,7 @@ def _chain(error: BaseException) -> list[BaseException]:
         "403",
         "404",
         "500",
+        "503",
         "exhausted-429",
         "open-breaker",
         "timeout",
@@ -137,6 +138,7 @@ def test_request_failures_stop_the_bounded_resource_and_preserve_the_cause(
         "params": params,
         "outcome": "failed",
         "error_type": type(original).__name__,
+        "http_status": int(failure_kind) if failure_kind.isdigit() else None,
         "counts_scope": "resource_invocation",
         "counts_unit": "requests",
         "counts": {"succeeded": 0, "expected_no_data": 0, "failed": 1, "deferred": 2},
@@ -215,6 +217,7 @@ def test_success_then_failure_reports_prior_fetch_and_deferred_requests(
     assert summary is not None
     assert summary["endpoint"] == endpoint
     assert summary["params"] != first_params
+    assert summary["http_status"] == 503
     assert summary["counts"] == {
         "succeeded": 1,
         "expected_no_data": 0,
@@ -255,6 +258,7 @@ def test_invalid_response_is_rejected_before_any_row_is_yielded(
     summary = request_failure_summary(exc_info.value)
     assert summary is not None
     assert summary["error_type"] == "ResponseValidationError"
+    assert summary["http_status"] is None
     assert summary["counts"] == {
         "succeeded": 0,
         "expected_no_data": 0,


### PR DESCRIPTION
HTTP 400/401/403/404/5xx failures introduced by F01 all reported only `error_type: "HTTPStatusError"` in structured receipts, hiding which response caused the failure. Add a numeric `http_status` from the original HTTP exception so season artifacts and CLI receipts preserve that distinction through dlt wrappers. Other error types use `null` and keep their existing classification, including rate-limit exhaustion and circuit-open failures.

Addresses the [valid P2 review finding in merged PR #119](https://github.com/rstover-fo/cfb-database/pull/119#discussion_r3941232382). This is an additive diagnostic change; request retries and failure propagation are unchanged.

Validation:
- Expanded regressions failed before the fix and pass after it. The focused resource, client, and loader suite passes all 121 tests, covering HTTP statuses, non-HTTP failures, earlier successful work, season summaries, and CLI output.
- Full offline suite: 2,260 passed / 447 skipped. MCP suite: 59 passed. Ruff lint/format and whitespace checks passed.
- Independent GPT-6 Astra review found no actionable defects.

No live API calls or database writes were performed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds the upstream HTTP response code to request-failure summaries while retaining `null` for failures without an HTTP response. The value remains available after resource extraction, season loading, and command-line error reporting.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the added status field is correctly populated for HTTP failures and remains absent for non-HTTP failures.

No actionable issues were found. Executed coverage confirmed HTTP statuses survive the resource, wrapped-error, season summary, and command-line reporting paths.

**Files Needing Attention:** None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated that SourceRequestError.\_\_init\_\_ captures the status code only when the error is an httpx.HTTPStatusError, and that to\_summary() reports that numeric status code at src/pipelines/utils/request\_outcomes.py:29-31, 40-51.
- Ran the validation suite and confirmed that a 401 status survives through resource extraction and the season summary to the CLI JSON output, and that 503 and non-HTTP None cases are covered by the resource tests; no source files were changed.

<a href="https://app.greptile.com/trex/runs/22748914/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Preserve HTTP status in request failure ..."](https://github.com/rstover-fo/cfb-database/commit/1314fb74478070f90351aacbce50a0d26c17a0f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60881699)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [College football data ingestion](https://app.greptile.com/formentera-operations/-/custom-context/knowledge-base/rstover-fo/cfb-database/-/docs/data-ingestion.md)
- Knowledge Base — [CFBD source loading](https://app.greptile.com/formentera-operations/-/custom-context/knowledge-base/rstover-fo/cfb-database/-/docs/cfbd-source-loading.md)
- Knowledge Base — [Fail loudly on rate limits](https://app.greptile.com/formentera-operations/-/custom-context/knowledge-base/rstover-fo/cfb-database/-/reverts/incident-mitigation_49-20260725-silent-rate-limit-data-loss-d3c69c3.md)
</details>


<!-- /greptile_comment -->