### PR TITLE
fix: reconcile lifecycle blockers and rebuild F03 production outputs

### DIFF
--- a/docs/brainstorms/2026-07-21-team-week-feature-design.md
+++ b/docs/brainstorms/2026-07-21-team-week-feature-design.md
@@ -829,3 +829,24 @@ Per-family assertions the gate runs against the freshly-built `team_week`
   optional volatility-modulated calibration experiment) was dropped with its
   substrate when `vol_net_epa` was rejected in the 2026-07-28 screen -- see
   that entry above -- so the plan's Definition of Done is met without it.
+
+### Production lifecycle reconciliation — September 6, 2026
+
+The rollout preflight found actual 2020 `spring_regular` and
+`spring_postseason` records. These are documented CFBD season types, not unknown
+status or exhibitions ([official Games schema](https://apinext.collegefootballdata.com/api/games)).
+For closure coverage only, recognize them as regular/postseason contest types;
+retain their raw season_type and the conservative 2020 July 1 floor. Their
+future dates, incomplete status and missing scores still block closure. This
+amendment does not alter historical feature week-index semantics.
+
+The same preflight identified reviewed non-contests and two missing official
+results. Extend the existing explicit event registry only with documented
+cancellations and matched replacement IDs. Correct Taylor–Defiance 2024 to
+63–12/completed and Sul Ross–Angelo State 2025 to 0–62/completed, with exact
+provider ID/season/team identity guards and official source citations. A
+contradictory non-NULL result must stop correction. Preserve the original stored
+rows in a private recovery journal before the bounded database repair; apply the
+same reviewed result correction on later game ingestion so it cannot regress.
+These are source-data repairs, not a change to the feature vector, fit vintage,
+week-index semantics, or permission to retrain. The 2025 fit remains frozen.

--- a/docs/plans/2026-09-06-f03-data-repair.sql
+++ b/docs/plans/2026-09-06-f03-data-repair.sql
@@ -1,0 +1,78 @@
+-- Explicit-file recovery only; not an automatic migration.
+-- Run transactionally via run_migrations.py after reviewing F03 recovery evidence.
+-- Retain exact pre-repair rows, including dlt metadata, in an owner-only journal.
+SET LOCAL lock_timeout = '10s';
+SET LOCAL statement_timeout = '60s';
+CREATE SCHEMA IF NOT EXISTS recovery;
+REVOKE ALL ON SCHEMA recovery FROM PUBLIC, anon, authenticated, analyst_ro;
+CREATE TABLE IF NOT EXISTS recovery.f03_row_archive (
+    source_table text NOT NULL,
+    row_id bigint NOT NULL,
+    payload jsonb NOT NULL,
+    archived_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (source_table,row_id)
+);
+REVOKE ALL ON recovery.f03_row_archive FROM PUBLIC, anon, authenticated, analyst_ro;
+
+-- Short table locks prevent concurrent ingestion or same-day prediction upserts
+-- from changing a row between its audit snapshot and repair/deletion.
+LOCK TABLE core.games, predictions.game_predictions IN SHARE ROW EXCLUSIVE MODE;
+LOCK TABLE features.model_metadata,features.model_coefficients IN SHARE MODE;
+-- Preserve the first pre-rebuild fit snapshot so postflight can prove equality.
+INSERT INTO recovery.f03_row_archive(source_table,row_id,payload)
+SELECT 'features.model_metadata',0,COALESCE(jsonb_agg(to_jsonb(m)), '[]'::jsonb)
+FROM features.model_metadata m ON CONFLICT DO NOTHING;
+INSERT INTO recovery.f03_row_archive(source_table,row_id,payload)
+SELECT 'features.model_coefficients',0,COALESCE(jsonb_agg(to_jsonb(c)), '[]'::jsonb)
+FROM features.model_coefficients c ON CONFLICT DO NOTHING;
+DO $repair$
+DECLARE expected record; actual core.games%ROWTYPE; n bigint;
+BEGIN
+ FOR expected IN SELECT * FROM (VALUES
+   -- Official Taylor game log, November 2, 2024:
+   -- https://taylor2023.prestosports.com/sports/fball/2024-25/bios/loveless_carter_825c
+   (401677463::bigint,2024,620,190,63,12),
+   -- Official Sul Ross box score, October 25, 2025 (October 26 UTC):
+   -- https://srlobos.com/sports/football/stats/2025/angelo-state/boxscore/3842
+   (401773541::bigint,2025,2834,2025,0,62)
+ ) AS r(id,season,home_id,away_id,home_points,away_points)
+ LOOP
+   SELECT * INTO STRICT actual FROM core.games WHERE id=expected.id;
+   IF actual.season IS DISTINCT FROM expected.season
+      OR actual.home_id IS DISTINCT FROM expected.home_id
+      OR actual.away_id IS DISTINCT FROM expected.away_id THEN
+     RAISE EXCEPTION 'Identity mismatch for game %',expected.id;
+   END IF;
+   IF (actual.home_points IS NOT NULL AND actual.home_points<>expected.home_points)
+      OR (actual.away_points IS NOT NULL AND actual.away_points<>expected.away_points) THEN
+     RAISE EXCEPTION 'Conflicting score for game %',expected.id;
+   END IF;
+   IF actual.completed IS TRUE AND actual.home_points=expected.home_points
+      AND actual.away_points=expected.away_points THEN CONTINUE; END IF;
+   INSERT INTO recovery.f03_row_archive(source_table,row_id,payload)
+   VALUES ('core.games',actual.id,to_jsonb(actual)) ON CONFLICT DO NOTHING;
+   IF NOT EXISTS (SELECT 1 FROM recovery.f03_row_archive
+       WHERE source_table='core.games' AND row_id=actual.id AND payload=to_jsonb(actual)) THEN
+     RAISE EXCEPTION 'Original game archive mismatch for %',actual.id;
+   END IF;
+   UPDATE core.games SET completed=true,home_points=expected.home_points,
+      away_points=expected.away_points WHERE id=expected.id;
+   RAISE NOTICE 'Restored reviewed result for game %',expected.id;
+ END LOOP;
+
+ INSERT INTO recovery.f03_row_archive(source_table,row_id,payload)
+ SELECT 'predictions.game_predictions',p.prediction_id,to_jsonb(p)
+ FROM predictions.game_predictions p WHERE game_id=401866625
+ ON CONFLICT DO NOTHING;
+ IF EXISTS (SELECT 1 FROM predictions.game_predictions p
+     LEFT JOIN recovery.f03_row_archive a ON a.source_table='predictions.game_predictions'
+       AND a.row_id=p.prediction_id
+     WHERE p.game_id=401866625 AND a.payload IS DISTINCT FROM to_jsonb(p)) THEN
+   RAISE EXCEPTION 'Prediction archive mismatch; no deletion permitted';
+ END IF;
+ DELETE FROM predictions.game_predictions p USING recovery.f03_row_archive a
+ WHERE p.game_id=401866625 AND a.source_table='predictions.game_predictions'
+   AND a.row_id=p.prediction_id AND a.payload=to_jsonb(p);
+ GET DIAGNOSTICS n=ROW_COUNT;
+ RAISE NOTICE 'Archived and removed % superseded-event prediction snapshots',n;
+END $repair$;

--- a/docs/plans/2026-09-06-f03-outlook-cleanup.sql
+++ b/docs/plans/2026-09-06-f03-outlook-cleanup.sql
@@ -1,0 +1,129 @@
+-- Explicit-file cleanup for the stale F03 2026 fitted_v1 outlook aliases.
+--
+-- Evidence: Deploy Schema diagnostic run 34065108610 reported exactly these
+-- 30 pre-recovery rows, each with zero current canonical regular-season games.
+-- They are obsolete provider/team labels, not evidence for a rename mapping;
+-- this script intentionally makes no alias or team-name normalization guess.
+--
+-- Run transactionally through run_migrations.py only after review.  The
+-- private recovery.f03_row_archive journal was created by f03-data-repair.sql.
+SET LOCAL lock_timeout = '10s';
+SET LOCAL statement_timeout = '60s';
+
+-- Keep the schedule fact and the append-only snapshots stable between the
+-- preflight, archive-equality check, and delete.
+LOCK TABLE core.games IN SHARE MODE;
+LOCK TABLE predictions.season_projections IN SHARE ROW EXCLUSIVE MODE;
+
+DO $outlook_cleanup$
+DECLARE
+    allowed_teams text[] := ARRAY[
+        'Albany State GA', 'Anderson (Sc)', 'Benedictine University',
+        'California Lutheran University', 'Castleton', 'Central State (OH)',
+        'College Of New Jersey', 'Concord University', 'Concordia',
+        'Concordia University Chicago', 'Concordia-Wisconsin', 'Dickinson (PA)',
+        'Eureka College', 'Greeneville', 'Lewis & Clark College', 'Linfield College',
+        'Little Rock', 'Louisiana College', 'Miles College', 'Morehouse College',
+        'NEWBERG', 'Saint Xavier (IL)', 'Savannah St', 'St Francis Illinois',
+        'Thomas More College', 'Virginia St', 'Virginia University Of Lynchburg',
+        'Western Connecticut St', 'Winston-Salem', 'Wisconsin-Lutheran'
+    ];
+    cutoff timestamptz := '2026-09-06 22:41:07+00'::timestamptz;
+    blocked_teams text[];
+    archived_count bigint;
+    deleted_count bigint;
+BEGIN
+    IF cardinality(allowed_teams) <> 30 THEN
+        RAISE EXCEPTION 'Expected exactly 30 reviewed stale outlook aliases';
+    END IF;
+
+    -- A now-canonical schedule or a fresh snapshot changes the diagnosis.
+    -- Stop rather than deleting a row whose team string may now be active.
+    SELECT array_agg(DISTINCT t.team ORDER BY t.team)
+    INTO blocked_teams
+    FROM unnest(allowed_teams) AS t(team)
+    JOIN core.games AS g
+      ON g.season = 2026
+     AND g.season_type = 'regular'
+     AND g.id <> 401866625
+     AND (g.home_team = t.team OR g.away_team = t.team);
+    IF blocked_teams IS NOT NULL THEN
+        RAISE EXCEPTION 'Reviewed stale outlook aliases now have canonical games: %', blocked_teams;
+    END IF;
+
+    SELECT array_agg(DISTINCT p.team ORDER BY p.team)
+    INTO blocked_teams
+    FROM predictions.season_projections AS p
+    WHERE p.season = 2026
+      AND p.model_version = 'fitted_v1'
+      AND p.team = ANY(allowed_teams)
+      AND p.computed_at >= cutoff;
+    IF blocked_teams IS NOT NULL THEN
+        RAISE EXCEPTION 'Reviewed stale outlook aliases now have recent projections: %', blocked_teams;
+    END IF;
+
+    INSERT INTO recovery.f03_row_archive(source_table, row_id, payload)
+    SELECT 'predictions.season_projections', p.projection_id, to_jsonb(p)
+    FROM predictions.season_projections AS p
+    WHERE p.season = 2026
+      AND p.model_version = 'fitted_v1'
+      AND p.team = ANY(allowed_teams)
+      AND p.computed_at < cutoff
+      AND NOT EXISTS (
+          SELECT 1
+          FROM core.games AS g
+          WHERE g.season = 2026
+            AND g.season_type = 'regular'
+            AND g.id <> 401866625
+            AND (g.home_team = p.team OR g.away_team = p.team)
+      )
+    ON CONFLICT DO NOTHING;
+    GET DIAGNOSTICS archived_count = ROW_COUNT;
+
+    -- A prior archive key is acceptable only when it has an equal JSONB
+    -- payload to the row about to be removed.
+    IF EXISTS (
+        SELECT 1
+        FROM predictions.season_projections AS p
+        LEFT JOIN recovery.f03_row_archive AS a
+          ON a.source_table = 'predictions.season_projections'
+         AND a.row_id = p.projection_id
+        WHERE p.season = 2026
+          AND p.model_version = 'fitted_v1'
+          AND p.team = ANY(allowed_teams)
+          AND p.computed_at < cutoff
+          AND NOT EXISTS (
+              SELECT 1
+              FROM core.games AS g
+              WHERE g.season = 2026
+                AND g.season_type = 'regular'
+                AND g.id <> 401866625
+                AND (g.home_team = p.team OR g.away_team = p.team)
+          )
+          AND a.payload IS DISTINCT FROM to_jsonb(p)
+    ) THEN
+        RAISE EXCEPTION 'Outlook archive mismatch; no deletion permitted';
+    END IF;
+
+    DELETE FROM predictions.season_projections AS p
+    USING recovery.f03_row_archive AS a
+    WHERE a.source_table = 'predictions.season_projections'
+      AND a.row_id = p.projection_id
+      AND a.payload = to_jsonb(p)
+      AND p.season = 2026
+      AND p.model_version = 'fitted_v1'
+      AND p.team = ANY(allowed_teams)
+      AND p.computed_at < cutoff
+      AND NOT EXISTS (
+          SELECT 1
+          FROM core.games AS g
+          WHERE g.season = 2026
+            AND g.season_type = 'regular'
+            AND g.id <> 401866625
+            AND (g.home_team = p.team OR g.away_team = p.team)
+      );
+    GET DIAGNOSTICS deleted_count = ROW_COUNT;
+
+    RAISE NOTICE 'Archived % stale F03 outlook snapshots', archived_count;
+    RAISE NOTICE 'Deleted % stale F03 outlook snapshots', deleted_count;
+END $outlook_cleanup$;

--- a/docs/plans/2026-09-06-f03-production-rebuild.md
+++ b/docs/plans/2026-09-06-f03-production-rebuild.md
@@ -111,22 +111,21 @@ journal. Final postflight now rejects any remaining old current-season fitted
 outlook. Future general reconciliation of removed or renamed schedule teams
 is separate from this bounded recovery.
 
-**Awaiting explicit cleanup approval:** automatic approval review rejected
-executing the outlook cleanup because the user's approval covered production
-rebuilds, not this additional deletion. No outlook cleanup ran. The
-[read-only count](https://github.com/rstover-fo/cfb-database/actions/runs/34065277035)
-confirmed **242 historical snapshots across 30 obsolete names**. The prepared
-script archives each complete payload before removal; the 716 current teams,
-other models/seasons, raw data, and frozen fits are retained. Independent review
-found no actionable issue. PostgreSQL tests using the actual projection schema
-passed repeat execution, scope retention, active/new-projection guards,
-archive-conflict rollback, and archive privacy after normal blanket grants.
+The user explicitly approved the additional archive-and-delete cleanup.
+[Cleanup and live verification](https://github.com/rstover-fo/cfb-database/actions/runs/34068212563)
+succeeded: **242 snapshots archived and removed**, clearing all 30 obsolete
+names. The API now exposes **716 teams, all 716 fresh and scored completely,
+with zero unscored team-games**. All 3,247 pending games have valid fitted
+scores, the repaired historical outcomes are in Elo, and the full model
+metadata/coefficient tables equal the pre-rebuild snapshot. Caller-role access
+and archive privacy checks passed. Campbell and Western Carolina each retain
+12 simulated games, projecting 5.67/6.33 and 7.54/4.46 wins/losses respectively.
 
-Approved production rebuilds and the initial live checks are complete. All
-3,247 pending games have fresh valid fitted scores, 716 teams were rebuilt with
-zero unscored team-games, the repaired outcomes are in Elo, and complete model
-metadata/coefficient tables match the private pre-rebuild snapshot. Campbell
-and Western Carolina each have 12 simulated games, projecting 5.67/6.33 and
-7.54/4.46 wins/losses respectively. The remaining 30 older API entries are the
-only identified outstanding cleanup; the strengthened final postflight is
-prepared to reject them until that separately approved cleanup executes.
+Greptile's remaining completeness finding was valid: coverage must be asserted,
+not merely logged. The final verifier now requires exactly 716 teams, 716 fresh
+rows, 716 fully scored schedules, and zero unscored team-games. PostgreSQL tests
+executed the full verifier with the real accuracy mart: the 716-team fixture
+passed, while missing 714 teams, one stale team, one unscored team, and one extra
+team each failed. The bounded cleanup itself passed independent review and
+actual projection-schema tests for repeat execution, scope retention,
+active/new-projection guards, archive-conflict rollback, and archive privacy.

--- a/docs/plans/2026-09-06-f03-production-rebuild.md
+++ b/docs/plans/2026-09-06-f03-production-rebuild.md
@@ -91,3 +91,22 @@ The first compute run completed successfully before cancellation reached it:
 frontier 2025, 3,247/3,247 upcoming games scored, 716 projections written, zero
 unscored team-games. Its outputs require the corrected historical Elo replay,
 so this is intermediate evidence, not the final recovery receipt.
+
+## Final outlook reconciliation
+
+The corrected replay [34064735040](https://github.com/rstover-fo/cfb-database/actions/runs/34064735040)
+succeeded in 5m27s. Initial live
+[postflight](https://github.com/rstover-fo/cfb-database/actions/runs/34065046695)
+confirmed unchanged fit tables, the two historical results in Elo, current
+scoring coverage and caller-role access. It also counted 746 latest outlook
+rows: 716 rebuilt and 30 old entries. A
+[bounded diagnostic](https://github.com/rstover-fo/cfb-database/actions/runs/34065108610)
+confirmed all 30 names have zero current canonical regular-season schedule
+rows; their stale snapshots date from August. No alias crosswalk is guessed.
+
+The explicit outlook cleanup archives and removes only these 30 named teams'
+old 2026 `fitted_v1` snapshots, requiring absent current schedules and no newer
+projection. It retains other models/seasons and all originals in the private
+journal. Final postflight now rejects any remaining old current-season fitted
+outlook. Future general reconciliation of removed or renamed schedule teams
+is separate from this bounded recovery.

--- a/docs/plans/2026-09-06-f03-production-rebuild.md
+++ b/docs/plans/2026-09-06-f03-production-rebuild.md
@@ -110,3 +110,23 @@ projection. It retains other models/seasons and all originals in the private
 journal. Final postflight now rejects any remaining old current-season fitted
 outlook. Future general reconciliation of removed or renamed schedule teams
 is separate from this bounded recovery.
+
+**Awaiting explicit cleanup approval:** automatic approval review rejected
+executing the outlook cleanup because the user's approval covered production
+rebuilds, not this additional deletion. No outlook cleanup ran. The
+[read-only count](https://github.com/rstover-fo/cfb-database/actions/runs/34065277035)
+confirmed **242 historical snapshots across 30 obsolete names**. The prepared
+script archives each complete payload before removal; the 716 current teams,
+other models/seasons, raw data, and frozen fits are retained. Independent review
+found no actionable issue. PostgreSQL tests using the actual projection schema
+passed repeat execution, scope retention, active/new-projection guards,
+archive-conflict rollback, and archive privacy after normal blanket grants.
+
+Approved production rebuilds and the initial live checks are complete. All
+3,247 pending games have fresh valid fitted scores, 716 teams were rebuilt with
+zero unscored team-games, the repaired outcomes are in Elo, and complete model
+metadata/coefficient tables match the private pre-rebuild snapshot. Campbell
+and Western Carolina each have 12 simulated games, projecting 5.67/6.33 and
+7.54/4.46 wins/losses respectively. The remaining 30 older API entries are the
+only identified outstanding cleanup; the strengthened final postflight is
+prepared to reject them until that separately approved cleanup executes.

--- a/docs/plans/2026-09-06-f03-production-rebuild.md
+++ b/docs/plans/2026-09-06-f03-production-rebuild.md
@@ -62,3 +62,18 @@ features/predictions beyond the affected 2026 recovery remain outside this run.
   conflicting scores/archive payloads. The real postflight SQL also executed
   against the fixture under anon, authenticated, and analyst_ro.
 - Production execution and final results are recorded below after completion.
+
+## Production receipts
+
+- [Guarded data repair](https://github.com/rstover-fo/cfb-database/actions/runs/34064297499)
+  succeeded September 6, 2026, 22:32 UTC. Both reviewed results were restored;
+  **117** superseded-event prediction snapshots were archived and removed.
+- [Derived rebuild](https://github.com/rstover-fo/cfb-database/actions/runs/34064338454)
+  dispatched from `16d5724` with `recover_season_projections --execute`.
+- Independent review's source-season guard and NULL-completion/latest-consumer
+  verification findings were resolved. PostgreSQL exercised the added NULL
+  pending-game failure case. The verification script is on `420ea8a`.
+
+Merge PR 124 so subsequent main-branch daily runs use the reconciled lifecycle
+and durable source corrections; running the recovery branch does not update
+the code used by scheduled jobs on main.

--- a/docs/plans/2026-09-06-f03-production-rebuild.md
+++ b/docs/plans/2026-09-06-f03-production-rebuild.md
@@ -39,7 +39,7 @@ existing Campbell–Western Carolina replacement remains 401866625 → 401917058
 2. `recover_season_projections --check` validates closure, target season, the
    frozen 2025 fit, and an actual synthetic scorer execution. `--execute` repeats
    preflight and holds fit-table SHARE locks across all rebuild subprocesses.
-   It rebuilds 2026 Elo/EPA/features/predictions/outlooks and refreshes marts,
+   It replays Elo for 2024, 2025, and 2026, then rebuilds 2026 EPA/features/predictions/outlooks and refreshes marts,
    including freshness. Dispatch uses the `daily-season-load` concurrency group.
 3. `2026-09-06-f03-rebuild-verification.sql` verifies unchanged complete fit
    tables, retained raw identity pair, no superseded rows in modeled outputs,
@@ -55,7 +55,7 @@ features/predictions beyond the affected 2026 recovery remain outside this run.
 
 ## Verification before production writes
 
-- Root suite: **2,360 passed, 449 skipped** with the documented virtualenv PATH.
+- Root suite: **2,361 passed, 449 skipped** with the documented virtualenv PATH.
 - Affected Ruff lint/format and whitespace checks passed.
 - PostgreSQL 16 disposable fixture executed the repair twice, verified observed
   zero/score preservation, exact archival, owner-only access, and rollback for
@@ -77,3 +77,17 @@ features/predictions beyond the affected 2026 recovery remain outside this run.
 Merge PR 124 so subsequent main-branch daily runs use the reconciled lifecycle
 and durable source corrections; running the recovery branch does not update
 the code used by scheduled jobs on main.
+
+## Automated review corrections
+
+Codex identified two valid rollout defects: historical result repairs need Elo
+replayed from 2024, and prediction_accuracy exposes aggregate rather than game
+grain. The runner now commits the 2024 → 2025 → 2026 Elo chain before downstream
+2026 work. Postflight compares the mart's 2026 threshold-zero population to the
+current game-grain API inputs. The actual repository mart definition was
+executed in PostgreSQL 16; a deliberately stale aggregate failed verification.
+
+The first compute run completed successfully before cancellation reached it:
+frontier 2025, 3,247/3,247 upcoming games scored, 716 projections written, zero
+unscored team-games. Its outputs require the corrected historical Elo replay,
+so this is intermediate evidence, not the final recovery receipt.

--- a/docs/plans/2026-09-06-f03-production-rebuild.md
+++ b/docs/plans/2026-09-06-f03-production-rebuild.md
@@ -1,0 +1,64 @@
+# F03 production rebuild
+
+The user approved the production rebuild after PR 123 merged. A read-only
+[preflight](https://github.com/rstover-fo/cfb-database/actions/runs/34063729439)
+stopped before writes: the contiguous closed frontier was 2019. A
+[status diagnostic](https://github.com/rstover-fo/cfb-database/actions/runs/34063816688)
+and [replacement diagnostic](https://github.com/rstover-fo/cfb-database/actions/runs/34063999225)
+identified the exact causes below.
+
+## Reviewed resolutions
+
+| Provider IDs | Resolution and evidence |
+|---|---|
+| 2020 spring games | Recognize CFBD's documented `spring_regular` / `spring_postseason` for closure only; retain raw types and calendar guards. [CFBD schema](https://apinext.collegefootballdata.com/api/games). |
+| 401540999, 401545766, 401545768, 401545773, 401545780, 401545781 | Alderson Broaddus suspended athletics before the 2023 season. [Conference statement](https://mountaineast.org/news/2023/8/11/general-mec-announces-2023-24-non-conference-scheduling-agreement-with-salem.aspx). |
+| 401549719 → 401611307 | Bowdoin–Trinity moved from October 28 to November 18, 2023; replacement is 21–58. [Rescheduling notice](https://athletics.middlebury.edu/news/2023/10/27/nescac-football-schedule-adjusted.aspx), [Bowdoin results](https://athletics.bowdoin.edu/sports/football/opponent-history/trinity/119). |
+| 401550299 → 401611308 | Bates–Williams moved to November 18, 2023; replacement is 0–43. [Williams schedule](https://ephsports.williams.edu/sports/football/schedule/2023). |
+| 401552878 → 401611306 | Colby–Middlebury moved to November 18, 2023; replacement is 28–35. [Middlebury schedule](https://athletics.middlebury.edu/sports/football/schedule/2023). |
+| 401552884 → 401612659 | Worcester–Framingham played November 11, 2023, 6–41. The November 12 stub is superseded by the matching completed provider record. [Worcester game log](https://worcester.prestosports.com/sports/fball/2023-24/bios/sturgis_turnbull_qc2l?view=gamelog). |
+| 401640992 | App State–Liberty canceled September 28, 2024; explicitly not rescheduled. [App State announcement](https://appstatesports.com/news/2024/9/27/app-state-liberty-football-game-canceled.aspx). |
+| 401677463 | Taylor–Defiance played November 2, 2024, 63–12. Repair missing scores and completion. [Taylor game log](https://taylor2023.prestosports.com/sports/fball/2024-25/bios/loveless_carter_825c). |
+| 401773541 | Sul Ross–Angelo State played October 25, 2025, 0–62. Restore the missing observed zero. [Official box score](https://srlobos.com/sports/football/stats/2025/angelo-state/boxscore/3842). |
+| 401833535 | Delta State–Kentucky State canceled November 15, 2025, despite provider `completed=true`. [Delta State schedule](https://gostatesmen.com/sports/football/schedule/2025). |
+
+Replacement rows were matched against production season, home/away IDs, date,
+and score. No old unresolved row is excluded solely because of its age. The
+existing Campbell–Western Carolina replacement remains 401866625 → 401917058.
+
+## Recovery sequence
+
+1. Explicit-file `2026-09-06-f03-data-repair.sql` archives the two original game
+   rows and frozen model tables in private `recovery.f03_row_archive`, restores
+   only reviewed results, and archives/removes snapshots for 401866625. Exact
+   identity, non-conflicting score, and archived-payload equality checks abort
+   on drift. Locks prevent concurrent writes during the short transaction.
+   The journal is outside schemas with blanket consumer grants. Raw event
+   identities and dlt provenance are retained. The original game row values
+   are recoverable from the journal.
+2. `recover_season_projections --check` validates closure, target season, the
+   frozen 2025 fit, and an actual synthetic scorer execution. `--execute` repeats
+   preflight and holds fit-table SHARE locks across all rebuild subprocesses.
+   It rebuilds 2026 Elo/EPA/features/predictions/outlooks and refreshes marts,
+   including freshness. Dispatch uses the `daily-season-load` concurrency group.
+3. `2026-09-06-f03-rebuild-verification.sql` verifies unchanged complete fit
+   tables, retained raw identity pair, no superseded rows in modeled outputs,
+   fresh valid scores for all pending 2026 targets, and complete 12-game
+   Campbell/Western Carolina projections. It reads consumer views under actual
+   caller roles and checks archive access.
+
+The two reviewed result corrections are also applied to copies during future
+games ingestion, so a later provider refresh cannot silently restore the same
+known missing fields. Conflicting provider scores or identities fail explicitly.
+No training or historical feature rebuild is included. Historical stored
+features/predictions beyond the affected 2026 recovery remain outside this run.
+
+## Verification before production writes
+
+- Root suite: **2,360 passed, 449 skipped** with the documented virtualenv PATH.
+- Affected Ruff lint/format and whitespace checks passed.
+- PostgreSQL 16 disposable fixture executed the repair twice, verified observed
+  zero/score preservation, exact archival, owner-only access, and rollback for
+  conflicting scores/archive payloads. The real postflight SQL also executed
+  against the fixture under anon, authenticated, and analyst_ro.
+- Production execution and final results are recorded below after completion.

--- a/docs/plans/2026-09-06-f03-rebuild-verification.sql
+++ b/docs/plans/2026-09-06-f03-rebuild-verification.sql
@@ -29,12 +29,24 @@ BEGIN
  SELECT count(*) INTO n FROM (
    SELECT game_id FROM predictions.game_predictions WHERE game_id=401866625
    UNION ALL SELECT game_id FROM api.game_predictions WHERE game_id=401866625
-   UNION ALL SELECT game_id FROM marts.prediction_accuracy WHERE game_id=401866625
    UNION ALL SELECT game_id FROM marts.scored_matchup_edges WHERE game_id=401866625
    UNION ALL SELECT game_id FROM features.team_week WHERE game_id=401866625
    UNION ALL SELECT game_id FROM analytics.house_elo_game WHERE game_id=401866625
  ) invalid;
  IF n<>0 THEN RAISE EXCEPTION 'Superseded derived rows remain: %',n; END IF;
+ -- prediction_accuracy is aggregated by model/season/threshold, not game ID.
+ -- Verify its unconditional population against current game-grain API inputs.
+ SELECT count(*) INTO n FROM (
+   SELECT p.model_version,p.season,count(*) AS n_games
+   FROM api.game_predictions p JOIN core.games g ON g.id=p.game_id
+   WHERE p.season=2026 AND g.completed AND g.home_points IS NOT NULL
+     AND g.away_points IS NOT NULL GROUP BY p.model_version,p.season
+ ) expected FULL JOIN (
+   SELECT model_version,season,n_games FROM marts.prediction_accuracy
+   WHERE season=2026 AND edge_threshold=0
+ ) actual USING(model_version,season)
+ WHERE expected.n_games IS DISTINCT FROM actual.n_games;
+ IF n<>0 THEN RAISE EXCEPTION 'Accuracy mart population differs from current inputs'; END IF;
  SELECT count(*) INTO n FROM core.games WHERE id IN (401866625,401917058);
  IF n<>2 THEN RAISE EXCEPTION 'Original/replacement raw records not retained'; END IF;
 

--- a/docs/plans/2026-09-06-f03-rebuild-verification.sql
+++ b/docs/plans/2026-09-06-f03-rebuild-verification.sql
@@ -1,0 +1,76 @@
+-- Read-only postflight for the approved F03 recovery; execute after the runner.
+SET TRANSACTION READ ONLY;
+SET LOCAL statement_timeout = '90s';
+DO $verify$
+DECLARE n bigint; baseline timestamptz; old_fit jsonb; current_fit jsonb; result json;
+        caller text;
+BEGIN
+ FOREACH caller IN ARRAY ARRAY['anon','authenticated','analyst_ro'] LOOP
+   IF has_schema_privilege(caller,'recovery','USAGE')
+      OR has_table_privilege(caller,'recovery.f03_row_archive','SELECT') THEN
+     RAISE EXCEPTION 'Recovery archive exposed to %',caller;
+   END IF;
+ END LOOP;
+ SELECT min(archived_at) INTO baseline FROM recovery.f03_row_archive;
+ IF baseline IS NULL THEN RAISE EXCEPTION 'Missing pre-recovery journal'; END IF;
+ SELECT jsonb_agg(v ORDER BY v::text) INTO old_fit
+ FROM recovery.f03_row_archive a CROSS JOIN LATERAL jsonb_array_elements(a.payload) v
+ WHERE a.source_table='features.model_metadata';
+ SELECT jsonb_agg(to_jsonb(m) ORDER BY to_jsonb(m)::text) INTO current_fit
+ FROM features.model_metadata m;
+ IF old_fit IS DISTINCT FROM current_fit THEN RAISE EXCEPTION 'Model metadata changed'; END IF;
+ SELECT jsonb_agg(v ORDER BY v::text) INTO old_fit
+ FROM recovery.f03_row_archive a CROSS JOIN LATERAL jsonb_array_elements(a.payload) v
+ WHERE a.source_table='features.model_coefficients';
+ SELECT jsonb_agg(to_jsonb(c) ORDER BY to_jsonb(c)::text) INTO current_fit
+ FROM features.model_coefficients c;
+ IF old_fit IS DISTINCT FROM current_fit THEN RAISE EXCEPTION 'Model coefficients changed'; END IF;
+
+ SELECT count(*) INTO n FROM (
+   SELECT game_id FROM predictions.game_predictions WHERE game_id=401866625
+   UNION ALL SELECT game_id FROM api.game_predictions WHERE game_id=401866625
+   UNION ALL SELECT game_id FROM marts.prediction_accuracy WHERE game_id=401866625
+   UNION ALL SELECT game_id FROM marts.scored_matchup_edges WHERE game_id=401866625
+   UNION ALL SELECT game_id FROM features.team_week WHERE game_id=401866625
+   UNION ALL SELECT game_id FROM analytics.house_elo_game WHERE game_id=401866625
+ ) invalid;
+ IF n<>0 THEN RAISE EXCEPTION 'Superseded derived rows remain: %',n; END IF;
+ SELECT count(*) INTO n FROM core.games WHERE id IN (401866625,401917058);
+ IF n<>2 THEN RAISE EXCEPTION 'Original/replacement raw records not retained'; END IF;
+
+ SELECT count(*) INTO n FROM core.games g
+ WHERE g.season=2026 AND NOT g.completed AND g.id<>401866625
+ AND NOT EXISTS (SELECT 1 FROM predictions.game_predictions p
+   WHERE p.game_id=g.id AND p.model_version='fitted_v1' AND p.computed_at>=baseline
+     AND p.home_win_prob BETWEEN 0 AND 1
+     AND p.expected_home_margin::text NOT IN ('NaN','Infinity','-Infinity'));
+ IF n<>0 THEN RAISE EXCEPTION 'Pending games without fresh valid fitted scores: %',n; END IF;
+
+ SELECT count(*) INTO n FROM api.season_outlook
+ WHERE season=2026 AND model_version='fitted_v1'
+   AND team IN ('Campbell','Western Carolina') AND computed_at>=baseline
+   AND games_scheduled=12 AND games_simulated=12 AND games_unscored=0
+   AND projected_wins BETWEEN 0 AND 12 AND projected_losses BETWEEN 0 AND 12;
+ IF n<>2 THEN RAISE EXCEPTION 'Expected two fresh complete 12-game outlooks; found %',n; END IF;
+ SELECT json_agg(row_to_json(r)) INTO result FROM (
+   SELECT team,computed_at,games_scheduled,games_simulated,games_unscored,
+          projected_wins,projected_losses FROM api.season_outlook
+   WHERE season=2026 AND model_version='fitted_v1'
+     AND team IN ('Campbell','Western Carolina')
+ ) r;
+ RAISE NOTICE 'F03 rebuilt outlooks: %',result;
+ RAISE NOTICE 'F03 fit equality, source retention, exclusion and scoring checks passed';
+END $verify$;
+SET LOCAL ROLE anon;
+SELECT count(*) FROM api.season_outlook WHERE season=2026 AND model_version='fitted_v1';
+SELECT count(*) FROM api.game_predictions WHERE game_id=401866625;
+SELECT has_schema_privilege(current_user,'recovery','USAGE') AS archive_access;
+RESET ROLE;
+SET LOCAL ROLE authenticated;
+SELECT count(*) FROM api.season_outlook WHERE season=2026 AND model_version='fitted_v1';
+SELECT has_schema_privilege(current_user,'recovery','USAGE') AS archive_access;
+RESET ROLE;
+SET LOCAL ROLE analyst_ro;
+SELECT count(*) FROM api.season_outlook WHERE season=2026 AND model_version='fitted_v1';
+SELECT has_schema_privilege(current_user,'recovery','USAGE') AS archive_access;
+RESET ROLE;

--- a/docs/plans/2026-09-06-f03-rebuild-verification.sql
+++ b/docs/plans/2026-09-06-f03-rebuild-verification.sql
@@ -59,6 +59,14 @@ BEGIN
      AND team IN ('Campbell','Western Carolina')
  ) r;
  RAISE NOTICE 'F03 rebuilt outlooks: %',result;
+ SELECT row_to_json(r) INTO result FROM (
+   SELECT count(*) AS teams,
+          count(*) FILTER (WHERE computed_at>=baseline) AS fresh_teams,
+          count(*) FILTER (WHERE games_unscored=0) AS complete_schedules,
+          sum(games_unscored) AS unscored_team_games
+   FROM api.season_outlook WHERE season=2026 AND model_version='fitted_v1'
+ ) r;
+ RAISE NOTICE 'F03 all-team outlook coverage: %',result;
  RAISE NOTICE 'F03 fit equality, source retention, exclusion and scoring checks passed';
 END $verify$;
 SET LOCAL ROLE anon;

--- a/docs/plans/2026-09-06-f03-rebuild-verification.sql
+++ b/docs/plans/2026-09-06-f03-rebuild-verification.sql
@@ -39,8 +39,8 @@ BEGIN
  IF n<>2 THEN RAISE EXCEPTION 'Original/replacement raw records not retained'; END IF;
 
  SELECT count(*) INTO n FROM core.games g
- WHERE g.season=2026 AND NOT g.completed AND g.id<>401866625
- AND NOT EXISTS (SELECT 1 FROM predictions.game_predictions p
+ WHERE g.season=2026 AND NOT COALESCE(g.completed,false) AND g.id<>401866625
+ AND NOT EXISTS (SELECT 1 FROM api.game_predictions p
    WHERE p.game_id=g.id AND p.model_version='fitted_v1' AND p.computed_at>=baseline
      AND p.home_win_prob BETWEEN 0 AND 1
      AND p.expected_home_margin::text NOT IN ('NaN','Infinity','-Infinity'));

--- a/docs/plans/2026-09-06-f03-rebuild-verification.sql
+++ b/docs/plans/2026-09-06-f03-rebuild-verification.sql
@@ -86,6 +86,9 @@ BEGIN
    FROM api.season_outlook WHERE season=2026 AND model_version='fitted_v1'
  ) r;
  RAISE NOTICE 'F03 all-team outlook coverage: %',result;
+ SELECT count(*) INTO n FROM api.season_outlook
+ WHERE season=2026 AND model_version='fitted_v1' AND computed_at<baseline;
+ IF n<>0 THEN RAISE EXCEPTION 'Older current-season outlooks remain: %',n; END IF;
  RAISE NOTICE 'F03 fit equality, source retention, exclusion and scoring checks passed';
 END $verify$;
 SET LOCAL ROLE anon;

--- a/docs/plans/2026-09-06-f03-rebuild-verification.sql
+++ b/docs/plans/2026-09-06-f03-rebuild-verification.sql
@@ -13,6 +13,9 @@ BEGIN
  END LOOP;
  SELECT min(archived_at) INTO baseline FROM recovery.f03_row_archive;
  IF baseline IS NULL THEN RAISE EXCEPTION 'Missing pre-recovery journal'; END IF;
+ -- Require outputs from the corrected replay, not the earlier intermediate run.
+ -- https://github.com/rstover-fo/cfb-database/actions/runs/34064735040
+ baseline := GREATEST(baseline,'2026-09-06 22:41:07+00'::timestamptz);
  SELECT jsonb_agg(v ORDER BY v::text) INTO old_fit
  FROM recovery.f03_row_archive a CROSS JOIN LATERAL jsonb_array_elements(a.payload) v
  WHERE a.source_table='features.model_metadata';
@@ -49,6 +52,10 @@ BEGIN
  IF n<>0 THEN RAISE EXCEPTION 'Accuracy mart population differs from current inputs'; END IF;
  SELECT count(*) INTO n FROM core.games WHERE id IN (401866625,401917058);
  IF n<>2 THEN RAISE EXCEPTION 'Original/replacement raw records not retained'; END IF;
+ SELECT count(*) INTO n FROM analytics.house_elo_game
+ WHERE (game_id=401677463 AND season=2024 AND actual_home_margin=51)
+    OR (game_id=401773541 AND season=2025 AND actual_home_margin=-62);
+ IF n<>2 THEN RAISE EXCEPTION 'Repaired historical outcomes missing from Elo replay'; END IF;
 
  SELECT count(*) INTO n FROM core.games g
  WHERE g.season=2026 AND NOT COALESCE(g.completed,false) AND g.id<>401866625

--- a/docs/plans/2026-09-06-f03-rebuild-verification.sql
+++ b/docs/plans/2026-09-06-f03-rebuild-verification.sql
@@ -86,6 +86,14 @@ BEGIN
    FROM api.season_outlook WHERE season=2026 AND model_version='fitted_v1'
  ) r;
  RAISE NOTICE 'F03 all-team outlook coverage: %',result;
+ -- This dated recovery has 716 verified current teams. Fail on missing/extra
+ -- output as well as stale or unscored teams; logging alone is not a gate.
+ IF (result->>'teams')::bigint IS DISTINCT FROM 716
+    OR (result->>'fresh_teams')::bigint IS DISTINCT FROM 716
+    OR (result->>'complete_schedules')::bigint IS DISTINCT FROM 716
+    OR (result->>'unscored_team_games')::bigint IS DISTINCT FROM 0 THEN
+   RAISE EXCEPTION 'Incomplete F03 all-team outlook coverage: %',result;
+ END IF;
  SELECT count(*) INTO n FROM api.season_outlook
  WHERE season=2026 AND model_version='fitted_v1' AND computed_at<baseline;
  IF n<>0 THEN RAISE EXCEPTION 'Older current-season outlooks remain: %',n; END IF;

--- a/docs/plans/2026-09-06-f03-rollout-diagnostic.sql
+++ b/docs/plans/2026-09-06-f03-rollout-diagnostic.sql
@@ -28,4 +28,15 @@ BEGIN
    FROM predictions.game_predictions WHERE game_id=401866625 GROUP BY model_version
  ) r;
  RAISE NOTICE 'Superseded prediction rows: %',result;
+ SELECT json_agg(row_to_json(r)) INTO result FROM (
+   SELECT id,season,season_type,week,start_date,completed,home_id,home_team,
+          away_id,away_team,home_points,away_points
+   FROM core.games
+   WHERE (season=2023 AND (home_id,away_id) IN
+          ((340,2977),(121,2731),(33,2394),(402,2967)))
+      OR (season=2024 AND (home_id,away_id)=(620,190))
+      OR (season=2025 AND (home_id,away_id)=(2834,2025))
+   ORDER BY season,home_id,start_date,id
+ ) r;
+ RAISE NOTICE 'Replacement candidates: %',result;
 END $diagnostic$;

--- a/docs/plans/2026-09-06-f03-rollout-diagnostic.sql
+++ b/docs/plans/2026-09-06-f03-rollout-diagnostic.sql
@@ -49,4 +49,17 @@ BEGIN
    ORDER BY o.team
  ) r;
  RAISE NOTICE 'Older outlook candidates: %',result;
+ SELECT row_to_json(r) INTO result FROM (
+   SELECT count(*) AS historical_snapshots,count(DISTINCT p.team) AS obsolete_names
+   FROM predictions.season_projections p
+   WHERE p.season=2026 AND p.model_version='fitted_v1'
+     AND p.computed_at<'2026-09-06 22:41:07+00'::timestamptz
+     AND p.team IN (SELECT o.team FROM api.season_outlook o
+       WHERE o.season=2026 AND o.model_version='fitted_v1'
+         AND o.computed_at<'2026-09-06 22:41:07+00'::timestamptz)
+     AND NOT EXISTS (SELECT 1 FROM core.games g WHERE g.season=2026
+       AND g.season_type='regular' AND g.id<>401866625
+       AND (g.home_team=p.team OR g.away_team=p.team))
+ ) r;
+ RAISE NOTICE 'Proposed outlook cleanup size: %',result;
 END $diagnostic$;

--- a/docs/plans/2026-09-06-f03-rollout-diagnostic.sql
+++ b/docs/plans/2026-09-06-f03-rollout-diagnostic.sql
@@ -1,0 +1,31 @@
+-- Read-only, bounded lifecycle diagnostics for the approved F03 production rebuild.
+SET TRANSACTION READ ONLY;
+SET LOCAL statement_timeout = '60s';
+DO $diagnostic$
+DECLARE result json;
+BEGIN
+ SELECT json_agg(row_to_json(r)) INTO result FROM (
+   SELECT season,season_type,count(*) AS games,
+          count(*) FILTER (WHERE NOT COALESCE(completed,false)) AS incomplete,
+          count(*) FILTER (WHERE start_date IS NULL) AS missing_date,
+          count(*) FILTER (WHERE home_points IS NULL OR away_points IS NULL) AS missing_score
+   FROM core.games WHERE season BETWEEN 2020 AND 2025 GROUP BY season,season_type
+   ORDER BY season,season_type
+ ) r;
+ RAISE NOTICE 'Lifecycle shape: %',result;
+ SELECT json_agg(row_to_json(r)) INTO result FROM (
+   SELECT id,season,season_type,week,start_date,completed,home_id,home_team,
+          away_id,away_team,home_points,away_points
+   FROM core.games
+   WHERE id IN (401773541,401833535,401640992,401677463,401540999,401545766,
+                401545768,401545773,401545780,401545781,401549719,401550299,
+                401552878,401552884,401279029,401279033)
+   ORDER BY season,id
+ ) r;
+ RAISE NOTICE 'Unresolved examples: %',result;
+ SELECT json_agg(row_to_json(r)) INTO result FROM (
+   SELECT model_version,count(*) AS invalid_predictions
+   FROM predictions.game_predictions WHERE game_id=401866625 GROUP BY model_version
+ ) r;
+ RAISE NOTICE 'Superseded prediction rows: %',result;
+END $diagnostic$;

--- a/docs/plans/2026-09-06-f03-rollout-diagnostic.sql
+++ b/docs/plans/2026-09-06-f03-rollout-diagnostic.sql
@@ -39,4 +39,14 @@ BEGIN
    ORDER BY season,home_id,start_date,id
  ) r;
  RAISE NOTICE 'Replacement candidates: %',result;
+ SELECT json_agg(row_to_json(r)) INTO result FROM (
+   SELECT o.team,o.computed_at,o.games_scheduled,o.games_simulated,
+          (SELECT count(*) FROM core.games g WHERE g.season=2026
+            AND g.season_type='regular' AND g.id<>401866625
+            AND (g.home_team=o.team OR g.away_team=o.team)) AS canonical_schedule_rows
+   FROM api.season_outlook o WHERE o.season=2026 AND o.model_version='fitted_v1'
+     AND o.computed_at<'2026-09-06 22:41:07+00'::timestamptz
+   ORDER BY o.team
+ ) r;
+ RAISE NOTICE 'Older outlook candidates: %',result;
 END $diagnostic$;

--- a/scripts/recover_season_projections.py
+++ b/scripts/recover_season_projections.py
@@ -13,6 +13,8 @@ from pathlib import Path
 
 COMMANDS = (
     ("refresh_marts", "--views", "marts.play_epa,marts.returning_production"),
+    ("compute_house_elo", "--season", "2024"),
+    ("compute_house_elo", "--season", "2025"),
     ("compute_house_elo", "--season", "2026"),
     ("compute_adjusted_epa", "--season", "2026"),
     ("compute_adjusted_epa_week", "--season", "2026"),

--- a/scripts/recover_season_projections.py
+++ b/scripts/recover_season_projections.py
@@ -6,6 +6,7 @@ invoke only for the explicitly authorized production recovery.
 """
 
 import argparse
+import math
 import subprocess
 import sys
 from pathlib import Path
@@ -24,7 +25,7 @@ COMMANDS = (
         "--views",
         "marts.house_elo,marts.house_elo_game,marts.team_adjusted_epa,"
         "marts.scored_matchup_edges,marts.prediction_accuracy,"
-        "marts.team_week_features,marts.adjusted_epa_week",
+        "marts.team_week_features,marts.adjusted_epa_week,marts.data_freshness",
     ),
 )
 
@@ -37,8 +38,8 @@ def execute_commands(commands=COMMANDS):
 
 def check_recovery_state(conn):
     """Fail before writes if the merged scorer cannot use the approved 2025 fit."""
-    from scripts.score_fitted import fetch_pending_game_counts
-    from scripts.train_model import fetch_refit_state
+    from scripts.score_fitted import fetch_pending_game_counts, load_fit, score_game
+    from scripts.train_model import TEAM_WEEK_SOURCE_COLUMNS, fetch_refit_state
 
     frontier, eligible_fits = fetch_refit_state(conn)
     pending = fetch_pending_game_counts(conn)
@@ -54,6 +55,32 @@ def check_recovery_state(conn):
         )
     if set(pending) != {2026}:
         raise RuntimeError(f"Recovery requires only 2026 pending targets; found {pending}")
+    # fetch_refit_state validates season finality and the metadata feature
+    # contract. Loading and exercising the fit proves both coefficient vectors
+    # and every frozen scaling statistic are usable before execute mode changes
+    # derived data.
+    fit = load_fit(conn, 2025)
+    neutral_features = dict.fromkeys(TEAM_WEEK_SOURCE_COLUMNS, 0.0)
+    margin, probability = score_game(
+        {
+            "season": 2026,
+            "neutral_site": False,
+            "home_tw": neutral_features,
+            "away_tw": neutral_features,
+        },
+        fit,
+    )
+    if not (math.isfinite(margin) and math.isfinite(probability)):
+        raise RuntimeError(
+            "Recovery requires the frozen 2025 fit to produce finite margin and probability"
+        )
+
+
+def execute_recovery(conn):
+    """Validate the complete scoring artifact before starting any subprocess."""
+
+    check_recovery_state(conn)
+    execute_commands()
 
 
 def main():
@@ -92,8 +119,7 @@ def main():
             train_through = cur.fetchone()[0]
             if train_through != 2025:
                 raise RuntimeError(f"Recovery requires the frozen 2025 fit; found {train_through}")
-        check_recovery_state(conn)
-        execute_commands()
+        execute_recovery(conn)
 
 
 if __name__ == "__main__":

--- a/scripts/recover_season_projections.py
+++ b/scripts/recover_season_projections.py
@@ -1,6 +1,7 @@
 """Run the reviewed September 2026 compute recovery without ingest or training.
 
-Defaults to printing the commands. --execute writes warehouse derived tables;
+Defaults to printing the commands. --check performs read-only production preflight.
+--execute writes warehouse derived tables;
 invoke only for the explicitly authorized production recovery.
 """
 
@@ -34,22 +35,48 @@ def execute_commands(commands=COMMANDS):
         subprocess.run([sys.executable, str(path), *args], check=True)
 
 
+def check_recovery_state(conn):
+    """Fail before writes if the merged scorer cannot use the approved 2025 fit."""
+    from scripts.score_fitted import fetch_pending_game_counts
+    from scripts.train_model import fetch_refit_state
+
+    frontier, eligible_fits = fetch_refit_state(conn)
+    pending = fetch_pending_game_counts(conn)
+    print(
+        f"RECOVERY_PREFLIGHT closed_frontier={frontier} "
+        f"eligible_fits={eligible_fits} pending_by_season={pending}",
+        flush=True,
+    )
+    if 2025 not in eligible_fits:
+        raise RuntimeError(
+            f"Recovery requires an eligible frozen 2025 fit; closed frontier={frontier}, "
+            f"eligible fits={eligible_fits}"
+        )
+    if set(pending) != {2026}:
+        raise RuntimeError(f"Recovery requires only 2026 pending targets; found {pending}")
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--execute", action="store_true")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--execute", action="store_true")
+    mode.add_argument("--check", action="store_true")
     args = parser.parse_args()
     for command in COMMANDS:
         print(" ".join(command), flush=True)
-    if not args.execute:
+    if not (args.execute or args.check):
         return
 
     import psycopg2
 
     from scripts.run_migrations import get_db_url
 
-    # Do not retrain during recovery, or let the outstanding F03 selection
-    # issue silently select an in-season fit.
+    # Preserve the approved frozen fit throughout the derived-data rebuild.
     with psycopg2.connect(get_db_url()) as conn:
+        if args.check:
+            conn.set_session(readonly=True)
+            check_recovery_state(conn)
+            return
         with conn.cursor() as cur:
             cur.execute("SET LOCAL lock_timeout = '10s'")
             cur.execute("SET LOCAL idle_in_transaction_session_timeout = 0")
@@ -65,14 +92,7 @@ def main():
             train_through = cur.fetchone()[0]
             if train_through != 2025:
                 raise RuntimeError(f"Recovery requires the frozen 2025 fit; found {train_through}")
-            cur.execute(
-                "SELECT DISTINCT season FROM core.games "
-                "WHERE NOT COALESCE(completed, false) AND season >= "
-                "(SELECT COALESCE(MAX(season), 0) FROM core.games WHERE completed)"
-            )
-            targets = {row[0] for row in cur.fetchall()}
-            if targets != {2026}:
-                raise RuntimeError(f"Recovery requires only 2026 pending targets; found {targets}")
+        check_recovery_state(conn)
         execute_commands()
 
 

--- a/src/pipelines/game_identity.py
+++ b/src/pipelines/game_identity.py
@@ -7,9 +7,39 @@ from collections.abc import Mapping
 # https://site.api.espn.com/apis/site/v2/sports/football/college-football/summary?event=401866625
 # https://site.api.espn.com/apis/site/v2/sports/football/college-football/summary?event=401917058
 # https://catamountsports.com/news/2026/9/5/football-catamounts-camels-postponed-until-sunday.aspx
-SUPERSEDED_GAME_REPLACEMENTS = {401866625: 401917058}
-# Add only after reviewing provider/official evidence; absence is not cancellation.
-CANCELLED_GAME_IDS: frozenset[int] = frozenset()
+SUPERSEDED_GAME_REPLACEMENTS = {
+    401866625: 401917058,
+    # Three October 28 Maine games moved to November 18. Provider replacement
+    # rows match season/team IDs, official date, and final scores.
+    # https://athletics.middlebury.edu/news/2023/10/27/nescac-football-schedule-adjusted.aspx
+    401549719: 401611307,  # Bowdoin 21, Trinity 58
+    401550299: 401611308,  # Bates 0, Williams 43
+    401552878: 401611306,  # Colby 28, Middlebury 35
+    # Worcester–Framingham played November 11; the November 12 stub did not.
+    # https://worcester.prestosports.com/sports/fball/2023-24/bios/sturgis_turnbull_qc2l?view=gamelog
+    401552884: 401612659,
+}
+# Alderson Broaddus suspended athletics before the 2023 season. These retained
+# provider schedule rows never became contests. The conference confirmed the
+# suspension; no age-based or team-name-based cancellation inference is used.
+# https://mountaineast.org/news/2023/8/11/general-mec-announces-2023-24-non-conference-scheduling-agreement-with-salem.aspx
+CANCELLED_GAME_IDS: frozenset[int] = frozenset(
+    {
+        401540999,
+        401545766,
+        401545768,
+        401545773,
+        401545780,
+        401545781,
+        # App State–Liberty: canceled, explicitly not rescheduled.
+        # https://appstatesports.com/news/2024/9/27/app-state-liberty-football-game-canceled.aspx
+        401640992,
+        # Delta State–Kentucky State: official schedule says canceled despite
+        # the provider's completed=true / NULL-score record.
+        # https://gostatesmen.com/sports/football/schedule/2025
+        401833535,
+    }
+)
 
 
 def eligible_game_sql(id_column: str = "g.id") -> str:

--- a/src/pipelines/game_results.py
+++ b/src/pipelines/game_results.py
@@ -1,0 +1,82 @@
+"""Narrow, verified corrections for CFBD ``/games`` result records.
+
+Corrections apply only after the provider event identity has been checked.  They
+never mutate the fetched response, so the shared games cache continues to hold
+the exact raw CFBD payload used by dependent resources.
+"""
+
+from collections.abc import Mapping
+
+# These are source-result corrections, not general team/date matching rules.
+# Taylor 63, Defiance 12: https://taylor2023.prestosports.com/sports/fball/2024-25/bios/loveless_carter_825c
+# Sul Ross 0, Angelo State 62: https://srlobos.com/sports/football/stats/2025/angelo-state/boxscore/3842
+VERIFIED_GAME_RESULTS: dict[int, dict[str, int]] = {
+    401677463: {
+        "season": 2024,
+        "homeId": 620,
+        "awayId": 190,
+        "homePoints": 63,
+        "awayPoints": 12,
+    },
+    401773541: {
+        "season": 2025,
+        "homeId": 2834,
+        "awayId": 2025,
+        "homePoints": 0,
+        "awayPoints": 62,
+    },
+}
+
+
+def validate_verified_result_source_season(
+    game: Mapping[str, object], requested_season: int
+) -> None:
+    """Reject a reviewed event whose supplied season conflicts with its request.
+
+    CFBD normally omits ``season`` from ``/games?year=...`` payloads.  If it
+    supplies one for a reviewed correction, preserve that evidence long enough
+    to validate it before the resource adds its requested partition season.
+    """
+    if game.get("id") not in VERIFIED_GAME_RESULTS:
+        return
+    source_season = game.get("season")
+    if source_season is not None and source_season != requested_season:
+        raise ValueError(
+            f"Verified result correction for game {game.get('id')} has source "
+            f"season={source_season!r}, requested season={requested_season}"
+        )
+
+
+def apply_verified_result_correction(game: Mapping[str, object]) -> dict[str, object]:
+    """Return a corrected copy for an exactly identified reviewed game.
+
+    A known event ID with a mismatching season or team identity is an upstream
+    identity change and must stop the load rather than transfer a score to a
+    different contest.  Existing non-null scores must already agree with the
+    reviewed result; only missing scores are filled.
+    """
+    correction = VERIFIED_GAME_RESULTS.get(game.get("id"))
+    if correction is None:
+        return dict(game)
+
+    identity_fields = ("season", "homeId", "awayId")
+    mismatches = [field for field in identity_fields if game.get(field) != correction[field]]
+    if mismatches:
+        raise ValueError(
+            f"Verified result correction for game {game.get('id')} has mismatching "
+            f"{', '.join(mismatches)}"
+        )
+
+    for field in ("homePoints", "awayPoints"):
+        existing = game.get(field)
+        if existing is not None and existing != correction[field]:
+            raise ValueError(
+                f"Verified result correction for game {game.get('id')} conflicts with "
+                f"existing {field}={existing!r}"
+            )
+
+    corrected = dict(game)
+    corrected["homePoints"] = correction["homePoints"]
+    corrected["awayPoints"] = correction["awayPoints"]
+    corrected["completed"] = True
+    return corrected

--- a/src/pipelines/season_lifecycle.py
+++ b/src/pipelines/season_lifecycle.py
@@ -25,6 +25,10 @@ MIN_GAMES_FOR_FINAL_SEASON = 100
 _POSTSEASON = "postseason"
 _CLOSURE_SEASON_TYPES = frozenset({"regular", _POSTSEASON})
 _IGNORED_SEASON_TYPES = frozenset({"allstar", "exhibition"})
+_CLOSURE_SEASON_TYPE_ALIASES = {
+    "spring_regular": "regular",
+    "spring_postseason": _POSTSEASON,
+}
 
 
 @dataclass(frozen=True)
@@ -97,6 +101,13 @@ def _canonical_rows(
         return rows, str(exc)
 
 
+def _closure_season_type(row: Mapping) -> str:
+    """Normalize documented CFBD spring enums only for closure decisions."""
+
+    raw_type = str(row.get("season_type") or "").lower()
+    return _CLOSURE_SEASON_TYPE_ALIASES.get(raw_type, raw_type)
+
+
 def classify_season(
     rows: Iterable[Mapping],
     season: int,
@@ -131,7 +142,7 @@ def classify_season(
     closure_rows: list[dict] = []
     unknown_type_ids: list[int] = []
     for row in canonical:
-        season_type = str(row.get("season_type") or "").lower()
+        season_type = _closure_season_type(row)
         if season_type in _CLOSURE_SEASON_TYPES:
             closure_rows.append(row)
         elif season_type not in _IGNORED_SEASON_TYPES:
@@ -156,7 +167,7 @@ def classify_season(
             completed,
         )
 
-    present_types = {str(row.get("season_type") or "").lower() for row in closure_rows}
+    present_types = {_closure_season_type(row) for row in closure_rows}
     missing_types = _CLOSURE_SEASON_TYPES - present_types
     if missing_types:
         return SeasonLifecycle(

--- a/src/pipelines/sources/games.py
+++ b/src/pipelines/sources/games.py
@@ -14,6 +14,10 @@ import dlt
 from dlt.sources import DltSource
 
 from ..config.years import YEAR_RANGES, get_current_season
+from ..game_results import (
+    apply_verified_result_correction,
+    validate_verified_result_source_season,
+)
 from ..utils.api_client import get_client
 from .base import make_request
 
@@ -90,9 +94,10 @@ def games_resource(
             data = _fetch_year_games(client, year, games_cache)
 
             for game in data:
-                # Add year for partitioning if needed
-                game["season"] = year
-                yield game
+                # Add the partition without changing the shared raw response;
+                # reviewed corrections require this season identity.
+                validate_verified_result_source_season(game, year)
+                yield apply_verified_result_correction({**game, "season": year})
 
     finally:
         client.close()

--- a/tests/test_backtest_canonical_inputs.py
+++ b/tests/test_backtest_canonical_inputs.py
@@ -8,6 +8,7 @@ week-one CTE's identity predicate is also asserted structurally.
 import sqlite3
 
 from scripts.backtest_preseason import _week1_games_query, fetch_scheduled_counts
+from src.pipelines.game_identity import eligible_game_sql
 
 
 class _Cursor:
@@ -70,5 +71,5 @@ def test_week_one_cte_and_scored_games_filter_the_superseded_identity():
     query = _week1_games_query()
     week1 = query[query.index("WITH week1 AS") : query.index(")\n        SELECT g.id")]
 
-    assert "game_id NOT IN (401866625)" in week1
-    assert "g.id NOT IN (401866625)" in query
+    assert eligible_game_sql("game_id") in week1
+    assert eligible_game_sql("g.id") in query

--- a/tests/test_game_identity.py
+++ b/tests/test_game_identity.py
@@ -6,7 +6,11 @@ from copy import deepcopy
 import pytest
 
 from scripts.compute_predictions import BACKFILL_GAMES_QUERY, TARGET_GAMES_QUERY
-from src.pipelines.game_identity import eligible_game_sql, select_canonical_game_rows
+from src.pipelines.game_identity import (
+    CANCELLED_GAME_IDS,
+    eligible_game_sql,
+    select_canonical_game_rows,
+)
 
 
 def event(game_id, **changes):
@@ -36,6 +40,19 @@ def test_missing_replacement_is_not_a_cancelled_contest():
 def test_sql_rejects_expression_as_identifier():
     with pytest.raises(ValueError, match="invalid"):
         eligible_game_sql("g.id); DROP TABLE core.games")
+
+
+def test_reviewed_cancellations_are_excluded_without_mutating_provider_rows():
+    rows = [event(game_id) for game_id in sorted(CANCELLED_GAME_IDS)] + [event(123)]
+    before = deepcopy(rows)
+    assert select_canonical_game_rows(rows) == [event(123)]
+    assert rows == before
+    with sqlite3.connect(":memory:") as conn:
+        conn.execute("CREATE TABLE games (id INTEGER)")
+        conn.executemany("INSERT INTO games VALUES (?)", [(r["game_id"],) for r in rows])
+        assert conn.execute(f"SELECT id FROM games g WHERE {eligible_game_sql()}").fetchall() == [
+            (123,)
+        ]
 
 
 @pytest.mark.parametrize("original_completed", [False, True])

--- a/tests/test_game_results.py
+++ b/tests/test_game_results.py
@@ -1,0 +1,91 @@
+"""Regression coverage for narrow, durable CFBD game-result corrections."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from dlt.extract.exceptions import ResourceExtractionError
+
+from src.pipelines.game_results import apply_verified_result_correction
+
+
+def _taylor_game(**changes):
+    return {
+        "id": 401677463,
+        "season": 2024,
+        "homeId": 620,
+        "awayId": 190,
+        "homePoints": None,
+        "awayPoints": None,
+        "completed": False,
+    } | changes
+
+
+def test_correction_fills_missing_scores_including_zero_and_is_idempotent():
+    sul_ross = {
+        "id": 401773541,
+        "season": 2025,
+        "homeId": 2834,
+        "awayId": 2025,
+        "homePoints": None,
+        "awayPoints": None,
+        "completed": False,
+    }
+
+    corrected = apply_verified_result_correction(sul_ross)
+
+    assert corrected == sul_ross | {"homePoints": 0, "awayPoints": 62, "completed": True}
+    assert sul_ross["homePoints"] is None
+    assert apply_verified_result_correction(corrected) == corrected
+
+
+@pytest.mark.parametrize("field, value", [("season", 2023), ("homeId", 1), ("awayId", 1)])
+def test_correction_rejects_known_id_with_different_game_identity(field, value):
+    with pytest.raises(ValueError, match="mismatching"):
+        apply_verified_result_correction(_taylor_game(**{field: value}))
+
+
+@pytest.mark.parametrize("field, value", [("homePoints", 62), ("awayPoints", 13)])
+def test_correction_rejects_conflicting_non_null_scores(field, value):
+    with pytest.raises(ValueError, match="conflicts"):
+        apply_verified_result_correction(_taylor_game(**{field: value}))
+
+
+def test_unrelated_game_is_unchanged_without_mutating_input():
+    game = {"id": 99, "homePoints": None, "completed": False}
+
+    corrected = apply_verified_result_correction(game)
+
+    assert corrected == game
+    assert corrected is not game
+
+
+def test_games_resource_applies_correction_after_partition_season_without_mutating_cache():
+    from src.pipelines.sources.games import games_resource
+
+    raw_game = _taylor_game()
+    del raw_game["season"]  # Normal CFBD /games payload shape remains supported.
+    expected_raw = dict(raw_game)
+    cache = {2024: [raw_game]}
+    client = MagicMock()
+    with patch("src.pipelines.sources.games.get_client", return_value=client):
+        rows = list(games_resource([2024], cache))
+
+    assert rows == [_taylor_game(homePoints=63, awayPoints=12, completed=True)]
+    assert raw_game == expected_raw
+    client.close.assert_called_once()
+
+
+def test_games_resource_rejects_reviewed_payload_with_stale_supplied_season():
+    """The actual resource generator must inspect CFBD's season before overwrite."""
+    from src.pipelines.sources.games import games_resource
+
+    raw_game = _taylor_game(season=2023)
+    client = MagicMock()
+    with patch("src.pipelines.sources.games.get_client", return_value=client):
+        with pytest.raises(
+            ResourceExtractionError, match="source season=2023, requested season=2024"
+        ):
+            list(games_resource([2024], {2024: [raw_game]}))
+
+    assert raw_game == _taylor_game(season=2023)
+    client.close.assert_called_once()

--- a/tests/test_recovery_commands.py
+++ b/tests/test_recovery_commands.py
@@ -2,7 +2,7 @@ import subprocess
 
 import pytest
 
-from scripts.recover_season_projections import execute_commands
+from scripts.recover_season_projections import COMMANDS, execute_commands
 
 
 def test_compute_failure_stops_downstream_writes(monkeypatch):
@@ -19,6 +19,14 @@ def test_compute_failure_stops_downstream_writes(monkeypatch):
     assert len(calls) == 1
 
 
+def test_final_refresh_updates_data_freshness_after_consumer_marts():
+    final_refresh = COMMANDS[-1]
+
+    assert final_refresh[0] == "refresh_marts"
+    assert final_refresh[1] == "--views"
+    assert final_refresh[2].endswith(",marts.data_freshness")
+
+
 @pytest.mark.parametrize(
     "frontier,fits,pending",
     [
@@ -32,15 +40,84 @@ def test_preflight_rejects_ineligible_rebuild_before_command_execution(
 ):
     from scripts.recover_season_projections import check_recovery_state
 
+    load_fit_calls = []
     monkeypatch.setattr("scripts.train_model.fetch_refit_state", lambda conn: (frontier, fits))
     monkeypatch.setattr("scripts.score_fitted.fetch_pending_game_counts", lambda conn: pending)
+    monkeypatch.setattr(
+        "scripts.score_fitted.load_fit",
+        lambda conn, season: load_fit_calls.append((conn, season)),
+    )
     with pytest.raises(RuntimeError, match="Recovery requires"):
         check_recovery_state(object())
+    assert load_fit_calls == []
 
 
 def test_preflight_accepts_approved_fit_and_target(monkeypatch):
     from scripts.recover_season_projections import check_recovery_state
 
+    conn = object()
+    load_fit_calls = []
+    score_calls = []
+    fit = object()
     monkeypatch.setattr("scripts.train_model.fetch_refit_state", lambda conn: (2025, [2024, 2025]))
     monkeypatch.setattr("scripts.score_fitted.fetch_pending_game_counts", lambda conn: {2026: 10})
-    check_recovery_state(object())
+    monkeypatch.setattr(
+        "scripts.score_fitted.load_fit",
+        lambda conn, season: (load_fit_calls.append((conn, season)), fit)[1],
+    )
+    monkeypatch.setattr(
+        "scripts.score_fitted.score_game",
+        lambda game, loaded_fit: (score_calls.append((game, loaded_fit)), (1.0, 0.5))[1],
+    )
+
+    check_recovery_state(conn)
+
+    assert load_fit_calls == [(conn, 2025)]
+    assert len(score_calls) == 1
+    game, loaded_fit = score_calls[0]
+    assert game["season"] == 2026
+    assert game["home_tw"] == game["away_tw"]
+    assert loaded_fit is fit
+
+
+def test_preflight_propagates_invalid_frozen_fit_before_recovery(monkeypatch):
+    from scripts.recover_season_projections import check_recovery_state
+
+    monkeypatch.setattr("scripts.train_model.fetch_refit_state", lambda conn: (2025, [2024, 2025]))
+    monkeypatch.setattr("scripts.score_fitted.fetch_pending_game_counts", lambda conn: {2026: 10})
+
+    def invalid_fit(conn, season):
+        raise ValueError(f"missing coefficient vector for {season}")
+
+    monkeypatch.setattr("scripts.score_fitted.load_fit", invalid_fit)
+
+    with pytest.raises(ValueError, match="missing coefficient vector for 2025"):
+        check_recovery_state(object())
+
+
+def test_missing_fit_scaling_stats_stop_before_commands(monkeypatch):
+    import scripts.recover_season_projections as recovery
+    from scripts.train_model import FEATURE_NAMES, TEAM_WEEK_SOURCE_COLUMNS
+
+    monkeypatch.setattr("scripts.train_model.fetch_refit_state", lambda conn: (2025, [2025]))
+    monkeypatch.setattr("scripts.score_fitted.fetch_pending_game_counts", lambda conn: {2026: 10})
+    monkeypatch.setattr(
+        "scripts.score_fitted.load_fit",
+        lambda conn, season: {
+            "train_through": season,
+            "feature_means": dict.fromkeys(TEAM_WEEK_SOURCE_COLUMNS, 0.0),
+            "diff_means": {},
+            "diff_stds": {},
+            "platt_a": 1.0,
+            "platt_b": 0.0,
+            "beta_margin": [0.0] * len(FEATURE_NAMES),
+            "beta_winprob": [0.0] * len(FEATURE_NAMES),
+        },
+    )
+    command_calls = []
+    monkeypatch.setattr(recovery, "execute_commands", lambda: command_calls.append(True))
+
+    with pytest.raises(KeyError, match="d_elo"):
+        recovery.execute_recovery(object())
+
+    assert command_calls == []

--- a/tests/test_recovery_commands.py
+++ b/tests/test_recovery_commands.py
@@ -1,4 +1,5 @@
 import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -17,6 +18,30 @@ def test_compute_failure_stops_downstream_writes(monkeypatch):
     with pytest.raises(subprocess.CalledProcessError):
         execute_commands((("compute_adjusted_epa",), ("simulate_season",)))
     assert len(calls) == 1
+
+
+def test_recovery_replays_repaired_elo_prefix_before_2026_dependents(monkeypatch):
+    calls = []
+
+    def record(command, *, check):
+        assert check
+        calls.append((Path(command[1]).stem, *command[2:]))
+
+    monkeypatch.setattr(subprocess, "run", record)
+
+    execute_commands()
+
+    assert calls[1:4] == [
+        ("compute_house_elo", "--season", "2024"),
+        ("compute_house_elo", "--season", "2025"),
+        ("compute_house_elo", "--season", "2026"),
+    ]
+    assert calls.index(("compute_house_elo", "--season", "2026")) < calls.index(
+        ("compute_adjusted_epa", "--season", "2026")
+    )
+    assert calls.index(("compute_house_elo", "--season", "2026")) < calls.index(
+        ("build_features", "--season", "2026")
+    )
 
 
 def test_final_refresh_updates_data_freshness_after_consumer_marts():

--- a/tests/test_recovery_commands.py
+++ b/tests/test_recovery_commands.py
@@ -17,3 +17,30 @@ def test_compute_failure_stops_downstream_writes(monkeypatch):
     with pytest.raises(subprocess.CalledProcessError):
         execute_commands((("compute_adjusted_epa",), ("simulate_season",)))
     assert len(calls) == 1
+
+
+@pytest.mark.parametrize(
+    "frontier,fits,pending",
+    [
+        (2024, [2024], {2026: 10}),
+        (None, [], {2026: 10}),
+        (2025, [2025], {2026: 10, 2027: 1}),
+    ],
+)
+def test_preflight_rejects_ineligible_rebuild_before_command_execution(
+    monkeypatch, frontier, fits, pending
+):
+    from scripts.recover_season_projections import check_recovery_state
+
+    monkeypatch.setattr("scripts.train_model.fetch_refit_state", lambda conn: (frontier, fits))
+    monkeypatch.setattr("scripts.score_fitted.fetch_pending_game_counts", lambda conn: pending)
+    with pytest.raises(RuntimeError, match="Recovery requires"):
+        check_recovery_state(object())
+
+
+def test_preflight_accepts_approved_fit_and_target(monkeypatch):
+    from scripts.recover_season_projections import check_recovery_state
+
+    monkeypatch.setattr("scripts.train_model.fetch_refit_state", lambda conn: (2025, [2024, 2025]))
+    monkeypatch.setattr("scripts.score_fitted.fetch_pending_game_counts", lambda conn: {2026: 10})
+    check_recovery_state(object())

--- a/tests/test_season_lifecycle.py
+++ b/tests/test_season_lifecycle.py
@@ -71,6 +71,59 @@ def test_2020_disruption_uses_july_floor():
     ).is_final
 
 
+def test_completed_2020_spring_schedule_closes_after_july_floor():
+    rows = _complete_schedule(2020)
+    for row in rows:
+        row["season_type"] = "spring_regular"
+    rows[-1]["season_type"] = "spring_postseason"
+
+    result = classify_season(
+        rows,
+        2020,
+        as_of=datetime(2021, 7, 1, tzinfo=UTC),
+    )
+
+    assert result.is_final is True
+    assert result.scheduled_games == 100
+    assert rows[0]["season_type"] == "spring_regular"
+    assert rows[-1]["season_type"] == "spring_postseason"
+
+
+def test_incomplete_spring_game_blocks_2020_closure():
+    rows = _complete_schedule(2020)
+    rows[0].update(
+        season_type="spring_regular",
+        completed=False,
+        home_points=None,
+        away_points=None,
+    )
+    rows[-1]["season_type"] = "spring_postseason"
+
+    result = classify_season(
+        rows,
+        2020,
+        as_of=datetime(2021, 7, 1, tzinfo=UTC),
+    )
+
+    assert result.is_final is False
+    assert result.unresolved_game_ids == (1,)
+
+
+def test_spring_postseason_satisfies_postseason_coverage():
+    rows = _complete_schedule(2020)
+    for row in rows:
+        row["season_type"] = "regular"
+    rows[-1]["season_type"] = "spring_postseason"
+
+    result = classify_season(
+        rows,
+        2020,
+        as_of=datetime(2021, 7, 1, tzinfo=UTC),
+    )
+
+    assert result.is_final is True
+
+
 def test_regular_only_truncated_schedule_cannot_close():
     rows = _complete_schedule()
     for row in rows:


### PR DESCRIPTION
F03 production preflight stopped the 2026 rebuild because spring-season handling and unresolved historical provider records capped the safe training frontier at 2019. This change recognizes documented spring enums, adds evidence-backed cancellation/replacement resolutions, and restores two verified results with guarded ingestion corrections.

Production recovery is complete: Elo replayed 2024–2026, followed by 2026 EPA, features, predictions, projections, and mart refreshes. All 3,247 pending games have fresh valid fitted scores; 716 team projections were rebuilt with zero unscored team-games. Live checks proved both historical results reached Elo, model metadata and coefficients were unchanged, invalid game predictions were excluded, and caller-role access was intact.

- Repair: https://github.com/rstover-fo/cfb-database/actions/runs/34064297499
- Corrected rebuild: https://github.com/rstover-fo/cfb-database/actions/runs/34064735040
- Live verification: https://github.com/rstover-fo/cfb-database/actions/runs/34065046695

The explicitly approved outlook cleanup also completed: 242 obsolete snapshots were preserved in the private journal and removed from active projections. Final API coverage is 716/716 fresh teams with zero unscored team-games. Cleanup and verification: https://github.com/rstover-fo/cfb-database/actions/runs/34068212563. The strengthened 716-team completeness assertions also passed in production: https://github.com/rstover-fo/cfb-database/actions/runs/34068303637

Validation: 2,361 root tests passed (449 integration skips), affected Ruff checks and implementation CI passed. PostgreSQL16 exercised the real accuracy mart and projection schema, repeated repair/cleanup, conflict rollback, scope retention, and role privacy. Both original Codex findings were fixed and resolved. The Greptile completeness finding is addressed with strict 716-team/freshness/scoring assertions and executed PostgreSQL negative cases.

Full evidence: docs/plans/2026-09-06-f03-production-rebuild.md. Merge this PR so scheduled main-branch jobs retain the lifecycle and ingestion fixes. No model retraining or historical feature/prediction backfill was performed.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds hard failure checks to the 2026 season-outlook verification so missing, extra, stale, or unscored team output cannot be treated as ready.

<h3>Confidence Score: 5/5</h3>

Safe to merge.

No outstanding findings remain. The prior issue is resolved: the verification now raises an exception unless the total, fresh, and complete outlook counts are all 716 and the number of unscored team-games is zero. greptile-apps[bot] resolved it without explanation.

<sub>Reviews (2): Last reviewed commit: ["fix: enforce complete outlook recovery a..."](https://github.com/rstover-fo/cfb-database/commit/89cb7b60103f7f5b6e8b06094a201c4352208a61) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61043443)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [CFBD source loading](https://app.greptile.com/formentera-operations/-/custom-context/knowledge-base/rstover-fo/cfb-database/-/docs/cfbd-source-loading.md)
- Knowledge Base — [Data quality and verification](https://app.greptile.com/formentera-operations/-/custom-context/knowledge-base/rstover-fo/cfb-database/-/docs/data-quality-and-verification.md)
- Knowledge Base — [Operational validation workflows](https://app.greptile.com/formentera-operations/-/custom-context/knowledge-base/rstover-fo/cfb-database/-/docs/operational-validation.md)
- Knowledge Base — [Ratings and game predictions](https://app.greptile.com/formentera-operations/-/custom-context/knowledge-base/rstover-fo/cfb-database/-/docs/ratings-and-predictions.md)
</details>


<!-- /greptile_comment -->