### PR TITLE
F03: prevent premature season closure and same-season fit leakage

### DIFF
--- a/docs/brainstorms/2026-07-21-team-week-feature-design.md
+++ b/docs/brainstorms/2026-07-21-team-week-feature-design.md
@@ -520,7 +520,10 @@ ever touches the transform.
 and by the greatest available `train_through_season < S` separately for each
 prediction season S during daily upcoming scoring. A same-season or future fit
 is never eligible, even if it is the newest stored fit. Missing eligible fits
-fail before any upcoming predictions are written. Grants follow
+fail before any upcoming predictions are written. Upcoming eligible vintages
+must also be at or below the shared contiguous closed training frontier and
+match the current feature contract; being earlier than a prediction season
+alone does not prove the training season was complete. Grants follow
 `predictions` house style: `GRANT USAGE ON SCHEMA features` + `SELECT` to
 `anon, authenticated`; revoke write.
 
@@ -590,7 +593,13 @@ For each `S` in `2018..2025`:
 10. **Daily upcoming:** select the latest eligible frozen fit separately for
     each pending season S, requiring `train_through_season < S`. Validate the
     fit against each game before vectorization. Resolve all required fits
-    before writing the upcoming batch; no eligible fit is an error.
+    before writing the upcoming batch; no eligible fit is an error. Exclude
+    vintages beyond the contiguous closed training frontier. Require at least
+    90% feature/scoring coverage independently for every pending season before
+    any upcoming write; aggregate coverage cannot hide a missing season. The
+    post-load verifier uses the same canonical pending population and per-season
+    threshold. Preseason backtests apply the reviewed identity exclusions to
+    both result rows and scheduled counts, including persisted feature sources.
 
 **Gate B:** `fitted_v1` must beat `elo_v1` on walk-forward **MAE and Brier**
 (target Brier ≲ 0.168 vs elo's 0.187). Fail → stays advisory, not wired into

--- a/docs/brainstorms/2026-07-21-team-week-feature-design.md
+++ b/docs/brainstorms/2026-07-21-team-week-feature-design.md
@@ -517,11 +517,43 @@ ever touches the transform.
 
 `score_fitted.py` selects the frozen fit by
 `(model_version='fitted_v1', train_through_season = S−1)` for backfill season S,
-and by `MAX(train_through_season)` for daily upcoming scoring. Grants follow
+and by the greatest available `train_through_season < S` separately for each
+prediction season S during daily upcoming scoring. A same-season or future fit
+is never eligible, even if it is the newest stored fit. Missing eligible fits
+fail before any upcoming predictions are written. Grants follow
 `predictions` house style: `GRANT USAGE ON SCHEMA features` + `SELECT` to
 `anon, authenticated`; revoke write.
 
 ---
+
+### F03 season and event lifecycle amendment — September 6, 2026
+
+Annual automatic refits and finished-season ingestion optimizations use one
+shared lifecycle classifier. Automatic refits require every season in the
+expanding training window from 2015 through the candidate to exist and be
+closed; a newer closed year cannot bypass an unresolved older year. The earliest closure date is February 1 following
+the season (July 1 for the disrupted 2020 spring season). This is a lower bound,
+not evidence that a season ended. Require at least 100 canonical contests,
+postseason coverage, known kickoff dates, complete results with both scores,
+and no future or unresolved contests. Explicit reviewed cancellations may be
+terminal without scores; missing records, unknown dates/status, and old
+unresolved rows are not inferred cancellations. A regular-only truncated slate
+cannot close. These checks detect known incompleteness; they do not prove that
+the provider has published every possible contest.
+
+The games schedule remains reachable in unattended ingestion after closure,
+using a schedule-only refresh. Explicit loads retain their full resource scope.
+A newly discovered unfinished contest reopens the season on the next lifecycle
+assessment; scoring eligibility independently prevents same-season fit use.
+
+Verified superseded event identities are centralized in an installed Python
+module. Preserve raw provider rows. Exclude a known superseded original from
+modeled results, training/scoring populations, and feature inputs; projection
+schedule and closure decisions additionally require its matching replacement.
+The September 2026 Campbell–Western Carolina crosswalk remains an explicit
+reviewed exception, not a team-name deduplication heuristic. No real cancelled
+IDs are added without evidence. Existing materializations are not repaired by
+changing source code: any historical rebuild is a separately reviewed rollout.
 
 ## 3. Walk-forward protocol (implementable checklist)
 
@@ -555,8 +587,10 @@ For each `S` in `2018..2025`:
    (`prediction_date = start_date::date`, so re-runs are idempotent under the
    `(game_id, model_version, prediction_date)` key). `marts/038` scores it
    automatically.
-10. **Daily upcoming:** score pending games with the latest frozen fit
-    (`MAX(train_through_season)`).
+10. **Daily upcoming:** select the latest eligible frozen fit separately for
+    each pending season S, requiring `train_through_season < S`. Validate the
+    fit against each game before vectorization. Resolve all required fits
+    before writing the upcoming batch; no eligible fit is an error.
 
 **Gate B:** `fitted_v1` must beat `elo_v1` on walk-forward **MAE and Brier**
 (target Brier ≲ 0.168 vs elo's 0.187). Fail → stays advisory, not wired into

--- a/docs/plans/2026-09-04-main-codebase-audit.md
+++ b/docs/plans/2026-09-04-main-codebase-audit.md
@@ -99,6 +99,17 @@ Evidence: [skip policy and completion test](https://github.com/rstover-fo/cfb-da
 
 **Acceptance:** playoff tail, postponed final, cancelled game, incomplete provider schedule, and old unresolved rows cannot freeze a live season or admit an invalid fit. A completed historical season eventually closes without requiring every cancelled row to become completed.
 
+**Implementation prepared — September 6, 2026:** shared conservative lifecycle
+policy replaces all three ratio predicates, while finalized unattended loads
+retain a schedule-only refresh. Automatic refits require a contiguous closed
+training window and ignore future/premature stored fits when assessing staleness.
+Upcoming scoring independently selects and validates a strictly prior vintage
+per prediction season. Reviewed superseded event identities now filter modeled
+inputs without deleting raw rows. See [F03 implementation and rollout plan](2026-09-06-f03-season-lifecycle.md).
+Offline verification: 2,327 root tests passed (449 skipped), 59 MCP tests passed;
+independent cross-review resolved one refit staleness defect. Production
+rebuilds/training and historical data repair remain outside this implementation.
+
 ### F04 — Historical reconstructions and published forecasts share ambiguous provenance
 
 **P1 · Confirmed design defect · L**

--- a/docs/plans/2026-09-06-f03-season-lifecycle.md
+++ b/docs/plans/2026-09-06-f03-season-lifecycle.md
@@ -1,0 +1,72 @@
+# F03: season closure and fit eligibility
+
+## Objective
+
+Replace the three 99%-complete predicates that can close a live season and
+trigger same-season training. Keep schedule corrections reachable and enforce
+strict seasonal fit eligibility independently at prediction time.
+
+## Implementation boundaries
+
+- Shared lifecycle classification for unattended loader skips, player overview
+  eligibility, and annual refit selection. No percentage tolerance. Require the
+  conservative calendar floor, schedule coverage, resolved identities, complete
+  scored contests, and no future or unresolved games. Automatic refits require
+  all years in the expanding training window to be present and closed.
+- Unattended finalized-season ingestion still refreshes `/games`; it does not
+  repeatedly fetch drives or ancillary game resources. Manual loads retain their
+  requested scope. A reopened schedule is visible to subsequent eligibility
+  decisions; existing fit metadata never overrides the per-game scoring guard.
+- Upcoming scoring resolves the latest strictly earlier fit for every pending
+  season. Backfill remains exact S-1. Validate the selected vintage per game and
+  reject missing eligibility before writing the batch.
+- Centralize the reviewed Campbell–Western Carolina event replacement. Raw
+  records remain intact. Exclude the superseded original from modeled inputs;
+  full schedule/closure decisions require the matching replacement.
+
+## Acceptance evidence to collect
+
+1. A 1,600-game slate with ten unfinished games remains open.
+2. Playoff tails, future/postponed games, missing dates/scores, a truncated
+   regular-only schedule, and old unresolved records cannot imply closure.
+3. An explicitly reviewed cancellation can be terminal; unreviewed missing rows
+   cannot. A resolved, fully completed historical season can close.
+4. Schedule-only reconciliation remains invoked on the unattended final path;
+   explicit loads preserve full resources and reopening remains possible.
+5. Mixed prediction seasons use independently eligible vintages; same/future
+   fits and a batch with no eligible fit cannot write predictions.
+6. Executed fixture queries exclude the false completed original while keeping
+   the replacement and unrelated repeated matchups.
+7. Independent review, affected lint/format checks, root tests, and PR CI pass.
+
+## Rollout and limits
+
+This change does not run ingestion, train models, deploy schema, repair stored
+fits, or rebuild historical predictions/features. Existing invalid snapshots
+need a separately reviewed rebuild; filtering query inputs does not erase them.
+After merge, inspect the next daily lifecycle/coverage gates. An unresolved
+historical season requires investigation and a reviewed correction or explicit
+cancellation resolution, not loosening the threshold.
+
+A local warehouse snapshot cannot prove the provider published every future
+contest. Calendar and coverage checks detect common incomplete schedules; the
+continuing reconciliation path and independent scoring guard contain that risk.
+The special 2020 closure floor accommodates the spring-season disruption:
+the [NCAA 2020–21 FCS bracket](https://www.ncaa.com/brackets/print/football/fcs/2020)
+places the championship on May 16, 2021. July 1 is our conservative policy
+buffer, not an NCAA definition of season completion.
+
+## Implemented and verified locally
+
+The shared classifier, schedule-only reconciliation, per-season scoring guard,
+contiguous automatic-refit frontier, and shared event exclusions are implemented.
+Independent cross-review found and resolved a staleness defect: an existing
+premature/future fit could suppress creation of the correct eligible vintage.
+Such vintages now do not count as current relative to the safe frontier.
+
+Full offline suite: 2,327 passed, 449 skipped. MCP suite: 59 passed. Executed
+SQLite fixtures cover canonical result/target queries; mocked orchestration
+executes real fit selection/vectorization and confirms no writes for invalid
+eligibility. Independent reviews found no remaining actionable correctness
+issues. The full Postgres feature query and production rebuild were not executed
+locally. No performance improvement or production repair is claimed.

--- a/docs/plans/2026-09-06-f03-season-lifecycle.md
+++ b/docs/plans/2026-09-06-f03-season-lifecycle.md
@@ -70,3 +70,27 @@ executes real fit selection/vectorization and confirms no writes for invalid
 eligibility. Independent reviews found no remaining actionable correctness
 issues. The full Postgres feature query and production rebuild were not executed
 locally. No performance improvement or production repair is claimed.
+
+## PR review corrections
+
+Four valid review findings required additional integration work:
+
+- Upcoming predictions now use only feature-compatible fits at or below the
+  shared contiguous closed training frontier, in addition to the independent
+  strictly-prior-season guard. A partial 2026 fit cannot score 2027 while the
+  closed frontier is 2025.
+- Every pending season must meet 90% coverage before any upcoming batch write.
+  A 1,600-game covered season cannot hide 20 featureless next-season games.
+- Daily coverage verification reuses the scorer's canonical pending predicate,
+  including its max-season anchor, and checks each season separately.
+- Preseason backtests exclude reviewed non-contests from result rows, scheduled
+  counts, and the earliest stored feature source.
+
+The actual PostgreSQL 16 backtest query was executed against a disposable local
+fixture: the false completed 0–0 original and its distinct week-one feature
+values were excluded; the replacement and a genuine rematch remained. The
+container was removed afterward. No production access or backtest run occurred.
+
+Review-fix validation: 2,340 root tests passed, 449 integration tests skipped;
+affected Ruff lint/format and whitespace checks passed. The PostgreSQL fixture
+validated the real backtest query, not production outcomes.

--- a/docs/warehouse-operations.md
+++ b/docs/warehouse-operations.md
@@ -117,7 +117,11 @@ assessment; expensive sources skipped earlier in that run resume on the next
 unattended run, or immediately through an explicit source load.
 
 Upcoming fitted predictions select a fit strictly earlier than each pending
-season, independently of closure. Missing eligible fits fail before writes.
+season and no later than the shared contiguous closed training frontier.
+Missing eligible fits fail before writes. Every pending season must separately
+meet the 90% feature/scoring coverage threshold before any upcoming write.
+The post-load verifier applies the same canonical pending population and
+per-season threshold.
 Backfills still require exactly the previous-season vintage. The reviewed event
 crosswalk in `src/pipelines/game_identity.py` excludes known superseded originals
 from modeled inputs while preserving raw data. The projection schedule also

--- a/docs/warehouse-operations.md
+++ b/docs/warehouse-operations.md
@@ -101,6 +101,33 @@ scoped runs; a code merge alone does not refresh stored outputs. The live blend
 path using full-season EPA remains separate from the weekly feature and
 as-of-backfill consumers covered here.
 
+## Season closure and fit eligibility
+
+`src/pipelines/season_lifecycle.py` owns finished-season decisions for loader
+skips, player overviews, and automatic refits. Closure requires a sufficiently
+populated regular/postseason schedule, the calendar floor, complete scored
+results with known dates, and no future or unresolved contests. The former 99%
+tolerance is removed. Unknown or old unresolved records stay open until
+reconciled; only reviewed cancellation IDs are terminal without results.
+
+The unattended finalized-season path still fetches `/games` with a schedule-only
+load. Explicit `--season`, `--sources`, and `--no-skip-final` requests retain full
+loading behavior. A newly discovered unfinished game reopens the next lifecycle
+assessment; expensive sources skipped earlier in that run resume on the next
+unattended run, or immediately through an explicit source load.
+
+Upcoming fitted predictions select a fit strictly earlier than each pending
+season, independently of closure. Missing eligible fits fail before writes.
+Backfills still require exactly the previous-season vintage. The reviewed event
+crosswalk in `src/pipelines/game_identity.py` excludes known superseded originals
+from modeled inputs while preserving raw data. The projection schedule also
+requires a matching replacement. Do not infer cancellations from age, 0–0
+scores, missing provider rows, or matching team names.
+
+See [F03 plan](plans/2026-09-06-f03-season-lifecycle.md) for acceptance and rollout
+limits. No existing materialization or stored prediction is repaired merely by
+merging these query changes.
+
 ## Season outlook schedule drift
 
 `api.season_outlook.games_scheduled` belongs to the saved projection snapshot;

--- a/scripts/backtest_preseason.py
+++ b/scripts/backtest_preseason.py
@@ -114,6 +114,7 @@ from scripts.simulate_season import (
     summarize,
 )
 from scripts.train_model import MODEL_VERSION, TEAM_WEEK_SOURCE_COLUMNS
+from src.pipelines.game_identity import eligible_game_sql
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
@@ -376,6 +377,7 @@ def _week1_games_query() -> str:
                    team, week_index, games_played_to_date, {tw_cols}
             FROM features.team_week
             WHERE season = %(season)s
+              AND {eligible_game_sql("game_id")}
             ORDER BY team, week_index, game_id
         )
         SELECT g.id AS game_id, g.season, g.season_type, g.week, g.start_date,
@@ -391,6 +393,7 @@ def _week1_games_query() -> str:
         JOIN week1 a ON a.team = g.away_team
         WHERE g.season = %(season)s
           AND g.season_type = %(season_type)s
+          AND {eligible_game_sql()}
           AND COALESCE(g.completed, false)
           AND g.home_points IS NOT NULL
           AND g.away_points IS NOT NULL
@@ -436,13 +439,15 @@ def fetch_scheduled_counts(conn, season: int) -> dict:
     """Regular-season games on each team's schedule, for coverage reporting."""
     with conn.cursor() as cur:
         cur.execute(
-            """
+            f"""
             SELECT team, COUNT(*) FROM (
-                SELECT home_team AS team FROM core.games
+                SELECT home_team AS team FROM core.games g
                 WHERE season = %(season)s AND season_type = %(season_type)s
+                  AND {eligible_game_sql()}
                 UNION ALL
-                SELECT away_team FROM core.games
+                SELECT away_team FROM core.games g
                 WHERE season = %(season)s AND season_type = %(season_type)s
+                  AND {eligible_game_sql()}
             ) t GROUP BY team
             """,
             {"season": season, "season_type": BACKTEST_SEASON_TYPE},

--- a/scripts/build_features.py
+++ b/scripts/build_features.py
@@ -70,6 +70,7 @@ import sys
 from collections import defaultdict
 
 from scripts.compute_predictions import fetch_elo_current, resolve_elo
+from src.pipelines.game_identity import eligible_game_sql
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
@@ -427,6 +428,7 @@ plays_wi AS (
     JOIN core.games g ON g.id = pe.game_id
     WHERE pe.season = %(season)s
       AND NOT pe.is_garbage_time
+      AND {eligible_game_sql()}
 ),
 off_week_agg AS (
     SELECT
@@ -464,6 +466,7 @@ drives_wi AS (
     FROM core.drives d
     JOIN core.games g ON g.id = d.game_id
     WHERE g.season = %(season)s
+      AND {eligible_game_sql()}
 ),
 off_drive_week_agg AS (
     SELECT
@@ -502,6 +505,7 @@ havoc_wi AS (
     FROM stats.game_havoc gh
     JOIN core.games g ON g.id = gh.game_id
     WHERE g.season = %(season)s
+      AND {eligible_game_sql()}
 ),
 havoc_week_agg AS (
     SELECT
@@ -522,14 +526,14 @@ spine AS (
         CASE WHEN g.season_type = 'postseason' THEN 100 + g.week ELSE g.week END AS week_index,
         g.home_team AS team, g.home_conference AS conference, true AS is_home
     FROM core.games g
-    WHERE g.season = %(season)s
+    WHERE g.season = %(season)s AND {eligible_game_sql()}
     UNION ALL
     SELECT
         g.id, g.season, g.season_type, g.week,
         CASE WHEN g.season_type = 'postseason' THEN 100 + g.week ELSE g.week END,
         g.away_team, g.away_conference, false
     FROM core.games g
-    WHERE g.season = %(season)s
+    WHERE g.season = %(season)s AND {eligible_game_sql()}
 )
 SELECT
     s.season,
@@ -655,6 +659,7 @@ LEFT JOIN LATERAL (
     FROM core.games gp
     WHERE COALESCE(gp.completed, false)
       AND gp.season = s.season
+      AND {eligible_game_sql("gp.id")}
       AND (gp.home_team = s.team OR gp.away_team = s.team)
       AND (CASE WHEN gp.season_type = 'postseason' THEN 100 + gp.week ELSE gp.week END)
           < s.week_index

--- a/scripts/compute_adjusted_epa.py
+++ b/scripts/compute_adjusted_epa.py
@@ -27,6 +27,8 @@ from collections.abc import Iterable
 
 import numpy as np
 
+from src.pipelines.game_identity import eligible_game_sql
+
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
 
@@ -41,7 +43,7 @@ LAMBDA = 100.0
 # Server-side cursor fetch batch size for the per-season play stream.
 CURSOR_ITERSIZE = 10_000
 
-PLAY_QUERY = """
+PLAY_QUERY = f"""
     SELECT
         pe.offense,
         pe.defense,
@@ -52,12 +54,17 @@ PLAY_QUERY = """
     WHERE pe.season = %s
       AND NOT pe.is_garbage_time
       AND pe.epa IS NOT NULL
+      AND {eligible_game_sql()}
 """
 
-TEAM_LIST_QUERY = """
-    SELECT DISTINCT offense AS team FROM marts.play_epa WHERE season = %s
+TEAM_LIST_QUERY = f"""
+    SELECT DISTINCT pe.offense AS team
+    FROM marts.play_epa pe
+    WHERE pe.season = %s AND {eligible_game_sql("pe.game_id")}
     UNION
-    SELECT DISTINCT defense AS team FROM marts.play_epa WHERE season = %s
+    SELECT DISTINCT pe.defense AS team
+    FROM marts.play_epa pe
+    WHERE pe.season = %s AND {eligible_game_sql("pe.game_id")}
 """
 
 
@@ -208,7 +215,9 @@ def get_season_teams(cur, season: int) -> list[str]:
 
 
 def get_max_season(cur) -> int | None:
-    cur.execute("SELECT MAX(season) FROM marts.play_epa")
+    cur.execute(
+        f"SELECT MAX(pe.season) FROM marts.play_epa pe WHERE {eligible_game_sql('pe.game_id')}"
+    )
     row = cur.fetchone()
     return int(row[0]) if row and row[0] is not None else None
 

--- a/scripts/compute_adjusted_epa_week.py
+++ b/scripts/compute_adjusted_epa_week.py
@@ -84,6 +84,7 @@ from scripts.compute_adjusted_epa import (
     get_max_season,
     get_season_teams,
 )
+from src.pipelines.game_identity import eligible_game_sql
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
@@ -91,7 +92,7 @@ logger = logging.getLogger(__name__)
 # Play row: (offense, defense, is_home_offense, epa) from compute_adjusted_epa's
 # PLAY_QUERY, plus week_index computed in SQL from the joined game's week /
 # season_type (see module docstring for the week_index convention).
-PLAY_QUERY_WEEK = """
+PLAY_QUERY_WEEK = f"""
     SELECT
         pe.offense,
         pe.defense,
@@ -104,19 +105,21 @@ PLAY_QUERY_WEEK = """
       AND g.season_type IN ('regular', 'postseason')
       AND NOT pe.is_garbage_time
       AND pe.epa IS NOT NULL
+      AND {eligible_game_sql()}
     ORDER BY week_index, pe.game_id
 """
 
-TARGET_WEEK_INDEX_QUERY = """
+TARGET_WEEK_INDEX_QUERY = f"""
     SELECT DISTINCT
         CASE
             WHEN season_type = 'regular' THEN week
             WHEN season_type = 'postseason' THEN 100 + week
         END AS week_index
-    FROM core.games
+    FROM core.games g
     WHERE season = %s
       AND week IS NOT NULL
       AND season_type IN ('regular', 'postseason')
+      AND {eligible_game_sql()}
     ORDER BY week_index
 """
 

--- a/scripts/compute_house_elo.py
+++ b/scripts/compute_house_elo.py
@@ -44,6 +44,8 @@ from collections import Counter, defaultdict
 
 import dlt
 
+from src.pipelines.game_identity import eligible_game_sql
+
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
 
@@ -327,7 +329,7 @@ def get_db_url() -> str:
     return url
 
 
-GAMES_QUERY = """
+GAMES_QUERY = f"""
     SELECT id, season, week, season_type, start_date, neutral_site,
            home_team, away_team, home_points, away_points,
            home_pregame_elo, away_pregame_elo
@@ -336,6 +338,7 @@ GAMES_QUERY = """
       AND home_points IS NOT NULL
       AND away_points IS NOT NULL
       AND season BETWEEN %s AND %s
+      AND {eligible_game_sql("id")}
     ORDER BY start_date NULLS LAST, id
 """
 
@@ -397,14 +400,16 @@ def compute_team_game_counts(season_games: list[dict]) -> dict[str, int]:
 # normal team into the pooled __FCS__ bucket and overwrite their carried
 # ratings with the 1500 pooled rating (Codex P1, PR #18). For fully played-out
 # historical seasons the two counts are identical, so --full is unaffected.
-SCHEDULED_COUNTS_QUERY = """
+SCHEDULED_COUNTS_QUERY = f"""
     SELECT season, team, COUNT(*) AS n
     FROM (
         SELECT season, home_team AS team
-        FROM core.games WHERE season BETWEEN %s AND %s
+        FROM core.games g
+        WHERE season BETWEEN %s AND %s AND {eligible_game_sql()}
         UNION ALL
         SELECT season, away_team AS team
-        FROM core.games WHERE season BETWEEN %s AND %s
+        FROM core.games g
+        WHERE season BETWEEN %s AND %s AND {eligible_game_sql()}
     ) sides
     GROUP BY season, team
 """
@@ -468,14 +473,17 @@ def seed_state(engine: EloEngine, conn, target_season: int) -> None:
 
 def fetch_max_season(conn) -> int | None:
     with conn.cursor() as cur:
-        cur.execute("SELECT MAX(season) FROM core.games")
+        cur.execute(f"SELECT MAX(season) FROM core.games WHERE {eligible_game_sql('id')}")
         row = cur.fetchone()
     return row[0] if row else None
 
 
 def fetch_max_completed_season(conn) -> int | None:
     with conn.cursor() as cur:
-        cur.execute("SELECT MAX(season) FROM core.games WHERE completed = true")
+        cur.execute(
+            f"SELECT MAX(season) FROM core.games "
+            f"WHERE completed = true AND {eligible_game_sql('id')}"
+        )
         row = cur.fetchone()
     return row[0] if row else None
 

--- a/scripts/compute_predictions.py
+++ b/scripts/compute_predictions.py
@@ -67,6 +67,7 @@ import sys
 from datetime import date
 
 from scripts.compute_house_elo import EloEngine, expected_score
+from src.pipelines.game_identity import eligible_game_sql
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
@@ -360,20 +361,25 @@ def get_db_url() -> str:
     return url
 
 
-TARGET_GAMES_QUERY = """
+TARGET_GAMES_QUERY = f"""
     SELECT id AS game_id, season, week, season_type, start_date, neutral_site,
            home_team, away_team
     FROM core.games
     WHERE NOT COALESCE(completed, false)
-      AND season >= (SELECT COALESCE(MAX(season), 0) FROM core.games WHERE completed)
+      AND {eligible_game_sql("id")}
+      AND season >= (
+          SELECT COALESCE(MAX(season), 0) FROM core.games
+          WHERE completed AND {eligible_game_sql("id")}
+      )
     ORDER BY season, start_date NULLS LAST, id
 """
 
-BACKFILL_GAMES_QUERY = """
+BACKFILL_GAMES_QUERY = f"""
     SELECT game_id, season, week, season_type, start_date, neutral_site,
            home_team, away_team, home_pregame_elo, away_pregame_elo
     FROM analytics.house_elo_game
     WHERE season = %s
+      AND {eligible_game_sql("game_id")}
     ORDER BY start_date NULLS LAST, game_id
 """
 

--- a/scripts/load_season.py
+++ b/scripts/load_season.py
@@ -19,6 +19,7 @@ import os
 import sys
 import time
 
+from src.pipelines.season_lifecycle import season_is_final
 from src.pipelines.utils.request_outcomes import request_failure_summary
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
@@ -196,7 +197,6 @@ ESTIMATED_CALLS = {
 #                  would skip the only seasons it is allowed to touch.
 IMMUTABLE_ONCE_FINAL = frozenset(
     {
-        "games",
         "playoffs",
         "game_stats",
         "plays",
@@ -221,31 +221,6 @@ IMMUTABLE_ONCE_FINAL = frozenset(
         "rosters",
     }
 )
-
-# A season counts as finished on the same terms train_model.py uses for its
-# refit guard -- one definition of "finished" in the codebase, not two. A
-# permanently un-completed row (a cancellation) must not freeze a season as
-# unfinished forever, hence a tolerance rather than requiring literal 100%.
-SEASON_COMPLETE_THRESHOLD = 0.99
-MIN_GAMES_FOR_FINISHED_SEASON = 100
-
-
-def season_is_final(conn, season: int) -> bool:
-    """True when `season` has essentially every scheduled game completed."""
-    with conn.cursor() as cur:
-        cur.execute(
-            """
-            SELECT COUNT(*) AS n,
-                   AVG(CASE WHEN COALESCE(completed, false) THEN 1.0 ELSE 0.0 END) AS pct
-            FROM core.games
-            WHERE season = %s
-            """,
-            (season,),
-        )
-        n, pct = cur.fetchone()
-    if not n or n < MIN_GAMES_FOR_FINISHED_SEASON:
-        return False
-    return float(pct or 0.0) >= SEASON_COMPLETE_THRESHOLD
 
 
 def sources_to_skip(active_sources, season_final: bool, allow_skip: bool):
@@ -483,6 +458,7 @@ def load_season(
     # dry-run figure and the budget check reflect what will actually be
     # fetched rather than what would have been.
     skipped_final = []
+    season_final = False
     if allow_skip_final:
         import psycopg2
 
@@ -490,10 +466,10 @@ def load_season(
 
         conn_check = psycopg2.connect(get_db_url())
         try:
-            final = season_is_final(conn_check, season)
+            season_final = season_is_final(conn_check, season)
         finally:
             conn_check.close()
-        skipped_final = sources_to_skip(active_sources, final, allow_skip_final)
+        skipped_final = sources_to_skip(active_sources, season_final, allow_skip_final)
         if skipped_final:
             saved = sum(ESTIMATED_CALLS.get(s, 50) for s in skipped_final)
             logger.info(
@@ -507,13 +483,15 @@ def load_season(
                 season,
             )
             active_sources = [s for s in active_sources if s not in skipped_final]
-        elif final:
+        elif season_final:
             logger.info("Season %d is finished but no immutable source was selected", season)
 
     # Estimate API calls. A resource-filtered source costs a call per named
     # resource per season, not the whole source's per-game fan-out.
     def estimate(src: str) -> int:
         named = resource_filters.get(src)
+        if src == "games" and season_final:
+            return 1
         return len(named) if named else ESTIMATED_CALLS.get(src, 50)
 
     total_est = sum(estimate(s) for s in active_sources)
@@ -572,7 +550,11 @@ def load_season(
         # scoped to the season this load_season() call targets. See
         # run_coach_profiles_pipeline and the IMMUTABLE_ONCE_FINAL comment above.
         "coach_profiles": lambda: run_coach_profiles_pipeline(),
-        "games": lambda: run_games_pipeline(years=[season]),
+        # Even after finality, keep the cheap /games schedule merge reachable
+        # so corrections and newly published rows can reopen the season.  The
+        # expensive drives/media/weather/records bundle is immutable enough to
+        # skip on the unattended path once lifecycle policy says final.
+        "games": lambda: run_games_pipeline(years=[season], schedule_only=season_final),
         "playoffs": lambda: run_playoffs_pipeline(years=[season]),
         "game_stats": game_stats_runner,
         "plays": lambda: run_plays_pipeline(years=[season]),

--- a/scripts/score_fitted.py
+++ b/scripts/score_fitted.py
@@ -18,8 +18,8 @@ side's ``team_week.elo_pregame`` (the pregame Elo the ``d_elo`` feature used).
 
 Frozen-fit selection (design section 2d / 3): for a backfill season ``S`` the fit
 at ``train_through_season = S-1`` is used (hard error if it is missing -- never
-silently fall back); for daily upcoming scoring the latest fit
-(``MAX(train_through_season)``) is used.
+silently fall back); for daily upcoming scoring each season ``S`` uses the
+latest fit with ``train_through_season < S``.
 
 Usage:
     python scripts/score_fitted.py --backfill 2018 2025
@@ -62,6 +62,7 @@ from scripts.train_model import (
     platt_transform,
     standardize,
 )
+from src.pipelines.game_identity import eligible_game_sql
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
@@ -110,17 +111,22 @@ def select_train_through(
 
     ``mode='backfill'``: score season ``S`` -> ``S-1`` (walk-forward: the game's
     season was never in that fit's train window). ``mode='upcoming'``: the latest
-    fit, ``max(available_train_through)``. Pure so both branches are testable
-    without a DB.
+    available fit strictly before ``score_season``. Pure so both branches are
+    testable without a DB.
     """
     if mode == "backfill":
         if score_season is None:
             raise ValueError("backfill selection needs score_season")
         return score_season - 1
     if mode == "upcoming":
-        if not available_train_through:
-            raise ValueError("no frozen fitted_v1 fits available for upcoming scoring")
-        return max(available_train_through)
+        if score_season is None:
+            raise ValueError("upcoming selection needs score_season")
+        eligible = [season for season in available_train_through or [] if season < score_season]
+        if not eligible:
+            raise ValueError(
+                f"no eligible frozen fitted_v1 fit with train_through_season < {score_season}"
+            )
+        return max(eligible)
     raise ValueError(f"unknown selection mode {mode!r}")
 
 
@@ -131,6 +137,12 @@ def score_game(game: dict, fit: dict) -> tuple[float, float]:
     stats, dots with the ridge-margin beta for the expected margin and with the
     IRLS beta for the logit, then Platt-calibrates. Returns Python floats (psycopg2
     does not adapt numpy scalars)."""
+    train_through = fit.get("train_through")
+    if train_through is None or train_through >= game["season"]:
+        raise ValueError(
+            f"fit train_through_season={train_through} must be before "
+            f"prediction season={game['season']}"
+        )
     x_raw = build_feature_vector(game, game["home_tw"], game["away_tw"], fit["feature_means"])
     x_std = standardize(x_raw, fit["diff_means"], fit["diff_stds"])
     expected_margin = float(x_std @ fit["beta_margin"])
@@ -213,13 +225,16 @@ def _score_games_query(where_clause: str) -> str:
 # Completed games of a single season (backfill scope).
 _BACKFILL_WHERE = (
     "g.season = %s AND COALESCE(g.completed, false) "
-    "AND g.home_points IS NOT NULL AND g.away_points IS NOT NULL"
+    "AND g.home_points IS NOT NULL AND g.away_points IS NOT NULL "
+    f"AND {eligible_game_sql('g.id')}"
 )
 # Pending games of the current-or-later season, mirroring
 # compute_predictions.TARGET_GAMES_QUERY's selection.
 _UPCOMING_WHERE = (
     "NOT COALESCE(g.completed, false) "
-    "AND g.season >= (SELECT COALESCE(MAX(season), 0) FROM core.games WHERE completed)"
+    f"AND {eligible_game_sql('g.id')} "
+    "AND g.season >= (SELECT COALESCE(MAX(season), 0) FROM core.games "
+    f"WHERE completed AND {eligible_game_sql('id')})"
 )
 
 
@@ -271,13 +286,10 @@ def fetch_pending_game_count(conn) -> int:
     """
     with conn.cursor() as cur:
         cur.execute(
-            """
+            f"""
             SELECT COUNT(*)
             FROM core.games g
-            WHERE NOT COALESCE(g.completed, false)
-              AND g.season >= (
-                  SELECT COALESCE(MAX(season), 0) FROM core.games WHERE completed
-              )
+            WHERE {_UPCOMING_WHERE}
             """
         )
         return int(cur.fetchone()[0])
@@ -290,6 +302,15 @@ def fetch_available_train_through(conn) -> list[int]:
             "SELECT DISTINCT train_through_season FROM features.model_metadata "
             "WHERE model_version = %s",
             (MODEL_VERSION,),
+        )
+        return [int(row[0]) for row in cur.fetchall()]
+
+
+def fetch_pending_seasons(conn) -> list[int]:
+    """All pending prediction seasons, including games missing feature rows."""
+    with conn.cursor() as cur:
+        cur.execute(
+            f"SELECT DISTINCT g.season FROM core.games g WHERE {_UPCOMING_WHERE} ORDER BY g.season"
         )
         return [int(row[0]) for row in cur.fetchall()]
 
@@ -414,16 +435,6 @@ def run_backfill(conn, start: int, end: int) -> None:
 
 
 def run_upcoming(conn) -> None:
-    available = fetch_available_train_through(conn)
-    if not available:
-        logger.error(
-            "No frozen %s fits in features.model_metadata; run train_model.py", MODEL_VERSION
-        )
-        sys.exit(1)
-    train_through = select_train_through("upcoming", available_train_through=available)
-    fit = load_fit(conn, train_through)
-    logger.info("Upcoming scoring with latest frozen fit train_through=%d", train_through)
-
     # Counted before the feature join -- see fetch_pending_game_count.
     n_pending = fetch_pending_game_count(conn)
     games = fetch_upcoming_games(conn)
@@ -445,6 +456,20 @@ def run_upcoming(conn) -> None:
         )
         sys.exit(1)
 
+    available = fetch_available_train_through(conn)
+    # Include pending seasons without feature coverage, so a missing eligible
+    # fit cannot hide behind the feature join or cause a partially written batch.
+    pending_seasons = set(fetch_pending_seasons(conn)) | {g["season"] for g in games}
+    train_through_by_season = {
+        season: select_train_through("upcoming", season, available)
+        for season in sorted(pending_seasons)
+    }
+    fits = {
+        train_through: load_fit(conn, train_through)
+        for train_through in sorted(set(train_through_by_season.values()))
+    }
+    logger.info("Upcoming frozen fits by prediction season: %s", train_through_by_season)
+
     game_ids = [g["game_id"] for g in games]
     if table_exists(conn, "betting", "line_snapshots"):
         market_by_game = fetch_market_from_snapshots(conn, game_ids)
@@ -456,6 +481,7 @@ def run_upcoming(conn) -> None:
     rows: list[dict] = []
     n_with_market = 0
     for game in games:
+        fit = fits[train_through_by_season[game["season"]]]
         expected_margin, win_prob = score_game(game, fit)
         market = market_by_game.get(game["game_id"])
         if market and market.get("spread") is not None:
@@ -474,7 +500,7 @@ def run_upcoming(conn) -> None:
     for season in sorted(per_season):
         print(
             f"SCORED_GATE season={season} rows={per_season[season]} model={MODEL_VERSION} "
-            f"train_through={train_through}"
+            f"train_through={train_through_by_season[season]}"
         )
 
     # Rows already written above -- partial output is more useful than none --
@@ -512,7 +538,8 @@ def main() -> None:
     group.add_argument(
         "--upcoming",
         action="store_true",
-        help="Score pending games with the latest frozen fit (default when no flag).",
+        help="Score each pending season with its latest strictly prior frozen fit "
+        "(default when no flag).",
     )
     args = parser.parse_args()
 

--- a/scripts/score_fitted.py
+++ b/scripts/score_fitted.py
@@ -20,6 +20,9 @@ Frozen-fit selection (design section 2d / 3): for a backfill season ``S`` the fi
 at ``train_through_season = S-1`` is used (hard error if it is missing -- never
 silently fall back); for daily upcoming scoring each season ``S`` uses the
 latest fit with ``train_through_season < S``.
+Upcoming fits must also satisfy the shared contiguous season-finality and
+feature-compatibility policy. Every pending season must meet the coverage
+threshold before any upcoming predictions are written.
 
 Usage:
     python scripts/score_fitted.py --backfill 2018 2025
@@ -59,6 +62,7 @@ from scripts.train_model import (
     MODEL_VERSION,
     TEAM_WEEK_SOURCE_COLUMNS,
     build_feature_vector,
+    fetch_refit_state,
     platt_transform,
     standardize,
 )
@@ -73,7 +77,7 @@ logger = logging.getLogger(__name__)
 # =============================================================================
 
 
-# Minimum share of pending games that must actually score for an upcoming run
+# Minimum share of pending games in EACH season that must score for an upcoming run
 # to be considered healthy. Below this, run_upcoming exits non-zero rather than
 # logging "nothing to write" and returning success -- the exact silent path
 # that left fitted_v1 with zero 2026 rows for six months of green workflow runs
@@ -230,7 +234,7 @@ _BACKFILL_WHERE = (
 )
 # Pending games of the current-or-later season, mirroring
 # compute_predictions.TARGET_GAMES_QUERY's selection.
-_UPCOMING_WHERE = (
+PENDING_GAMES_WHERE = (
     "NOT COALESCE(g.completed, false) "
     f"AND {eligible_game_sql('g.id')} "
     "AND g.season >= (SELECT COALESCE(MAX(season), 0) FROM core.games "
@@ -272,27 +276,31 @@ def fetch_upcoming_games(conn) -> list[dict]:
     import psycopg2.extras
 
     with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
-        cur.execute(_score_games_query(_UPCOMING_WHERE))
+        cur.execute(_score_games_query(PENDING_GAMES_WHERE))
         return _rows_to_games(cur.fetchall())
 
 
-def fetch_pending_game_count(conn) -> int:
+def fetch_pending_game_counts(conn) -> dict[int, int]:
     """Pending games in the projection window, counted from ``core.games``
     ALONE -- deliberately without the ``features.team_week`` join.
 
     This is the denominator the coverage gate needs: joining team_week here
     would make the count agree with the scored count by construction and the
-    gate could never fire. Predicate matches ``_UPCOMING_WHERE`` exactly.
+    gate could never fire. Grouping by season prevents a large covered season
+    from hiding missing features in a smaller pending season. Predicate matches
+    ``PENDING_GAMES_WHERE`` exactly.
     """
     with conn.cursor() as cur:
         cur.execute(
             f"""
-            SELECT COUNT(*)
+            SELECT g.season, COUNT(*)
             FROM core.games g
-            WHERE {_UPCOMING_WHERE}
+            WHERE {PENDING_GAMES_WHERE}
+            GROUP BY g.season
+            ORDER BY g.season
             """
         )
-        return int(cur.fetchone()[0])
+        return {int(season): int(count) for season, count in cur.fetchall()}
 
 
 def fetch_available_train_through(conn) -> list[int]:
@@ -302,15 +310,6 @@ def fetch_available_train_through(conn) -> list[int]:
             "SELECT DISTINCT train_through_season FROM features.model_metadata "
             "WHERE model_version = %s",
             (MODEL_VERSION,),
-        )
-        return [int(row[0]) for row in cur.fetchall()]
-
-
-def fetch_pending_seasons(conn) -> list[int]:
-    """All pending prediction seasons, including games missing feature rows."""
-    with conn.cursor() as cur:
-        cur.execute(
-            f"SELECT DISTINCT g.season FROM core.games g WHERE {_UPCOMING_WHERE} ORDER BY g.season"
         )
         return [int(row[0]) for row in cur.fetchall()]
 
@@ -435,34 +434,55 @@ def run_backfill(conn, start: int, end: int) -> None:
 
 
 def run_upcoming(conn) -> None:
-    # Counted before the feature join -- see fetch_pending_game_count.
-    n_pending = fetch_pending_game_count(conn)
+    # Each denominator is counted before the feature join.
+    pending_counts = fetch_pending_game_counts(conn)
     games = fetch_upcoming_games(conn)
+    per_season = Counter(g["season"] for g in games)
+    n_pending = sum(pending_counts.values())
 
-    if not games:
-        ok, coverage = coverage_verdict(n_pending, 0)
+    if not pending_counts and not games:
         print(
-            f"FITTED_COVERAGE_GATE pending={n_pending} scored=0 "
+            "FITTED_COVERAGE_GATE pending=0 scored=0 "
+            f"coverage=1.000 threshold={MIN_UPCOMING_COVERAGE:.2f}"
+        )
+        logger.info("No pending games at all; nothing to write")
+        return
+
+    failed_seasons = []
+    for season in sorted(set(pending_counts) | set(per_season)):
+        pending = pending_counts.get(season, 0)
+        scored = per_season[season]
+        ok, coverage = coverage_verdict(pending, scored)
+        print(
+            f"FITTED_COVERAGE_GATE season={season} pending={pending} scored={scored} "
             f"coverage={coverage:.3f} threshold={MIN_UPCOMING_COVERAGE:.2f}"
         )
-        if ok:
-            logger.info("No pending games at all; nothing to write")
-            return
+        # A season appearing only after the denominator query is not a verified
+        # scoring population; require a retry rather than bypassing its gate.
+        if not ok or season not in pending_counts:
+            failed_seasons.append(season)
+    _, total_coverage = coverage_verdict(n_pending, len(games))
+    print(
+        f"FITTED_COVERAGE_GATE pending={n_pending} scored={len(games)} "
+        f"coverage={total_coverage:.3f} threshold={MIN_UPCOMING_COVERAGE:.2f}"
+    )
+    if failed_seasons:
         logger.error(
-            "%d pending game(s) exist but NONE have features.team_week rows -- the "
-            "feature substrate has not been built for the upcoming season. Run "
-            "scripts/build_features.py --incremental.",
-            n_pending,
+            "Pending season(s) %s failed the per-season coverage gate; no predictions written. "
+            "Run scripts/build_features.py --incremental and retry.",
+            failed_seasons,
         )
         sys.exit(1)
 
-    available = fetch_available_train_through(conn)
-    # Include pending seasons without feature coverage, so a missing eligible
-    # fit cannot hide behind the feature join or cause a partially written batch.
-    pending_seasons = set(fetch_pending_seasons(conn)) | {g["season"] for g in games}
+    frontier, available = fetch_refit_state(conn)
+    if frontier is None:
+        raise ValueError("no safe closed training frontier for upcoming fitted_v1 scoring")
+    # The shared state also rejects incompatible stored feature contracts. The
+    # strict per-game season guard remains independent of that lifecycle gate.
+    available = [season for season in available if season <= frontier]
     train_through_by_season = {
         season: select_train_through("upcoming", season, available)
-        for season in sorted(pending_seasons)
+        for season in sorted(pending_counts)
     }
     fits = {
         train_through: load_fit(conn, train_through)
@@ -496,30 +516,11 @@ def run_upcoming(conn) -> None:
         n_with_market,
     )
 
-    per_season = Counter(g["season"] for g in games)
     for season in sorted(per_season):
         print(
             f"SCORED_GATE season={season} rows={per_season[season]} model={MODEL_VERSION} "
             f"train_through={train_through_by_season[season]}"
         )
-
-    # Rows already written above -- partial output is more useful than none --
-    # but a shortfall still fails the run so it cannot pass silently.
-    ok, coverage = coverage_verdict(n_pending, len(games))
-    print(
-        f"FITTED_COVERAGE_GATE pending={n_pending} scored={len(games)} "
-        f"coverage={coverage:.3f} threshold={MIN_UPCOMING_COVERAGE:.2f}"
-    )
-    if not ok:
-        logger.error(
-            "fitted_v1 scored only %d of %d pending game(s) (%.1f%% < %.0f%%); "
-            "features.team_week is incomplete for the upcoming season",
-            len(games),
-            n_pending,
-            coverage * 100,
-            MIN_UPCOMING_COVERAGE * 100,
-        )
-        sys.exit(1)
 
 
 def main() -> None:

--- a/scripts/simulate_season.py
+++ b/scripts/simulate_season.py
@@ -87,6 +87,8 @@ import logging
 import math
 import sys
 
+from src.pipelines.game_identity import eligible_game_sql, select_canonical_game_rows
+
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
 
@@ -157,15 +159,6 @@ MIN_SIGMA_GAMES = 100
 # projections to jump as the postseason bracket is published.
 PROJECTION_SEASON_TYPE = "regular"
 
-# Explicit incident crosswalk, not a same-opponent deduplication heuristic.
-# CFBD retains the postponed September 5 event alongside the September 6 game:
-# - original: https://site.api.espn.com/apis/site/v2/sports/football/college-football/summary?event=401866625
-# - replacement: https://site.api.espn.com/apis/site/v2/sports/football/college-football/summary?event=401917058
-# ESPN reports the original as STATUS_POSTPONED with no stats/drives, while the
-# replacement is the game that was played. Western Carolina's official notice:
-# https://catamountsports.com/news/2026/9/5/football-catamounts-camels-postponed-until-sunday.aspx
-SUPERSEDED_GAME_REPLACEMENTS = {401866625: 401917058}
-
 # --- v1.1 correlated draws ---------------------------------------------------
 # Share of margin variance attributed to a per-team SEASON-STRENGTH offset,
 # drawn once per simulation and applied to every game that team plays, rather
@@ -235,41 +228,8 @@ def normalize_strength_share(strength_share: float) -> float:
 
 
 def select_projection_game_rows(rows: list[dict]) -> list[dict]:
-    """Remove only verified superseded events from season-projection inputs.
-
-    The replacement must be present in the same fetched season and must carry
-    the same home and away teams. Failing closed prevents an incomplete fetch
-    from silently deleting a scheduled game or re-rolling the wrong matchup.
-    The returned list is new; source rows and caller-owned input are unchanged.
-    """
-    rows_by_id = {row["game_id"]: row for row in rows}
-    suppressed_ids = set()
-
-    for original_id, replacement_id in SUPERSEDED_GAME_REPLACEMENTS.items():
-        original = rows_by_id.get(original_id)
-        if original is None:
-            continue
-
-        replacement = rows_by_id.get(replacement_id)
-        if replacement is None:
-            raise ValueError(
-                f"Superseded game {original_id} is present without replacement "
-                f"{replacement_id}; refusing to build an incomplete projection schedule"
-            )
-
-        pair_fields = ("season", "home_team", "away_team")
-        mismatches = [
-            field for field in pair_fields if original.get(field) != replacement.get(field)
-        ]
-        if mismatches:
-            raise ValueError(
-                f"Superseded game {original_id} and replacement {replacement_id} disagree "
-                f"on {', '.join(mismatches)}; refusing to suppress either event"
-            )
-
-        suppressed_ids.add(original_id)
-
-    return [row for row in rows if row["game_id"] not in suppressed_ids]
+    """Apply shared reviewed event resolutions to the projection schedule."""
+    return select_canonical_game_rows(rows)
 
 
 def strength_sd(sigma: float, strength_share: float) -> tuple[float, float]:
@@ -811,7 +771,7 @@ REF_CLASSIFICATION_QUERY = """
 # probability, the error would propagate into every number this script writes.
 # DISTINCT ON takes the last snapshot at or before kickoff -- the pregame read
 # the simulation is actually modelling.
-RESIDUAL_SIGMA_QUERY = """
+RESIDUAL_SIGMA_QUERY = f"""
     WITH latest AS (
         SELECT DISTINCT ON (p.game_id)
                p.game_id,
@@ -820,6 +780,7 @@ RESIDUAL_SIGMA_QUERY = """
         FROM predictions.game_predictions p
         JOIN core.games g ON g.id = p.game_id
         WHERE p.model_version = %(model)s
+          AND {eligible_game_sql()}
           AND COALESCE(g.completed, false)
           AND g.home_points IS NOT NULL AND g.away_points IS NOT NULL
           AND p.expected_home_margin IS NOT NULL

--- a/scripts/train_model.py
+++ b/scripts/train_model.py
@@ -40,6 +40,9 @@ import sys
 
 import numpy as np
 
+from src.pipelines.game_identity import eligible_game_sql
+from src.pipelines.season_lifecycle import season_is_final
+
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
 
@@ -464,6 +467,7 @@ def _train_games_query() -> str:
         JOIN features.team_week a
           ON a.game_id = g.id AND a.team = g.away_team
         WHERE g.season = ANY(%s)
+          AND {eligible_game_sql("g.id")}
           AND COALESCE(g.completed, false)
           AND g.home_points IS NOT NULL
           AND g.away_points IS NOT NULL
@@ -699,53 +703,42 @@ def stale_score_seasons(
     return list(range(max_existing + 2, target + 2))
 
 
-# A season counts as FINISHED once at least this share of its games are
-# complete. Not 100%: a cancelled or never-reconciled game would otherwise keep
-# a season "unfinished" forever and permanently freeze the refit. 99% clears a
-# handful of stragglers on a ~1,600-game season while still requiring the
-# season to be genuinely over.
-SEASON_COMPLETE_THRESHOLD = 0.99
-
-# Below this many games a season is too small to judge complete by ratio alone
-# (an early season with 3 of 3 games played would look 100% finished).
-MIN_GAMES_FOR_FINISHED_SEASON = 100
-
-
 def fetch_refit_state(conn) -> tuple[int | None, list[int]]:
     """``(latest FINISHED season, existing fitted_v1 train_through values)``.
 
-    "Finished" deliberately means *the whole season is over*, not "has at least
-    one completed game". Using ``MAX(season) WHERE completed`` would flip to the
-    new season the moment its first game ends, and the consequences compound:
-
-      1. ``stale_score_seasons`` would train a fit labelled
-         ``train_through_season = S`` on a season with a handful of games played,
-      2. ``score_fitted --upcoming`` selects ``MAX(train_through_season)`` and
-         would adopt it,
-      3. the remaining games of season S would then be scored **in-sample**, and
-      4. the staleness check would never fire again, because the S key now
-         exists.
-
-    That is a leak that inflates apparent accuracy rather than an outage, so it
-    would not announce itself. Requiring a finished season keeps every fit
-    strictly walk-forward.
+    Use the shared schedule/correction-aware lifecycle policy, newest candidate
+    first. Every year in the expanding train window must exist and be final;
+    an unresolved or missing earlier year caps the safe automatic-refit frontier.
     """
     with conn.cursor() as cur:
         cur.execute(
-            """
-            SELECT MAX(season) FROM (
-                SELECT season
-                FROM core.games
-                GROUP BY season
-                HAVING COUNT(*) >= %s
-                   AND AVG(CASE WHEN COALESCE(completed, false) THEN 1.0 ELSE 0.0 END) >= %s
-            ) finished
-            """,
-            (MIN_GAMES_FOR_FINISHED_SEASON, SEASON_COMPLETE_THRESHOLD),
+            "SELECT DISTINCT season FROM core.games WHERE season >= %s ORDER BY season DESC",
+            (TRAIN_START_SEASON,),
         )
-        row = cur.fetchone()[0]
-        latest_finished = int(row) if row is not None else None
+        candidates = [int(row[0]) for row in cur.fetchall()]
 
+    present = set(candidates)
+    finality: dict[int, bool] = {}
+
+    def is_final(season: int) -> bool:
+        if season not in finality:
+            finality[season] = season in present and season_is_final(conn, season)
+        return finality[season]
+
+    latest_finished = next((season for season in candidates if is_final(season)), None)
+    if latest_finished is not None:
+        for season in range(TRAIN_START_SEASON, latest_finished + 1):
+            if not is_final(season):
+                logger.warning(
+                    "Automatic refit cannot include season=%d: missing or unfinished within "
+                    "the expanding training window through %d",
+                    season,
+                    latest_finished,
+                )
+                latest_finished = season - 1 if season > TRAIN_START_SEASON else None
+                break
+
+    with conn.cursor() as cur:
         # A fit counts as EXISTING only if it was written under the CURRENT
         # feature contract (PR #56 review, P1).
         #
@@ -777,11 +770,21 @@ def fetch_refit_state(conn) -> tuple[int | None, list[int]]:
         expected = set(TEAM_WEEK_SOURCE_COLUMNS)
         existing = []
         stale_by_contract = []
+        beyond_frontier = []
         for season, means in cur.fetchall():
             if isinstance(means, dict) and set(means) == expected:
-                existing.append(int(season))
+                if latest_finished is not None and int(season) <= latest_finished:
+                    existing.append(int(season))
+                else:
+                    beyond_frontier.append(int(season))
             else:
                 stale_by_contract.append(int(season))
+        if beyond_frontier:
+            logger.warning(
+                "Ignoring stored fit(s) beyond safe automatic-refit frontier %s: %s",
+                latest_finished,
+                sorted(beyond_frontier),
+            )
         if stale_by_contract:
             logger.warning(
                 "%d stored fit(s) predate the current %d-feature contract and will be "

--- a/scripts/verify_load.py
+++ b/scripts/verify_load.py
@@ -302,36 +302,41 @@ def check_fitted_coverage(cur, report: Report) -> None:
     Season-independent (the pending window spans whatever seasons have
     schedules), so it takes no season argument.
     """
-    from scripts.score_fitted import MIN_UPCOMING_COVERAGE, coverage_verdict
+    from scripts.score_fitted import (
+        MIN_UPCOMING_COVERAGE,
+        PENDING_GAMES_WHERE,
+        coverage_verdict,
+    )
 
     cur.execute(
-        """
+        f"""
         WITH pending AS (
-            SELECT g.id
+            SELECT g.id, g.season
             FROM core.games g
-            WHERE NOT COALESCE(g.completed, false)
-              AND g.season >= (
-                  SELECT COALESCE(MAX(season), 0) FROM core.games WHERE completed
-              )
+            WHERE {PENDING_GAMES_WHERE}
         )
-        SELECT
-            (SELECT COUNT(*) FROM pending),
-            (SELECT COUNT(*) FROM pending p
-             WHERE EXISTS (
-                 SELECT 1 FROM predictions.game_predictions gp
-                 WHERE gp.game_id = p.id AND gp.model_version = 'fitted_v1'
-             ))
+        SELECT p.season, COUNT(*),
+               SUM(CASE WHEN EXISTS (
+                   SELECT 1 FROM predictions.game_predictions gp
+                   WHERE gp.game_id = p.id AND gp.model_version = 'fitted_v1'
+               ) THEN 1 ELSE 0 END)
+        FROM pending p
+        GROUP BY p.season
+        ORDER BY p.season
         """
     )
-    n_pending, n_scored = cur.fetchone()
-    n_pending, n_scored = int(n_pending), int(n_scored)
-    ok, coverage = coverage_verdict(n_pending, n_scored)
-    report.record(
-        PASS if ok else FAIL,
-        "fitted_coverage",
-        f"fitted_v1 covers {n_scored}/{n_pending} pending game(s) "
-        f"({coverage:.1%}, threshold {MIN_UPCOMING_COVERAGE:.0%})",
-    )
+    counts = cur.fetchall()
+    if not counts:
+        report.record(PASS, "fitted_coverage", "no canonical pending games")
+    for season, n_pending, n_scored in counts:
+        n_pending, n_scored = int(n_pending), int(n_scored)
+        ok, coverage = coverage_verdict(n_pending, n_scored)
+        report.record(
+            PASS if ok else FAIL,
+            "fitted_coverage",
+            f"season={season}: fitted_v1 covers {n_scored}/{n_pending} pending game(s) "
+            f"({coverage:.1%}, threshold {MIN_UPCOMING_COVERAGE:.0%})",
+        )
 
 
 # How old the newest predictions.model_backtest row may be before the honesty

--- a/src/pipelines/game_identity.py
+++ b/src/pipelines/game_identity.py
@@ -1,0 +1,62 @@
+"""Reviewed provider event resolutions; raw warehouse rows remain unchanged."""
+
+import re
+from collections.abc import Mapping
+
+# Original ESPN event is postponed with no stats/drives; its replacement was played.
+# https://site.api.espn.com/apis/site/v2/sports/football/college-football/summary?event=401866625
+# https://site.api.espn.com/apis/site/v2/sports/football/college-football/summary?event=401917058
+# https://catamountsports.com/news/2026/9/5/football-catamounts-camels-postponed-until-sunday.aspx
+SUPERSEDED_GAME_REPLACEMENTS = {401866625: 401917058}
+# Add only after reviewing provider/official evidence; absence is not cancellation.
+CANCELLED_GAME_IDS: frozenset[int] = frozenset()
+
+
+def eligible_game_sql(id_column: str = "g.id") -> str:
+    """Exclude reviewed non-contests from modeled inputs, including partial fetches.
+
+    This only filters identities; callers retain their season/result predicates.
+    A missing replacement must never make a known postponed original a result.
+    Schedule/closure callers additionally validate the replacement pair below.
+    Column names are developer-supplied identifiers, never user SQL fragments.
+    """
+    if not re.fullmatch(r"[A-Za-z_][A-Za-z_0-9]*(?:\.[A-Za-z_][A-Za-z_0-9]*)?", id_column):
+        raise ValueError("invalid game ID column")
+    excluded = sorted(set(SUPERSEDED_GAME_REPLACEMENTS) | set(CANCELLED_GAME_IDS))
+    return f"{id_column} NOT IN ({', '.join(str(i) for i in excluded)})" if excluded else "TRUE"
+
+
+def select_canonical_game_rows(
+    rows: list[dict],
+    *,
+    cancelled_game_ids: frozenset[int] = CANCELLED_GAME_IDS,
+    superseded_game_replacements: Mapping[int, int] = SUPERSEDED_GAME_REPLACEMENTS,
+) -> list[dict]:
+    """Resolve a complete fetched schedule without changing source rows.
+
+    The replacement must exist and match season/home/away identity. Missing
+    identity fields do not count as agreement. Repeated matchups are retained.
+    """
+    rows_by_id = {row["game_id"]: row for row in rows}
+    for original_id, replacement_id in superseded_game_replacements.items():
+        original = rows_by_id.get(original_id)
+        if original is None:
+            continue
+        replacement = rows_by_id.get(replacement_id)
+        if replacement is None:
+            raise ValueError(
+                f"Superseded game {original_id} is present without replacement "
+                f"{replacement_id}; refusing an incomplete schedule"
+            )
+        mismatches = [
+            field
+            for field in ("season", "home_team", "away_team")
+            if original.get(field) is None or original.get(field) != replacement.get(field)
+        ]
+        if mismatches:
+            raise ValueError(
+                f"Superseded game {original_id} and replacement {replacement_id} disagree "
+                f"on {', '.join(mismatches)}; refusing to suppress either event"
+            )
+    excluded = set(superseded_game_replacements) | set(cancelled_game_ids)
+    return [row for row in rows if row["game_id"] not in excluded]

--- a/src/pipelines/run.py
+++ b/src/pipelines/run.py
@@ -8,6 +8,7 @@ from typing import NoReturn
 
 import dlt
 
+from .season_lifecycle import season_is_final
 from .sources.betting import betting_source
 from .sources.coaches import coach_profiles_source, coach_tenures_source, coaches_source
 from .sources.conferences import conferences_source
@@ -189,7 +190,12 @@ def run_reference_pipeline():
     return info
 
 
-def run_games_pipeline(years: list[int] | None = None, mode: str = "incremental"):
+def run_games_pipeline(
+    years: list[int] | None = None,
+    mode: str = "incremental",
+    *,
+    schedule_only: bool = False,
+):
     """Run the games data pipeline.
 
     Two sequential loads, not one: games commits first, THEN drives (and
@@ -199,6 +205,11 @@ def run_games_pipeline(years: list[int] | None = None, mode: str = "incremental"
     that carries a new parent row has committed. Sequencing removes the
     race; the shared games_cache guarantees the drives orphan filter sees
     exactly the /games response the first load merged (see games_source).
+
+    ``schedule_only`` stops after the one cached ``/games`` fetch. The
+    unattended season loader uses it only after conservative finality so
+    schedule corrections remain reachable without re-fetching drives and
+    ancillary game resources.
     """
     years_str = f"years={years}" if years else f"mode={mode}"
     print(f"\n=== Loading Games Data ({years_str}) ===\n")
@@ -216,6 +227,9 @@ def run_games_pipeline(years: list[int] | None = None, mode: str = "incremental"
     )
     info = pipeline.run(games_only)
     print(f"\nLoad info (games): {info}")
+
+    if schedule_only:
+        return info
 
     rest = games_source(years=years, mode=mode, games_cache=games_cache).with_resources(
         "drives", "game_media", "game_weather", "records"
@@ -1056,45 +1070,6 @@ def run_metrics_wp_pipeline(
     }
 
 
-# Same "finished season" definition as scripts/load_season.py's
-# season_is_final (and scripts/train_model.py's independent copy of the
-# same rule for its refit guard) -- duplicated here rather than imported.
-# scripts/ has no __init__.py and is not part of the installed package
-# (pyproject.toml's `packages = ["src"]`); src.pipelines.run is also
-# installed as the `cfb-pipeline` console script and must not depend on the
-# repo's top-level scripts/ directory being importable -- see
-# _metrics_wp_db_url's docstring for the same reasoning applied to DB URLs.
-_SEASON_COMPLETE_THRESHOLD = 0.99
-_MIN_GAMES_FOR_FINISHED_SEASON = 100
-
-
-def _season_is_final(conn, season: int) -> bool:
-    """True when `season` has essentially every scheduled game completed.
-
-    Mirrors scripts/load_season.py::season_is_final -- see that function's
-    docstring and load_season.py's IMMUTABLE_ONCE_FINAL comment block for
-    why a tolerance (not literal 100%) and a games-count floor are both
-    needed. Used by run_player_overview_pipeline's completed-season gate: a
-    season's usage/PPA/box-score totals mutate weekly while it is still
-    being played, so loading its overview rows early would freeze them
-    stale.
-    """
-    with conn.cursor() as cur:
-        cur.execute(
-            """
-            SELECT COUNT(*) AS n,
-                   AVG(CASE WHEN COALESCE(completed, false) THEN 1.0 ELSE 0.0 END) AS pct
-            FROM core.games
-            WHERE season = %s
-            """,
-            (season,),
-        )
-        n, pct = cur.fetchone()
-    if not n or n < _MIN_GAMES_FOR_FINISHED_SEASON:
-        return False
-    return float(pct or 0.0) >= _SEASON_COMPLETE_THRESHOLD
-
-
 def _dedup_rows(*row_lists) -> list[tuple]:
     """Union any number of row lists into a de-duplicated list, stable order.
 
@@ -1264,7 +1239,7 @@ def run_player_overview_pipeline(
 
     - **Completed-seasons gate**: a season's usage/PPA totals mutate weekly
       while it is in progress, so a season is only eligible once
-      `_season_is_final` says so -- an in-progress season is excluded
+      `season_is_final` says so -- an in-progress season is excluded
       entirely rather than loaded early and re-loaded. From January (once
       the just-finished season's games are marked complete) the daily path
       starts draining it at `max_players`/run; the gate is what keeps every
@@ -1331,7 +1306,7 @@ def run_player_overview_pipeline(
             else:
                 candidate_seasons = sorted(set(seasons), reverse=True)
 
-            eligible_seasons = [s for s in candidate_seasons if _season_is_final(conn, s)]
+            eligible_seasons = [s for s in candidate_seasons if season_is_final(conn, s)]
 
             # Fetched once, outside the per-season loop -- the ledger isn't
             # scoped by season, so there's nothing to gain by re-querying it

--- a/src/pipelines/season_lifecycle.py
+++ b/src/pipelines/season_lifecycle.py
@@ -1,0 +1,236 @@
+"""Conservative, shared season-finality policy.
+
+Finality gates immutable-source skips, player-overview ingestion, and model
+refits.  It is intentionally stricter than a completion percentage: a season
+cannot close while a known contest remains unresolved, before its postseason
+calendar has elapsed, or from a regular-season-only partial schedule.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, time
+
+from .game_identity import (
+    CANCELLED_GAME_IDS,
+    SUPERSEDED_GAME_REPLACEMENTS,
+    select_canonical_game_rows,
+)
+
+logger = logging.getLogger(__name__)
+
+MIN_GAMES_FOR_FINAL_SEASON = 100
+_POSTSEASON = "postseason"
+_CLOSURE_SEASON_TYPES = frozenset({"regular", _POSTSEASON})
+_IGNORED_SEASON_TYPES = frozenset({"allstar", "exhibition"})
+
+
+@dataclass(frozen=True)
+class SeasonResolutions:
+    """Reviewed terminal and replacement event identities.
+
+    Callers may pass a small fixture-specific value to the pure classifier.
+    Production uses the reviewed registry in :mod:`game_identity`.
+    """
+
+    cancelled_game_ids: frozenset[int]
+    superseded_game_replacements: Mapping[int, int]
+
+
+DEFAULT_RESOLUTIONS = SeasonResolutions(
+    cancelled_game_ids=CANCELLED_GAME_IDS,
+    superseded_game_replacements=SUPERSEDED_GAME_REPLACEMENTS,
+)
+
+
+@dataclass(frozen=True)
+class SeasonLifecycle:
+    """Pure classification result with enough detail for logs and tests."""
+
+    is_final: bool
+    reason: str
+    scheduled_games: int
+    completed_games: int
+    unresolved_game_ids: tuple[int, ...] = ()
+
+
+def season_close_floor(season: int) -> datetime:
+    """Earliest instant a season may be final.
+
+    February 1 covers the ordinary bowl/CFP tail.  The 2020 season uses July 1
+    because pandemic-disrupted schedules continued into spring 2021.  This is
+    only an eligibility floor; passing it never turns an unresolved row into a
+    cancellation.
+    """
+
+    month = 7 if season == 2020 else 2
+    return datetime.combine(date(season + 1, month, 1), time.min, tzinfo=UTC)
+
+
+def _as_utc(value: datetime | date | None) -> datetime:
+    if value is None:
+        return datetime.now(UTC)
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=UTC)
+        return value.astimezone(UTC)
+    return datetime.combine(value, time.max, tzinfo=UTC)
+
+
+def _canonical_rows(
+    rows: list[dict], resolutions: SeasonResolutions
+) -> tuple[list[dict], str | None]:
+    """Apply reviewed identities, returning a reconciliation error as state."""
+
+    try:
+        return (
+            select_canonical_game_rows(
+                rows,
+                cancelled_game_ids=resolutions.cancelled_game_ids,
+                superseded_game_replacements=resolutions.superseded_game_replacements,
+            ),
+            None,
+        )
+    except ValueError as exc:
+        return rows, str(exc)
+
+
+def classify_season(
+    rows: Iterable[Mapping],
+    season: int,
+    *,
+    as_of: datetime | date | None = None,
+    resolutions: SeasonResolutions = DEFAULT_RESOLUTIONS,
+) -> SeasonLifecycle:
+    """Classify a fully fetched schedule without database or network access.
+
+    ``rows`` must contain game_id, season, season_type, start_date, completed,
+    home_team, away_team, home_points, and away_points.  Missing dates, missing
+    scores on completed games, future games, and incomplete games all remain
+    unresolved.  A row's age is never evidence that it was cancelled.
+    """
+
+    normalized = [dict(row) for row in rows]
+    canonical, reconciliation_error = _canonical_rows(normalized, resolutions)
+    if reconciliation_error:
+        return SeasonLifecycle(False, reconciliation_error, len(normalized), 0)
+
+    mixed_season_ids = [int(row["game_id"]) for row in canonical if row.get("season") != season]
+    if mixed_season_ids:
+        ids = tuple(sorted(set(mixed_season_ids)))
+        return SeasonLifecycle(
+            False,
+            f"game(s) do not belong to season {season}: {', '.join(map(str, ids[:10]))}",
+            len(canonical),
+            0,
+            ids,
+        )
+
+    closure_rows: list[dict] = []
+    unknown_type_ids: list[int] = []
+    for row in canonical:
+        season_type = str(row.get("season_type") or "").lower()
+        if season_type in _CLOSURE_SEASON_TYPES:
+            closure_rows.append(row)
+        elif season_type not in _IGNORED_SEASON_TYPES:
+            unknown_type_ids.append(int(row["game_id"]))
+
+    scheduled = len(closure_rows)
+    completed = sum(bool(row.get("completed")) for row in closure_rows)
+    if unknown_type_ids:
+        ids = tuple(sorted(set(unknown_type_ids)))
+        return SeasonLifecycle(
+            False,
+            f"unknown season type for game(s) {', '.join(map(str, ids[:10]))}",
+            scheduled,
+            completed,
+            ids,
+        )
+    if scheduled < MIN_GAMES_FOR_FINAL_SEASON:
+        return SeasonLifecycle(
+            False,
+            f"schedule has only {scheduled} canonical games",
+            scheduled,
+            completed,
+        )
+
+    present_types = {str(row.get("season_type") or "").lower() for row in closure_rows}
+    missing_types = _CLOSURE_SEASON_TYPES - present_types
+    if missing_types:
+        return SeasonLifecycle(
+            False,
+            f"schedule has no {' or '.join(sorted(missing_types))} games",
+            scheduled,
+            completed,
+        )
+
+    observed_at = _as_utc(as_of)
+    close_floor = season_close_floor(season)
+    if observed_at < close_floor:
+        return SeasonLifecycle(
+            False,
+            f"calendar floor {close_floor.date().isoformat()} has not passed",
+            scheduled,
+            completed,
+        )
+
+    unresolved: list[int] = []
+    for row in closure_rows:
+        game_id = int(row["game_id"])
+        start_date = row.get("start_date")
+        if start_date is None:
+            unresolved.append(game_id)
+            continue
+        kickoff = _as_utc(start_date)
+        if kickoff > observed_at:
+            unresolved.append(game_id)
+            continue
+        if not row.get("completed"):
+            unresolved.append(game_id)
+            continue
+        if row.get("home_points") is None or row.get("away_points") is None:
+            unresolved.append(game_id)
+
+    if unresolved:
+        ids = tuple(sorted(set(unresolved)))
+        sample = ", ".join(map(str, ids[:10]))
+        return SeasonLifecycle(
+            False,
+            f"{len(ids)} canonical game(s) remain unresolved: {sample}",
+            scheduled,
+            completed,
+            ids,
+        )
+    return SeasonLifecycle(True, "all canonical games are resolved", scheduled, completed)
+
+
+_SEASON_GAMES_QUERY = """
+    SELECT id AS game_id,
+           season,
+           season_type,
+           start_date,
+           completed,
+           home_id,
+           home_team,
+           home_points,
+           away_id,
+           away_team,
+           away_points
+    FROM core.games
+    WHERE season = %s
+"""
+
+
+def season_is_final(conn, season: int, *, as_of: datetime | date | None = None) -> bool:
+    """Return whether ``season`` is conservatively safe to treat as final."""
+
+    with conn.cursor() as cur:
+        cur.execute(_SEASON_GAMES_QUERY, (season,))
+        columns = [description[0] for description in cur.description]
+        rows = [dict(zip(columns, row, strict=True)) for row in cur.fetchall()]
+    lifecycle = classify_season(rows, season, as_of=as_of)
+    if not lifecycle.is_final:
+        logger.info("Season %d is not final: %s", season, lifecycle.reason)
+    return lifecycle.is_final

--- a/tests/test_backtest_canonical_inputs.py
+++ b/tests/test_backtest_canonical_inputs.py
@@ -1,0 +1,74 @@
+"""SQLite regression coverage for canonical preseason-backtest inputs.
+
+The schedule-count query is executed unchanged except for DB-API placeholder
+adaptation. PostgreSQL's ``DISTINCT ON`` is unavailable in SQLite, so the
+week-one CTE's identity predicate is also asserted structurally.
+"""
+
+import sqlite3
+
+from scripts.backtest_preseason import _week1_games_query, fetch_scheduled_counts
+
+
+class _Cursor:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        self._cursor.close()
+
+    def execute(self, query, params):
+        self._cursor.execute(
+            query.replace("%(season)s", ":season").replace("%(season_type)s", ":season_type"),
+            params,
+        )
+
+    def fetchall(self):
+        return self._cursor.fetchall()
+
+
+class _Connection:
+    def __init__(self):
+        self.db = sqlite3.connect(":memory:")
+
+    def cursor(self):
+        return _Cursor(self.db.cursor())
+
+
+def test_backtest_schedule_counts_exclude_superseded_original_and_keep_rematch():
+    conn = _Connection()
+    try:
+        conn.db.executescript(
+            """
+            ATTACH DATABASE ':memory:' AS core;
+            CREATE TABLE core.games (
+                id INTEGER PRIMARY KEY, season INTEGER, season_type TEXT,
+                home_team TEXT, away_team TEXT, completed BOOLEAN,
+                home_points INTEGER, away_points INTEGER
+            );
+            """
+        )
+        conn.db.executemany(
+            "INSERT INTO core.games VALUES (?, 2026, 'regular', 'Campbell', "
+            "'Western Carolina', ?, ?, ?)",
+            [
+                (401866625, True, 0, 0),
+                (401917058, True, 24, 17),
+                (777777777, True, 21, 20),
+            ],
+        )
+
+        assert fetch_scheduled_counts(conn, 2026) == {"Campbell": 2, "Western Carolina": 2}
+    finally:
+        conn.db.close()
+
+
+def test_week_one_cte_and_scored_games_filter_the_superseded_identity():
+    query = _week1_games_query()
+    week1 = query[query.index("WITH week1 AS") : query.index(")\n        SELECT g.id")]
+
+    assert "game_id NOT IN (401866625)" in week1
+    assert "g.id NOT IN (401866625)" in query

--- a/tests/test_canonical_game_inputs.py
+++ b/tests/test_canonical_game_inputs.py
@@ -1,0 +1,103 @@
+"""Regression fixtures for canonical modeled-game SQL inputs.
+
+SQLite runs the portable query shapes against the reviewed postponed/replacement
+pair. It proves the original cannot enter modeled inputs even if a provider
+incorrectly marks it completed 0-0; PostgreSQL cursor/type behavior remains a
+separate integration concern.
+"""
+
+import sqlite3
+
+from scripts.compute_adjusted_epa import PLAY_QUERY, TEAM_LIST_QUERY
+from scripts.compute_adjusted_epa_week import PLAY_QUERY_WEEK, TARGET_WEEK_INDEX_QUERY
+from scripts.compute_house_elo import GAMES_QUERY, SCHEDULED_COUNTS_QUERY
+
+
+def _sqlite_query(query: str) -> str:
+    return query.replace("%s", "?").replace("NULLS LAST", "")
+
+
+def _warehouse() -> sqlite3.Connection:
+    db = sqlite3.connect(":memory:")
+    db.executescript(
+        """
+        ATTACH DATABASE ':memory:' AS core;
+        ATTACH DATABASE ':memory:' AS marts;
+        CREATE TABLE core.games (
+            id INTEGER PRIMARY KEY, season INTEGER, week INTEGER, season_type TEXT,
+            start_date TEXT, neutral_site BOOLEAN, home_team TEXT, away_team TEXT,
+            home_points INTEGER, away_points INTEGER, home_pregame_elo REAL,
+            away_pregame_elo REAL, completed BOOLEAN
+        );
+        CREATE TABLE marts.play_epa (
+            game_id INTEGER, season INTEGER, offense TEXT, defense TEXT,
+            epa REAL, is_garbage_time BOOLEAN
+        );
+        """
+    )
+    # The first event was postponed, but an upstream completed=True/0-0 value
+    # must not make it a played model input. The Sunday replacement and a later
+    # genuine rematch both remain canonical events.
+    db.executemany(
+        "INSERT INTO core.games VALUES (?, 2026, ?, 'regular', ?, false, 'Campbell', "
+        "'Western Carolina', ?, ?, NULL, NULL, ?)",
+        [
+            (401866625, 1, "2026-09-05", 0, 0, True),
+            (401917058, 2, "2026-09-06", 24, 17, True),
+            (777777777, 3, "2026-10-01", 21, 20, True),
+        ],
+    )
+    db.executemany(
+        "INSERT INTO marts.play_epa VALUES (?, 2026, 'Campbell', 'Western Carolina', ?, false)",
+        [
+            (401866625, 999.0),
+            (401917058, 0.4),
+            (777777777, 0.2),
+        ],
+    )
+    return db
+
+
+def test_house_elo_results_and_schedule_counts_exclude_only_superseded_event():
+    db = _warehouse()
+    try:
+        result_ids = [row[0] for row in db.execute(_sqlite_query(GAMES_QUERY), (2026, 2026))]
+        assert result_ids == [401917058, 777777777]
+
+        counts = db.execute(
+            _sqlite_query(SCHEDULED_COUNTS_QUERY), (2026, 2026, 2026, 2026)
+        ).fetchall()
+        assert counts == [(2026, "Campbell", 2), (2026, "Western Carolina", 2)]
+    finally:
+        db.close()
+
+
+def test_epa_play_team_and_weekly_schedule_inputs_exclude_superseded_event():
+    db = _warehouse()
+    try:
+        fit_epas = [row[2] for row in db.execute(_sqlite_query(PLAY_QUERY), (2026,))]
+        assert fit_epas == [0.4, 0.2]
+        assert db.execute(_sqlite_query(TEAM_LIST_QUERY), (2026, 2026)).fetchall() == [
+            ("Campbell",),
+            ("Western Carolina",),
+        ]
+
+        weekly_epas = [row[2] for row in db.execute(_sqlite_query(PLAY_QUERY_WEEK), (2026,))]
+        assert weekly_epas == [0.4, 0.2]
+        target_weeks = db.execute(_sqlite_query(TARGET_WEEK_INDEX_QUERY), (2026,)).fetchall()
+        assert target_weeks == [(2,), (3,)]
+    finally:
+        db.close()
+
+
+def test_epa_team_layout_remains_play_derived_for_unmatched_provider_rows():
+    db = _warehouse()
+    try:
+        db.execute(
+            "INSERT INTO marts.play_epa VALUES "
+            "(999, 2026, 'Unmatched A', 'Unmatched B', 0.1, false)"
+        )
+        teams = {r[0] for r in db.execute(_sqlite_query(TEAM_LIST_QUERY), (2026, 2026))}
+        assert teams == {"Campbell", "Western Carolina", "Unmatched A", "Unmatched B"}
+    finally:
+        db.close()

--- a/tests/test_fitted_coverage_verification.py
+++ b/tests/test_fitted_coverage_verification.py
@@ -1,0 +1,75 @@
+"""Execute the daily verifier's real SQL against canonical pending fixtures."""
+
+import sqlite3
+
+import pytest
+
+from scripts.verify_load import Report, check_fitted_coverage
+
+
+@pytest.fixture
+def warehouse():
+    conn = sqlite3.connect(":memory:")
+    conn.executescript("""
+        ATTACH DATABASE ':memory:' AS core;
+        ATTACH DATABASE ':memory:' AS predictions;
+        CREATE TABLE core.games (id INTEGER PRIMARY KEY, season INTEGER, completed BOOLEAN);
+        CREATE TABLE predictions.game_predictions (game_id INTEGER, model_version TEXT);
+    """)
+    yield conn
+    conn.close()
+
+
+def test_only_incomplete_superseded_original_is_empty_pending(warehouse, capsys):
+    warehouse.execute("INSERT INTO core.games VALUES (401866625, 2026, false)")
+    report = Report()
+    check_fitted_coverage(warehouse.cursor(), report)
+    assert report.failures == 0
+    assert "no canonical pending games" in capsys.readouterr().out
+
+
+def test_superseded_completed_row_does_not_advance_pending_anchor(warehouse, capsys):
+    warehouse.executemany(
+        "INSERT INTO core.games VALUES (?, ?, ?)",
+        [
+            (401866625, 2027, True),
+            (401917058, 2026, False),
+        ],
+    )
+    report = Report()
+    check_fitted_coverage(warehouse.cursor(), report)
+    assert report.failures == 1
+    assert "season=2026: fitted_v1 covers 0/1" in capsys.readouterr().out
+
+
+def test_large_covered_season_cannot_hide_empty_next_season(warehouse, capsys):
+    warehouse.executemany(
+        "INSERT INTO core.games VALUES (?, 2026, false)", [(n,) for n in range(1, 1601)]
+    )
+    warehouse.executemany(
+        "INSERT INTO core.games VALUES (?, 2027, false)", [(n,) for n in range(1601, 1621)]
+    )
+    warehouse.executemany(
+        "INSERT INTO predictions.game_predictions VALUES (?, 'fitted_v1')",
+        [(n,) for n in range(1, 1601)],
+    )
+    report = Report()
+    check_fitted_coverage(warehouse.cursor(), report)
+    assert report.failures == 1
+    output = capsys.readouterr().out
+    assert "[PASS] fitted_coverage: season=2026" in output
+    assert "[FAIL] fitted_coverage: season=2027" in output
+
+
+def test_replacement_and_rematch_count_once_despite_prediction_snapshots(warehouse, capsys):
+    warehouse.executemany(
+        "INSERT INTO core.games VALUES (?, 2026, false)", [(401866625,), (401917058,), (123,)]
+    )
+    warehouse.executemany(
+        "INSERT INTO predictions.game_predictions VALUES (?, 'fitted_v1')",
+        [(401917058,), (401917058,), (123,)],
+    )
+    report = Report()
+    check_fitted_coverage(warehouse.cursor(), report)
+    assert report.failures == 0
+    assert "covers 2/2" in capsys.readouterr().out

--- a/tests/test_fitted_lifecycle.py
+++ b/tests/test_fitted_lifecycle.py
@@ -45,10 +45,9 @@ def game(season, game_id=1):
 def upcoming_io(monkeypatch):
     """Mock only I/O; selection, vectorization, row assembly, and gates execute."""
     names = (
-        "fetch_pending_game_count",
-        "fetch_pending_seasons",
+        "fetch_pending_game_counts",
         "fetch_upcoming_games",
-        "fetch_available_train_through",
+        "fetch_refit_state",
         "load_fit",
         "table_exists",
         "fetch_market_from_lines",
@@ -57,10 +56,9 @@ def upcoming_io(monkeypatch):
     mocks = {name: Mock(name=name) for name in names}
     for name, mock in mocks.items():
         monkeypatch.setattr(scoring, name, mock)
-    mocks["fetch_pending_game_count"].return_value = 1
-    mocks["fetch_pending_seasons"].return_value = [2026]
+    mocks["fetch_pending_game_counts"].return_value = {2026: 1}
     mocks["fetch_upcoming_games"].return_value = [game(2026)]
-    mocks["fetch_available_train_through"].return_value = [2025]
+    mocks["fetch_refit_state"].return_value = (2025, [2025])
     mocks["load_fit"].side_effect = lambda _conn, season: frozen_fit(season)
     mocks["table_exists"].return_value = False
     mocks["fetch_market_from_lines"].return_value = {}
@@ -81,15 +79,14 @@ def test_score_game_accepts_a_strictly_prior_fit():
 
 
 def test_mixed_pending_seasons_use_their_own_latest_eligible_fits(upcoming_io, capsys):
-    upcoming_io["fetch_pending_game_count"].return_value = 3
-    upcoming_io["fetch_pending_seasons"].return_value = [2026, 2027]
+    upcoming_io["fetch_pending_game_counts"].return_value = {2026: 2, 2027: 1}
     upcoming_io["fetch_upcoming_games"].return_value = [game(2027, 3), game(2026, 1), game(2026, 2)]
-    upcoming_io["fetch_available_train_through"].return_value = [2027, 2025, 2026]
+    upcoming_io["fetch_refit_state"].return_value = (2025, [2025])
 
     def write(_conn, rows):
-        assert [call.args[1] for call in upcoming_io["load_fit"].call_args_list] == [2025, 2026]
+        assert [call.args[1] for call in upcoming_io["load_fit"].call_args_list] == [2025]
         assert [(r["game_id"], r["expected_home_margin"]) for r in rows] == [
-            (3, 6.0),
+            (3, 5.0),
             (1, 5.0),
             (2, 5.0),
         ]
@@ -99,31 +96,76 @@ def test_mixed_pending_seasons_use_their_own_latest_eligible_fits(upcoming_io, c
     upcoming_io["write_upcoming"].assert_called_once()
     output = capsys.readouterr().out
     assert "season=2026 rows=2 model=fitted_v1 train_through=2025" in output
-    assert "season=2027 rows=1 model=fitted_v1 train_through=2026" in output
+    assert "season=2027 rows=1 model=fitted_v1 train_through=2025" in output
 
 
 @pytest.mark.parametrize("available", [[], [2026], [2026, 2027]])
 def test_no_eligible_fit_prevents_all_writes(upcoming_io, available):
-    upcoming_io["fetch_available_train_through"].return_value = available
+    upcoming_io["fetch_refit_state"].return_value = (2025, available)
     with pytest.raises(ValueError, match="no eligible"):
         scoring.run_upcoming(object())
     upcoming_io["load_fit"].assert_not_called()
     upcoming_io["write_upcoming"].assert_not_called()
 
 
-def test_pending_season_without_features_still_needs_an_eligible_fit(upcoming_io):
-    upcoming_io["fetch_pending_game_count"].return_value = 2
-    upcoming_io["fetch_pending_seasons"].return_value = [2025, 2026]
-    with pytest.raises(ValueError, match="train_through_season < 2025"):
+def test_pending_season_without_features_fails_before_fit_loading(upcoming_io):
+    upcoming_io["fetch_pending_game_counts"].return_value = {2025: 1, 2026: 1}
+    with pytest.raises(SystemExit):
+        scoring.run_upcoming(object())
+    upcoming_io["load_fit"].assert_not_called()
+    upcoming_io["write_upcoming"].assert_not_called()
+
+
+def test_no_closed_training_frontier_fails_before_writing(upcoming_io):
+    upcoming_io["fetch_refit_state"].return_value = (None, [])
+    with pytest.raises(ValueError, match="no safe closed training frontier"):
+        scoring.run_upcoming(object())
+    upcoming_io["load_fit"].assert_not_called()
+    upcoming_io["write_upcoming"].assert_not_called()
+
+
+@pytest.mark.parametrize("small_season_scored", [0, 17])
+def test_large_covered_season_cannot_hide_a_small_uncovered_season(
+    upcoming_io, small_season_scored, capsys
+):
+    upcoming_io["fetch_pending_game_counts"].return_value = {2026: 1600, 2027: 20}
+    upcoming_io["fetch_upcoming_games"].return_value = [
+        game(2026, game_id) for game_id in range(1, 1601)
+    ] + [game(2027, game_id) for game_id in range(1601, 1601 + small_season_scored)]
+    with pytest.raises(SystemExit) as error:
+        scoring.run_upcoming(object())
+    assert error.value.code == 1
+    upcoming_io["load_fit"].assert_not_called()
+    upcoming_io["write_upcoming"].assert_not_called()
+    output = capsys.readouterr().out
+    assert "season=2026 pending=1600 scored=1600 coverage=1.000" in output
+    assert f"season=2027 pending=20 scored={small_season_scored}" in output
+
+
+def test_each_season_at_the_coverage_threshold_can_write(upcoming_io, capsys):
+    upcoming_io["fetch_pending_game_counts"].return_value = {2026: 10, 2027: 20}
+    upcoming_io["fetch_upcoming_games"].return_value = [
+        game(2026, game_id) for game_id in range(1, 10)
+    ] + [game(2027, game_id) for game_id in range(10, 28)]
+    scoring.run_upcoming(object())
+    upcoming_io["write_upcoming"].assert_called_once()
+    assert len(upcoming_io["write_upcoming"].call_args.args[1]) == 27
+    output = capsys.readouterr().out
+    assert "season=2026 pending=10 scored=9 coverage=0.900" in output
+    assert "season=2027 pending=20 scored=18 coverage=0.900" in output
+
+
+def test_scored_season_missing_from_denominator_requires_retry(upcoming_io):
+    upcoming_io["fetch_upcoming_games"].return_value = [game(2026), game(2027, 2)]
+    with pytest.raises(SystemExit):
         scoring.run_upcoming(object())
     upcoming_io["write_upcoming"].assert_not_called()
 
 
 def test_all_required_fits_load_before_any_scoring_or_writes(upcoming_io, monkeypatch):
-    upcoming_io["fetch_pending_game_count"].return_value = 2
-    upcoming_io["fetch_pending_seasons"].return_value = [2026, 2027]
+    upcoming_io["fetch_pending_game_counts"].return_value = {2026: 1, 2027: 1}
     upcoming_io["fetch_upcoming_games"].return_value = [game(2026), game(2027, 2)]
-    upcoming_io["fetch_available_train_through"].return_value = [2025, 2026]
+    upcoming_io["fetch_refit_state"].return_value = (2026, [2025, 2026])
     upcoming_io["load_fit"].side_effect = [frozen_fit(2025), RuntimeError("missing coefficients")]
     score = Mock()
     monkeypatch.setattr(scoring, "score_game", score)
@@ -134,10 +176,10 @@ def test_all_required_fits_load_before_any_scoring_or_writes(upcoming_io, monkey
 
 
 def test_empty_pending_scope_does_not_require_a_fit(upcoming_io):
-    upcoming_io["fetch_pending_game_count"].return_value = 0
+    upcoming_io["fetch_pending_game_counts"].return_value = {}
     upcoming_io["fetch_upcoming_games"].return_value = []
     scoring.run_upcoming(object())
-    upcoming_io["fetch_available_train_through"].assert_not_called()
+    upcoming_io["fetch_refit_state"].assert_not_called()
     upcoming_io["write_upcoming"].assert_not_called()
 
 
@@ -149,12 +191,12 @@ def test_missing_feature_coverage_still_fails_without_writes(upcoming_io):
     upcoming_io["write_upcoming"].assert_not_called()
 
 
-def test_partial_coverage_keeps_existing_write_then_fail_policy(upcoming_io):
-    upcoming_io["fetch_pending_game_count"].return_value = 10
+def test_partial_coverage_now_fails_before_writing(upcoming_io):
+    upcoming_io["fetch_pending_game_counts"].return_value = {2026: 10}
     with pytest.raises(SystemExit) as error:
         scoring.run_upcoming(object())
     assert error.value.code == 1
-    upcoming_io["write_upcoming"].assert_called_once()
+    upcoming_io["write_upcoming"].assert_not_called()
 
 
 def test_backfill_requires_exact_prior_vintage_even_when_older_fits_exist(monkeypatch):
@@ -188,6 +230,39 @@ class ResultCursor:
 
     def fetchone(self):
         return self.rows[0] if self.rows else None
+
+
+@pytest.mark.parametrize("compatible_closed_fit", [True, False])
+def test_upcoming_uses_actual_shared_frontier_and_contract_filter(
+    upcoming_io, monkeypatch, compatible_closed_fit
+):
+    # A partial 2026 vintage is earlier than prediction season 2027, but its
+    # training season remains open. Only a compatible closed 2025 fit is safe.
+    current = dict.fromkeys(training.TEAM_WEEK_SOURCE_COLUMNS, 0.0)
+    older_means = current if compatible_closed_fit else {**current, "removed_feature": 0.0}
+    conn = Mock()
+    conn.cursor.return_value = ResultCursor(
+        [
+            [(season,) for season in range(2026, training.TRAIN_START_SEASON - 1, -1)],
+            [(2025, older_means), (2026, current)],
+        ]
+    )
+    monkeypatch.setattr(training, "season_is_final", lambda _conn, season: season <= 2025)
+    monkeypatch.setattr(scoring, "fetch_refit_state", training.fetch_refit_state)
+    upcoming_io["fetch_pending_game_counts"].return_value = {2027: 1}
+    upcoming_io["fetch_upcoming_games"].return_value = [game(2027)]
+
+    if compatible_closed_fit:
+        scoring.run_upcoming(conn)
+        upcoming_io["load_fit"].assert_called_once_with(conn, 2025)
+        rows = upcoming_io["write_upcoming"].call_args.args[1]
+        assert rows[0]["season"] == 2027
+        assert rows[0]["expected_home_margin"] == 5.0
+    else:
+        with pytest.raises(ValueError, match="no eligible"):
+            scoring.run_upcoming(conn)
+        upcoming_io["load_fit"].assert_not_called()
+        upcoming_io["write_upcoming"].assert_not_called()
 
 
 @pytest.mark.parametrize("closed_season", [2025, None])
@@ -342,8 +417,9 @@ def test_pending_scope_excludes_reviewed_original_in_count_seasons_and_scoring(
     insert_game(game_database, original, 2028, completed=original_completed)
     insert_game(game_database, replacement, 2026)
     insert_game(game_database, 2, 2027)
-    assert scoring.fetch_pending_game_count(game_database) == 2
-    assert scoring.fetch_pending_seasons(game_database) == [2026, 2027]
+    insert_game(game_database, 3, 2027)
+    game_database.db.execute("DELETE FROM features.team_week WHERE game_id = 3")
+    assert scoring.fetch_pending_game_counts(game_database) == {2026: 1, 2027: 2}
     assert [g["game_id"] for g in scoring.fetch_upcoming_games(game_database)] == [replacement, 2]
 
 

--- a/tests/test_fitted_lifecycle.py
+++ b/tests/test_fitted_lifecycle.py
@@ -1,0 +1,357 @@
+"""Offline checks for fit eligibility, lifecycle delegation, and event exclusions."""
+
+import sqlite3
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+
+from scripts import score_fitted as scoring
+from scripts import train_model as training
+from src.pipelines.game_identity import SUPERSEDED_GAME_REPLACEMENTS
+
+
+def frozen_fit(train_through):
+    beta = np.zeros(len(training.FEATURE_NAMES))
+    beta[0] = train_through - 2020
+    return {
+        "train_through": train_through,
+        "feature_means": dict.fromkeys(training.TEAM_WEEK_SOURCE_COLUMNS, 0.0),
+        "diff_means": dict.fromkeys(training.FEATURE_NAMES, 0.0),
+        "diff_stds": dict.fromkeys(training.FEATURE_NAMES, 1.0),
+        "beta_margin": beta,
+        "beta_winprob": np.zeros(len(training.FEATURE_NAMES)),
+        "platt_a": 1.0,
+        "platt_b": 0.0,
+    }
+
+
+def game(season, game_id=1):
+    return {
+        "game_id": game_id,
+        "season": season,
+        "season_type": "regular",
+        "week": 1,
+        "home_team": "Alpha",
+        "away_team": "Bravo",
+        "neutral_site": False,
+        "start_date": None,
+        "home_tw": dict.fromkeys(training.TEAM_WEEK_SOURCE_COLUMNS, 0.0),
+        "away_tw": dict.fromkeys(training.TEAM_WEEK_SOURCE_COLUMNS, 0.0),
+    }
+
+
+@pytest.fixture
+def upcoming_io(monkeypatch):
+    """Mock only I/O; selection, vectorization, row assembly, and gates execute."""
+    names = (
+        "fetch_pending_game_count",
+        "fetch_pending_seasons",
+        "fetch_upcoming_games",
+        "fetch_available_train_through",
+        "load_fit",
+        "table_exists",
+        "fetch_market_from_lines",
+        "write_upcoming",
+    )
+    mocks = {name: Mock(name=name) for name in names}
+    for name, mock in mocks.items():
+        monkeypatch.setattr(scoring, name, mock)
+    mocks["fetch_pending_game_count"].return_value = 1
+    mocks["fetch_pending_seasons"].return_value = [2026]
+    mocks["fetch_upcoming_games"].return_value = [game(2026)]
+    mocks["fetch_available_train_through"].return_value = [2025]
+    mocks["load_fit"].side_effect = lambda _conn, season: frozen_fit(season)
+    mocks["table_exists"].return_value = False
+    mocks["fetch_market_from_lines"].return_value = {}
+    return mocks
+
+
+@pytest.mark.parametrize("train_through", [2026, 2027, None])
+def test_score_game_rejects_ineligible_fit_before_vectorization(train_through):
+    # No vectors: the temporal guard must run before touching feature inputs.
+    with pytest.raises(ValueError, match="must be before prediction season=2026"):
+        scoring.score_game({"season": 2026}, {"train_through": train_through})
+
+
+def test_score_game_accepts_a_strictly_prior_fit():
+    margin, probability = scoring.score_game(game(2026), frozen_fit(2025))
+    assert margin == 5.0
+    assert probability == 0.5
+
+
+def test_mixed_pending_seasons_use_their_own_latest_eligible_fits(upcoming_io, capsys):
+    upcoming_io["fetch_pending_game_count"].return_value = 3
+    upcoming_io["fetch_pending_seasons"].return_value = [2026, 2027]
+    upcoming_io["fetch_upcoming_games"].return_value = [game(2027, 3), game(2026, 1), game(2026, 2)]
+    upcoming_io["fetch_available_train_through"].return_value = [2027, 2025, 2026]
+
+    def write(_conn, rows):
+        assert [call.args[1] for call in upcoming_io["load_fit"].call_args_list] == [2025, 2026]
+        assert [(r["game_id"], r["expected_home_margin"]) for r in rows] == [
+            (3, 6.0),
+            (1, 5.0),
+            (2, 5.0),
+        ]
+
+    upcoming_io["write_upcoming"].side_effect = write
+    scoring.run_upcoming(object())
+    upcoming_io["write_upcoming"].assert_called_once()
+    output = capsys.readouterr().out
+    assert "season=2026 rows=2 model=fitted_v1 train_through=2025" in output
+    assert "season=2027 rows=1 model=fitted_v1 train_through=2026" in output
+
+
+@pytest.mark.parametrize("available", [[], [2026], [2026, 2027]])
+def test_no_eligible_fit_prevents_all_writes(upcoming_io, available):
+    upcoming_io["fetch_available_train_through"].return_value = available
+    with pytest.raises(ValueError, match="no eligible"):
+        scoring.run_upcoming(object())
+    upcoming_io["load_fit"].assert_not_called()
+    upcoming_io["write_upcoming"].assert_not_called()
+
+
+def test_pending_season_without_features_still_needs_an_eligible_fit(upcoming_io):
+    upcoming_io["fetch_pending_game_count"].return_value = 2
+    upcoming_io["fetch_pending_seasons"].return_value = [2025, 2026]
+    with pytest.raises(ValueError, match="train_through_season < 2025"):
+        scoring.run_upcoming(object())
+    upcoming_io["write_upcoming"].assert_not_called()
+
+
+def test_all_required_fits_load_before_any_scoring_or_writes(upcoming_io, monkeypatch):
+    upcoming_io["fetch_pending_game_count"].return_value = 2
+    upcoming_io["fetch_pending_seasons"].return_value = [2026, 2027]
+    upcoming_io["fetch_upcoming_games"].return_value = [game(2026), game(2027, 2)]
+    upcoming_io["fetch_available_train_through"].return_value = [2025, 2026]
+    upcoming_io["load_fit"].side_effect = [frozen_fit(2025), RuntimeError("missing coefficients")]
+    score = Mock()
+    monkeypatch.setattr(scoring, "score_game", score)
+    with pytest.raises(RuntimeError, match="missing coefficients"):
+        scoring.run_upcoming(object())
+    score.assert_not_called()
+    upcoming_io["write_upcoming"].assert_not_called()
+
+
+def test_empty_pending_scope_does_not_require_a_fit(upcoming_io):
+    upcoming_io["fetch_pending_game_count"].return_value = 0
+    upcoming_io["fetch_upcoming_games"].return_value = []
+    scoring.run_upcoming(object())
+    upcoming_io["fetch_available_train_through"].assert_not_called()
+    upcoming_io["write_upcoming"].assert_not_called()
+
+
+def test_missing_feature_coverage_still_fails_without_writes(upcoming_io):
+    upcoming_io["fetch_upcoming_games"].return_value = []
+    with pytest.raises(SystemExit) as error:
+        scoring.run_upcoming(object())
+    assert error.value.code == 1
+    upcoming_io["write_upcoming"].assert_not_called()
+
+
+def test_partial_coverage_keeps_existing_write_then_fail_policy(upcoming_io):
+    upcoming_io["fetch_pending_game_count"].return_value = 10
+    with pytest.raises(SystemExit) as error:
+        scoring.run_upcoming(object())
+    assert error.value.code == 1
+    upcoming_io["write_upcoming"].assert_called_once()
+
+
+def test_backfill_requires_exact_prior_vintage_even_when_older_fits_exist(monkeypatch):
+    load = Mock(side_effect=RuntimeError("missing exact prior fit"))
+    write = Mock()
+    monkeypatch.setattr(scoring, "load_fit", load)
+    monkeypatch.setattr(scoring, "write_backfill_season", write)
+    monkeypatch.setattr(scoring, "fetch_available_train_through", Mock(return_value=[2024]))
+    conn = object()
+    with pytest.raises(RuntimeError, match="missing exact prior fit"):
+        scoring.run_backfill(conn, 2026, 2026)
+    load.assert_called_once_with(conn, 2025)
+    write.assert_not_called()
+
+
+class ResultCursor:
+    def __init__(self, results):
+        self.results = iter(results)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+    def execute(self, query, params=None):
+        self.rows = next(self.results)
+
+    def fetchall(self):
+        return self.rows
+
+    def fetchone(self):
+        return self.rows[0] if self.rows else None
+
+
+@pytest.mark.parametrize("closed_season", [2025, None])
+def test_refit_delegates_finality_newest_first_and_keeps_contract_filter(
+    monkeypatch, closed_season
+):
+    current = dict.fromkeys(training.TEAM_WEEK_SOURCE_COLUMNS, 0.0)
+    incompatible = {**current, "removed_feature": 0.0}
+    conn = Mock()
+    conn.cursor.return_value = ResultCursor(
+        [
+            [(season,) for season in range(2027, training.TRAIN_START_SEASON - 1, -1)],
+            [(2025, current), (2024, incompatible), (2023, None)],
+        ]
+    )
+    final = Mock(
+        side_effect=lambda _conn, season: closed_season is not None and season <= closed_season
+    )
+    monkeypatch.setattr(training, "season_is_final", final)
+    assert training.fetch_refit_state(conn) == (closed_season, [2025] if closed_season else [])
+    assert [call.args[1] for call in final.call_args_list] == (
+        [2027, 2026, 2025, *range(training.TRAIN_START_SEASON, 2025)]
+        if closed_season
+        else list(range(2027, training.TRAIN_START_SEASON - 1, -1))
+    )
+
+
+@pytest.mark.parametrize("gap_kind", ["missing", "unfinished"])
+@pytest.mark.parametrize("gap_season", [2015, 2020])
+def test_refit_frontier_stops_before_a_gap_inside_the_training_window(
+    monkeypatch, gap_kind, gap_season
+):
+    seasons = list(range(2025, training.TRAIN_START_SEASON - 1, -1))
+    if gap_kind == "missing":
+        seasons.remove(gap_season)
+    conn = Mock()
+    conn.cursor.return_value = ResultCursor([[(season,) for season in seasons], []])
+    final = Mock(side_effect=lambda _conn, season: season != gap_season)
+    monkeypatch.setattr(training, "season_is_final", final)
+    frontier, existing = training.fetch_refit_state(conn)
+    assert frontier == (gap_season - 1 if gap_season > training.TRAIN_START_SEASON else None)
+    assert existing == []
+    assert [call.args[1] for call in final.call_args_list].count(2025) == 1
+    if gap_kind == "missing":
+        assert gap_season not in [call.args[1] for call in final.call_args_list]
+
+
+def test_premature_existing_fit_cannot_block_the_eligible_annual_refit(monkeypatch):
+    current = dict.fromkeys(training.TEAM_WEEK_SOURCE_COLUMNS, 0.0)
+    conn = Mock()
+    conn.cursor.return_value = ResultCursor(
+        [
+            [(season,) for season in range(2026, training.TRAIN_START_SEASON - 1, -1)],
+            [(2024, current), (2026, current)],
+        ]
+    )
+    monkeypatch.setattr(training, "season_is_final", lambda _conn, season: season <= 2025)
+    frontier, existing = training.fetch_refit_state(conn)
+    assert (frontier, existing) == (2025, [2024])
+    assert training.stale_score_seasons(frontier, existing) == [2026]
+
+
+def test_loaded_fit_carries_the_vintage_checked_by_score_game():
+    fit = frozen_fit(2025)
+    metadata = [(1.0, 0.0, fit["feature_means"], fit["diff_means"], fit["diff_stds"])]
+    coefs = [
+        (component, index, feature, values[index])
+        for component, values in (("margin", fit["beta_margin"]), ("winprob", fit["beta_winprob"]))
+        for index, feature in enumerate(training.FEATURE_NAMES)
+    ]
+    conn = Mock()
+    conn.cursor.return_value = ResultCursor([metadata, coefs])
+    loaded = scoring.load_fit(conn, 2025)
+    assert loaded["train_through"] == 2025
+    assert scoring.score_game(game(2026), loaded) == (5.0, 0.5)
+
+
+class SQLiteCursor:
+    def __init__(self, cursor, *, dictionaries=False):
+        self.cursor = cursor
+        self.dictionaries = dictionaries
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.cursor.close()
+
+    def execute(self, query, params=()):
+        if "ANY(%s)" in query:
+            # SQLite adapter for PostgreSQL's array membership predicate only.
+            query = query.replace("= ANY(%s)", "IN (" + ",".join("?" for _ in params[0]) + ")")
+            params = params[0]
+        self.cursor.execute(query.replace("%s", "?"), params)
+
+    def fetchall(self):
+        rows = self.cursor.fetchall()
+        if self.dictionaries:
+            columns = [col[0] for col in self.cursor.description]
+            return [dict(zip(columns, row, strict=True)) for row in rows]
+        return rows
+
+    def fetchone(self):
+        return self.cursor.fetchone()
+
+
+class SQLiteConnection:
+    def __init__(self):
+        self.db = sqlite3.connect(":memory:")
+
+    def cursor(self, *, cursor_factory=None):
+        return SQLiteCursor(self.db.cursor(), dictionaries=cursor_factory is not None)
+
+
+@pytest.fixture
+def game_database():
+    conn = SQLiteConnection()
+    conn.db.executescript("""
+        ATTACH DATABASE ':memory:' AS core;
+        ATTACH DATABASE ':memory:' AS features;
+        CREATE TABLE core.games (
+            id INTEGER PRIMARY KEY, season INTEGER, season_type TEXT,
+            week INTEGER, start_date TEXT, neutral_site BOOLEAN,
+            home_team TEXT, away_team TEXT, home_points INTEGER,
+            away_points INTEGER, completed BOOLEAN
+        );
+    """)
+    columns = ", ".join(f"{column} REAL" for column in training.TEAM_WEEK_SOURCE_COLUMNS)
+    conn.db.execute(f"CREATE TABLE features.team_week (game_id INTEGER, team TEXT, {columns})")
+    yield conn
+    conn.db.close()
+
+
+def insert_game(conn, game_id, season, *, completed=False):
+    conn.db.execute(
+        "INSERT INTO core.games VALUES (?, ?, 'regular', 1, NULL, false, 'Alpha', 'Bravo', "
+        "21, 14, ?)",
+        (game_id, season, completed),
+    )
+    conn.db.executemany(
+        "INSERT INTO features.team_week (game_id, team) VALUES (?, ?)",
+        [(game_id, "Alpha"), (game_id, "Bravo")],
+    )
+
+
+@pytest.mark.parametrize("original_completed", [False, True])
+def test_pending_scope_excludes_reviewed_original_in_count_seasons_and_scoring(
+    game_database, original_completed
+):
+    original, replacement = next(iter(SUPERSEDED_GAME_REPLACEMENTS.items()))
+    insert_game(game_database, 1, 2025, completed=True)
+    insert_game(game_database, original, 2028, completed=original_completed)
+    insert_game(game_database, replacement, 2026)
+    insert_game(game_database, 2, 2027)
+    assert scoring.fetch_pending_game_count(game_database) == 2
+    assert scoring.fetch_pending_seasons(game_database) == [2026, 2027]
+    assert [g["game_id"] for g in scoring.fetch_upcoming_games(game_database)] == [replacement, 2]
+
+
+def test_training_and_backfill_exclude_superseded_results(game_database):
+    original, replacement = next(iter(SUPERSEDED_GAME_REPLACEMENTS.items()))
+    insert_game(game_database, original, 2026, completed=True)
+    insert_game(game_database, replacement, 2026, completed=True)
+    assert [g["game_id"] for g in training.fetch_games(game_database, [2026])] == [replacement]
+    assert [g["game_id"] for g in scoring.fetch_backfill_games(game_database, 2026)] == [
+        replacement
+    ]

--- a/tests/test_fitted_model.py
+++ b/tests/test_fitted_model.py
@@ -238,7 +238,7 @@ class TestStandardize:
 
 
 # =============================================================================
-# 6. Frozen-model selection -- backfill S-1, upcoming MAX.
+# 6. Frozen-model selection -- backfill S-1, upcoming latest strictly prior fit.
 # =============================================================================
 
 
@@ -248,11 +248,25 @@ class TestSelectTrainThrough:
         assert select_train_through("backfill", score_season=2025) == 2024
 
     def test_upcoming_uses_latest_fit(self):
-        assert select_train_through("upcoming", available_train_through=[2017, 2024, 2019]) == 2024
+        assert (
+            select_train_through(
+                "upcoming", score_season=2025, available_train_through=[2017, 2024, 2019]
+            )
+            == 2024
+        )
+
+    def test_upcoming_rejects_same_season_and_future_fits(self):
+        assert select_train_through("upcoming", 2026, [2025, 2026, 2027]) == 2025
+        with pytest.raises(ValueError, match="no eligible"):
+            select_train_through("upcoming", 2026, [2026, 2027])
+
+    def test_upcoming_requires_prediction_season(self):
+        with pytest.raises(ValueError, match="needs score_season"):
+            select_train_through("upcoming", available_train_through=[2025])
 
     def test_upcoming_without_fits_raises(self):
         with pytest.raises(ValueError):
-            select_train_through("upcoming", available_train_through=[])
+            select_train_through("upcoming", score_season=2026, available_train_through=[])
 
     def test_unknown_mode_raises(self):
         with pytest.raises(ValueError):
@@ -445,9 +459,8 @@ class TestStaleScoreSeasons:
 class TestRefitLeakRegression:
     """PR #48 P1-A. `stale_score_seasons` must be fed the last FULLY FINISHED
     season. Feeding it a season that has merely started trains a fit on partial
-    data, which `score_fitted --upcoming` then adopts as MAX(train_through) and
-    uses to score the remainder of that same season -- in-sample, and never
-    refreshed again because the key now exists."""
+    data. Scoring independently rejects that same-season fit, but the lifecycle
+    gate must still prevent persisting an unfinished training vintage."""
 
     def test_in_progress_season_would_produce_an_in_sample_fit(self):
         # 2025 finished; 2026 has kicked off. Passing 2026 (the WRONG input)

--- a/tests/test_game_identity.py
+++ b/tests/test_game_identity.py
@@ -1,0 +1,81 @@
+"""Reviewed event identities across schedule and actual prediction SQL."""
+
+import sqlite3
+from copy import deepcopy
+
+import pytest
+
+from scripts.compute_predictions import BACKFILL_GAMES_QUERY, TARGET_GAMES_QUERY
+from src.pipelines.game_identity import eligible_game_sql, select_canonical_game_rows
+
+
+def event(game_id, **changes):
+    return dict(game_id=game_id, season=2026, home_team="Campbell", away_team="WCU") | changes
+
+
+def test_schedule_resolution_preserves_replacement_and_rematches():
+    rows = [event(401866625), event(401917058), event(123)]
+    before = deepcopy(rows)
+    assert [r["game_id"] for r in select_canonical_game_rows(rows)] == [401917058, 123]
+    assert rows == before
+
+
+@pytest.mark.parametrize("field", ["season", "home_team", "away_team"])
+def test_missing_pair_identity_is_not_agreement(field):
+    original, replacement = event(401866625), event(401917058)
+    original[field] = replacement[field] = None
+    with pytest.raises(ValueError, match="disagree"):
+        select_canonical_game_rows([original, replacement])
+
+
+def test_missing_replacement_is_not_a_cancelled_contest():
+    with pytest.raises(ValueError, match="without replacement"):
+        select_canonical_game_rows([event(401866625)])
+
+
+def test_sql_rejects_expression_as_identifier():
+    with pytest.raises(ValueError, match="invalid"):
+        eligible_game_sql("g.id); DROP TABLE core.games")
+
+
+@pytest.mark.parametrize("original_completed", [False, True])
+def test_real_upcoming_query_excludes_original_even_without_replacement(original_completed):
+    with sqlite3.connect(":memory:") as conn:
+        conn.executescript("""
+            ATTACH DATABASE ':memory:' AS core;
+            CREATE TABLE core.games (
+                id INTEGER, season INTEGER, week INTEGER, season_type TEXT,
+                start_date TEXT, neutral_site BOOLEAN, home_team TEXT, away_team TEXT,
+                completed BOOLEAN
+            );
+        """)
+        conn.executemany(
+            "INSERT INTO core.games VALUES (?, ?, 1, 'regular', '2026-09-06', false, 'A', 'B', ?)",
+            [(401866625, 2027, original_completed), (123, 2026, False)],
+        )
+        # A bogus future completed original must not advance the target window.
+        assert [r[0] for r in conn.execute(TARGET_GAMES_QUERY)] == [123]
+        conn.execute(
+            "INSERT INTO core.games VALUES "
+            "(401917058, 2026, 1, 'regular', '2026-09-06', false, 'A', 'B', false)"
+        )
+        assert {r[0] for r in conn.execute(TARGET_GAMES_QUERY)} == {123, 401917058}
+
+
+def test_backfill_excludes_stale_original_elo_rows():
+    with sqlite3.connect(":memory:") as conn:
+        conn.executescript("""
+            ATTACH DATABASE ':memory:' AS analytics;
+            CREATE TABLE analytics.house_elo_game (
+                game_id INTEGER, season INTEGER, week INTEGER, season_type TEXT,
+                start_date TEXT, neutral_site BOOLEAN, home_team TEXT, away_team TEXT,
+                home_pregame_elo REAL, away_pregame_elo REAL
+            );
+        """)
+        conn.executemany(
+            "INSERT INTO analytics.house_elo_game VALUES "
+            "(?, 2026, 1, 'regular', '2026-09-06', false, 'A', 'B', 1500, 1500)",
+            [(401866625,), (401917058,), (123,)],
+        )
+        result = conn.execute(BACKFILL_GAMES_QUERY.replace("%s", "?"), (2026,))
+        assert {r[0] for r in result} == {401917058, 123}

--- a/tests/test_load_season.py
+++ b/tests/test_load_season.py
@@ -1,6 +1,7 @@
 """Unit tests for load_season's season-selection helpers (no DB, no API)."""
 
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml
@@ -8,15 +9,12 @@ import yaml
 from scripts.load_season import (
     ESTIMATED_CALLS,
     IMMUTABLE_ONCE_FINAL,
-    MIN_GAMES_FOR_FINISHED_SEASON,
     PRESEASON_ESTIMATED_CALLS,
     PRESEASON_INPUT_SOURCES,
     PRESEASON_STATS_RESOURCES,
-    SEASON_COMPLETE_THRESHOLD,
     SOURCE_ORDER,
     load_season,
     parse_source_specs,
-    season_is_final,
     sources_to_skip,
     upcoming_schedule_season,
     validate_resource_filters,
@@ -152,31 +150,6 @@ class TestMetricsWpWiring:
 
         captured = capsys.readouterr()
         assert "metrics_wp" in captured.out
-
-
-class FakeCursor:
-    def __init__(self, row):
-        self._row = row
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *a):
-        return False
-
-    def execute(self, *a, **k):
-        pass
-
-    def fetchone(self):
-        return self._row
-
-
-class FakeConn:
-    def __init__(self, row):
-        self._row = row
-
-    def cursor(self):
-        return FakeCursor(self._row)
 
 
 class TestExpansionUnitWiring:
@@ -500,41 +473,6 @@ class TestRushingWiring:
         assert args.source == "rushing"
 
 
-class TestSeasonIsFinal:
-    """The daily workflow runs with no --season, so get_current_season()
-    resolves to `year - 1` until August: every off-season run re-ingested the
-    entire, complete, immutable previous season. plays fans out to one
-    /plays/stats call PER GAME and rosters to one per team -- roughly 2,000
-    calls a day against the then-75,000/month budget, for data that cannot change.
-    That is what exhausted the quota behind the 2026-07-25 three-hour run."""
-
-    def test_a_completed_season_is_final(self):
-        assert season_is_final(FakeConn((900, 1.0)), 2025) is True
-
-    def test_tolerance_allows_a_stray_uncompleted_game(self):
-        """A cancellation that never completes must not freeze a season as
-        unfinished forever -- that would permanently disable the skip."""
-        assert season_is_final(FakeConn((900, 0.995)), 2025) is True
-
-    def test_a_season_in_progress_is_not_final(self):
-        assert season_is_final(FakeConn((900, 0.60)), 2026) is False
-
-    def test_just_below_threshold_is_not_final(self):
-        assert season_is_final(FakeConn((900, SEASON_COMPLETE_THRESHOLD - 0.01)), 2026) is False
-
-    def test_too_few_games_is_not_final(self):
-        """Week 1 of a new season is 100% complete over three games. Without a
-        floor that would read as finished and skip the entire ingest."""
-        assert season_is_final(FakeConn((3, 1.0)), 2026) is False
-        assert season_is_final(FakeConn((MIN_GAMES_FOR_FINISHED_SEASON - 1, 1.0)), 2026) is False
-
-    def test_an_unloaded_season_is_not_final(self):
-        assert season_is_final(FakeConn((0, None)), 2027) is False
-
-    def test_null_percentage_does_not_crash(self):
-        assert season_is_final(FakeConn((500, None)), 2027) is False
-
-
 class TestSourcesToSkip:
     def test_immutable_sources_are_skipped_for_a_finished_season(self):
         skipped = sources_to_skip(list(SOURCE_ORDER), season_final=True, allow_skip=True)
@@ -555,6 +493,67 @@ class TestSourcesToSkip:
         teams and venues arrive."""
         skipped = sources_to_skip(list(SOURCE_ORDER), season_final=True, allow_skip=True)
         assert "reference" not in skipped
+
+    def test_games_schedule_reconciliation_is_never_skipped(self):
+        skipped = sources_to_skip(list(SOURCE_ORDER), season_final=True, allow_skip=True)
+
+        assert "games" not in skipped
+
+
+class TestFinalSeasonScheduleReconciliation:
+    def test_final_unattended_dispatch_uses_schedule_only_games(self):
+        run_games = MagicMock(return_value="loaded")
+        conn = MagicMock()
+        limiter = MagicMock()
+        limiter.get_status.return_value = {"remaining": 10_000}
+
+        with (
+            patch("scripts.load_season.season_is_final", return_value=True),
+            patch("psycopg2.connect", return_value=conn),
+            patch("scripts.compute_predictions.get_db_url", return_value="postgres://fake"),
+            patch("src.pipelines.run.run_games_pipeline", run_games),
+            patch("src.pipelines.utils.rate_limiter.get_rate_limiter", return_value=limiter),
+        ):
+            result = load_season(
+                2025,
+                sources=["games"],
+                skip_refresh=True,
+                allow_skip_final=True,
+            )
+
+        run_games.assert_called_once_with(years=[2025], schedule_only=True)
+        assert result["results"]["games"]["status"] == "ok"
+
+    def test_explicit_load_keeps_full_games_bundle(self):
+        run_games = MagicMock(return_value="loaded")
+        limiter = MagicMock()
+        limiter.get_status.return_value = {"remaining": 10_000}
+
+        with (
+            patch("src.pipelines.run.run_games_pipeline", run_games),
+            patch("src.pipelines.utils.rate_limiter.get_rate_limiter", return_value=limiter),
+        ):
+            load_season(2025, sources=["games"], skip_refresh=True, allow_skip_final=False)
+
+        run_games.assert_called_once_with(years=[2025], schedule_only=False)
+
+    def test_schedule_only_runner_does_not_fetch_drives_or_ancillary_resources(self):
+        from src.pipelines.run import run_games_pipeline
+
+        pipeline = MagicMock()
+        pipeline.run.return_value = "loaded"
+        source = MagicMock()
+
+        with (
+            patch("src.pipelines.run.dlt.pipeline", return_value=pipeline),
+            patch("src.pipelines.run.games_source", return_value=source) as games_source,
+        ):
+            result = run_games_pipeline(years=[2025], schedule_only=True)
+
+        assert result == "loaded"
+        games_source.assert_called_once()
+        source.with_resources.assert_called_once_with("games")
+        pipeline.run.assert_called_once()
 
     def test_metrics_wp_stays_eligible_even_on_a_finished_season(self):
         """PR #54 review, P1.

--- a/tests/test_season_lifecycle.py
+++ b/tests/test_season_lifecycle.py
@@ -1,0 +1,310 @@
+"""Pure fixtures for the shared, conservative season lifecycle policy."""
+
+from datetime import UTC, datetime
+
+from src.pipelines.season_lifecycle import (
+    SeasonResolutions,
+    classify_season,
+    season_close_floor,
+    season_is_final,
+)
+
+
+def _game(game_id: int, season: int = 2025, **changes) -> dict:
+    row = {
+        "game_id": game_id,
+        "season": season,
+        "season_type": "postseason" if game_id == 100 else "regular",
+        "start_date": datetime(season + 1, 1, 10, tzinfo=UTC),
+        "completed": True,
+        "home_id": game_id * 2,
+        "home_team": f"Home {game_id}",
+        "home_points": 24,
+        "away_id": game_id * 2 + 1,
+        "away_team": f"Away {game_id}",
+        "away_points": 17,
+    }
+    row.update(changes)
+    return row
+
+
+def _complete_schedule(season: int = 2025, games: int = 100) -> list[dict]:
+    rows = [_game(game_id, season) for game_id in range(1, games + 1)]
+    if rows:
+        rows[-1]["season_type"] = "postseason"
+    return rows
+
+
+def _as_of(season: int = 2025) -> datetime:
+    return datetime(season + 1, 2, 1, tzinfo=UTC)
+
+
+def test_complete_historical_season_closes_after_floor():
+    result = classify_season(_complete_schedule(), 2025, as_of=_as_of())
+
+    assert result.is_final is True
+    assert result.reason == "all canonical games are resolved"
+
+
+def test_calendar_floor_blocks_a_complete_partial_current_schedule():
+    result = classify_season(
+        _complete_schedule(2026),
+        2026,
+        as_of=datetime(2026, 10, 1, tzinfo=UTC),
+    )
+
+    assert result.is_final is False
+    assert "calendar floor" in result.reason
+
+
+def test_2020_disruption_uses_july_floor():
+    assert season_close_floor(2020) == datetime(2021, 7, 1, tzinfo=UTC)
+    assert not classify_season(
+        _complete_schedule(2020),
+        2020,
+        as_of=datetime(2021, 6, 30, 23, 59, tzinfo=UTC),
+    ).is_final
+    assert classify_season(
+        _complete_schedule(2020),
+        2020,
+        as_of=datetime(2021, 7, 1, tzinfo=UTC),
+    ).is_final
+
+
+def test_regular_only_truncated_schedule_cannot_close():
+    rows = _complete_schedule()
+    for row in rows:
+        row["season_type"] = "regular"
+
+    result = classify_season(rows, 2025, as_of=_as_of())
+
+    assert result.is_final is False
+    assert result.reason == "schedule has no postseason games"
+
+
+def test_postseason_only_truncated_schedule_cannot_close():
+    rows = _complete_schedule()
+    for row in rows:
+        row["season_type"] = "postseason"
+
+    result = classify_season(rows, 2025, as_of=_as_of())
+
+    assert result.is_final is False
+    assert result.reason == "schedule has no regular games"
+
+
+def test_sparse_complete_schedule_cannot_close():
+    result = classify_season(_complete_schedule(games=99), 2025, as_of=_as_of())
+
+    assert result.is_final is False
+    assert "only 99 canonical games" in result.reason
+
+
+def test_unfinished_allstar_game_does_not_hold_season_open():
+    rows = _complete_schedule()
+    rows.append(
+        _game(
+            101,
+            season_type="allstar",
+            completed=False,
+            home_points=None,
+            away_points=None,
+        )
+    )
+
+    result = classify_season(rows, 2025, as_of=_as_of())
+
+    assert result.is_final is True
+    assert result.scheduled_games == 100
+
+
+def test_unknown_or_missing_season_type_remains_unresolved():
+    for season_type in (None, "spring"):
+        rows = _complete_schedule()
+        rows.append(_game(101, season_type=season_type))
+
+        result = classify_season(rows, 2025, as_of=_as_of())
+
+        assert result.is_final is False
+        assert result.unresolved_game_ids == (101,)
+        assert "unknown season type" in result.reason
+
+
+def test_mixed_season_rows_refuse_classification():
+    rows = _complete_schedule()
+    rows[-1]["season"] = 2024
+
+    result = classify_season(rows, 2025, as_of=_as_of())
+
+    assert result.is_final is False
+    assert result.unresolved_game_ids == (100,)
+    assert "do not belong to season 2025" in result.reason
+
+
+def test_playoff_tail_blocks_finality():
+    rows = _complete_schedule()
+    rows[-1].update(completed=False, home_points=None, away_points=None)
+
+    result = classify_season(rows, 2025, as_of=_as_of())
+
+    assert result.is_final is False
+    assert result.unresolved_game_ids == (100,)
+    assert "100" in result.reason
+
+
+def test_future_postseason_game_blocks_finality_even_if_marked_complete():
+    rows = _complete_schedule()
+    rows[-1]["start_date"] = datetime(2026, 2, 2, tzinfo=UTC)
+
+    result = classify_season(rows, 2025, as_of=_as_of())
+
+    assert result.is_final is False
+    assert result.unresolved_game_ids == (100,)
+
+
+def test_missing_kickoff_or_completed_score_is_unresolved():
+    rows = _complete_schedule()
+    rows[0]["start_date"] = None
+    rows[1]["home_points"] = None
+
+    result = classify_season(rows, 2025, as_of=_as_of())
+
+    assert result.is_final is False
+    assert result.unresolved_game_ids == (1, 2)
+
+
+def test_old_incomplete_row_is_not_inferred_cancelled_from_age():
+    rows = _complete_schedule(2022)
+    rows[0].update(completed=False, home_points=None, away_points=None)
+
+    result = classify_season(
+        rows,
+        2022,
+        as_of=datetime(2026, 9, 1, tzinfo=UTC),
+    )
+
+    assert result.is_final is False
+    assert result.unresolved_game_ids == (1,)
+
+
+def test_reviewed_cancellation_allows_historical_closure_without_completion():
+    rows = _complete_schedule(2022, games=101)
+    rows[0].update(completed=False, home_points=None, away_points=None)
+    resolutions = SeasonResolutions(
+        cancelled_game_ids=frozenset({1}),
+        superseded_game_replacements={},
+    )
+
+    result = classify_season(
+        rows,
+        2022,
+        as_of=datetime(2026, 9, 1, tzinfo=UTC),
+        resolutions=resolutions,
+    )
+
+    assert result.is_final is True
+    assert result.scheduled_games == 100
+
+
+def test_reviewed_postponement_uses_completed_replacement():
+    rows = _complete_schedule()
+    replacement = _game(
+        1001,
+        home_team="Campbell",
+        away_team="Western Carolina",
+    )
+    original = _game(
+        1000,
+        home_team="Campbell",
+        away_team="Western Carolina",
+        completed=False,
+        home_points=None,
+        away_points=None,
+    )
+    rows.extend([original, replacement])
+    resolutions = SeasonResolutions(frozenset(), {1000: 1001})
+
+    result = classify_season(rows, 2025, as_of=_as_of(), resolutions=resolutions)
+
+    assert result.is_final is True
+    assert result.scheduled_games == 101
+
+
+def test_postponement_with_unfinished_replacement_stays_open():
+    rows = _complete_schedule()
+    original = _game(1000, home_team="A", away_team="B", completed=False)
+    replacement = _game(
+        1001,
+        home_team="A",
+        away_team="B",
+        completed=False,
+        home_points=None,
+        away_points=None,
+    )
+    rows.extend([original, replacement])
+
+    result = classify_season(
+        rows,
+        2025,
+        as_of=_as_of(),
+        resolutions=SeasonResolutions(frozenset(), {1000: 1001}),
+    )
+
+    assert result.is_final is False
+    assert result.unresolved_game_ids == (1001,)
+
+
+def test_postponement_identity_mismatch_refuses_suppression():
+    rows = _complete_schedule()
+    rows.extend(
+        [
+            _game(1000, home_team="A", away_team="B"),
+            _game(1001, home_team="A", away_team="Different"),
+        ]
+    )
+
+    result = classify_season(
+        rows,
+        2025,
+        as_of=_as_of(),
+        resolutions=SeasonResolutions(frozenset(), {1000: 1001}),
+    )
+
+    assert result.is_final is False
+    assert "disagree on away_team" in result.reason
+
+
+class _Cursor:
+    def __init__(self, rows):
+        self.rows = rows
+        self.description = [(name,) for name in rows[0]] if rows else []
+        self.executed = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def execute(self, query, params):
+        self.executed = (query, params)
+
+    def fetchall(self):
+        return [tuple(row.values()) for row in self.rows]
+
+
+class _Connection:
+    def __init__(self, rows):
+        self.cursor_instance = _Cursor(rows)
+
+    def cursor(self):
+        return self.cursor_instance
+
+
+def test_database_wrapper_uses_shared_classifier_contract():
+    conn = _Connection(_complete_schedule())
+
+    assert season_is_final(conn, 2025, as_of=_as_of()) is True
+    query, params = conn.cursor_instance.executed
+    assert "FROM core.games" in query
+    assert params == (2025,)

--- a/tests/test_sources/test_player_overview.py
+++ b/tests/test_sources/test_player_overview.py
@@ -2,8 +2,8 @@
 
 Covers src/pipelines/sources/player_overview.py::player_overview_source /
 player_season_overview_resource (mocked CFBD client -- no network) and
-src/pipelines/run.py::run_player_overview_pipeline plus its helpers
-(_season_is_final, _dedup_rows) (mocked psycopg2/rate-limiter/dlt -- no DB,
+src/pipelines/run.py::run_player_overview_pipeline plus its row helpers
+(_dedup_rows) (mocked psycopg2/rate-limiter/dlt -- no DB,
 no network). Mirrors test_sources/test_metrics_wp.py's split between
 resource-level and pipeline-level tests, since /player/season/overview is
 the same DB-set-difference-drainer shape as /metrics/wp.
@@ -506,75 +506,6 @@ class TestDedupRows:
 
 
 # ---------------------------------------------------------------------------
-# _season_is_final (src/pipelines/run.py) -- mirrors
-# scripts/load_season.py::season_is_final; same FakeConn/FakeCursor testing
-# precedent as tests/test_load_season.py::TestSeasonIsFinal.
-# ---------------------------------------------------------------------------
-
-
-class _FakeCursor:
-    def __init__(self, row):
-        self._row = row
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *a):
-        return False
-
-    def execute(self, *a, **k):
-        pass
-
-    def fetchone(self):
-        return self._row
-
-
-class _FakeConn:
-    def __init__(self, row):
-        self._row = row
-
-    def cursor(self):
-        return _FakeCursor(self._row)
-
-
-class TestSeasonIsFinalGate:
-    """A season's box score/usage/PPA totals mutate weekly while games are
-    still being played -- this gate is what keeps run_player_overview_pipeline
-    from loading a season early and re-loading it every day."""
-
-    def test_a_completed_season_is_final(self):
-        from src.pipelines.run import _season_is_final
-
-        assert _season_is_final(_FakeConn((900, 1.0)), 2025) is True
-
-    def test_tolerance_allows_a_stray_uncompleted_game(self):
-        from src.pipelines.run import _season_is_final
-
-        assert _season_is_final(_FakeConn((900, 0.995)), 2025) is True
-
-    def test_a_season_in_progress_is_not_final(self):
-        from src.pipelines.run import _season_is_final
-
-        assert _season_is_final(_FakeConn((3677, 0.0158)), 2026) is False
-
-    def test_too_few_games_is_not_final(self):
-        from src.pipelines.run import _MIN_GAMES_FOR_FINISHED_SEASON, _season_is_final
-
-        assert _season_is_final(_FakeConn((3, 1.0)), 2026) is False
-        assert _season_is_final(_FakeConn((_MIN_GAMES_FOR_FINISHED_SEASON - 1, 1.0)), 2026) is False
-
-    def test_near_complete_season_is_final(self):
-        from src.pipelines.run import _season_is_final
-
-        assert _season_is_final(_FakeConn((3801, 0.9995)), 2024) is True
-
-    def test_an_unloaded_season_is_not_final(self):
-        from src.pipelines.run import _season_is_final
-
-        assert _season_is_final(_FakeConn((0, None)), 2027) is False
-
-
-# ---------------------------------------------------------------------------
 # run_player_overview_pipeline (src/pipelines/run.py)
 # ---------------------------------------------------------------------------
 
@@ -613,7 +544,7 @@ class TestRunPlayerOverviewPipelineBatching:
         with (
             patch("src.pipelines.run._metrics_wp_db_url", return_value="postgres://fake"),
             patch("psycopg2.connect", return_value=conn),
-            patch("src.pipelines.run._season_is_final", return_value=True),
+            patch("src.pipelines.run.season_is_final", return_value=True),
             patch("src.pipelines.run.dlt.pipeline", return_value=mock_pipeline),
             patch("src.pipelines.run.player_overview_source") as mock_source,
         ):
@@ -636,7 +567,7 @@ class TestRunPlayerOverviewPipelineBatching:
         with (
             patch("src.pipelines.run._metrics_wp_db_url", return_value="postgres://fake"),
             patch("psycopg2.connect", return_value=conn),
-            patch("src.pipelines.run._season_is_final", return_value=True),
+            patch("src.pipelines.run.season_is_final", return_value=True),
             patch("src.pipelines.run.dlt.pipeline", return_value=mock_pipeline),
             patch("src.pipelines.run.player_overview_source") as mock_source,
         ):
@@ -659,7 +590,7 @@ class TestRunPlayerOverviewPipelineBatching:
         with (
             patch("src.pipelines.run._metrics_wp_db_url", return_value="postgres://fake"),
             patch("psycopg2.connect", return_value=conn),
-            patch("src.pipelines.run._season_is_final", return_value=True),
+            patch("src.pipelines.run.season_is_final", return_value=True),
             patch("src.pipelines.run.dlt.pipeline", return_value=mock_pipeline),
             patch("src.pipelines.run.player_overview_source") as mock_source,
         ):
@@ -690,7 +621,7 @@ class TestRunPlayerOverviewPipelineBatching:
         with (
             patch("src.pipelines.run._metrics_wp_db_url", return_value="postgres://fake"),
             patch("psycopg2.connect", return_value=conn),
-            patch("src.pipelines.run._season_is_final", return_value=True),
+            patch("src.pipelines.run.season_is_final", return_value=True),
             patch("src.pipelines.run.dlt.pipeline", return_value=mock_pipeline),
             patch("src.pipelines.run.player_overview_source"),
         ):
@@ -708,7 +639,7 @@ class TestRunPlayerOverviewPipelineBatching:
         with (
             patch("src.pipelines.run._metrics_wp_db_url", return_value="postgres://fake"),
             patch("psycopg2.connect", return_value=conn),
-            patch("src.pipelines.run._season_is_final", return_value=True),
+            patch("src.pipelines.run.season_is_final", return_value=True),
             patch("src.pipelines.run.dlt.pipeline", return_value=mock_pipeline),
         ):
             result = run_player_overview_pipeline(seasons=[2024], batch_size=50)
@@ -728,7 +659,7 @@ class TestRunPlayerOverviewPipelineBatching:
         with (
             patch("src.pipelines.run._metrics_wp_db_url", return_value="postgres://fake"),
             patch("psycopg2.connect", return_value=conn),
-            patch("src.pipelines.run._season_is_final", return_value=True),
+            patch("src.pipelines.run.season_is_final", return_value=True),
             patch("src.pipelines.run.dlt.pipeline", return_value=mock_pipeline),
             patch("src.pipelines.run.player_overview_source"),
         ):
@@ -763,7 +694,7 @@ class TestRunPlayerOverviewPipelineSeasonGate:
         with (
             patch("src.pipelines.run._metrics_wp_db_url", return_value="postgres://fake"),
             patch("psycopg2.connect", return_value=conn),
-            patch("src.pipelines.run._season_is_final", return_value=True),
+            patch("src.pipelines.run.season_is_final", return_value=True),
         ):
             result = run_player_overview_pipeline()
 
@@ -790,7 +721,7 @@ class TestRunPlayerOverviewPipelineSeasonGate:
         with (
             patch("src.pipelines.run._metrics_wp_db_url", return_value="postgres://fake"),
             patch("psycopg2.connect", return_value=conn),
-            patch("src.pipelines.run._season_is_final", side_effect=fake_is_final),
+            patch("src.pipelines.run.season_is_final", side_effect=fake_is_final),
         ):
             result = run_player_overview_pipeline(seasons=[2026, 2025])
 
@@ -814,7 +745,7 @@ class TestRunPlayerOverviewPipelineBudgetGuard:
         with (
             patch("src.pipelines.run._metrics_wp_db_url", return_value="postgres://fake"),
             patch("psycopg2.connect", return_value=conn),
-            patch("src.pipelines.run._season_is_final", return_value=True),
+            patch("src.pipelines.run.season_is_final", return_value=True),
             patch("src.pipelines.run.get_rate_limiter", return_value=mock_rate_limiter),
             patch("src.pipelines.run.dlt.pipeline", return_value=mock_pipeline),
         ):
@@ -838,7 +769,7 @@ class TestRunPlayerOverviewPipelineBudgetGuard:
         with (
             patch("src.pipelines.run._metrics_wp_db_url", return_value="postgres://fake"),
             patch("psycopg2.connect", return_value=conn),
-            patch("src.pipelines.run._season_is_final", return_value=True),
+            patch("src.pipelines.run.season_is_final", return_value=True),
             patch("src.pipelines.run.get_rate_limiter", return_value=mock_rate_limiter),
             patch("src.pipelines.run.dlt.pipeline", return_value=mock_pipeline),
             patch("src.pipelines.run.player_overview_source"),
@@ -869,7 +800,7 @@ class TestRunPlayerOverviewPipelineFanoutMisses:
         with (
             patch("src.pipelines.run._metrics_wp_db_url", return_value="postgres://fake"),
             patch("psycopg2.connect", return_value=conn),
-            patch("src.pipelines.run._season_is_final", return_value=True),
+            patch("src.pipelines.run.season_is_final", return_value=True),
             patch("src.pipelines.run.dlt.pipeline", return_value=mock_pipeline),
             patch("src.pipelines.run.player_overview_source") as mock_source,
         ):
@@ -889,7 +820,7 @@ class TestRunPlayerOverviewPipelineFanoutMisses:
         with (
             patch("src.pipelines.run._metrics_wp_db_url", return_value="postgres://fake"),
             patch("psycopg2.connect", return_value=conn),
-            patch("src.pipelines.run._season_is_final", return_value=True),
+            patch("src.pipelines.run.season_is_final", return_value=True),
             patch("src.pipelines.run.dlt.pipeline", return_value=mock_pipeline),
             patch("src.pipelines.run.player_overview_source"),
         ):
@@ -908,7 +839,7 @@ class TestRunPlayerOverviewPipelineFanoutMisses:
         with (
             patch("src.pipelines.run._metrics_wp_db_url", return_value="postgres://fake"),
             patch("psycopg2.connect", return_value=conn),
-            patch("src.pipelines.run._season_is_final", return_value=True),
+            patch("src.pipelines.run.season_is_final", return_value=True),
             patch("src.pipelines.run.dlt.pipeline", return_value=mock_pipeline),
         ):
             result = run_player_overview_pipeline(seasons=[2024], batch_size=50)
@@ -935,7 +866,7 @@ class TestRunPlayerOverviewPipelineFanoutMisses:
         with (
             patch("src.pipelines.run._metrics_wp_db_url", return_value="postgres://fake"),
             patch("psycopg2.connect", return_value=conn),
-            patch("src.pipelines.run._season_is_final", return_value=True),
+            patch("src.pipelines.run.season_is_final", return_value=True),
             patch("src.pipelines.run.dlt.pipeline", return_value=mock_pipeline),
             patch("src.pipelines.run.player_overview_source", side_effect=fake_source),
             patch(
@@ -974,7 +905,7 @@ class TestRunPlayerOverviewPipelineFanoutMisses:
         with (
             patch("src.pipelines.run._metrics_wp_db_url", return_value="postgres://fake"),
             patch("psycopg2.connect", return_value=conn),
-            patch("src.pipelines.run._season_is_final", return_value=True),
+            patch("src.pipelines.run.season_is_final", return_value=True),
             patch("src.pipelines.run.dlt.pipeline", return_value=mock_pipeline),
             patch("src.pipelines.run.player_overview_source", side_effect=fake_source),
             patch("src.pipelines.run._record_fanout_misses"),
@@ -994,7 +925,7 @@ class TestRunPlayerOverviewPipelineFanoutMisses:
         with (
             patch("src.pipelines.run._metrics_wp_db_url", return_value="postgres://fake"),
             patch("psycopg2.connect", return_value=conn),
-            patch("src.pipelines.run._season_is_final", return_value=True),
+            patch("src.pipelines.run.season_is_final", return_value=True),
             patch("src.pipelines.run.dlt.pipeline", return_value=mock_pipeline),
             patch("src.pipelines.run.player_overview_source"),
         ):
@@ -1012,7 +943,7 @@ class TestRunPlayerOverviewPipelineFanoutMisses:
         with (
             patch("src.pipelines.run._metrics_wp_db_url", return_value="postgres://fake"),
             patch("psycopg2.connect", return_value=conn),
-            patch("src.pipelines.run._season_is_final", return_value=True),
+            patch("src.pipelines.run.season_is_final", return_value=True),
             patch("src.pipelines.run.dlt.pipeline", return_value=mock_pipeline),
             patch("src.pipelines.run.player_overview_source"),
             patch("src.pipelines.run._record_fanout_misses") as mock_record,
@@ -1042,7 +973,7 @@ class TestRunPlayerOverviewPipelineFanoutMisses:
         with (
             patch("src.pipelines.run._metrics_wp_db_url", return_value="postgres://fake"),
             patch("psycopg2.connect", return_value=conn),
-            patch("src.pipelines.run._season_is_final", return_value=True),
+            patch("src.pipelines.run.season_is_final", return_value=True),
             patch("src.pipelines.run.dlt.pipeline", return_value=mock_pipeline),
             patch("src.pipelines.run.player_overview_source") as mock_source,
         ):


### PR DESCRIPTION
A season with 1,590 completed games out of 1,600 could pass the old 99% closure rule, stop schedule ingestion, and trigger a fit that upcoming games in the same season would then use.

Replace all three completion predicates with one conservative lifecycle policy. Require a calendar floor, regular/postseason coverage, complete scored results, and no future or unresolved contests. Reviewed cancellations and replacements are explicit; old unresolved rows are never inferred cancelled. Finalized unattended loads still perform a one-call games schedule refresh; explicit loads keep their full resource scope.

Automatic refits require a contiguous closed training window and ignore premature stored vintages when deciding whether a fit is current. Upcoming scoring independently selects a feature-compatible strictly prior vintage at or below the shared closed training frontier for every pending season, loads all required fits before writing, and validates eligibility per game. Every pending season must meet 90% coverage before any upcoming write; the daily verifier uses the same canonical population and per-season gate. Backfill retains exact S-1 behavior.

Centralize the reviewed Campbell–Western Carolina replacement mapping and exclude its false completed original from Elo, EPA, feature, training, prediction, and simulation inputs while preserving raw rows. Projection schedules and closure also require the matching replacement.

Validation: 2,340 offline root tests passed / 449 skipped; 59 MCP tests passed; affected Ruff lint/format, whitespace, and agent-setup checks passed. Executed SQLite fixtures exercise real portable query paths; orchestration tests verify mixed-season fits, invalid-fit no-write behavior, schedule-only dispatch, reopening, and postponed/cancelled/partial schedules. Independent reviews resolved one refit-staleness finding and found no remaining actionable defects.

Rollout: no production ingestion, training, schema deployment, or historical rebuild was run. Existing materializations are not repaired merely by merging these input filters. The actual PostgreSQL16 preseason-backtest query passed a disposable local fixture covering canonical results and earliest feature selection. Full PostgreSQL feature-build query execution remains unverified locally. See docs/plans/2026-09-06-f03-season-lifecycle.md for acceptance evidence and rollout limits.




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change strengthens season-finality handling for fitted-model scoring. Upcoming games now use only compatible model vintages from the closed training frontier, and each pending season must meet its own feature-coverage threshold before predictions are written.

<h3>Confidence Score: 5/5</h3>

Safe to merge.

No outstanding findings remain. The prior issue was resolved: upcoming scoring filters persisted model vintages to the closed training frontier before selecting the latest model that predates each prediction season.

<sub>Reviews (2): Last reviewed commit: ["fix: close PR review gaps in fit safety ..."](https://github.com/rstover-fo/cfb-database/commit/7e8b8278c2836770915ac9a5fc9c8fd47a5b9ace) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61025263)</sub>

<!-- /greptile_comment -->