### PR TITLE
Recover player comparison refresh and season projections

### DIFF
--- a/.github/workflows/deploy-schema.yml
+++ b/.github/workflows/deploy-schema.yml
@@ -68,7 +68,9 @@ on:
         type: string
 
 concurrency:
-  group: deploy-schema
+  # Recovery reads loaded inputs through several subprocesses. Serialize it
+  # with ingestion and historical refresh for the whole run, not just dispatch.
+  group: ${{ inputs.compute_script == 'recover_season_projections' && 'daily-season-load' || 'deploy-schema' }}
   cancel-in-progress: false # never kill a mid-deploy run; a queued run waits
 
 permissions:

--- a/.github/workflows/deploy-schema.yml
+++ b/.github/workflows/deploy-schema.yml
@@ -129,5 +129,5 @@ jobs:
           if [ -n "$BACKFILL_END_INPUT" ]; then ARGS+=(--backfill-end "$BACKFILL_END_INPUT"); fi
           if [ -n "$SOURCES_INPUT" ]; then ARGS+=(--sources "$SOURCES_INPUT"); fi
           if [ -n "$COMPUTE_SCRIPT_INPUT" ]; then ARGS+=(--compute-script "$COMPUTE_SCRIPT_INPUT"); fi
-          if [ -n "$COMPUTE_ARGS_INPUT" ]; then ARGS+=(--compute-args "$COMPUTE_ARGS_INPUT"); fi
+          if [ -n "$COMPUTE_ARGS_INPUT" ]; then ARGS+=("--compute-args=$COMPUTE_ARGS_INPUT"); fi
           python scripts/deploy_schema.py "${ARGS[@]}"

--- a/docs/SCHEMA_CONTRACT.md
+++ b/docs/SCHEMA_CONTRACT.md
@@ -950,7 +950,7 @@ cfb-app for advanced features.
 | `marts.play_epa` | Deployed | Per-play EPA values |
 | `marts.player_game_epa` | Deployed | Player EPA aggregated per game |
 | `marts.player_season_epa` | Deployed | Player EPA aggregated per season |
-| `marts.player_comparison` | Deployed; metadata-grain recovery prepared | Player stats pivoted from EAV at `(player_id, team, season)` with positional percentiles (PERCENT_RANK). Name/position use a coherent modal observed pair, with populated-field and lexical tie-breaks. Metadata corrections must not split the published key. Unique index: `(player_id, team, season)`; additional season/position-group, name and team/season indexes. |
+| `marts.player_comparison` | Deployed; metadata-grain recovery verified 2026-09-06 | Player stats pivoted from EAV at `(player_id, team, season)` with positional percentiles (PERCENT_RANK). Name/position use a coherent modal observed pair, with populated-field and lexical tie-breaks. Metadata corrections must not split the published key. Unique index: `(player_id, team, season)`; additional season/position-group, name and team/season indexes. |
 | `marts.team_playcalling_tendencies` | Deployed | Team play-calling mix (run/pass rates) by situation: down, distance, field position, score state. ~492K rows. Grain: team + season + situation. |
 | `marts.team_situational_success` | Deployed | Team situational effectiveness (success rate, EPA, explosiveness) by context. ~492K rows. Min 10-play threshold for rate metrics. |
 | `marts.coaching_tenure` | Deployed | Coaching tenure analytics with gap detection. One row per coach-team-tenure. Includes W-L, bowl record, inherited vs recruited talent. 2,752 rows. `coach_id` added 2026-08-30 (additive). |

--- a/docs/SCHEMA_CONTRACT.md
+++ b/docs/SCHEMA_CONTRACT.md
@@ -950,7 +950,7 @@ cfb-app for advanced features.
 | `marts.play_epa` | Deployed | Per-play EPA values |
 | `marts.player_game_epa` | Deployed | Player EPA aggregated per game |
 | `marts.player_season_epa` | Deployed | Player EPA aggregated per season |
-| `marts.player_comparison` | Deployed | Player stats pivoted from EAV with positional percentiles (PERCENT_RANK). Indexes: (player_id, season) unique, (season, position_group) |
+| `marts.player_comparison` | Deployed; metadata-grain recovery prepared | Player stats pivoted from EAV at `(player_id, team, season)` with positional percentiles (PERCENT_RANK). Name/position use a coherent modal observed pair, with populated-field and lexical tie-breaks. Metadata corrections must not split the published key. Unique index: `(player_id, team, season)`; additional season/position-group, name and team/season indexes. |
 | `marts.team_playcalling_tendencies` | Deployed | Team play-calling mix (run/pass rates) by situation: down, distance, field position, score state. ~492K rows. Grain: team + season + situation. |
 | `marts.team_situational_success` | Deployed | Team situational effectiveness (success rate, EPA, explosiveness) by context. ~492K rows. Min 10-play threshold for rate metrics. |
 | `marts.coaching_tenure` | Deployed | Coaching tenure analytics with gap detection. One row per coach-team-tenure. Includes W-L, bowl record, inherited vs recruited talent. 2,752 rows. `coach_id` added 2026-08-30 (additive). |

--- a/docs/brainstorms/2026-07-21-team-week-feature-design.md
+++ b/docs/brainstorms/2026-07-21-team-week-feature-design.md
@@ -115,6 +115,10 @@ when W has no plays yet. Do not emit an empty fit when no earlier plays exist.
 This covers upcoming games, bye/sparse weeks, and the entering-postseason
 boundary without waiting for target-week outcomes.
 
+Source plays, like target weeks, must belong to regular or postseason games.
+Exclude all-star and other game types before accumulating fits; their raw week
+numbers do not place them in the regular/postseason observation window.
+
 Snapshots for later scheduled weeks describe the currently available earlier
 plays, not proof that those weeks' inputs are complete. Each season rebuild
 replaces its snapshots from the current play data so added or corrected earlier

--- a/docs/plans/2026-07-25-preseason-outlook-model-plan.md
+++ b/docs/plans/2026-07-25-preseason-outlook-model-plan.md
@@ -1422,3 +1422,19 @@ able to explain why an interval widened on the day the share changed. NULL
 means "written before v1.1" rather than a back-filled value the writer never
 used. The migration also supersedes the `n_sims` column comment, which still
 told consumers the tails were understated.
+
+### Recovery amendment — verified replacement event (2026-09-06)
+
+Season projections count one contest when the provider retains a postponed
+original alongside its verified replacement. The reviewed incident mapping
+`401866625 -> 401917058` identifies Campbell–Western Carolina's move from
+September 5 to September 6. ESPN marks the original postponed with no stats;
+the replacement carries the actual contest. The source records remain intact.
+
+Before result parsing or simulation, exclude the original only when the
+replacement exists with the same season and home/away teams; otherwise stop
+with an explicit reconciliation error. Do not infer replacements from repeated
+opponents or arbitrary date proximity. Preserve the existing model, fitted
+vintage, probability calculation and missing-prediction semantics. This is
+input identity correction, not a new statistical candidate. Other consumers'
+shared season/event lifecycle handling remains F03 follow-up work.

--- a/docs/plans/2026-09-06-projection-freshness-diagnostics.sql
+++ b/docs/plans/2026-09-06-projection-freshness-diagnostics.sql
@@ -1,0 +1,46 @@
+-- Read-only cloud diagnostics. RAISE NOTICE exposes results in Deploy Schema logs.
+SET TRANSACTION READ ONLY;
+SET LOCAL statement_timeout = '60s';
+DO $probe$
+DECLARE result json;
+BEGIN
+  SELECT json_agg(row_to_json(r)) INTO result FROM (SELECT team, season, model_version, computed_at, games_scheduled,
+       games_simulated, games_unscored
+FROM api.season_outlook
+WHERE season = 2026 AND team IN ('Campbell', 'Western Carolina')) r;
+  RAISE NOTICE 'recovery_probe_1: %', result;
+  SELECT json_agg(row_to_json(r)) INTO result FROM (SELECT id, week, season_type, start_date, home_team, away_team, completed
+FROM core.games
+WHERE season = 2026
+  AND (home_team IN ('Campbell', 'Western Carolina')
+       OR away_team IN ('Campbell', 'Western Carolina'))
+ORDER BY start_date, id) r;
+  RAISE NOTICE 'recovery_probe_2: %', result;
+  SELECT json_agg(row_to_json(r)) INTO result FROM (SELECT player_id, player, team, position, season, COUNT(*) AS stat_rows
+FROM stats.player_season_stats
+WHERE player_id::text = '5302440' AND season = 2026 AND team = 'Alabama State'
+GROUP BY player_id, player, team, position, season) r;
+  RAISE NOTICE 'recovery_probe_3: %', result;
+  SELECT json_agg(row_to_json(r)) INTO result FROM (SELECT id, team, year, height, weight, jersey
+FROM core.roster
+WHERE id::text = '5302440' AND year = 2026 AND team = 'Alabama State') r;
+  RAISE NOTICE 'recovery_probe_4: %', result;
+  SELECT json_agg(row_to_json(r)) INTO result FROM (SELECT *
+FROM metrics.ppa_players_season
+WHERE id::text = '5302440' AND season = 2026) r;
+  RAISE NOTICE 'recovery_probe_5: %', result;
+  SELECT json_agg(row_to_json(r)) INTO result FROM (WITH RECURSIVE deps AS (
+ SELECT 'marts.player_comparison'::regclass::oid AS oid
+ UNION
+ SELECT r.ev_class FROM deps p JOIN pg_depend d ON d.refobjid=p.oid
+ JOIN pg_rewrite r ON r.oid=d.objid WHERE r.ev_class<>p.oid
+) SELECT n.nspname AS schema, c.relname, c.relkind, pg_get_userbyid(c.relowner) AS owner,
+ c.relacl::text AS acl, c.reloptions,
+ CASE WHEN c.relkind='v' THEN pg_get_viewdef(c.oid,true) END AS definition
+FROM deps JOIN pg_class c USING(oid) JOIN pg_namespace n ON n.oid=c.relnamespace) r;
+  RAISE NOTICE 'recovery_probe_6: %', result;
+  SELECT json_agg(row_to_json(r)) INTO result FROM (SELECT column_name, data_type FROM information_schema.columns
+WHERE table_schema='core' AND table_name='games' AND column_name LIKE '%dlt%') r;
+  RAISE NOTICE 'recovery_probe_7: %', result;
+END
+$probe$;

--- a/docs/plans/2026-09-06-projection-freshness-investigation.md
+++ b/docs/plans/2026-09-06-projection-freshness-investigation.md
@@ -24,11 +24,9 @@ the vintage of the remaining projection fields.
   `2026-09-05 13:26:39.236668+00`, with 12 stored scheduled games versus 13
   current regular-season games. Producer-filter regression passed independently.
 
-The changed game ID, whether the extra row is legitimate or duplicated, and
-the exact source of the player-key duplication remain unverified. Local DB
-and Supabase management credentials are unavailable; no production writes or
-workflow reruns were performed. The two matching count changes do not prove
-that one new Campbell–Western Carolina game caused both.
+Initial local investigation lacked warehouse credentials. On explicit user
+approval, the existing Deploy Schema workflow ran read-only diagnostics with
+its configured secret and logged the results; see the recovery evidence below.
 
 ## Source inspection and next diagnostics
 
@@ -42,6 +40,38 @@ that one new Campbell–Western Carolina game caused both.
 These are hypotheses for this incident, not confirmed live root causes. Run
 the accompanying read-only SQL against the configured warehouse to inspect
 the failing key and affected schedules before selecting a repair.
+
+## Recovery evidence
+
+- [Warehouse probe](https://github.com/rstover-fo/cfb-database/actions/runs/34047820046)
+  confirmed Amarion Fuller has DE metadata on three source stat rows and DL on
+  seven, with exactly one matching roster row and no PPA row. The stats pivot's
+  metadata grouping is the demonstrated duplicate-producing path.
+- The live dependency closure contains only the mart and `api.player_comparison`.
+  Both are owned by postgres. The mart grants SELECT to anon/authenticated;
+  the API additionally grants SELECT to analyst_ro. No relation options exist.
+- The candidate uses one grouped aggregation at player/team/season and selects
+  a coherent modal observed name/position pair, with deterministic tie-breaking.
+  Migration 061 snapshots and restores privileges/owners/comments, uses no
+  CASCADE, and rejects unexpected relation options or column metadata. Local
+  PostgreSQL 16 executed it twice with exact ACL preservation and successful
+  reads under anon, authenticated, and analyst_ro. Independent review passed.
+- [CFBD probe](https://github.com/rstover-fo/cfb-database/actions/runs/34047986266)
+  still lists both 401866625 (Saturday) and 401917058 (Sunday). The old event is
+  marked completed by CFBD; that flag alone cannot establish a played game.
+- [Western Carolina's official postponement release](https://catamountsports.com/news/2026/9/5/football-catamounts-camels-postponed-until-sunday.aspx)
+  confirms one game moved to Sunday at 11 a.m. ET. ESPN's
+  [original event](https://site.api.espn.com/apis/site/v2/sports/football/college-football/summary?event=401866625)
+  reports STATUS_POSTPONED with no statistics/drives, while its
+  [replacement event](https://site.api.espn.com/apis/site/v2/sports/football/college-football/summary?event=401917058)
+  carries the live Sunday contest and statistics. Retain provider records;
+  a reviewed replacement mapping must prevent counting both in projections.
+- The prior havoc variant failure is already corrected in current main's
+  `variant_twins.py` allow-list; no additional havoc arithmetic change is needed.
+
+Production migration and downstream compute require the explicit approvals
+requested after automatic approval review rejected the first migration dispatch.
+Preparation and local execution do not establish production recovery.
 
 ## Recovery order
 

--- a/docs/plans/2026-09-06-projection-freshness-investigation.md
+++ b/docs/plans/2026-09-06-projection-freshness-investigation.md
@@ -52,7 +52,7 @@ the failing key and affected schedules before selecting a repair.
   the API additionally grants SELECT to analyst_ro. No relation options exist.
 - The candidate uses one grouped aggregation at player/team/season and selects
   a coherent modal observed name/position pair, with deterministic tie-breaking.
-  Migration 061 snapshots and restores privileges/owners/comments, uses no
+  Migration 062 snapshots and restores privileges/owners/comments, uses no
   CASCADE, and rejects unexpected relation options or column metadata. Local
   PostgreSQL 16 executed it twice with exact ACL preservation and successful
   reads under anon, authenticated, and analyst_ro. Independent review passed.
@@ -114,3 +114,12 @@ This incident is separate from F03's premature season-closure predicate.
 F03 should address the verified postponed-event identity/status problem in
 shared lifecycle handling; the scoped projection mapping does not hide the
 original provider row from other consumers or upstream feature computations.
+
+## Review correction: migration identity
+
+The recovery file is now `062_player_comparison_grain_recovery.sql`; `061`
+is reserved for the existing PFF migration. The successful September 6
+deployment used the former filename `061_player_comparison_grain_recovery.sql`.
+Its SQL body is unchanged; the rename does not require another production
+application. Historical run links and references to that deployed filename
+remain as evidence, not instructions to apply the PFF migration.

--- a/docs/plans/2026-09-06-projection-freshness-investigation.md
+++ b/docs/plans/2026-09-06-projection-freshness-investigation.md
@@ -69,9 +69,30 @@ the failing key and affected schedules before selecting a repair.
 - The prior havoc variant failure is already corrected in current main's
   `variant_twins.py` allow-list; no additional havoc arithmetic change is needed.
 
-Production migration and downstream compute require the explicit approvals
-requested after automatic approval review rejected the first migration dispatch.
-Preparation and local execution do not establish production recovery.
+The user explicitly approved migration 061 after automatic approval review
+requested that confirmation. Production recovery is now verified:
+
+- [Migration run](https://github.com/rstover-fo/cfb-database/actions/runs/34048517981)
+  applied 061 successfully in approximately 17 seconds.
+- The first compute attempt stopped before data changes because the workflow
+  passed an option-valued argument as a separate argparse token. Passing it as
+  `--compute-args=<value>` fixed the invocation; focused tests and CI passed.
+- [Compute recovery](https://github.com/rstover-fo/cfb-database/actions/runs/34048655032)
+  refreshed prerequisite marts, rebuilt 2026 Elo/EPA/features, scored all 3,248
+  pending games with the frozen 2025 fit, wrote 716 season projections, and
+  refreshed all seven consumer marts. No ingestion or training ran.
+- [Verification](https://github.com/rstover-fo/cfb-database/actions/runs/34048945546)
+  found no duplicate player keys and exactly one row for the affected player.
+  SELECTs under anon, authenticated and analyst_ro succeeded. Both outlooks
+  were computed at `2026-09-06 17:32:26.03744+00`, with 12 scheduled,
+  12 simulated and zero unscored games. Campbell projected wins/losses:
+  5.67/6.33; Western Carolina: 7.54/4.46.
+
+Raw provider records remain intact. Their raw schedule still has 13 entries;
+the reviewed event mapping produces the correct 12-contest projection slate.
+This is not a live-score ingestion run; outputs reflect the loaded inputs.
+PR 122 must be merged so subsequent daily code runs retain the replacement
+mapping and the canonical mart definition matches the deployed repair.
 
 ## Recovery order
 
@@ -88,6 +109,8 @@ Preparation and local execution do not establish production recovery.
 5. Verify projection timestamps, scheduled counts, unscored games and finite
    outputs for both teams, and confirm no duplicate player keys remain.
 
-This operational incident is separate from F03's premature season-closure
-predicate. The investigation identifies the blocked refresh; it does not mark
-the warehouse repaired or the projections fresh.
+The refresh blocker and affected projection freshness are now repaired.
+This incident is separate from F03's premature season-closure predicate.
+F03 should address the verified postponed-event identity/status problem in
+shared lifecycle handling; the scoped projection mapping does not hide the
+original provider row from other consumers or upstream feature computations.

--- a/docs/plans/2026-09-06-projection-freshness-investigation.md
+++ b/docs/plans/2026-09-06-projection-freshness-investigation.md
@@ -1,0 +1,63 @@
+# Projection freshness investigation — September 6, 2026
+
+## Finding
+
+The September 6 daily load stopped before predictions and season projections.
+This explains why the Campbell and Western Carolina outlooks still carry
+September 5 snapshots. Refreshing only their schedule counts would misrepresent
+the vintage of the remaining projection fields.
+
+## Executed evidence
+
+- [September 5 daily run](https://github.com/rstover-fo/cfb-database/actions/runs/33968074057):
+  season simulation succeeded at 13:26:40 UTC, writing 716 team projections for
+  2026. The later verification step failed on unexpected `stats.game_havoc`
+  variant columns; that failure did not prevent those projections being written.
+- [September 6 daily run](https://github.com/rstover-fo/cfb-database/actions/runs/34035735070):
+  all 20 source loads reported success, including games. The mart refresh failed
+  at 13:35:28 UTC on `idx_player_comparison_pk`, duplicate key
+  `(player_id, team, season) = (5302440, Alabama State, 2026)`.
+  The load command exited 1; all subsequent Elo, EPA, prediction, feature,
+  training, scoring and projection steps were skipped.
+- [PR 121 CI run](https://github.com/rstover-fo/cfb-database/actions/runs/34043232927):
+  live query found both affected `fitted_v1` projections computed at
+  `2026-09-05 13:26:39.236668+00`, with 12 stored scheduled games versus 13
+  current regular-season games. Producer-filter regression passed independently.
+
+The changed game ID, whether the extra row is legitimate or duplicated, and
+the exact source of the player-key duplication remain unverified. Local DB
+and Supabase management credentials are unavailable; no production writes or
+workflow reruns were performed. The two matching count changes do not prove
+that one new Campbell–Western Carolina game caused both.
+
+## Source inspection and next diagnostics
+
+`src/schemas/marts/020_player_comparison.sql` has three possible fanout paths:
+
+1. The stats pivot groups by name and position in addition to the published
+   player/team/season key. Different names or positions can create multiple rows.
+2. The exact roster join is not deduplicated on player/team/year.
+3. The PPA join uses player/season without team or a uniqueness reduction.
+
+These are hypotheses for this incident, not confirmed live root causes. Run
+the accompanying read-only SQL against the configured warehouse to inspect
+the failing key and affected schedules before selecting a repair.
+
+## Recovery order
+
+1. Verify the affected schedule rows and identify the duplicate-producing input.
+2. Prepare a grain-preserving mart repair with an independent review and an
+   executed regression for the observed input. Do not drop the unique index or
+   silently discard conflicting player records to make the refresh pass.
+3. On an authorized production target, apply the repair and refresh its required
+   dependency closure. Investigate the separate havoc variant warning before
+   expecting the entire daily workflow to finish successfully.
+4. Run the appropriate downstream compute sequence through season simulation
+   using current inputs; a full ingestion rerun is not required merely to update
+   stored projections. Reuse the daily workflow's ordering and model gates.
+5. Verify projection timestamps, scheduled counts, unscored games and finite
+   outputs for both teams, and confirm no duplicate player keys remain.
+
+This operational incident is separate from F03's premature season-closure
+predicate. The investigation identifies the blocked refresh; it does not mark
+the warehouse repaired or the projections fresh.

--- a/docs/plans/2026-09-06-recovery-verification.sql
+++ b/docs/plans/2026-09-06-recovery-verification.sql
@@ -1,0 +1,40 @@
+-- Read-only post-migration and post-compute checks through Deploy Schema.
+SET TRANSACTION READ ONLY;
+SET LOCAL statement_timeout = '60s';
+DO $verify$
+DECLARE n bigint; result json;
+BEGIN
+ SELECT count(*) INTO n FROM (
+   SELECT player_id,team,season FROM marts.player_comparison
+   GROUP BY player_id,team,season HAVING count(*)>1
+ ) duplicates;
+ IF n<>0 THEN RAISE EXCEPTION 'Duplicate player keys remain: %',n; END IF;
+ SELECT count(*) INTO n FROM marts.player_comparison
+ WHERE player_id::text='5302440' AND team='Alabama State' AND season=2026;
+ IF n<>1 THEN RAISE EXCEPTION 'Affected player expected once, found %',n; END IF;
+ RAISE NOTICE 'Player comparison uniqueness and affected key passed';
+ SELECT json_agg(row_to_json(r)) INTO result FROM (
+   SELECT team,season,model_version,computed_at,games_scheduled,
+          games_simulated,games_unscored,projected_wins,projected_losses
+   FROM api.season_outlook
+   WHERE season=2026 AND team IN ('Campbell','Western Carolina')
+ ) r;
+ RAISE NOTICE 'Recovered outlooks: %',result;
+ SELECT count(*) INTO n FROM api.season_outlook
+ WHERE season=2026 AND team IN ('Campbell','Western Carolina')
+   AND model_version='fitted_v1' AND computed_at::date=CURRENT_DATE
+   AND games_scheduled=12 AND games_simulated<=games_scheduled
+   AND games_unscored=games_scheduled-games_simulated
+   AND projected_wins BETWEEN 0 AND games_simulated
+   AND projected_losses BETWEEN 0 AND games_simulated;
+ IF n<>2 THEN RAISE EXCEPTION 'Expected two fresh, valid 12-game outlooks; found %',n; END IF;
+END $verify$;
+SET LOCAL ROLE anon;
+SELECT count(*) FROM api.player_comparison WHERE player_id::text='5302440';
+RESET ROLE;
+SET LOCAL ROLE authenticated;
+SELECT count(*) FROM api.player_comparison WHERE player_id::text='5302440';
+RESET ROLE;
+SET LOCAL ROLE analyst_ro;
+SELECT count(*) FROM api.player_comparison WHERE player_id::text='5302440';
+RESET ROLE;

--- a/scripts/compute_adjusted_epa_week.py
+++ b/scripts/compute_adjusted_epa_week.py
@@ -101,6 +101,7 @@ PLAY_QUERY_WEEK = """
     FROM marts.play_epa pe
     JOIN core.games g ON g.id = pe.game_id
     WHERE pe.season = %s
+      AND g.season_type IN ('regular', 'postseason')
       AND NOT pe.is_garbage_time
       AND pe.epa IS NOT NULL
     ORDER BY week_index, pe.game_id

--- a/scripts/deploy_schema.py
+++ b/scripts/deploy_schema.py
@@ -216,6 +216,11 @@ def plan_from_manifest(manifest: dict) -> Plan:
         compute=compute,
     )
     validate_plan(plan)
+    if plan.compute and plan.compute.script == "recover_season_projections":
+        raise ValueError(
+            "recover_season_projections requires workflow_dispatch with compute_script; "
+            "manifest execution does not share the daily ingestion concurrency group"
+        )
     return plan
 
 

--- a/scripts/deploy_schema.py
+++ b/scripts/deploy_schema.py
@@ -64,6 +64,7 @@ VALID_ACTIONS = {"presence_check", "apply", "backfill", "compute"}
 COMPUTE_SCRIPTS = {
     # Read-only one-request schedule probe for the September 2026 recovery.
     "probe_projection_schedule",
+    "recover_season_projections",
     "compute_house_elo",
     "compute_adjusted_epa",
     "compute_predictions",

--- a/scripts/deploy_schema.py
+++ b/scripts/deploy_schema.py
@@ -62,6 +62,8 @@ VALID_ACTIONS = {"presence_check", "apply", "backfill", "compute"}
 # These land in later Tier 2 + Tier 3 phases -- membership is checked, not file
 # existence, so this action can be wired up before the scripts themselves exist.
 COMPUTE_SCRIPTS = {
+    # Read-only one-request schedule probe for the September 2026 recovery.
+    "probe_projection_schedule",
     "compute_house_elo",
     "compute_adjusted_epa",
     "compute_predictions",

--- a/scripts/probe_projection_schedule.py
+++ b/scripts/probe_projection_schedule.py
@@ -1,0 +1,36 @@
+"""Bounded, read-only provider check for the September 2026 recovery."""
+
+import json
+import os
+
+import httpx
+
+
+def main():
+    # One request, no automatic retry or warehouse mutation.
+    token = os.environ["SOURCES__CFBD__API_KEY"]
+    response = httpx.get(
+        "https://api.collegefootballdata.com/games",
+        params={"year": 2026, "team": "Campbell", "seasonType": "regular"},
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=60,
+    )
+    response.raise_for_status()
+    games = response.json()
+    if not isinstance(games, list):
+        raise ValueError("Expected a games list")
+    fields = (
+        "id",
+        "season",
+        "week",
+        "seasonType",
+        "startDate",
+        "homeTeam",
+        "awayTeam",
+        "completed",
+    )
+    print(json.dumps([{field: game.get(field) for field in fields} for game in games]))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/probe_projection_schedule.py
+++ b/scripts/probe_projection_schedule.py
@@ -28,6 +28,9 @@ def main():
         "homeTeam",
         "awayTeam",
         "completed",
+        "homePoints",
+        "awayPoints",
+        "notes",
     )
     print(json.dumps([{field: game.get(field) for field in fields} for game in games]))
 

--- a/scripts/recover_season_projections.py
+++ b/scripts/recover_season_projections.py
@@ -1,0 +1,80 @@
+"""Run the reviewed September 2026 compute recovery without ingest or training.
+
+Defaults to printing the commands. --execute writes warehouse derived tables;
+invoke only for the explicitly authorized production recovery.
+"""
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+COMMANDS = (
+    ("refresh_marts", "--views", "marts.play_epa,marts.returning_production"),
+    ("compute_house_elo", "--season", "2026"),
+    ("compute_adjusted_epa", "--season", "2026"),
+    ("compute_adjusted_epa_week", "--season", "2026"),
+    ("compute_predictions",),
+    ("build_features", "--season", "2026"),
+    ("score_fitted", "--upcoming"),
+    ("simulate_season", "--season", "2026", "--model", "fitted_v1"),
+    (
+        "refresh_marts",
+        "--views",
+        "marts.house_elo,marts.house_elo_game,marts.team_adjusted_epa,"
+        "marts.scored_matchup_edges,marts.prediction_accuracy,"
+        "marts.team_week_features,marts.adjusted_epa_week",
+    ),
+)
+
+
+def execute_commands(commands=COMMANDS):
+    for name, *args in commands:
+        path = Path(__file__).resolve().parent / f"{name}.py"
+        subprocess.run([sys.executable, str(path), *args], check=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--execute", action="store_true")
+    args = parser.parse_args()
+    for command in COMMANDS:
+        print(" ".join(command), flush=True)
+    if not args.execute:
+        return
+
+    import psycopg2
+
+    from scripts.run_migrations import get_db_url
+
+    # Do not retrain during recovery, or let the outstanding F03 selection
+    # issue silently select an in-season fit.
+    with psycopg2.connect(get_db_url()) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SET LOCAL lock_timeout = '10s'")
+            cur.execute("SET LOCAL idle_in_transaction_session_timeout = 0")
+            # SHARE permits scorer reads while preventing any concurrent fit
+            # writer from changing the selected vintage or coefficient vectors.
+            cur.execute(
+                "LOCK TABLE features.model_metadata, features.model_coefficients IN SHARE MODE"
+            )
+            cur.execute(
+                "SELECT MAX(train_through_season) FROM features.model_metadata "
+                "WHERE model_version = 'fitted_v1'"
+            )
+            train_through = cur.fetchone()[0]
+            if train_through != 2025:
+                raise RuntimeError(f"Recovery requires the frozen 2025 fit; found {train_through}")
+            cur.execute(
+                "SELECT DISTINCT season FROM core.games "
+                "WHERE NOT COALESCE(completed, false) AND season >= "
+                "(SELECT COALESCE(MAX(season), 0) FROM core.games WHERE completed)"
+            )
+            targets = {row[0] for row in cur.fetchall()}
+            if targets != {2026}:
+                raise RuntimeError(f"Recovery requires only 2026 pending targets; found {targets}")
+        execute_commands()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/simulate_season.py
+++ b/scripts/simulate_season.py
@@ -157,6 +157,15 @@ MIN_SIGMA_GAMES = 100
 # projections to jump as the postseason bracket is published.
 PROJECTION_SEASON_TYPE = "regular"
 
+# Explicit incident crosswalk, not a same-opponent deduplication heuristic.
+# CFBD retains the postponed September 5 event alongside the September 6 game:
+# - original: https://site.api.espn.com/apis/site/v2/sports/football/college-football/summary?event=401866625
+# - replacement: https://site.api.espn.com/apis/site/v2/sports/football/college-football/summary?event=401917058
+# ESPN reports the original as STATUS_POSTPONED with no stats/drives, while the
+# replacement is the game that was played. Western Carolina's official notice:
+# https://catamountsports.com/news/2026/9/5/football-catamounts-camels-postponed-until-sunday.aspx
+SUPERSEDED_GAME_REPLACEMENTS = {401866625: 401917058}
+
 # --- v1.1 correlated draws ---------------------------------------------------
 # Share of margin variance attributed to a per-team SEASON-STRENGTH offset,
 # drawn once per simulation and applied to every game that team plays, rather
@@ -223,6 +232,44 @@ def normalize_strength_share(strength_share: float) -> float:
             f"{STRENGTH_SHARE_DECIMALS} decimals, got {strength_share!r} -> {value!r}"
         )
     return value
+
+
+def select_projection_game_rows(rows: list[dict]) -> list[dict]:
+    """Remove only verified superseded events from season-projection inputs.
+
+    The replacement must be present in the same fetched season and must carry
+    the same home and away teams. Failing closed prevents an incomplete fetch
+    from silently deleting a scheduled game or re-rolling the wrong matchup.
+    The returned list is new; source rows and caller-owned input are unchanged.
+    """
+    rows_by_id = {row["game_id"]: row for row in rows}
+    suppressed_ids = set()
+
+    for original_id, replacement_id in SUPERSEDED_GAME_REPLACEMENTS.items():
+        original = rows_by_id.get(original_id)
+        if original is None:
+            continue
+
+        replacement = rows_by_id.get(replacement_id)
+        if replacement is None:
+            raise ValueError(
+                f"Superseded game {original_id} is present without replacement "
+                f"{replacement_id}; refusing to build an incomplete projection schedule"
+            )
+
+        pair_fields = ("season", "home_team", "away_team")
+        mismatches = [
+            field for field in pair_fields if original.get(field) != replacement.get(field)
+        ]
+        if mismatches:
+            raise ValueError(
+                f"Superseded game {original_id} and replacement {replacement_id} disagree "
+                f"on {', '.join(mismatches)}; refusing to suppress either event"
+            )
+
+        suppressed_ids.add(original_id)
+
+    return [row for row in rows if row["game_id"] not in suppressed_ids]
 
 
 def strength_sd(sigma: float, strength_share: float) -> tuple[float, float]:
@@ -826,6 +873,7 @@ def fetch_season_games(conn, season: int, model: str) -> list[dict]:
         )
         rows = [dict(r) for r in cur.fetchall()]
 
+    rows = select_projection_game_rows(rows)
     games = []
     for r in rows:
         home_win = None

--- a/src/schemas/migrations/061_player_comparison_grain_recovery.sql
+++ b/src/schemas/migrations/061_player_comparison_grain_recovery.sql
@@ -1,3 +1,34 @@
+-- 061: Repair player-comparison grain after DE/DL source metadata drift.
+-- Explicit-file deployment: scripts/run_migrations.py --file <this file>.
+-- Atomic and repeatable. No CASCADE: unexpected dependents stop the repair.
+-- Canonical definition: src/schemas/marts/020_player_comparison.sql.
+BEGIN;
+SET LOCAL lock_timeout = '10s';
+CREATE TEMP TABLE recovery_player_objects ON COMMIT DROP AS
+SELECT c.oid, n.nspname, c.relname, c.relkind,
+       pg_get_userbyid(c.relowner) AS owner,
+       c.relacl, obj_description(c.oid, 'pg_class') AS comment,
+       c.reloptions,
+       CASE WHEN c.relkind = 'v' THEN pg_get_viewdef(c.oid, true) END AS definition
+FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE c.oid IN ('marts.player_comparison'::regclass, 'api.player_comparison'::regclass);
+CREATE TEMP TABLE recovery_player_grants ON COMMIT DROP AS
+SELECT o.nspname, o.relname, x.grantee, x.privilege_type, x.is_grantable
+FROM recovery_player_objects o
+CROSS JOIN LATERAL aclexplode(COALESCE(o.relacl, acldefault('r', o.owner::regrole))) x;
+-- Column-level grants/comments would need their own preservation path.
+DO $guard$
+BEGIN
+ IF EXISTS (SELECT 1 FROM pg_attribute a JOIN recovery_player_objects o ON o.oid=a.attrelid
+            WHERE a.attnum>0 AND (a.attacl IS NOT NULL OR col_description(a.attrelid,a.attnum) IS NOT NULL)) THEN
+   RAISE EXCEPTION 'Unexpected column grants/comments; inspect before recovery';
+ END IF;
+ IF EXISTS (SELECT 1 FROM recovery_player_objects WHERE reloptions IS NOT NULL) THEN
+   RAISE EXCEPTION 'Unexpected relation options; inspect before recovery';
+ END IF;
+END $guard$;
+DROP VIEW api.player_comparison;
+
 -- marts.player_comparison
 -- Player stats with positional percentiles for comparison.
 -- Pre-computes EAV pivot + PERCENT_RANK() window functions so
@@ -243,3 +274,32 @@ CREATE UNIQUE INDEX idx_player_comparison_pk ON marts.player_comparison (player_
 CREATE INDEX idx_player_comparison_season_posgroup ON marts.player_comparison (season, position_group);
 CREATE INDEX idx_player_comparison_name ON marts.player_comparison (name);
 CREATE INDEX idx_player_comparison_team_season ON marts.player_comparison (team, season);
+
+DO $restore$
+DECLARE o record; g record; target text; recipient text;
+BEGIN
+ SELECT * INTO STRICT o FROM recovery_player_objects WHERE nspname='api';
+ EXECUTE format('CREATE VIEW api.player_comparison AS %s', o.definition);
+ FOR o IN SELECT * FROM recovery_player_objects LOOP
+   target := format('%I.%I', o.nspname, o.relname);
+   EXECUTE format('ALTER %s %s OWNER TO %I',
+                  CASE WHEN o.relkind='m' THEN 'MATERIALIZED VIEW' ELSE 'VIEW' END,
+                  target, o.owner);
+   EXECUTE format('COMMENT ON %s %s IS %L',
+                  CASE WHEN o.relkind='m' THEN 'MATERIALIZED VIEW' ELSE 'VIEW' END,
+                  target, o.comment);
+   -- Remove creation-time default grants before restoring the captured ACL.
+   FOR g IN SELECT DISTINCT x.grantee FROM pg_class c,
+       LATERAL aclexplode(COALESCE(c.relacl, acldefault('r',c.relowner))) x
+       WHERE c.oid=target::regclass LOOP
+     recipient := CASE WHEN g.grantee=0 THEN 'PUBLIC' ELSE quote_ident(pg_get_userbyid(g.grantee)) END;
+     EXECUTE format('REVOKE ALL ON TABLE %s FROM %s',target,recipient);
+   END LOOP;
+ END LOOP;
+ FOR g IN SELECT * FROM recovery_player_grants LOOP
+   recipient := CASE WHEN g.grantee=0 THEN 'PUBLIC' ELSE quote_ident(pg_get_userbyid(g.grantee)) END;
+   EXECUTE format('GRANT %s ON TABLE %I.%I TO %s%s',g.privilege_type,g.nspname,g.relname,
+                  recipient,CASE WHEN g.is_grantable THEN ' WITH GRANT OPTION' ELSE '' END);
+ END LOOP;
+END $restore$;
+COMMIT;

--- a/src/schemas/migrations/062_player_comparison_grain_recovery.sql
+++ b/src/schemas/migrations/062_player_comparison_grain_recovery.sql
@@ -1,4 +1,4 @@
--- 061: Repair player-comparison grain after DE/DL source metadata drift.
+-- 062: Repair player-comparison grain after DE/DL source metadata drift.
 -- Explicit-file deployment: scripts/run_migrations.py --file <this file>.
 -- Atomic and repeatable. No CASCADE: unexpected dependents stop the repair.
 -- Canonical definition: src/schemas/marts/020_player_comparison.sql.

--- a/tests/test_adjusted_epa_week_integration.py
+++ b/tests/test_adjusted_epa_week_integration.py
@@ -105,6 +105,25 @@ def rebuild(conn):
     return rows, teams
 
 
+@pytest.mark.parametrize("excluded_type", ["allstar", "exhibition", None])
+def test_nonseason_plays_do_not_change_scheduled_fits(warehouse, excluded_type):
+    add_game(warehouse, 1, 1, completed=True)
+    add_game(warehouse, 2, 3)
+    add_game(warehouse, 3, 1, season_type="postseason", completed=True)
+    add_game(warehouse, 4, 2, season_type="postseason")
+    add_plays(warehouse, 1)
+    add_plays(warehouse, 3, epa=0.6)
+    baseline, _ = rebuild(warehouse)
+    baseline_consumer = build_features.fetch_adj_epa_week_rows(warehouse, 2026)
+
+    add_game(warehouse, 5, 2, season_type=excluded_type, completed=True)
+    add_plays(warehouse, 5, epa=10000)
+    actual, _ = rebuild(warehouse)
+    assert actual == baseline
+    assert {r["week_index"] for r in actual} == {3, 101, 102}
+    assert build_features.fetch_adj_epa_week_rows(warehouse, 2026) == baseline_consumer
+
+
 def test_schedule_targets_survive_sql_staging_and_feature_resolution(warehouse, monkeypatch):
     add_game(warehouse, 1, 1, completed=True)
     add_game(warehouse, 2, 2)

--- a/tests/test_deploy_schema.py
+++ b/tests/test_deploy_schema.py
@@ -25,6 +25,7 @@ class TestValidActions:
 class TestComputeScripts:
     def test_expected_allowlist(self):
         assert COMPUTE_SCRIPTS == {
+            "probe_projection_schedule",
             "check_backtest",
             "compute_house_elo",
             "compute_adjusted_epa",

--- a/tests/test_deploy_schema.py
+++ b/tests/test_deploy_schema.py
@@ -18,6 +18,19 @@ from scripts.deploy_schema import (
 
 
 class TestValidActions:
+    def test_recovery_manifest_rejected_but_dispatch_plan_allowed(self):
+        with pytest.raises(ValueError, match="requires workflow_dispatch"):
+            plan_from_manifest(
+                {
+                    "action": "compute",
+                    "compute": {"script": "recover_season_projections", "args": ["--execute"]},
+                }
+            )
+        plan = plan_from_cli(
+            action="compute", compute_script="recover_season_projections", compute_args="--execute"
+        )
+        assert plan.compute.args == ["--execute"]
+
     def test_expected_actions(self):
         assert VALID_ACTIONS == {"presence_check", "apply", "backfill", "compute"}
 

--- a/tests/test_deploy_schema.py
+++ b/tests/test_deploy_schema.py
@@ -26,6 +26,7 @@ class TestComputeScripts:
     def test_expected_allowlist(self):
         assert COMPUTE_SCRIPTS == {
             "probe_projection_schedule",
+            "recover_season_projections",
             "check_backtest",
             "compute_house_elo",
             "compute_adjusted_epa",

--- a/tests/test_player_comparison_recovery.py
+++ b/tests/test_player_comparison_recovery.py
@@ -1,0 +1,114 @@
+"""Regression coverage for the player-comparison metadata-drift repair."""
+
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+MART_SQL = PROJECT_ROOT / "src" / "schemas" / "marts" / "020_player_comparison.sql"
+CREATE_MARKER = "CREATE MATERIALIZED VIEW marts.player_comparison AS"
+END_MARKER = "WITH DATA;"
+
+
+def _mart_select() -> str:
+    """Extract the materialized-view SELECT so fixtures exercise production SQL."""
+    sql = MART_SQL.read_text()
+    return sql.split(CREATE_MARKER, 1)[1].split(END_MARKER, 1)[0].strip()
+
+
+def _fixture_query() -> str:
+    select_sql = _mart_select()
+    fixture_ctes = """
+WITH fixture_player_season_stats(
+    player_id, player, team, position, season, category, stat_type, stat
+) AS (
+    VALUES
+        ('5302440', 'A. Runner', 'Alabama State', 'RB', 2026, 'rushing', 'CAR', '12'),
+        ('5302440', 'Alex Runner', 'Alabama State', 'WR', 2026, 'rushing', 'YDS', '87'),
+        ('5302440', 'Alex Runner', 'Alabama State', 'WR', 2026, 'rushing', 'TD', '2'),
+        ('5302440', 'Alex Runner', 'Alabama State', 'WR', 2026, 'rushing', 'YPC', ''),
+        ('5302440', 'Alex Runner', 'Prairie View', 'WR', 2026, 'receiving', 'REC', '4'),
+        ('6000000', 'Zed Tie', 'Tie State', 'RB', 2026, 'rushing', 'CAR', '9'),
+        ('6000000', 'Aaron Tie', 'Tie State', 'WR', 2026, 'rushing', 'YDS', '45')
+),
+fixture_roster(id, year, height, weight, jersey, home_city, home_state, team) AS (
+    SELECT
+        NULL::bigint, NULL::integer, NULL::integer, NULL::integer,
+        NULL::integer, NULL::text, NULL::text, NULL::text
+    WHERE FALSE
+),
+fixture_recruits(athlete_id, stars, rating, ranking, year) AS (
+    SELECT NULL::bigint, NULL::integer, NULL::numeric, NULL::integer, NULL::integer
+    WHERE FALSE
+),
+fixture_ppa(id, season, average_ppa__all, total_ppa__all) AS (
+    SELECT NULL::bigint, NULL::integer, NULL::numeric, NULL::numeric
+    WHERE FALSE
+),
+"""
+    select_sql = select_sql.replace(
+        "WITH position_groups AS (", fixture_ctes + "position_groups AS ("
+    )
+    replacements = {
+        "stats.player_season_stats": "fixture_player_season_stats",
+        "core.roster": "fixture_roster",
+        "recruiting.recruits": "fixture_recruits",
+        "metrics.ppa_players_season": "fixture_ppa",
+    }
+    for source, fixture in replacements.items():
+        select_sql = select_sql.replace(source, fixture)
+    return select_sql
+
+
+def test_fixture_query_uses_mart_select_and_replaces_physical_sources():
+    query = _fixture_query()
+
+    assert "PERCENT_RANK()" in query
+    assert "MODE() WITHIN GROUP" in query
+    assert all(
+        source not in query
+        for source in (
+            "stats.player_season_stats",
+            "core.roster",
+            "recruiting.recruits",
+            "metrics.ppa_players_season",
+        )
+    )
+
+
+def test_metadata_drift_keeps_unique_grain_and_all_stats(db_conn):
+    """Execute the real mart SELECT against read-only CTE fixtures."""
+    with db_conn.cursor() as cur:
+        cur.execute(_fixture_query())
+        columns = [description.name for description in cur.description]
+        rows = [dict(zip(columns, row, strict=True)) for row in cur.fetchall()]
+
+    assert len(rows) == 3
+    by_key = {(row["player_id"], row["team"]): row for row in rows}
+    assert set(by_key) == {
+        ("5302440", "Alabama State"),
+        ("5302440", "Prairie View"),
+        ("6000000", "Tie State"),
+    }
+
+    repaired = by_key[("5302440", "Alabama State")]
+    assert repaired["player_id"] == "5302440"
+    # The most frequent metadata pair wins and remains an observed pair,
+    # rather than combining a name and position from different source rows.
+    assert (repaired["name"], repaired["position"]) == ("Alex Runner", "WR")
+    assert (repaired["name"], repaired["position"]) in {
+        ("A. Runner", "RB"),
+        ("Alex Runner", "WR"),
+    }
+    assert repaired["rush_car"] == 12
+    assert repaired["rush_yds"] == 87
+    assert repaired["rush_td"] == 2
+    assert repaired["rush_ypc"] is None
+
+    separate_team = by_key[("5302440", "Prairie View")]
+    assert separate_team["rec"] == 4
+    assert separate_team["rush_yds"] is None
+
+    # Equal-frequency modes resolve to the earliest JSONB ordering.
+    tied = by_key[("6000000", "Tie State")]
+    assert (tied["name"], tied["position"]) == ("Aaron Tie", "WR")
+    assert tied["rush_car"] == 9
+    assert tied["rush_yds"] == 45

--- a/tests/test_recovery_commands.py
+++ b/tests/test_recovery_commands.py
@@ -1,0 +1,19 @@
+import subprocess
+
+import pytest
+
+from scripts.recover_season_projections import execute_commands
+
+
+def test_compute_failure_stops_downstream_writes(monkeypatch):
+    calls = []
+
+    def fail(command, *, check):
+        calls.append(command)
+        assert check
+        raise subprocess.CalledProcessError(1, command)
+
+    monkeypatch.setattr(subprocess, "run", fail)
+    with pytest.raises(subprocess.CalledProcessError):
+        execute_commands((("compute_adjusted_epa",), ("simulate_season",)))
+    assert len(calls) == 1

--- a/tests/test_simulate_season.py
+++ b/tests/test_simulate_season.py
@@ -16,6 +16,9 @@ Two tests are load-bearing:
   silent-degradation failure this project already hit once.
 """
 
+from copy import deepcopy
+from unittest.mock import MagicMock
+
 import pytest
 
 pytest.importorskip("numpy")
@@ -33,8 +36,10 @@ from scripts.simulate_season import (  # noqa: E402
     build_projection_row,
     conference_title_probs,
     expected_slate_games,
+    fetch_season_games,
     normalize_strength_share,
     schedule_strength,
+    select_projection_game_rows,
     simulate_wins,
     standard_slate,
     strength_sd,
@@ -73,6 +78,78 @@ def _wins(games, n_sims, sigma, seed=None):
     """simulate_wins()['wins'] -- most tests only care about the overall tally."""
     kwargs = {"seed": seed} if seed is not None else {}
     return simulate_wins(games, n_sims, sigma, **kwargs)["wins"]
+
+
+def _raw_game(game_id, season=2026, home="Campbell", away="Western Carolina", **overrides):
+    row = {
+        "game_id": game_id,
+        "season": season,
+        "home_team": home,
+        "away_team": away,
+        "completed": False,
+        "home_points": None,
+        "away_points": None,
+        "home_conference": "TestConf",
+        "away_conference": "TestConf",
+        "home_classification": "fcs",
+        "away_classification": "fcs",
+        "conference_game": False,
+        "expected_home_margin": 3.0,
+    }
+    row.update(overrides)
+    return row
+
+
+class TestSupersededProjectionGames:
+    def test_verified_pair_suppresses_fake_completed_original_only(self):
+        original = _raw_game(
+            401866625,
+            completed=True,
+            home_points=0,
+            away_points=0,
+        )
+        replacement = _raw_game(401917058)
+        rows = [original, replacement]
+        before = deepcopy(rows)
+        selected_rows = select_projection_game_rows(rows)
+        conn = MagicMock()
+        conn.cursor.return_value.__enter__.return_value.fetchall.return_value = rows
+
+        selected = fetch_season_games(conn, 2026, "fitted_v1")
+
+        assert [row["game_id"] for row in selected_rows] == [401917058]
+        assert rows == before, "selector must not mutate caller-owned input"
+        assert [row["game_id"] for row in selected] == [401917058]
+        sim = simulate_wins(selected, 20, 18.5, seed=1)
+        assert sim["games_simulated"] == {"Campbell": 1, "Western Carolina": 1}
+
+    def test_original_without_replacement_is_rejected(self):
+        with pytest.raises(ValueError, match="present without replacement"):
+            select_projection_game_rows([_raw_game(401866625)])
+
+    @pytest.mark.parametrize(
+        "replacement",
+        [
+            _raw_game(401917058, season=2027),
+            _raw_game(401917058, home="Western Carolina"),
+            _raw_game(401917058, away="Campbell"),
+        ],
+        ids=["season", "home_team", "away_team"],
+    )
+    def test_mismatched_pair_is_rejected(self, replacement):
+        with pytest.raises(ValueError, match="disagree"):
+            select_projection_game_rows([_raw_game(401866625), replacement])
+
+    def test_original_absent_and_unrelated_same_opponent_games_are_untouched(self):
+        replacement = _raw_game(401917058)
+        future_rematch = _raw_game(499999999, season=2027)
+        unrelated = _raw_game(123, home="Other Home", away="Other Away")
+        rows = [replacement, future_rematch, unrelated]
+
+        selected = select_projection_game_rows(rows)
+
+        assert selected == rows
+        assert selected is not rows
 
 
 class TestSimulateWins:


### PR DESCRIPTION
The September 6 daily load merged source data, then failed refreshing player_comparison: Amarion Fuller’s DE and DL metadata split one player/team/season into duplicate rows. All downstream compute was skipped. Live investigation also identified a postponed Campbell–Western Carolina event retained alongside its actual Sunday replacement.

Aggregate player statistics at the published key and choose a coherent observed modal name/position pair. Migration 062 atomically rebuilds the mart and API view without CASCADE, restoring owners, grants and comments and rejecting unexpected metadata. Retain raw games while explicitly mapping verified original401866625 to replacement401917058 in season-projection inputs, requiring matching teams/season and replacement presence.

The recovery runner defaults to a dry run. Explicit execution refreshes prerequisite marts, computes2026 Elo/EPA/features and current predictions, simulates2026, then refreshes all seven consumer marts. It performs no ingestion or training, requires the frozen2025 fit and only2026 pending targets, holds model-table SHARE locks, and stops on failure. Workflow dispatch shares daily ingestion concurrency. Includes approved diagnostic scripts, evidence, and post-recovery SQL.

Validation: 2,279 offline tests passed /449 skipped. Actual mart SELECT fixtures passed on PostgreSQL16. The recovery SQL (originally named 061, now 062) executed twice locally with exact ACL preservation, unique grain and anon/authenticated/analyst_ro reads. Independent Astra reviews clean after resolving performance and concurrency findings. Ruff, whitespace and agent-setup checks passed.

Production recovery verified: [migration deployment under its original 061 filename](https://github.com/rstover-fo/cfb-database/actions/runs/34048517981), [compute recovery](https://github.com/rstover-fo/cfb-database/actions/runs/34048655032), and [read-only verification](https://github.com/rstover-fo/cfb-database/actions/runs/34048945546) all succeeded. Both teams now have fresh12-game outlooks with12 simulated and0 unscored games; the duplicate player key is gone, and actual anon/authenticated/analyst_ro reads pass. All3248pending2026games were scored with the frozen2025fit; no ingestion or training ran. Raw provider records remain intact. Merge this PR so daily runs retain the projection mapping and source-controlled mart repair.

Review fixes: weekly EPA source plays now exclude non-regular/non-postseason games, with executed SQL regression coverage. Recovery through push manifests is rejected so operational recovery uses serialized workflow dispatch. Migration 062 removes the sequence collision with PFF; its SQL body is unchanged from the completed deployment. Both Codex threads are resolved; the Greptile finding is addressed in e3846b6.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR preserves player-comparison relation metadata during aggregation rebuilds, adds guarded projection recovery and dispatch controls, reconciles the verified postponed/replacement game pair for season simulation, and ensures weekly EPA inputs contain only regular-season and postseason games.

<h3>Confidence Score: 5/5</h3>

Safe to merge.

No outstanding findings remain. The previously reported all-star-game contamination is addressed: the weekly EPA play query now restricts source games to regular and postseason types.

<sub>Reviews (2): Last reviewed commit: ["fix: address recovery PR review findings"](https://github.com/rstover-fo/cfb-database/commit/e3846b6879bf52677e2d54c892adde7ff56099dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60992297)</sub>

<!-- /greptile_comment -->