### PR TITLE
F04: separate published forecasts from reconstructed prediction history

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,28 @@ jobs:
       - run: ./scripts/setup_dev.sh
       - run: PATH="$PWD/.venv/bin:$PATH" ruff check mcp
       - run: PATH="$PWD/.venv/bin:$PATH" python -m pytest mcp/tests -q --tb=short
+
+  prediction-provenance:
+    name: Prediction Provenance SQL
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - run: ./scripts/setup_dev.sh
+      - run: .venv/bin/python -m pytest tests/test_prediction_provenance_sql.py -q --tb=short
+        env:
+          F04_TEST_DB_URL: postgresql://postgres@127.0.0.1:5432/postgres

--- a/.github/workflows/daily-load.yml
+++ b/.github/workflows/daily-load.yml
@@ -100,7 +100,8 @@ jobs:
       - name: Score fitted model (upcoming)
         run: python scripts/score_fitted.py --upcoming
       - name: Simulate season projections
-        run: python scripts/simulate_season.py
+        # F04 cold start writes no projections but must not block mart refresh/verification.
+        run: python scripts/simulate_season.py --allow-calibration-cold-start
       # Runs DAILY, not annually, even though the measurement only moves on a
       # refit or a feature rebuild. Two reasons. api.model_backtest.run_date is
       # what cfb-app checks to decide whether its cached honesty numbers are

--- a/deploys/f04-prediction-provenance-manifest.json
+++ b/deploys/f04-prediction-provenance-manifest.json
@@ -1,0 +1,11 @@
+{
+  "action": "apply",
+  "files": [
+    "src/schemas/migrations/063_prediction_provenance.sql",
+    "src/schemas/marts/037_scored_matchup_edges.sql",
+    "src/schemas/marts/038_prediction_accuracy.sql",
+    "src/schemas/api/030_scored_matchup_edges.sql",
+    "src/schemas/api/031_prediction_accuracy.sql",
+    "src/schemas/api/032_game_predictions.sql"
+  ]
+}

--- a/docs/SCHEMA_CONTRACT.md
+++ b/docs/SCHEMA_CONTRACT.md
@@ -4,7 +4,7 @@
 > only depend on objects listed here as **public**. Everything else is internal and may change
 > without notice.
 
-Last updated: 2026-09-03
+Last updated: 2026-09-07
 
 > **Note on cfb-analytics:** the retired OU-only app (rstover-fo/cfb-analytics) was never a
 > warehouse consumer -- it ran its own DuckDB ingestion. Its unique features (rivals page,
@@ -14,6 +14,33 @@ Last updated: 2026-09-03
 ---
 
 ## Recent Contract Changes
+
+- **2026-09-07 — F04 prediction provenance (pending deployment).** Migration
+  `063_prediction_provenance.sql` retains every existing row and ID as
+  `legacy_unknown`, with new provenance fields NULL. Historical dates do not
+  establish publication. New writes append immutable IDs even within one day.
+  `predictions.model_artifacts` retains a content-addressed snapshot of the
+  consumed fit/closed-form parameters and implementation fingerprint;
+  `input_snapshot` and `input_hash` preserve the actual scoring inputs.
+  - `api.game_predictions` becomes **published-only**, latest by `published_at`
+    then `prediction_id`. Existing payload columns remain; additive metadata is
+    `evaluation_mode`, `created_at`, `published_at`, `simulated_as_of_at`,
+    `experiment_label`, `fit_id`, and `input_hash`.
+  - New `api.prediction_history` exposes the same columns for **all** modes:
+    `legacy_unknown`, `published_forecast`, `walk_forward_reconstruction`, and
+    `hindsight_experiment`. Heavy input JSON remains in the underlying ledger.
+  - `api.scored_matchup_edges` uses published rows only. Accuracy and simulation
+    residual calibration require known kickoff and strict `published_at <
+    start_date`, filtering before latest-row selection. A same-day late forecast
+    is excluded. The metric columns and formulas remain unchanged.
+  - **Cold start:** the prospective cohort can initially be empty. Historical
+    backfills cannot populate it; simulation fails closed below its existing
+    minimum published sample, preserving the last stored outlook. July accuracy
+    figures below are historical reconstruction observations, not evidence of
+    prospective performance. `api.model_backtest` remains explicitly retrospective.
+  - Regenerate downstream API types for the additive metadata/history view during
+    the coordinated rollout. No consumer repository or production has been changed
+    by this migration's preparation. See the F04 implementation/rollout plan.
 
 - **2026-09-03 — rushing charting unit: five `stats.rushing_*` raw tables
   (Stage A, live), three `api.rushing_charting_*` views and a
@@ -709,11 +736,11 @@ Last updated: 2026-09-03
     Normally empty out of season -- that is expected behavior, not a data-quality failure.
     Exposed as `api.scored_matchup_edges`.
   - **Predictions:** new `predictions` schema (`predictions.game_predictions`) holds
-    append-only daily snapshots -- one immutable row per `(game_id, model_version,
-    prediction_date)`, written by `scripts/compute_predictions.py`. It is readable directly,
-    but downstream consumers should prefer `api.game_predictions` (latest snapshot per
-    game/model via `DISTINCT ON`) unless the full day-by-day history is needed.
-  - **Backtest surface:** `marts.prediction_accuracy` -- retroactive scoring (margin MAE/RMSE,
+    an immutable ledger keyed by `prediction_id` after F04. Both prediction writers
+    append explicit modes and captured provenance. Prefer `api.game_predictions`
+    for latest published forecasts and `api.prediction_history` for all modes.
+  - **Published accuracy surface (F04):** `marts.prediction_accuracy` -- scoring of
+    forecasts published strictly before known kickoff (margin MAE/RMSE,
     ATS record, Brier score vs. CFBD's own pregame win probability) by season, model, and
     edge-threshold. Exposed as `api.prediction_accuracy`.
   - **`marts.matchup_edges` (016) is now documented as style-only.** It predates house Elo/EPA
@@ -866,8 +893,9 @@ These are the primary PostgREST-accessible views. Queries go through Supabase cl
 | `api.team_elo` | **Live** | ~29,000 | Season-end house Elo rating per team-season, ranked within season. Columns: team, season, season_end_elo, elo_rank, games_played, low_confidence, cfbd_elo |
 | `api.game_elo_history` | **Live** | ~71,000 | Game-grain house Elo history: pregame/postgame Elo both sides, win probability, expected vs actual margin, CFBD Elo copies for validation. Columns: game_id, season, week, season_type, start_date, neutral_site, home_team, away_team, home_pregame_elo, away_pregame_elo, home_postgame_elo, away_postgame_elo, home_win_prob, expected_home_margin, actual_home_margin, mov_multiplier, cfbd_home_pregame_elo, cfbd_away_pregame_elo, margin_error, abs_margin_error |
 | `api.scored_matchup_edges` | **Live** | Varies (in-season) | House model expected margin/win probability vs. the market line for upcoming games, with the resulting edge. Empty out of season by design -- not a failure. Columns: game_id, season, week, season_type, start_date, home_team, away_team, neutral_site, model_version, prediction_date, home_elo_pregame, away_elo_pregame, elo_margin, epa_margin, expected_home_margin, home_win_prob, market_provider, market_spread, market_home_margin, market_captured_at, edge, edge_pick, abs_edge. Carries all three model versions -- see House Model Versions below. |
-| `api.prediction_accuracy` | **Live** | ~90 | Retroactive scoring of house predictions by season/model/edge-threshold: margin MAE/RMSE, ATS record, Brier score (house vs. CFBD). Columns: model_version, season, edge_threshold, n_games, n_with_market, margin_mae, margin_rmse, ats_wins, ats_losses, ats_pushes, ats_hit_rate, brier, cfbd_brier, n_scored_win_prob. No model wins on all three metrics -- see House Model Versions below for the 2025 tradeoff, and note `cfbd_brier` beats every house model. |
-| `api.game_predictions` | **Live** | ~20,000+ | Latest house prediction snapshot per (game, model), from the append-only `predictions.game_predictions` log. Columns: prediction_id, computed_at, prediction_date, model_version, game_id, season, week, season_type, home_team, away_team, neutral_site, home_elo_pregame, away_elo_pregame, elo_margin, epa_margin, expected_home_margin, home_win_prob, market_provider, market_home_margin, market_spread, market_captured_at, edge, edge_pick. **Three `model_version` values, not two** -- `elo_v1`, `elo_epa_blend_v1` and `fitted_v1` (2018+ only, its own Platt-scaled `home_win_prob`, `elo_margin`/`epa_margin` NULL). Read the House Model Versions table below before selecting or defaulting a model. |
+| `api.prediction_accuracy` | **F04 pending** | May be 0 | Strict pre-kickoff published scoring of house predictions by season/model/edge-threshold: margin MAE/RMSE, ATS record, Brier score (house vs. CFBD). Columns: model_version, season, edge_threshold, n_games, n_with_market, margin_mae, margin_rmse, ats_wins, ats_losses, ats_pushes, ats_hit_rate, brier, cfbd_brier, n_scored_win_prob. No model wins on all three metrics -- see House Model Versions below for the 2025 tradeoff, and note `cfbd_brier` beats every house model. |
+| `api.game_predictions` | **F04 pending** | May be 0 | Latest published house prediction snapshot per (game, model), from the append-only `predictions.game_predictions` log. Columns: prediction_id, computed_at, prediction_date, model_version, game_id, season, week, season_type, home_team, away_team, neutral_site, home_elo_pregame, away_elo_pregame, elo_margin, epa_margin, expected_home_margin, home_win_prob, market_provider, market_home_margin, market_spread, market_captured_at, edge, edge_pick, evaluation_mode, created_at, published_at, simulated_as_of_at, experiment_label, fit_id, input_hash. **Three `model_version` values, not two** -- `elo_v1`, `elo_epa_blend_v1` and `fitted_v1` (2018+ only, its own Platt-scaled `home_win_prob`, `elo_margin`/`epa_margin` NULL). Read the House Model Versions table below before selecting or defaulting a model. |
+| `api.prediction_history` | **F04 pending** | All ledger rows | All evaluation modes with the same columns as `api.game_predictions`; use provenance labels, never infer publication from historical prediction dates. |
 | `api.season_outlook` | **Deployed** | ~350 per projection season | Latest Monte Carlo season projection per (season, team, model), from the append-only `predictions.season_projections` log. Projected wins with a full distribution, schedule strength and conference title odds. Columns: projection_id, computed_at, projection_date, model_version, season, team, conference, games_scheduled, games_simulated, games_unscored, games_completed, actual_wins, schedule_complete, projected_wins, projected_losses, median_wins, wins_p10, wins_p25, wins_p75, wins_p90, p_win_dist, p_bowl_eligible, p_ten_plus, sos_rating, sos_rank, conf_title_prob, playoff_prob, n_sims, residual_sigma, strength_share, classification, is_projection. **Filter on `classification` before ranking** -- the view mixes FBS/FCS/DII/DIII (350 teams across 49 conferences in 2026), so an unfiltered `ORDER BY projected_wins` compares teams playing entirely different schedules; it is season-accurate (realignment-safe) and NULL means unplaceable, not FBS. **Check `is_projection` before calling anything a forecast** -- false means `games_simulated = games_completed`, so the row is a settled record (`projected_wins = actual_wins`, `wins_p10 = wins_p90`, and `conf_title_prob` values such as an exact 0.2500 shared by four teams are a tie split evenly, not a title race); it is per row, so use `bool_or(is_projection)` for a season-level answer. `schedule_complete` is division-aware (a 10-game Ivy League slate is complete) and `p_bowl_eligible` is NULL outside FBS. **Read `games_unscored` before trusting `projected_losses`** -- a pending game with no prediction is excluded from the simulation, and every projected quantity is computed over `games_simulated`, never `games_scheduled`. `p_win_dist` is `{"0": p, "1": p, ...}` summing to 1. From v1.1 each simulation draws one per-team season-strength offset (`strength_share`, calibrated to 0.15 against backtest coverage), so the tails are no longer understated; per-game variance is unchanged so `projected_wins` is unaffected. `playoff_prob` is NULL by design. **FCS/D2 caveat:** CFBD labels non-FBS playoff bracket games `season_type='regular'`, so `games_scheduled` for an FCS/D2 team can include a playoff run (completed seasons only -- no forward-looking row is affected). Do not rank FCS against FBS teams on `projected_wins` alone. |
 | `api.model_backtest` | **Pending deploy** | -- | Latest walk-forward **preseason** backtest per `(model_version, scope, season_start, season_end, strength_share)`, from the append-only `predictions.model_backtest` log (migration 045). How wrong `api.season_outlook`'s projections actually are -- the numbers an outlook answer must be quoted with. Columns: backtest_id, computed_at, run_date, model_version, feature_build_version, scope, season_start, season_end, seasons_covered, train_through_min, train_through_max, n_sims, seed, strength_share, max_games_played_to_date, games_dropped_outcome_dependent, n, win_mae, rmse, bias, coverage, baseline_prior_mae, baseline_flat_mae, beats_prior_baseline, beats_flat_baseline, resid_p05, resid_p10, resid_p25, resid_p50, resid_p75, resid_p90, resid_p95, bowl_brier, ten_plus_brier, calibration, respectable_win_mae. **`n` counts TEAM-SEASONS, not games** -- a multi-season FBS backtest is in the high hundreds, not the thousands a game-grain reading would suggest. **Use `resid_p10`/`resid_p90` for an interval, never `± win_mae`** -- MAE is an average loss, not a half-width; a `±MAE` band spans ~58% of a normal error distribution, not the ~80% a reader assumes. The 80% band is `[projected_wins + resid_p10, projected_wins + resid_p90]` and it is **asymmetric in general** -- read both ends from the row rather than mirroring one (the 2026-07-26 run measured `[-2.68, +3.02]`). `scope` is `'fbs'` (default reporting population) or `'all_divisions'`; the two are different measurements, not a superset -- CFBD labels FCS/D2 playoff bracket games `season_type='regular'`, so those slates run long. **More than one row per `model_version` is expected** when the season range or `strength_share` changed; filter on `scope`/`season_start`/`season_end` rather than taking whichever row comes first. `seasons_covered` may be shorter than `[season_start, season_end]` (a season with no frozen S-1 fit is excluded), and seasons scored only to seed the residual sigma are not listed. `max_games_played_to_date` above 0 means some "week-1" feature vector already contained that season's own games and **every error metric on that row is understated**. `calibration` is `{"p_bowl_eligible": [{bucket, n, mean_predicted, observed}, ...], "p_ten_plus": [...]}` with empty buckets omitted. `respectable_win_mae` is the advisory bar (plan 4.5), not a verdict -- **no verdict is stored**, by design: apply your own bar. **NO ROW means the model was never backtested** -- render that as unmeasured; it is not an error and it is not zero error. `run_date` is exposed so a cached copy can be checked for staleness. Sweep runs (`--sweep-strength-share`) deliberately write nothing. |
 | `api.game_recaps` | **Deployed** | 0 (fills nightly) | Nightly LLM-generated game recap. **Content is LLM-generated from warehouse facts, not CFBD data** -- regenerated only via the `regenerate` flag; a missing `game_id` means not yet generated. cfb-app should render `headline`/`recap` as prose, not structured stats. Columns: game_id, season, week, headline, recap, wp_available, model, generated_at |
@@ -1130,14 +1158,17 @@ Tables: `drives`, `games`, `games__away_line_scores`, `games__home_line_scores`,
 
 Added 2026-07-21 (Tier 2 analytics). `predictions.game_predictions` is **readable**
 (`SELECT` granted to `anon`/`authenticated`; `INSERT`/`UPDATE`/`DELETE` are revoked) but it is
-pipeline output, not the contract surface -- it is an append-only log with one immutable row
-per `(game_id, model_version, prediction_date)`. Downstream consumers should prefer
-`api.game_predictions`, which resolves to the latest snapshot per game/model, unless the full
-day-by-day prediction history is actually needed.
+pipeline output. F04 makes its grain one immutable `prediction_id`, with no daily
+uniqueness or update path. Prefer `api.game_predictions` for latest published
+forecasts and `api.prediction_history` for all explicitly labeled modes.
+Legacy rows have NULL provenance; a simulated as-of time does not prove historic
+input availability. New creation/publication timestamps come from the database
+INSERT statement, not a client-supplied date or transaction start.
 
 | Table | Description |
 |-------|-------------|
-| `predictions.game_predictions` | Append-only daily house prediction snapshots (house Elo + ridge-adjusted-EPA expected margin/win probability vs. the market line). Written by `scripts/compute_predictions.py`. Prefer `api.game_predictions` for the latest-snapshot contract view. |
+| `predictions.game_predictions` | Immutable IDs, explicit evaluation mode, actual publication time, consumed artifact ID, and captured input snapshot/hash. Written by `compute_predictions.py` and `score_fitted.py`. |
+| `predictions.model_artifacts` | Immutable consumed-artifact snapshots keyed by SHA-256 `fit_id`; full artifact JSON and model version. This records scoring lineage, not an upstream training manifest. |
 | `predictions.season_projections` | Append-only daily Monte Carlo season-outcome snapshots (win-total distribution, SOS, conference title odds). Written by `scripts/simulate_season.py`. Prefer `api.season_outlook` for the latest-snapshot contract view -- `analyst_ro` cannot read this schema directly. |
 | `predictions.model_backtest` | Append-only preseason-backtest accuracy snapshots, one immutable row per `(model_version, UTC run_date, scope, season_start, season_end, strength_share)`. Written by `scripts/backtest_preseason.py`. Prefer `api.model_backtest` for the latest-snapshot contract view -- `analyst_ro` cannot read this schema directly. Query this table for run-by-run history (accuracy drift across annual refits), which the view deliberately does not expose. |
 

--- a/docs/brainstorms/2026-07-21-team-week-feature-design.md
+++ b/docs/brainstorms/2026-07-21-team-week-feature-design.md
@@ -587,9 +587,9 @@ For each `S` in `2018..2025`:
    **frozen S−1** `feature_means`/scaling, apply β → `expected_home_margin`,
    apply logistic+Platt → `home_win_prob`, and write a
    `model_version='fitted_v1'` row into `predictions.game_predictions`
-   (`prediction_date = start_date::date`, so re-runs are idempotent under the
-   `(game_id, model_version, prediction_date)` key). `marts/038` scores it
-   automatically.
+   as an immutable `walk_forward_reconstruction` with the actual artifact and
+   input snapshot, actual creation time, and nominal kickoff as-of time. Re-runs
+   append new IDs; reconstruction rows never enter published accuracy (F04).
 10. **Daily upcoming:** select the latest eligible frozen fit separately for
     each pending season S, requiring `train_through_season < S`. Validate the
     fit against each game before vectorization. Resolve all required fits
@@ -850,3 +850,40 @@ rows in a private recovery journal before the bounded database repair; apply the
 same reviewed result correction on later game ingestion so it cannot regress.
 These are source-data repairs, not a change to the feature vector, fit vintage,
 week-index semantics, or permission to retrain. The 2025 fit remains frozen.
+
+### F04 prediction provenance amendment — September 7, 2026
+
+Prediction history is an append-only ledger, not a mutable daily cache. Preserve
+existing IDs/values and label all pre-migration rows `legacy_unknown`; existing
+computed/date fields cannot prove when a forecast was actually published.
+New modes are `published_forecast`, `walk_forward_reconstruction`, and
+`hindsight_experiment`. All new rows record database write-time `created_at`,
+content-addressed `fit_id`, `input_hash`, and the exact captured input snapshot.
+A separate immutable model-artifact table retains the consumed coefficients,
+scaling/calibration or closed-form parameters, and implementation fingerprint.
+This identifies the artifact actually consumed; it does not invent the training
+manifest or upstream data-generation history deferred to F05.
+
+For published rows, `published_at` is the actual database write instant, never
+kickoff or transaction-start time. Reconstructions/experiments have no
+publication timestamp and record their nominal `simulated_as_of_at` from a
+known kickoff. Hindsight requires an explicit nonempty experiment label.
+Backfill defaults to as-of-week reconstruction and never overwrites a published
+row. Same-day reruns append distinct immutable prediction IDs. Compatibility
+`prediction_date` remains descriptive and is never an identity or eligibility
+key. The original source/fit snapshots remain recoverable after source refresh
+or retraining. No feature-vector, calibration algorithm, or production fit is
+changed by this amendment.
+
+Public forecast, edge, accuracy, and season-simulation inputs use only published
+rows. Prospective accuracy/calibration require known kickoff and strictly
+`published_at < kickoff`, selecting the latest eligible timestamp then ID.
+Unknown legacy, reconstructions, hindsight, at-kickoff, and post-kickoff rows
+cannot affect that cohort. An explicit history API exposes all modes with their
+provenance. The separate preseason walk-forward backtest stays unchanged.
+
+Cutover may leave published accuracy unmeasured and simulation calibration below
+its existing minimum sample threshold. Keep the existing fail-closed policy;
+do not seed it with legacy or reconstructed predictions or silently invent a
+fallback. New production schema deployment and scoring require a separately
+authorized rollout, with the cold-start limitation explicit before deployment.

--- a/docs/plans/2026-09-07-f04-prediction-provenance.md
+++ b/docs/plans/2026-09-07-f04-prediction-provenance.md
@@ -1,0 +1,122 @@
+# F04: prediction provenance and prospective evaluation
+
+## Goal
+
+Historical reconstruction and hindsight must never replace published forecasts
+or change their measured accuracy or simulation calibration. Preserve existing
+ambiguous history honestly and retain the consumed model/input artifacts for
+new predictions. F05 still owns immutable training manifests/deployment pointers.
+
+## Contract
+
+- Modes: `legacy_unknown`, `published_forecast`,
+  `walk_forward_reconstruction`, `hindsight_experiment`.
+- Existing prediction IDs and payloads remain; new provenance is unknown/NULL
+  for those rows. New rows append, with no daily-key upsert.
+- New provenance columns: `evaluation_mode`, `created_at`, `published_at`,
+  `simulated_as_of_at`, `experiment_label`, `fit_id`, `input_hash`,
+  `input_snapshot`. `fit_id` references immutable
+  `predictions.model_artifacts(fit_id,model_version,artifact,created_at)`.
+- Published timestamps are database write instants. Reconstructed timestamps
+  are nominal as-of times, never fabricated publication times. A missing
+  historical kickoff cannot be replaced with January 1 for provenance.
+- Canonical JSON hashing captures the exact consumed model/input data and an
+  implementation fingerprint. Artifacts retain coefficients/normalization or
+  closed-form parameters; source inputs retain features/Elo/EPA/market data.
+- Existing forecast API columns stay, with additive provenance metadata.
+  `api.game_predictions` is published-only; `api.prediction_history` exposes
+  all retained modes. Prospective accuracy and calibration apply strict
+  pre-kickoff eligibility before selecting the latest timestamp/ID.
+- Blend reconstruction defaults to as-of-week EPA. Full-season hindsight is an
+  explicit labeled experiment. Fitted historical S-1 scoring is reconstruction.
+
+## Development and verification
+
+Use disjoint writer, consumer, and schema ownership, integrate through a shared
+provenance helper, then independent review. Test actual PostgreSQL migration
+upgrade twice and actual API/mart/calibration SQL, not invented fixture columns.
+Fixtures distinguish midday/at-kickoff/post-kickoff published rows from newer
+reconstruction, hindsight, and unknown rows. Verify immutable IDs/artifacts,
+legacy retention, correct API roles/grants, and invariant calibration/accuracy
+when historical experiments are added. Run affected checks and repository CI.
+
+## Rollout boundary
+
+No F04 production writes are authorized by the earlier F03 recovery approvals.
+Prepare a dependency-complete deployment manifest and operational checks.
+Pause prediction writers for schema/index/consumer cutover, then deploy updated
+writers together. Legacy forecasts are not automatically promoted. Upcoming
+published rows must be regenerated in an authorized run. Accuracy may be empty;
+simulation must fail closed until its existing minimum number of eligible
+published outcomes exists. Preserve the last stored outlook rather than
+silently deriving a new sigma from unknown history. Historical backtests remain
+explicitly retrospective and isolated from production calibration.
+
+## Coordinated deployment procedure (requires separate approval)
+
+1. Pause/drain nightly, recovery, and ad-hoc prediction writers. Record ledger
+   row count and IDs and inspect `pg_depend` for every dependent of
+   `marts.scored_matchup_edges` and `marts.prediction_accuracy`. The checked-in
+   closure is their two thin API views; preserve any additional production-only
+   dependents/grants before using their existing `DROP ... CASCADE` definitions.
+2. Apply `deploys/f04-prediction-provenance-manifest.json` from the reviewed
+   revision. Files commit individually: keep writers paused throughout, and
+   resume a failed apply at the failed step after correcting the cause. The
+   migration and complete ordered manifest are repeatable. Never reapply old
+   migration 024 after 063: its obsolete daily unique index is incompatible.
+3. Confirm every pre-cutover row/ID remains `legacy_unknown` with NULL new
+   provenance, both rebuilt marts and all four API views exist, and `anon`,
+   `authenticated`, and the API-only `analyst_ro` can SELECT the intended views.
+   Confirm consumer DML remains denied and update triggers are installed.
+4. Deploy the new prediction writers and consumers together. Run authorized
+   upcoming scoring, then refresh edges/accuracy. Verify new rows have artifact
+   and input hashes, database publication timestamps, and complete pending-game
+   coverage. No historical promotion or mass reconstruction is required.
+5. Regenerate cfb-app/cfb-scout API types and verify empty prospective accuracy
+   and stale retained season outlook are represented honestly. That cross-repo
+   rollout is pending; the warehouse alone cannot verify deployed consumers.
+6. Resume nightly work. `--allow-calibration-cold-start` is used only by the
+   daily simulation step: it explicitly warns and writes no new projections
+   until sufficient published outcomes exist, allowing mart refresh, backtest,
+   and verification to continue. Default/manual simulation and recovery still
+   fail on cold start. Invalid sigma or unrelated errors always fail. Retained
+   outlooks keep their old timestamps; this is not evidence of fresh simulation.
+
+The write role retains controlled archival/deletion authority for recovery;
+normal prediction/model artifact writers only insert. Consumer roles cannot
+mutate the ledger. An owner can disable triggers for approved maintenance;
+this is not a tamper-proof audit store against a privileged administrator.
+
+## Verification environments
+
+`tests/test_prediction_provenance_sql.py` uses only explicit
+`F04_TEST_DB_URL` pointing to an empty disposable local PostgreSQL database.
+CI provisions PostgreSQL 16 separately from the live warehouse checks. It
+executes the actual migration, views, marts and sigma query, including upgrade
+and repeat application, timestamp filtering, provenance retention and caller
+roles. It must never fall back to production credentials.
+
+Before 063 is deployed, live `api.game_predictions` checks retain its previous
+column contract; the new history view check reports an explicit deployment skip.
+Once the base provenance column exists, all additive API columns and history
+are required. This allows review before production deployment without claiming
+that production has already adopted the new contract.
+
+## Implementation evidence
+
+- Independent Astra review completed with all material findings resolved:
+  transitive scoring fingerprint coverage, explicit nightly cold-start handling,
+  and disposable-test cleanup ownership guards.
+- PostgreSQL 16 disposable database: **10 passed**, including migration upgrade
+  twice, real writer/JSON/artifact round trips, publication-vs-transaction time,
+  strict intraday eligibility, experimental-cohort invariance and caller roles.
+- Main suite: **2,389 passed, 460 skipped**. Skips include live warehouse tests
+  and the separately executed explicit-DSN PostgreSQL suite; they do not prove
+  production rollout. MCP: **59 passed**.
+- Ruff check/format and agent setup validation pass for repository/F04 files.
+  An initial unrestricted Ruff run found nine preexisting errors in unrelated,
+  untracked `scripts/film/update_storage_uri.py`; that user work was preserved
+  and excluded from the subsequent lint scope and this PR.
+- Production catalog closure, migration timing/performance, deployed consumer
+  types, and real prospective sample accumulation remain rollout checks. No
+  production migration, scoring, reconstruction, or rebuild was performed.

--- a/scripts/check_backtest.py
+++ b/scripts/check_backtest.py
@@ -24,9 +24,9 @@ docs/plans/2026-07-21-tier2-analytics-plan.md Phase 5) and prints:
 This script never fails the gate itself -- reading the printed numbers
 against the plan's thresholds and deciding whether to re-tune (K, lambda,
 blend weights) is a human call in the Phase 5 loop, per the plan. The only
-failure mode here is the mart itself being missing or empty, which means
-`compute_predictions.py --backfill <start> <end>` and a mart refresh haven't
-run yet.
+failure mode here is the mart itself being missing or empty, which may be an
+expected F04 prospective cold start. Historical backfills cannot populate this
+published-forecast cohort.
 
 Usage:
     python scripts/check_backtest.py
@@ -173,9 +173,8 @@ def run() -> int:
         with conn.cursor() as cur:
             if not table_exists(cur, "marts", "prediction_accuracy"):
                 logger.error(
-                    "marts.prediction_accuracy is MISSING -- run "
-                    "`python scripts/compute_predictions.py --backfill <start> <end>` "
-                    "then refresh marts (python scripts/refresh_marts.py) before retrying."
+                    "marts.prediction_accuracy is MISSING -- apply its schema and API "
+                    "dependency closure before retrying."
                 )
                 return 1
 
@@ -183,9 +182,10 @@ def run() -> int:
             (count,) = cur.fetchone()
             if count == 0:
                 logger.error(
-                    "marts.prediction_accuracy is EMPTY -- run "
-                    "`python scripts/compute_predictions.py --backfill <start> <end>` "
-                    "then refresh marts (python scripts/refresh_marts.py) before retrying."
+                    "marts.prediction_accuracy is EMPTY -- no eligible prospective "
+                    "published outcomes are available. Publish forecasts before kickoff, "
+                    "wait for completed outcomes, then refresh marts. Historical "
+                    "backfills cannot populate this cohort."
                 )
                 return 1
 

--- a/scripts/compute_predictions.py
+++ b/scripts/compute_predictions.py
@@ -7,7 +7,7 @@ plus the small lookup helpers below them) is pure -- plain floats/dicts, no
 I/O -- so it is fully unit-testable without a database (see
 tests/test_predictions.py). Everything below `# --- I/O layer ---` is a thin
 wrapper: fetch games + ratings + market lines, feed them through the pure
-functions, upsert the results into predictions.game_predictions
+functions, append the results to predictions.game_predictions
 (src/schemas/migrations/024_predictions_schema.sql).
 
 House Elo's `expected_score` (the 400-scale logistic) and the season-carryover
@@ -38,18 +38,13 @@ Usage:
         same date the DB itself would use, one single commit.
 
     python scripts/compute_predictions.py --backfill 2015 2025
-        Retroactively score completed games for seasons 2015-2025 (inclusive)
-        using each game's true walk-forward pregame Elo from
-        analytics.house_elo_game and SAME-SEASON-ONLY ridge-adjusted EPA
-        (documented leaky-for-blend -- see marts/038_prediction_accuracy.sql's
-        header). Market line: betting.lines only (closing-line proxy).
-        prediction_date = the game's start_date::date, falling back to
-        make_date(season, 1, 1) when start_date is NULL, so re-running a
-        backfill is idempotent under the (game_id, model_version,
-        prediction_date) unique key. Commits once per season.
+        Retroactively score completed games as walk-forward reconstructions.
+        Elo comes from analytics.house_elo_game and EPA defaults to the
+        leak-free as-of-week ladder described below. A known kickoff is
+        required and becomes simulated_as_of_at. Every run appends new rows.
 
     python scripts/compute_predictions.py --backfill 2015 2025 --as-of-week
-        Same as --backfill but LEAK-FREE for the blend (Tier 3 Pillar A):
+        Compatibility alias for the default leak-free backfill behavior:
         the EPA arm reads analytics.adjusted_epa_week_build coefficients
         ENTERING each game's week (greatest stored week_index <= the game's
         week_index with plays >= MIN_TEAM_PLAYS), falling back to the
@@ -59,14 +54,31 @@ Usage:
         the Gate A invariant. week_index convention matches
         scripts/build_features.py: week for regular season, 100 + week for
         postseason.
+
+    python scripts/compute_predictions.py --backfill 2015 2025 \
+        --hindsight-experiment LABEL
+        Explicitly score the blend from same-season full-season EPA. These
+        append-only rows are labeled hindsight_experiment and remain outside
+        published forecast evaluation.
 """
 
 import argparse
 import logging
 import sys
-from datetime import date
 
+from scripts import compute_house_elo as house_elo_module
 from scripts.compute_house_elo import EloEngine, expected_score
+from scripts.prediction_provenance import (
+    ARTIFACT_SCHEMA_VERSION,
+    HINDSIGHT_EXPERIMENT,
+    INPUT_SCHEMA_VERSION,
+    PUBLISHED_FORECAST,
+    WALK_FORWARD_RECONSTRUCTION,
+    attach_prediction_provenance,
+    identify_model_artifact,
+    implementation_fingerprint,
+    insert_model_artifacts,
+)
 from src.pipelines.game_identity import eligible_game_sql
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
@@ -321,6 +333,79 @@ def build_predictions_for_game(
     return rows
 
 
+def closed_form_model_artifacts() -> dict[str, tuple[str, dict]]:
+    """Return content-addressed artifacts for both transparent models."""
+    implementation = implementation_fingerprint(house_elo_module, sys.modules[__name__])
+    common_parameters = {
+        "elo_seed": EloEngine.SEED,
+        "elo_home_field_advantage": EloEngine.HFA,
+        "elo_margin_divisor": EloEngine.DIVISOR,
+        "elo_carryover": EloEngine.CARRYOVER,
+    }
+    elo_artifact = {
+        "schema_version": ARTIFACT_SCHEMA_VERSION,
+        "artifact_kind": "closed_form",
+        "parameters": common_parameters,
+        "implementation": implementation,
+    }
+    blend_artifact = {
+        "schema_version": ARTIFACT_SCHEMA_VERSION,
+        "artifact_kind": "closed_form",
+        "parameters": {
+            **common_parameters,
+            "plays_per_game": PLAYS,
+            "blend_elo_weight": BLEND_ELO,
+            "blend_epa_weight": BLEND_EPA,
+            "as_of_min_team_plays": MIN_TEAM_PLAYS,
+            "postseason_week_offset": POSTSEASON_WEEK_OFFSET,
+        },
+        "implementation": implementation,
+    }
+    return {
+        MODEL_ELO: identify_model_artifact(MODEL_ELO, elo_artifact),
+        MODEL_BLEND: identify_model_artifact(MODEL_BLEND, blend_artifact),
+    }
+
+
+_GAME_INPUT_COLUMNS = (
+    "game_id",
+    "season",
+    "week",
+    "season_type",
+    "start_date",
+    "home_team",
+    "away_team",
+    "neutral_site",
+)
+
+
+def closed_form_input_snapshot(
+    game: dict,
+    *,
+    model_version: str,
+    home_elo: float,
+    away_elo: float,
+    market: dict | None,
+    home_epa: dict | None = None,
+    away_epa: dict | None = None,
+    epa_source: str | None = None,
+) -> dict:
+    """Capture the exact game, rating, EPA, and market values consumed."""
+    snapshot = {
+        "schema_version": INPUT_SCHEMA_VERSION,
+        "game": {column: game.get(column) for column in _GAME_INPUT_COLUMNS},
+        "elo": {"home": home_elo, "away": away_elo},
+        "market": market,
+    }
+    if model_version == MODEL_BLEND:
+        snapshot["epa"] = {
+            "source": epa_source,
+            "home": home_epa,
+            "away": away_epa,
+        }
+    return snapshot
+
+
 # =============================================================================
 # --- I/O layer --- (thin: fetch games/ratings/market, drive the math, write)
 # =============================================================================
@@ -397,9 +482,9 @@ MARKET_LINES_QUERY = """
     ORDER BY game_id, CASE WHEN provider = 'consensus' THEN 0 ELSE 1 END, provider
 """
 
-# Column order matches predictions.game_predictions exactly (see
-# src/schemas/migrations/024_predictions_schema.sql), minus computed_at and
-# prediction_date, which the two write_* functions handle separately.
+# Column order matches the mutable-free writer contract. Database triggers own
+# created_at and published_at; the templates below own only the compatibility
+# computed_at/prediction_date columns.
 _ROW_COLUMNS = [
     "model_version",
     "game_id",
@@ -421,55 +506,41 @@ _ROW_COLUMNS = [
     "market_captured_at",
     "edge",
     "edge_pick",
+    "evaluation_mode",
+    "simulated_as_of_at",
+    "experiment_label",
+    "fit_id",
+    "input_hash",
+    "input_snapshot",
 ]
 
-_UPDATE_SET_COLUMNS = [
-    "computed_at",
-    "season",
-    "week",
-    "season_type",
-    "home_team",
-    "away_team",
-    "neutral_site",
-    "home_elo_pregame",
-    "away_elo_pregame",
-    "elo_margin",
-    "epa_margin",
-    "expected_home_margin",
-    "home_win_prob",
-    "market_provider",
-    "market_home_margin",
-    "market_spread",
-    "market_captured_at",
-    "edge",
-    "edge_pick",
-]
-
-_UPSERT_SQL = """
+_INSERT_SQL = """
     INSERT INTO predictions.game_predictions (
         computed_at, prediction_date, model_version, game_id, season, week,
         season_type, home_team, away_team, neutral_site,
         home_elo_pregame, away_elo_pregame, elo_margin, epa_margin,
         expected_home_margin, home_win_prob,
         market_provider, market_home_margin, market_spread, market_captured_at,
-        edge, edge_pick
+        edge, edge_pick, evaluation_mode, simulated_as_of_at, experiment_label,
+        fit_id, input_hash, input_snapshot
     ) VALUES %s
-    ON CONFLICT (game_id, model_version, prediction_date) DO UPDATE SET
-        {update_set}
-""".format(update_set=",\n        ".join(f"{c} = EXCLUDED.{c}" for c in _UPDATE_SET_COLUMNS))
+"""
 
 _ROW_PLACEHOLDERS = ", ".join(["%s"] * len(_ROW_COLUMNS))
 # Upcoming mode: prediction_date is a fixed SQL-side expression (same value
 # for every row in the batch -- one INSERT statement, one transaction-local
 # `now()`), never a Python-computed date.
-_UPCOMING_TEMPLATE = f"(now(), (now() AT TIME ZONE 'utc')::date, {_ROW_PLACEHOLDERS})"
+_UPCOMING_TEMPLATE = (
+    f"(statement_timestamp(), "
+    f"(statement_timestamp() AT TIME ZONE 'utc')::date, {_ROW_PLACEHOLDERS})"
+)
 # Backfill mode: prediction_date varies per game (each game's start_date),
 # so it is a bound parameter, prepended ahead of the shared row values.
-_BACKFILL_TEMPLATE = f"(now(), %s, {_ROW_PLACEHOLDERS})"
+_BACKFILL_TEMPLATE = f"(statement_timestamp(), %s, {_ROW_PLACEHOLDERS})"
 
 
-def _row_values(row: dict) -> tuple:
-    return tuple(row[c] for c in _ROW_COLUMNS)
+def _row_values(row: dict, json_adapter) -> tuple:
+    return tuple(json_adapter(row[c]) if c == "input_snapshot" else row[c] for c in _ROW_COLUMNS)
 
 
 def table_exists(conn, schema: str, table: str) -> bool:
@@ -526,6 +597,9 @@ def fetch_epa_week_coefs(conn, season: int) -> dict[str, list[tuple[int, dict]]]
                 (
                     int(week_index),
                     {
+                        "team": team,
+                        "season": season,
+                        "week_index": int(week_index),
                         "off_coef": float(off_coef),
                         "def_coef": float(def_coef),
                         "hfa_coef": float(hfa_coef),
@@ -550,6 +624,8 @@ def fetch_epa_coefs(conn, season: int | None = None) -> dict[tuple[str, int], di
             if off_coef is None or def_coef is None or hfa_coef is None:
                 continue
             result[(team, row_season)] = {
+                "team": team,
+                "season": int(row_season),
                 "off_coef": float(off_coef),
                 "def_coef": float(def_coef),
                 "hfa_coef": float(hfa_coef),
@@ -588,24 +664,26 @@ def fetch_market_from_lines(conn, game_ids: list[int]) -> dict[int, dict]:
 
 
 def write_upcoming(conn, rows: list[dict]) -> None:
-    from psycopg2.extras import execute_values
+    from psycopg2.extras import Json, execute_values
 
     if not rows:
         return
-    values = [_row_values(r) for r in rows]
+    insert_model_artifacts(conn, rows)
+    values = [_row_values(r, Json) for r in rows]
     with conn.cursor() as cur:
-        execute_values(cur, _UPSERT_SQL, values, template=_UPCOMING_TEMPLATE)
+        execute_values(cur, _INSERT_SQL, values, template=_UPCOMING_TEMPLATE)
     conn.commit()
 
 
 def write_backfill_season(conn, rows: list[dict]) -> None:
-    from psycopg2.extras import execute_values
+    from psycopg2.extras import Json, execute_values
 
     if not rows:
         return
-    values = [(r["prediction_date"], *_row_values(r)) for r in rows]
+    insert_model_artifacts(conn, rows)
+    values = [(r["prediction_date"], *_row_values(r, Json)) for r in rows]
     with conn.cursor() as cur:
-        execute_values(cur, _UPSERT_SQL, values, template=_BACKFILL_TEMPLATE)
+        execute_values(cur, _INSERT_SQL, values, template=_BACKFILL_TEMPLATE)
     conn.commit()
 
 
@@ -618,6 +696,7 @@ def run_upcoming(conn) -> None:
 
     elo_current = fetch_elo_current(conn)
     epa_by_team_season = fetch_epa_coefs(conn)
+    artifacts = closed_form_model_artifacts()
 
     game_ids = [g["game_id"] for g in games]
     if table_exists(conn, "betting", "line_snapshots"):
@@ -632,14 +711,44 @@ def run_upcoming(conn) -> None:
     for game in games:
         home_elo = resolve_elo(game["home_team"], game["season"], elo_current)
         away_elo = resolve_elo(game["away_team"], game["season"], elo_current)
+        home_epa = lookup_epa_coefs(
+            epa_by_team_season, game["home_team"], game["season"], lookback=1
+        )
+        away_epa = lookup_epa_coefs(
+            epa_by_team_season, game["away_team"], game["season"], lookback=1
+        )
         market = market_by_game.get(game["game_id"])
         if market and market.get("spread") is not None:
             n_with_market += 1
-        rows.extend(
-            build_predictions_for_game(
-                game, home_elo, away_elo, epa_by_team_season, epa_lookback=1, market=market
-            )
+        game_rows = build_predictions_for_game(
+            game,
+            home_elo,
+            away_elo,
+            epa_by_team_season,
+            epa_lookback=1,
+            market=market,
+            epa_rows=(home_epa, away_epa),
         )
+        for row in game_rows:
+            fit_id, artifact = artifacts[row["model_version"]]
+            rows.append(
+                attach_prediction_provenance(
+                    row,
+                    evaluation_mode=PUBLISHED_FORECAST,
+                    fit_id=fit_id,
+                    model_artifact=artifact,
+                    input_snapshot=closed_form_input_snapshot(
+                        game,
+                        model_version=row["model_version"],
+                        home_elo=home_elo,
+                        away_elo=away_elo,
+                        market=market,
+                        home_epa=home_epa,
+                        away_epa=away_epa,
+                        epa_source="current_or_prior_season",
+                    ),
+                )
+            )
 
     write_upcoming(conn, rows)
     logger.info(
@@ -648,7 +757,35 @@ def run_upcoming(conn) -> None:
     )
 
 
-def run_backfill(conn, start: int, end: int, as_of_week: bool = False) -> None:
+def _historical_prediction_date(game: dict):
+    start_date = game.get("start_date")
+    if start_date is None:
+        raise ValueError(
+            f"game_id={game['game_id']} has no kickoff; cannot create historical provenance"
+        )
+    return start_date.date()
+
+
+def run_backfill(
+    conn,
+    start: int,
+    end: int,
+    as_of_week: bool = True,
+    hindsight_experiment: str | None = None,
+) -> None:
+    if hindsight_experiment is not None:
+        hindsight_experiment = hindsight_experiment.strip()
+        if not hindsight_experiment:
+            raise ValueError("--hindsight-experiment requires a nonempty label")
+        if as_of_week:
+            raise ValueError("hindsight backfills cannot use as-of-week EPA")
+        evaluation_mode = HINDSIGHT_EXPERIMENT
+    else:
+        if not as_of_week:
+            raise ValueError("full-season EPA requires --hindsight-experiment LABEL")
+        evaluation_mode = WALK_FORWARD_RECONSTRUCTION
+
+    artifacts = closed_form_model_artifacts()
     total_games = total_rows = total_with_market = 0
     for season in range(start, end + 1):
         games = fetch_backfill_games(conn, season)
@@ -688,7 +825,7 @@ def run_backfill(conn, start: int, end: int, as_of_week: bool = False) -> None:
                 n_with_market += 1
 
             start_date = game["start_date"]
-            prediction_date = start_date.date() if start_date is not None else date(season, 1, 1)
+            prediction_date = _historical_prediction_date(game)
 
             epa_rows = None
             if as_of_week:
@@ -708,6 +845,16 @@ def run_backfill(conn, start: int, end: int, as_of_week: bool = False) -> None:
                 else:
                     src_counts["week"] += 1
                 epa_rows = (home_row, away_row)
+                epa_source = {"home": home_src, "away": away_src}
+            else:
+                home_row = lookup_epa_coefs(
+                    epa_by_team_season, game["home_team"], season, lookback=0
+                )
+                away_row = lookup_epa_coefs(
+                    epa_by_team_season, game["away_team"], season, lookback=0
+                )
+                epa_rows = (home_row, away_row)
+                epa_source = "same_season_full_fit"
 
             game_rows = build_predictions_for_game(
                 game,
@@ -719,8 +866,26 @@ def run_backfill(conn, start: int, end: int, as_of_week: bool = False) -> None:
                 epa_rows=epa_rows,
             )
             for row in game_rows:
-                row["prediction_date"] = prediction_date
-            rows.extend(game_rows)
+                fit_id, artifact = artifacts[row["model_version"]]
+                provenance_row = attach_prediction_provenance(
+                    {**row, "prediction_date": prediction_date},
+                    evaluation_mode=evaluation_mode,
+                    fit_id=fit_id,
+                    model_artifact=artifact,
+                    input_snapshot=closed_form_input_snapshot(
+                        game,
+                        model_version=row["model_version"],
+                        home_elo=home_elo,
+                        away_elo=away_elo,
+                        market=market,
+                        home_epa=home_row,
+                        away_epa=away_row,
+                        epa_source=epa_source,
+                    ),
+                    simulated_as_of_at=start_date,
+                    experiment_label=hindsight_experiment,
+                )
+                rows.append(provenance_row)
 
         write_backfill_season(conn, rows)
         if as_of_week:
@@ -753,21 +918,32 @@ def main() -> None:
         type=int,
         metavar=("START", "END"),
         help="Backfill completed games for seasons START..END (inclusive) using "
-        "walk-forward pregame Elo + same-season EPA; prediction_date = each "
-        "game's start_date (fallback: Jan 1 of its season). Default (no flag): "
+        "walk-forward pregame Elo + as-of-week EPA; prediction_date and "
+        "simulated_as_of_at come from each known kickoff. Default (no flag): "
         "score upcoming/pending games using current ratings.",
     )
     parser.add_argument(
         "--as-of-week",
         action="store_true",
-        help="With --backfill: leak-free blend via as-of-week EPA coefficients "
+        help="Compatibility alias for the default backfill behavior: leak-free "
+        "blend via as-of-week EPA coefficients "
         "(analytics.adjusted_epa_week_build entering each game's week, prior-"
         "season full fit fallback, else Elo-only). elo_v1 rows are unchanged.",
+    )
+    parser.add_argument(
+        "--hindsight-experiment",
+        metavar="LABEL",
+        help="With --backfill: use same-season full-season EPA and label the "
+        "append-only rows as an explicit hindsight experiment.",
     )
     args = parser.parse_args()
 
     if args.as_of_week and not args.backfill:
         parser.error("--as-of-week requires --backfill")
+    if args.hindsight_experiment and not args.backfill:
+        parser.error("--hindsight-experiment requires --backfill")
+    if args.as_of_week and args.hindsight_experiment:
+        parser.error("--as-of-week and --hindsight-experiment are mutually exclusive")
 
     import psycopg2
 
@@ -778,7 +954,13 @@ def main() -> None:
             if start > end:
                 logger.error(f"--backfill start {start} is after end {end}")
                 sys.exit(1)
-            run_backfill(conn, start, end, as_of_week=args.as_of_week)
+            run_backfill(
+                conn,
+                start,
+                end,
+                as_of_week=not bool(args.hindsight_experiment),
+                hindsight_experiment=args.hindsight_experiment,
+            )
         else:
             run_upcoming(conn)
     except Exception:

--- a/scripts/prediction_provenance.py
+++ b/scripts/prediction_provenance.py
@@ -1,0 +1,184 @@
+"""Canonical provenance helpers shared by prediction writers.
+
+F04 stores two separate immutable records: a content-addressed model artifact
+describing the implementation and parameters actually consumed, and a
+per-prediction input snapshot.  This module keeps their serialization and
+hashing contract identical across the closed-form and fitted writers.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import math
+from collections.abc import Callable, Mapping, Sequence
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any
+
+ARTIFACT_SCHEMA_VERSION = 1
+INPUT_SCHEMA_VERSION = 1
+
+PUBLISHED_FORECAST = "published_forecast"
+WALK_FORWARD_RECONSTRUCTION = "walk_forward_reconstruction"
+HINDSIGHT_EXPERIMENT = "hindsight_experiment"
+
+NEW_EVALUATION_MODES = frozenset(
+    {PUBLISHED_FORECAST, WALK_FORWARD_RECONSTRUCTION, HINDSIGHT_EXPERIMENT}
+)
+
+
+def json_value(value: Any) -> Any:
+    """Return a deterministic JSON-compatible representation of ``value``.
+
+    Database timestamps are retained as ISO-8601 strings, mappings are copied
+    with string keys, and numpy-like scalar/array values are converted through
+    their public ``item``/``tolist`` protocols.  Non-finite numbers are rejected
+    because PostgreSQL JSONB cannot preserve them as ordinary JSON numbers.
+    """
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    if isinstance(value, Decimal):
+        # Preserve the exact database numeric representation. Scoring code may
+        # separately coerce it to float, but the source snapshot must not lose
+        # digits before it is hashed and retained.
+        return str(value)
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("prediction provenance cannot contain non-finite numbers")
+        return value
+    if isinstance(value, Mapping):
+        return {str(key): json_value(item) for key, item in value.items()}
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [json_value(item) for item in value]
+    if hasattr(value, "tolist"):
+        return json_value(value.tolist())
+    if hasattr(value, "item"):
+        return json_value(value.item())
+    raise TypeError(f"unsupported prediction provenance value: {type(value).__name__}")
+
+
+def canonical_json(value: Any) -> str:
+    """Serialize ``value`` with the stable F04 canonical JSON encoding."""
+    return json.dumps(
+        json_value(value),
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def canonical_hash(value: Any) -> str:
+    """Return the lowercase SHA-256 hex digest of canonical JSON ``value``."""
+    return hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def implementation_fingerprint(*objects: Callable[..., Any] | Any) -> dict[str, Any]:
+    """Fingerprint complete modules or individual callables consumed by a model."""
+    sources = []
+    for obj in objects:
+        if inspect.ismodule(obj):
+            module = obj.__name__
+            qualname = "<module>"
+        else:
+            module = obj.__module__
+            qualname = obj.__qualname__
+        sources.append(
+            {
+                "module": module,
+                "qualname": qualname,
+                "source": inspect.getsource(obj),
+            }
+        )
+    return {"algorithm": "sha256", "digest": canonical_hash(sources)}
+
+
+def identify_model_artifact(model_version: str, artifact: Mapping[str, Any]) -> tuple[str, dict]:
+    """Normalize an artifact and return its content-addressed ``fit_id``."""
+    normalized = json_value(artifact)
+    address = {"model_version": model_version, "artifact": normalized}
+    return canonical_hash(address), normalized
+
+
+def attach_prediction_provenance(
+    row: Mapping[str, Any],
+    *,
+    evaluation_mode: str,
+    fit_id: str,
+    model_artifact: Mapping[str, Any],
+    input_snapshot: Mapping[str, Any],
+    simulated_as_of_at: datetime | None = None,
+    experiment_label: str | None = None,
+) -> dict[str, Any]:
+    """Return ``row`` with validated F04 provenance fields attached.
+
+    ``_model_artifact`` is an internal writer value.  It is inserted into
+    ``predictions.model_artifacts`` in the same transaction and is deliberately
+    excluded from ``predictions.game_predictions``.
+    """
+    if evaluation_mode not in NEW_EVALUATION_MODES:
+        raise ValueError(f"unsupported new prediction evaluation mode {evaluation_mode!r}")
+    if not fit_id:
+        raise ValueError("new predictions require fit_id")
+    if evaluation_mode == PUBLISHED_FORECAST:
+        if simulated_as_of_at is not None:
+            raise ValueError("published forecasts cannot have simulated_as_of_at")
+        if experiment_label is not None:
+            raise ValueError("published forecasts cannot have experiment_label")
+    else:
+        if simulated_as_of_at is None:
+            raise ValueError("historical predictions require a known simulated_as_of_at")
+        if evaluation_mode == HINDSIGHT_EXPERIMENT:
+            experiment_label = (experiment_label or "").strip()
+            if not experiment_label:
+                raise ValueError("hindsight experiments require a nonempty label")
+        elif experiment_label is not None:
+            raise ValueError("walk-forward reconstructions cannot have experiment_label")
+
+    normalized_snapshot = json_value(input_snapshot)
+    return {
+        **row,
+        "evaluation_mode": evaluation_mode,
+        "simulated_as_of_at": simulated_as_of_at,
+        "experiment_label": experiment_label,
+        "fit_id": fit_id,
+        "input_hash": canonical_hash(normalized_snapshot),
+        "input_snapshot": normalized_snapshot,
+        "_model_artifact": json_value(model_artifact),
+    }
+
+
+def insert_model_artifacts(conn, rows: Sequence[Mapping[str, Any]]) -> None:
+    """Insert each distinct content-addressed artifact without mutating one."""
+    from psycopg2.extras import Json, execute_values
+
+    artifacts: dict[str, tuple[str, dict]] = {}
+    for row in rows:
+        fit_id = row["fit_id"]
+        model_version = row["model_version"]
+        artifact = row["_model_artifact"]
+        candidate = (model_version, artifact)
+        prior = artifacts.setdefault(fit_id, candidate)
+        if prior != candidate:
+            raise ValueError(f"fit_id {fit_id} maps to conflicting artifacts in one write")
+    if not artifacts:
+        return
+
+    values = [
+        (fit_id, model_version, Json(artifact))
+        for fit_id, (model_version, artifact) in artifacts.items()
+    ]
+    with conn.cursor() as cur:
+        execute_values(
+            cur,
+            """
+            INSERT INTO predictions.model_artifacts (fit_id, model_version, artifact)
+            VALUES %s
+            ON CONFLICT (fit_id) DO NOTHING
+            """,
+            values,
+        )

--- a/scripts/score_fitted.py
+++ b/scripts/score_fitted.py
@@ -7,11 +7,12 @@ The feature vectorization + transforms (``build_feature_vector``, ``standardize`
 ``sigmoid``, ``platt_transform`` and the ``FEATURE_NAMES`` /
 ``TEAM_WEEK_SOURCE_COLUMNS`` contract) are imported from ``train_model`` so train
 and score share one implementation; the market lookup, edge math and the exact
-``predictions.game_predictions`` upsert (``compute_edge``, ``write_backfill_season``,
+``predictions.game_predictions`` append (``compute_edge``, ``write_backfill_season``,
 ``write_upcoming``, the market fetchers, ``get_db_url``) are imported from
 ``compute_predictions`` so ``fitted_v1`` rows are written byte-identically to the
-existing models -- same ``(game_id, model_version, prediction_date)`` conflict key,
-same ``edge = expected_home_margin + market_spread`` convention. ``fitted_v1``'s
+existing models -- same ``edge = expected_home_margin + market_spread`` convention.
+Every row carries the immutable frozen fit artifact and its exact feature/market
+input snapshot. ``fitted_v1``'s
 ``elo_margin`` / ``epa_margin`` columns are always NULL (it is neither an Elo nor a
 blend model); ``home_elo_pregame`` / ``away_elo_pregame`` are populated from each
 side's ``team_week.elo_pregame`` (the pregame Elo the ``d_elo`` feature used).
@@ -27,8 +28,8 @@ threshold before any upcoming predictions are written.
 Usage:
     python scripts/score_fitted.py --backfill 2018 2025
         Score every completed game in each season S with the FROZEN S-1 fit;
-        prediction_date = the game's start_date::date (fallback Jan 1 of its
-        season), idempotent under the daily conflict key. Market: betting.lines
+        prediction_date = the game's start_date::date, which must be known;
+        every run appends a walk_forward_reconstruction. Market: betting.lines
         (closing-line proxy), same as compute_predictions --backfill.
 
     python scripts/score_fitted.py            # or --upcoming
@@ -45,10 +46,11 @@ import argparse
 import logging
 import sys
 from collections import Counter
-from datetime import date
 
 import numpy as np
 
+from scripts import compute_predictions as predictions_module
+from scripts import train_model as training_module
 from scripts.compute_predictions import (
     compute_edge,
     fetch_market_from_lines,
@@ -58,7 +60,17 @@ from scripts.compute_predictions import (
     write_backfill_season,
     write_upcoming,
 )
+from scripts.prediction_provenance import (
+    ARTIFACT_SCHEMA_VERSION,
+    INPUT_SCHEMA_VERSION,
+    PUBLISHED_FORECAST,
+    WALK_FORWARD_RECONSTRUCTION,
+    attach_prediction_provenance,
+    identify_model_artifact,
+    implementation_fingerprint,
+)
 from scripts.train_model import (
+    FEATURE_NAMES,
     MODEL_VERSION,
     TEAM_WEEK_SOURCE_COLUMNS,
     build_feature_vector,
@@ -196,6 +208,64 @@ def build_score_row(
         "market_captured_at": market_captured_at,
         "edge": edge,
         "edge_pick": edge_pick,
+    }
+
+
+def fitted_model_artifact(fit: dict) -> tuple[str, dict]:
+    """Capture the exact frozen fitted_v1 state consumed while scoring."""
+    coefficients = [
+        {
+            "feature_order": index,
+            "feature_name": feature,
+            "margin": float(fit["beta_margin"][index]),
+            "winprob": float(fit["beta_winprob"][index]),
+        }
+        for index, feature in enumerate(FEATURE_NAMES)
+    ]
+    artifact = {
+        "schema_version": ARTIFACT_SCHEMA_VERSION,
+        "artifact_kind": "frozen_fitted_model",
+        "train_through_season": int(fit["train_through"]),
+        "feature_names": list(FEATURE_NAMES),
+        "feature_means": fit["feature_means"],
+        "feature_diff_means": fit["diff_means"],
+        "feature_diff_stds": fit["diff_stds"],
+        "coefficients": coefficients,
+        "calibration": {"platt_a": fit["platt_a"], "platt_b": fit["platt_b"]},
+        "implementation": {
+            "source": implementation_fingerprint(
+                predictions_module, training_module, sys.modules[__name__]
+            ),
+            "runtime_constants": {
+                "max_logit": training_module._MAX_LOGIT,
+                "diff_feature_columns": list(training_module.DIFF_FEATURE_COLUMNS),
+                "feature_names": list(FEATURE_NAMES),
+                "team_week_source_columns": list(TEAM_WEEK_SOURCE_COLUMNS),
+            },
+        },
+    }
+    return identify_model_artifact(MODEL_VERSION, artifact)
+
+
+def fitted_input_snapshot(game: dict, market: dict | None) -> dict:
+    """Capture the exact raw game and team-week feature inputs consumed."""
+    return {
+        "schema_version": INPUT_SCHEMA_VERSION,
+        "game": {
+            "game_id": game["game_id"],
+            "season": game["season"],
+            "season_type": game["season_type"],
+            "week": game["week"],
+            "start_date": game.get("start_date"),
+            "home_team": game["home_team"],
+            "away_team": game["away_team"],
+            "neutral_site": game["neutral_site"],
+        },
+        "team_week": {
+            "home": {column: game["home_tw"].get(column) for column in TEAM_WEEK_SOURCE_COLUMNS},
+            "away": {column: game["away_tw"].get(column) for column in TEAM_WEEK_SOURCE_COLUMNS},
+        },
+        "market": market,
     }
 
 
@@ -351,8 +421,6 @@ def load_fit(conn, train_through: int) -> dict:
         for component, _order, feature_name, coefficient in cur.fetchall():
             coef_by_component.setdefault(component, {})[feature_name] = float(coefficient)
 
-    from scripts.train_model import FEATURE_NAMES
-
     def _beta(component: str) -> np.ndarray:
         coefs = coef_by_component.get(component)
         if not coefs:
@@ -377,11 +445,13 @@ def load_fit(conn, train_through: int) -> dict:
 
 
 def _prediction_date(game: dict):
-    """Backfill prediction_date: the game's start_date::date, falling back to
-    Jan 1 of its season when start_date is NULL -- matches
-    compute_predictions.run_backfill so re-runs are idempotent."""
-    start_date = game["start_date"]
-    return start_date.date() if start_date is not None else date(game["season"], 1, 1)
+    """Backfill date from a known kickoff; historical time is never fabricated."""
+    start_date = game.get("start_date")
+    if start_date is None:
+        raise ValueError(
+            f"game_id={game['game_id']} has no kickoff; cannot create historical provenance"
+        )
+    return start_date.date()
 
 
 def run_backfill(conn, start: int, end: int) -> None:
@@ -393,6 +463,7 @@ def run_backfill(conn, start: int, end: int) -> None:
     for season in range(start, end + 1):
         train_through = select_train_through("backfill", score_season=season)
         fit = load_fit(conn, train_through)  # hard error if the frozen fit is missing
+        fit_id, artifact = fitted_model_artifact(fit)
 
         games = fetch_backfill_games(conn, season)
         if not games:
@@ -412,8 +483,16 @@ def run_backfill(conn, start: int, end: int) -> None:
             if market and market.get("spread") is not None:
                 n_with_market += 1
             row = build_score_row(game, expected_margin, win_prob, market)
-            row["prediction_date"] = _prediction_date(game)
-            rows.append(row)
+            rows.append(
+                attach_prediction_provenance(
+                    {**row, "prediction_date": _prediction_date(game)},
+                    evaluation_mode=WALK_FORWARD_RECONSTRUCTION,
+                    fit_id=fit_id,
+                    model_artifact=artifact,
+                    input_snapshot=fitted_input_snapshot(game, market),
+                    simulated_as_of_at=game["start_date"],
+                )
+            )
 
         write_backfill_season(conn, rows)
         total_rows += len(rows)
@@ -488,6 +567,7 @@ def run_upcoming(conn) -> None:
         train_through: load_fit(conn, train_through)
         for train_through in sorted(set(train_through_by_season.values()))
     }
+    artifacts = {train_through: fitted_model_artifact(fit) for train_through, fit in fits.items()}
     logger.info("Upcoming frozen fits by prediction season: %s", train_through_by_season)
 
     game_ids = [g["game_id"] for g in games]
@@ -501,12 +581,22 @@ def run_upcoming(conn) -> None:
     rows: list[dict] = []
     n_with_market = 0
     for game in games:
-        fit = fits[train_through_by_season[game["season"]]]
+        train_through = train_through_by_season[game["season"]]
+        fit = fits[train_through]
         expected_margin, win_prob = score_game(game, fit)
         market = market_by_game.get(game["game_id"])
         if market and market.get("spread") is not None:
             n_with_market += 1
-        rows.append(build_score_row(game, expected_margin, win_prob, market))
+        fit_id, artifact = artifacts[train_through]
+        rows.append(
+            attach_prediction_provenance(
+                build_score_row(game, expected_margin, win_prob, market),
+                evaluation_mode=PUBLISHED_FORECAST,
+                fit_id=fit_id,
+                model_artifact=artifact,
+                input_snapshot=fitted_input_snapshot(game, market),
+            )
+        )
 
     write_upcoming(conn, rows)
     logger.info(

--- a/scripts/simulate_season.py
+++ b/scripts/simulate_season.py
@@ -717,10 +717,13 @@ def get_db_url() -> str:
     return url
 
 
-# Latest snapshot per game for the chosen model. predictions.game_predictions
-# is append-only across days, so DISTINCT ON picks the most recent read rather
-# than an arbitrary historical one -- the same idiom
-# compute_predictions.MARKET_SNAPSHOTS_QUERY uses.
+# Latest published snapshot per game for the chosen model. Descriptive
+# prediction_date/computed_at values do not establish publication order or
+# prospective eligibility. A known kickoff therefore bounds the snapshot
+# strictly before kickoff; pending games without a kickoff can still use their
+# latest published forecast. Completed games with no known kickoff deliberately
+# carry no prediction -- their result does not need one, and a missing score
+# must not turn a late historical prediction into a simulated forecast.
 SEASON_GAMES_QUERY = """
     SELECT g.id AS game_id, g.season, g.home_team, g.away_team,
            COALESCE(g.completed, false) AS completed,
@@ -737,8 +740,15 @@ SEASON_GAMES_QUERY = """
     LEFT JOIN LATERAL (
         SELECT gp.expected_home_margin
         FROM predictions.game_predictions gp
-        WHERE gp.game_id = g.id AND gp.model_version = %(model)s
-        ORDER BY gp.prediction_date DESC, gp.computed_at DESC
+        WHERE gp.game_id = g.id
+          AND gp.model_version = %(model)s
+          AND gp.evaluation_mode = 'published_forecast'
+          AND gp.published_at IS NOT NULL
+          AND (
+              (g.start_date IS NOT NULL AND gp.published_at < g.start_date)
+              OR (g.start_date IS NULL AND NOT COALESCE(g.completed, false))
+          )
+        ORDER BY gp.published_at DESC, gp.prediction_id DESC
         LIMIT 1
     ) p ON true
     WHERE g.season = %(season)s
@@ -764,13 +774,13 @@ REF_CLASSIFICATION_QUERY = """
 """
 
 # ONE snapshot per game before the aggregate. predictions.game_predictions is
-# append-only daily, so a naive join contributes a game once per day it was
+# append-only per run, so a naive join contributes a game once per run it was
 # predicted: games that sat on the board for weeks would dominate the estimate,
 # and their early, worse predictions would mix with the final pregame one. That
 # is not a per-game residual SD, and since sigma drives every simulated
 # probability, the error would propagate into every number this script writes.
-# DISTINCT ON takes the last snapshot at or before kickoff -- the pregame read
-# the simulation is actually modelling.
+# DISTINCT ON takes the last eligible published snapshot strictly before a
+# known kickoff -- the prospective read the simulation is actually modelling.
 RESIDUAL_SIGMA_QUERY = f"""
     WITH latest AS (
         SELECT DISTINCT ON (p.game_id)
@@ -784,13 +794,20 @@ RESIDUAL_SIGMA_QUERY = f"""
           AND COALESCE(g.completed, false)
           AND g.home_points IS NOT NULL AND g.away_points IS NOT NULL
           AND p.expected_home_margin IS NOT NULL
-          AND (g.start_date IS NULL OR p.prediction_date <= g.start_date::date)
-        ORDER BY p.game_id, p.prediction_date DESC, p.computed_at DESC
+          AND p.evaluation_mode = 'published_forecast'
+          AND p.published_at IS NOT NULL
+          AND g.start_date IS NOT NULL
+          AND p.published_at < g.start_date
+        ORDER BY p.game_id, p.published_at DESC, p.prediction_id DESC
     )
     SELECT stddev_pop(actual_margin::double precision - expected_home_margin),
            COUNT(*)
     FROM latest
 """
+
+
+class CalibrationColdStartError(RuntimeError):
+    """Too few prospective published outcomes; no projection may be written."""
 
 
 def fetch_sigma(conn, model: str) -> float:
@@ -804,13 +821,15 @@ def fetch_sigma(conn, model: str) -> float:
     with conn.cursor() as cur:
         cur.execute(RESIDUAL_SIGMA_QUERY, {"model": model})
         sigma, n_games = cur.fetchone()
-    if sigma is None or n_games < MIN_SIGMA_GAMES:
-        raise RuntimeError(
-            f"Only {n_games or 0} completed game(s) with a pregame {model} prediction "
+    if n_games is None or n_games < MIN_SIGMA_GAMES:
+        raise CalibrationColdStartError(
+            f"Only {n_games or 0} completed game(s) with an eligible pre-kickoff "
+            f"published {model} forecast "
             f"(need >= {MIN_SIGMA_GAMES}); cannot measure a trustworthy residual sigma. "
-            "Backfill predictions before simulating."
+            "Simulation remains unavailable until enough prospective published forecasts "
+            "have completed outcomes."
         )
-    if sigma <= 0.0:
+    if sigma is None or not math.isfinite(sigma) or sigma <= 0.0:
         # Degenerate rather than merely small: every draw would collapse onto
         # its mean, so every game would resolve deterministically and every
         # win probability would be exactly 0 or 1. That is a broken input
@@ -818,7 +837,7 @@ def fetch_sigma(conn, model: str) -> float:
         # model, and it must not pass silently.
         raise RuntimeError(
             f"Residual sigma for {model} measured as {sigma} over {n_games} game(s); "
-            "a non-positive sigma would make every simulated game deterministic."
+            "sigma must be finite and positive for simulation."
         )
     logger.info("Measured residual sigma for %s: %.2f over %d game(s)", model, sigma, n_games)
     return float(sigma)
@@ -1087,6 +1106,12 @@ def main() -> None:
         help=f"Share of margin variance carried by the per-team season-strength "
         f"offset (default {DEFAULT_STRENGTH_SHARE}; 0 reproduces v1)",
     )
+    parser.add_argument(
+        "--allow-calibration-cold-start",
+        action="store_true",
+        help="Warn and preserve stored outlooks when published calibration is too small; "
+        "continue unrelated nightly work. Other failures remain fatal.",
+    )
     args = parser.parse_args()
 
     try:
@@ -1108,9 +1133,20 @@ def main() -> None:
 
         total = 0
         for season in seasons:
-            total += simulate_one_season(
-                conn, season, args.model, args.sims, args.seed, args.strength_share
-            )
+            try:
+                total += simulate_one_season(
+                    conn, season, args.model, args.sims, args.seed, args.strength_share
+                )
+            except CalibrationColdStartError as exc:
+                if not args.allow_calibration_cold_start:
+                    raise
+                conn.rollback()
+                logger.warning(
+                    "Season %s calibration cold start: no projections written; "
+                    "stored outlook retained. %s",
+                    season,
+                    exc,
+                )
         logger.info("Wrote %d projection row(s) across %d season(s)", total, len(seasons))
     except Exception:
         conn.rollback()

--- a/scripts/verify_load.py
+++ b/scripts/verify_load.py
@@ -311,14 +311,18 @@ def check_fitted_coverage(cur, report: Report) -> None:
     cur.execute(
         f"""
         WITH pending AS (
-            SELECT g.id, g.season
+            SELECT g.id, g.season, g.start_date
             FROM core.games g
             WHERE {PENDING_GAMES_WHERE}
         )
         SELECT p.season, COUNT(*),
                SUM(CASE WHEN EXISTS (
                    SELECT 1 FROM predictions.game_predictions gp
-                   WHERE gp.game_id = p.id AND gp.model_version = 'fitted_v1'
+                   WHERE gp.game_id = p.id
+                     AND gp.model_version = 'fitted_v1'
+                     AND gp.evaluation_mode = 'published_forecast'
+                     AND gp.published_at IS NOT NULL
+                     AND (p.start_date IS NULL OR gp.published_at < p.start_date)
                ) THEN 1 ELSE 0 END)
         FROM pending p
         GROUP BY p.season

--- a/src/schemas/api/030_scored_matchup_edges.sql
+++ b/src/schemas/api/030_scored_matchup_edges.sql
@@ -42,3 +42,12 @@ FROM marts.scored_matchup_edges;
 GRANT SELECT ON api.scored_matchup_edges TO anon, authenticated;
 
 COMMENT ON VIEW api.scored_matchup_edges IS 'House model expected margin/win-prob vs the market line for upcoming games. Columns: game_id, season, week, season_type, start_date, home_team, away_team, neutral_site, model_version, prediction_date, home_elo_pregame, away_elo_pregame, elo_margin, epa_margin, expected_home_margin, home_win_prob, market_provider, market_spread, market_home_margin, market_captured_at, edge, edge_pick, abs_edge. edge = expected_home_margin + spread (positive = home undervalued by the market). Backed by marts.scored_matchup_edges; normally empty out of season.';
+
+-- Preserve the API-only analyst role even when deployed by a different owner.
+DO $grants$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'analyst_ro') THEN
+        GRANT SELECT ON api.scored_matchup_edges TO analyst_ro;
+    END IF;
+END
+$grants$;

--- a/src/schemas/api/031_prediction_accuracy.sql
+++ b/src/schemas/api/031_prediction_accuracy.sql
@@ -30,3 +30,12 @@ FROM marts.prediction_accuracy;
 GRANT SELECT ON api.prediction_accuracy TO anon, authenticated;
 
 COMMENT ON VIEW api.prediction_accuracy IS 'Retroactive scoring of house predictions by season/model/edge-threshold. Columns: model_version, season, edge_threshold, n_games, n_with_market, margin_mae, margin_rmse, ats_wins, ats_losses, ats_pushes, ats_hit_rate, brier, cfbd_brier, n_scored_win_prob. brier/cfbd_brier let the house win-prob model be benchmarked directly against CFBD''s pregame win probability. Backed by marts.prediction_accuracy.';
+
+-- Preserve the API-only analyst role even when deployed by a different owner.
+DO $grants$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'analyst_ro') THEN
+        GRANT SELECT ON api.prediction_accuracy TO analyst_ro;
+    END IF;
+END
+$grants$;

--- a/src/schemas/api/032_game_predictions.sql
+++ b/src/schemas/api/032_game_predictions.sql
@@ -1,20 +1,5 @@
--- api.game_predictions
--- Latest snapshot per (game, model) from the append-only prediction log:
--- house Elo + ridge-adjusted-EPA expected margin/win-prob vs the market
--- line, as of each game's most recent prediction_date.
--- Thin latest-snapshot view over predictions.game_predictions (Tier 2
--- analytics, docs/plans/2026-07-21-tier2-analytics-plan.md).
---
--- predictions.game_predictions is append-only across days (one immutable row
--- per game_id/model_version/UTC prediction_date -- see
--- migrations/024_predictions_schema.sql), so this view picks the most recent
--- prediction_date per (game_id, model_version) via DISTINCT ON. Query the
--- base table directly if the full day-by-day history is needed instead.
---
--- PostgREST usage:
---   GET /api/game_predictions?game_id=eq.401628455
---   GET /api/game_predictions?season=eq.2026&week=eq.5&model_version=eq.house_v1
-
+-- Latest published forecast per game/model. Historical modes remain discoverable
+-- through prediction_history. Neither prediction_date nor computed_at selects a row.
 CREATE OR REPLACE VIEW api.game_predictions AS
 SELECT DISTINCT ON (game_id, model_version)
     prediction_id,
@@ -39,10 +24,64 @@ SELECT DISTINCT ON (game_id, model_version)
     market_spread,
     market_captured_at,
     edge,
-    edge_pick
+    edge_pick,
+    evaluation_mode,
+    created_at,
+    published_at,
+    simulated_as_of_at,
+    experiment_label,
+    fit_id,
+    input_hash
 FROM predictions.game_predictions
-ORDER BY game_id, model_version, prediction_date DESC;
+WHERE evaluation_mode = 'published_forecast'
+ORDER BY game_id, model_version, published_at DESC, prediction_id DESC;
 
 GRANT SELECT ON api.game_predictions TO anon, authenticated;
 
-COMMENT ON VIEW api.game_predictions IS 'Latest house prediction snapshot per (game_id, model_version), from the append-only predictions.game_predictions log. Columns: prediction_id, computed_at, prediction_date, model_version, game_id, season, week, season_type, home_team, away_team, neutral_site, home_elo_pregame, away_elo_pregame, elo_margin, epa_margin, expected_home_margin, home_win_prob, market_provider, market_home_margin, market_spread, market_captured_at, edge, edge_pick. DISTINCT ON (game_id, model_version) ORDER BY prediction_date DESC selects the most recent snapshot; query predictions.game_predictions directly for full day-by-day history.';
+COMMENT ON VIEW api.game_predictions IS 'Latest published forecast by publication timestamp and immutable prediction_id. Published does not alone imply pre-kickoff; accuracy applies its strict kickoff cutoff.';
+
+CREATE OR REPLACE VIEW api.prediction_history AS
+SELECT
+    prediction_id,
+    computed_at,
+    prediction_date,
+    model_version,
+    game_id,
+    season,
+    week,
+    season_type,
+    home_team,
+    away_team,
+    neutral_site,
+    home_elo_pregame,
+    away_elo_pregame,
+    elo_margin,
+    epa_margin,
+    expected_home_margin,
+    home_win_prob,
+    market_provider,
+    market_home_margin,
+    market_spread,
+    market_captured_at,
+    edge,
+    edge_pick,
+    evaluation_mode,
+    created_at,
+    published_at,
+    simulated_as_of_at,
+    experiment_label,
+    fit_id,
+    input_hash
+FROM predictions.game_predictions;
+
+GRANT SELECT ON api.prediction_history TO anon, authenticated;
+COMMENT ON VIEW api.prediction_history IS 'All prediction modes and immutable IDs, including legacy_unknown. Simulated as-of timestamps are reconstruction intent, not original publication evidence.';
+
+-- Preserve the API-only analyst role even when deployed by a different owner.
+DO $grants$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'analyst_ro') THEN
+        GRANT SELECT ON api.game_predictions, api.prediction_history TO analyst_ro;
+    END IF;
+END
+$grants$;

--- a/src/schemas/marts/037_scored_matchup_edges.sql
+++ b/src/schemas/marts/037_scored_matchup_edges.sql
@@ -5,7 +5,7 @@
 -- The FORWARD-LOOKING surface: house expected margin vs the market line for
 -- UPCOMING (not-yet-completed) games only. One row per (game_id, model_version):
 -- the LATEST prediction snapshot for that game+model, chosen by
--- DISTINCT ON (game_id, model_version) ORDER BY prediction_date DESC. As new
+-- DISTINCT ON (game_id, model_version) ordered by published_at and prediction_id. As new
 -- daily snapshots land in predictions.game_predictions the mart re-materializes
 -- to the freshest read on each game.
 --
@@ -31,7 +31,7 @@
 -- this ordering.
 --
 -- NO EMPTY-GUARD (by design): this mart is legitimately EMPTY out of season and
--- until the Phase 5 predictions backfill / in-season daily runs populate
+-- until prospective in-season scoring runs populate
 -- predictions.game_predictions. An empty result is a valid state, not a failure,
 -- so it must not RAISE at deploy time (unlike the Tier 1 marts).
 --
@@ -77,7 +77,8 @@ SELECT DISTINCT ON (p.game_id, p.model_version)
 FROM predictions.game_predictions p
 JOIN core.games g ON g.id = p.game_id
 WHERE NOT COALESCE(g.completed, false)
-ORDER BY p.game_id, p.model_version, p.prediction_date DESC;
+  AND p.evaluation_mode = 'published_forecast'
+ORDER BY p.game_id, p.model_version, p.published_at DESC, p.prediction_id DESC;
 
 -- Required for REFRESH CONCURRENTLY; also the natural grain key. DISTINCT ON
 -- (game_id, model_version) guarantees one row per pair, so this is unique.

--- a/src/schemas/marts/038_prediction_accuracy.sql
+++ b/src/schemas/marts/038_prediction_accuracy.sql
@@ -2,7 +2,7 @@
 -- =============================================================================
 -- Tier 2 analytics (docs/plans/2026-07-21-tier2-analytics-plan.md), Phase 4/5.
 --
--- THE BACKTEST / AUDIT SURFACE. This file IS the prediction-scoring methodology
+-- THE PUBLISHED-FORECAST AUDIT SURFACE. This file IS the prediction-scoring methodology
 -- for the house model -- every rule below is authoritative and intentionally
 -- documented in full so the numbers are reproducible from the SQL alone.
 --
@@ -18,7 +18,7 @@
 -- SCORING BASE
 -- ---------------------------------------------------------------------------
 -- One row per (game_id, model_version): the LATEST prediction snapshot,
--- DISTINCT ON (game_id, model_version) ORDER BY prediction_date DESC, joined to
+-- DISTINCT ON (game_id, model_version) ordered by published_at and prediction_id, joined to
 -- core.games and restricted to COMPLETED games that actually have both scores
 -- (home_points/away_points NOT NULL). Derived per game:
 --   actual_home_margin  = home_points - away_points
@@ -83,25 +83,11 @@
 -- ---------------------------------------------------------------------------
 -- CAVEATS (read before trusting a row)
 -- ---------------------------------------------------------------------------
--- * LEAKAGE -- FIXED (2026-07-21, Tier 3): 'elo_epa_blend_v1' used to fold in
---   ridge-adjusted EPA fit on the FULL season, so retro rows for early-season
---   games were MILDLY LEAKY (the fit "saw" games that hadn't happened yet at
---   kickoff). This is now closed: scripts/compute_predictions.py --as-of-week
---   backfills each game using analytics.adjusted_epa_week_build coefficients
---   as of THAT game's week (prior-season fallback when the current season has
---   no fit yet at that point, Elo-only when neither is available), so both
---   model_versions are walk-forward honest. The previously documented 56.1%
---   ATS>=6 hit rate was that leakage, not real edge -- the honest numbers are
---   elo_epa_blend_v1 ATS>=6 = 50.1% (n=3,462) vs elo_v1 = 50.3%; nobody beats
---   the closing line. The blend still edges elo_v1 on margin MAE (16.31 vs
---   16.46).
--- * CLOSING-LINE PROXY: past-game market_spread comes from betting.lines, which
---   is approximately the CLOSING line. True line-movement history only begins
---   accruing 2026-07-21, so pre-2026 ATS/edge figures are scored against
---   closing, not against the number the model would have seen earlier in the week.
---
--- NO EMPTY-GUARD (by design): legitimately EMPTY until the Phase 5 predictions
--- backfill populates predictions.game_predictions with completed-game snapshots.
+-- Only observed publications strictly before known kickoff are scored. Historical
+-- reconstructions, hindsight experiments, and legacy_unknown rows are excluded.
+-- As-of reconstruction cannot prove inputs/closing lines were available then.
+-- Empty accuracy after migration is valid until published games complete; backfill
+-- never populates this prospective cohort.
 
 DROP MATERIALIZED VIEW IF EXISTS marts.prediction_accuracy CASCADE;
 
@@ -124,7 +110,10 @@ WITH latest_pred AS (
     WHERE g.completed
       AND g.home_points IS NOT NULL
       AND g.away_points IS NOT NULL
-    ORDER BY p.game_id, p.model_version, p.prediction_date DESC
+      AND p.evaluation_mode = 'published_forecast'
+      AND g.start_date IS NOT NULL
+      AND p.published_at < g.start_date
+    ORDER BY p.game_id, p.model_version, p.published_at DESC, p.prediction_id DESC
 ),
 scored AS (
     -- Attach actuals + CFBD's pregame win prob (1:1 join, post-DISTINCT ON).

--- a/src/schemas/migrations/063_prediction_provenance.sql
+++ b/src/schemas/migrations/063_prediction_provenance.sql
@@ -1,0 +1,127 @@
+-- F04 prediction ledger. Explicit-file migration (not MIGRATION_ORDER).
+-- Pause prediction writers for the coordinated schema/code cutover. Then apply
+-- marts/037, marts/038, api/030, api/031 and api/032 in that order.
+-- Existing computed_at/prediction_date values are NOT publication evidence.
+
+CREATE TABLE IF NOT EXISTS predictions.model_artifacts (
+    fit_id TEXT PRIMARY KEY CHECK (fit_id ~ '^[0-9a-f]{64}$'),
+    model_version TEXT NOT NULL,
+    artifact JSONB NOT NULL CHECK (jsonb_typeof(artifact) = 'object'),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT statement_timestamp(),
+    UNIQUE (fit_id, model_version)
+);
+
+ALTER TABLE predictions.game_predictions
+    ADD COLUMN IF NOT EXISTS evaluation_mode TEXT NOT NULL DEFAULT 'legacy_unknown',
+    ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS published_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS simulated_as_of_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS experiment_label TEXT,
+    ADD COLUMN IF NOT EXISTS fit_id TEXT,
+    ADD COLUMN IF NOT EXISTS input_hash TEXT,
+    ADD COLUMN IF NOT EXISTS input_snapshot JSONB;
+
+-- No default mode for new writes: each producer must state its intent.
+ALTER TABLE predictions.game_predictions ALTER COLUMN evaluation_mode DROP DEFAULT;
+DROP INDEX IF EXISTS predictions.game_predictions_daily_key;
+
+DO $migration$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'predictions.game_predictions'::regclass
+          AND conname = 'game_predictions_provenance_check'
+    ) THEN
+        ALTER TABLE predictions.game_predictions ADD CONSTRAINT game_predictions_provenance_check
+        CHECK (
+            (evaluation_mode = 'legacy_unknown'
+                AND created_at IS NULL AND published_at IS NULL
+                AND simulated_as_of_at IS NULL AND experiment_label IS NULL
+                AND fit_id IS NULL AND input_hash IS NULL AND input_snapshot IS NULL)
+            OR
+            (evaluation_mode IN ('published_forecast', 'walk_forward_reconstruction', 'hindsight_experiment')
+                AND created_at IS NOT NULL
+                AND fit_id IS NOT NULL AND fit_id ~ '^[0-9a-f]{64}$'
+                AND input_hash IS NOT NULL AND input_hash ~ '^[0-9a-f]{64}$'
+                AND input_snapshot IS NOT NULL AND jsonb_typeof(input_snapshot) = 'object'
+                AND (
+                    (evaluation_mode = 'published_forecast'
+                        AND published_at IS NOT NULL AND published_at = created_at
+                        AND simulated_as_of_at IS NULL AND experiment_label IS NULL)
+                    OR
+                    (evaluation_mode = 'walk_forward_reconstruction'
+                        AND published_at IS NULL AND simulated_as_of_at IS NOT NULL
+                        AND experiment_label IS NULL)
+                    OR
+                    (evaluation_mode = 'hindsight_experiment'
+                        AND published_at IS NULL AND simulated_as_of_at IS NOT NULL
+                        AND experiment_label IS NOT NULL AND length(btrim(experiment_label)) > 0)
+                ))
+        );
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'predictions.game_predictions'::regclass
+          AND conname = 'game_predictions_artifact_fk'
+    ) THEN
+        ALTER TABLE predictions.game_predictions ADD CONSTRAINT game_predictions_artifact_fk
+            FOREIGN KEY (fit_id, model_version)
+            REFERENCES predictions.model_artifacts (fit_id, model_version);
+    END IF;
+END
+$migration$;
+
+CREATE OR REPLACE FUNCTION predictions.stamp_prediction_provenance()
+RETURNS trigger LANGUAGE plpgsql SET search_path = '' AS $function$
+BEGIN
+    IF NEW.evaluation_mode IS NULL OR NEW.evaluation_mode = 'legacy_unknown' THEN
+        RAISE EXCEPTION 'New predictions require explicit non-legacy provenance';
+    END IF;
+    -- statement_timestamp, unlike now(), is not the start of a transaction
+    -- which may have spent minutes loading/scoring. Never trust a supplied time.
+    NEW.created_at := statement_timestamp();
+    NEW.published_at := CASE WHEN NEW.evaluation_mode = 'published_forecast'
+        THEN NEW.created_at ELSE NULL END;
+    RETURN NEW;
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION predictions.reject_snapshot_update()
+RETURNS trigger LANGUAGE plpgsql SET search_path = '' AS $function$
+BEGIN
+    RAISE EXCEPTION 'Prediction and model artifact snapshots are immutable; append a new snapshot';
+END
+$function$;
+
+DROP TRIGGER IF EXISTS stamp_prediction_provenance ON predictions.game_predictions;
+CREATE TRIGGER stamp_prediction_provenance BEFORE INSERT ON predictions.game_predictions
+    FOR EACH ROW EXECUTE FUNCTION predictions.stamp_prediction_provenance();
+DROP TRIGGER IF EXISTS reject_prediction_update ON predictions.game_predictions;
+CREATE TRIGGER reject_prediction_update BEFORE UPDATE ON predictions.game_predictions
+    FOR EACH ROW EXECUTE FUNCTION predictions.reject_snapshot_update();
+DROP TRIGGER IF EXISTS reject_artifact_update ON predictions.model_artifacts;
+CREATE TRIGGER reject_artifact_update BEFORE UPDATE ON predictions.model_artifacts
+    FOR EACH ROW EXECUTE FUNCTION predictions.reject_snapshot_update();
+
+CREATE INDEX IF NOT EXISTS game_predictions_published_idx
+    ON predictions.game_predictions (game_id, model_version, published_at DESC, prediction_id DESC)
+    WHERE evaluation_mode = 'published_forecast';
+CREATE INDEX IF NOT EXISTS game_predictions_fit_idx ON predictions.game_predictions (fit_id);
+
+COMMENT ON TABLE predictions.game_predictions IS
+    'Immutable prediction ledger keyed by prediction_id. New rows explicitly distinguish published_forecast, walk_forward_reconstruction and hindsight_experiment. Legacy rows retain unknown provenance; prediction_date and computed_at are not publication evidence.';
+COMMENT ON COLUMN predictions.game_predictions.created_at IS
+    'Actual database INSERT statement time for new ledger entries; NULL for unverifiable legacy rows.';
+COMMENT ON COLUMN predictions.game_predictions.published_at IS
+    'Database write-time publication, set only for published_forecast. Prospective scoring requires known kickoff and published_at strictly before kickoff.';
+COMMENT ON COLUMN predictions.game_predictions.simulated_as_of_at IS
+    'Nominal reconstructed kickoff, not evidence that corrected inputs or closing market lines were available then.';
+COMMENT ON TABLE predictions.model_artifacts IS
+    'Content-addressed immutable snapshot of the artifact actually consumed for scoring, including implementation fingerprint. Does not reconstruct upstream training history.';
+
+GRANT USAGE ON SCHEMA predictions TO anon, authenticated;
+GRANT SELECT ON predictions.model_artifacts, predictions.game_predictions TO anon, authenticated;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON predictions.model_artifacts, predictions.game_predictions
+    FROM anon, authenticated;
+REVOKE ALL ON FUNCTION predictions.stamp_prediction_provenance() FROM PUBLIC;
+REVOKE ALL ON FUNCTION predictions.reject_snapshot_update() FROM PUBLIC;

--- a/tests/test_api_views.py
+++ b/tests/test_api_views.py
@@ -400,6 +400,13 @@ GAME_PREDICTIONS_COLUMNS = {
     "market_captured_at",
     "edge",
     "edge_pick",
+    "evaluation_mode",
+    "created_at",
+    "published_at",
+    "simulated_as_of_at",
+    "experiment_label",
+    "fit_id",
+    "input_hash",
 }
 
 # Phase 5 of the preseason outlook plan -- latest Monte Carlo season
@@ -889,8 +896,8 @@ class TestViewsExistAndReturnRows:
             # retro 2015-2025 x 2 models
             ("api.team_elo", 5000),
             ("api.game_elo_history", 40000),
-            ("api.prediction_accuracy", 80),
-            ("api.game_predictions", 15000),
+            ("api.prediction_accuracy", 0),
+            ("api.game_predictions", 0),
             # Tier 3 analytics: feature vectors and adjusted EPA coefficients
             ("api.team_week_features", 15000),
             ("api.adjusted_epa_week", 50000),
@@ -984,6 +991,7 @@ class TestViewColumns:
             ("api.scored_matchup_edges", SCORED_MATCHUP_EDGES_COLUMNS),
             ("api.prediction_accuracy", PREDICTION_ACCURACY_COLUMNS),
             ("api.game_predictions", GAME_PREDICTIONS_COLUMNS),
+            ("api.prediction_history", GAME_PREDICTIONS_COLUMNS),
             # game_recaps starts empty (fills nightly) -- column check only, no
             # row-count entry in TestViewsExistAndReturnRows.
             ("api.game_recaps", GAME_RECAPS_COLUMNS),
@@ -1029,6 +1037,7 @@ class TestViewColumns:
             "scored_matchup_edges",
             "prediction_accuracy",
             "game_predictions",
+            "prediction_history",
             "game_recaps",
             "game_win_probability",
             "team_week_features",
@@ -1052,6 +1061,29 @@ class TestViewColumns:
     )
     def test_columns_present(self, db_conn, view_name, expected_columns):
         """All expected columns are present in the view."""
+        if view_name in {"api.game_predictions", "api.prediction_history"}:
+            deployed = _fetch_count(
+                db_conn,
+                """
+                SELECT COUNT(*) FROM information_schema.columns
+                WHERE table_schema = 'predictions' AND table_name = 'game_predictions'
+                  AND column_name = 'evaluation_mode'
+            """,
+            )
+            if not deployed:
+                if view_name == "api.prediction_history":
+                    pytest.skip(
+                        "F04 not deployed on this live target; isolated SQL CI tests its contract"
+                    )
+                expected_columns = expected_columns - {
+                    "evaluation_mode",
+                    "created_at",
+                    "published_at",
+                    "simulated_as_of_at",
+                    "experiment_label",
+                    "fit_id",
+                    "input_hash",
+                }
         _, columns = _fetch_all(db_conn, f"SELECT * FROM {view_name} LIMIT 1")
         actual = set(columns)
         missing = expected_columns - actual
@@ -1853,7 +1885,8 @@ class TestSeasonOutlook:
                        NULL::integer AS away_points,
                        'Test'::text AS home_conference, 'Test'::text AS away_conference,
                        'fbs'::text AS home_classification, 'fbs'::text AS away_classification,
-                       false AS conference_game
+                       false AS conference_game,
+                       TIMESTAMPTZ '2026-09-02' AS start_date
                 FROM (VALUES
                     (1, 2026, 'regular'), (2, 2026, 'regular'),
                     (3, 2026, 'postseason'), (4, 2025, 'regular')
@@ -1862,7 +1895,10 @@ class TestSeasonOutlook:
                 SELECT 1 AS game_id, 'test'::text AS model_version,
                        7.0::numeric AS expected_home_margin,
                        DATE '2026-09-01' AS prediction_date,
-                       TIMESTAMP '2026-09-01' AS computed_at
+                       TIMESTAMP '2026-09-01' AS computed_at,
+                       'published_forecast'::text AS evaluation_mode,
+                       TIMESTAMPTZ '2026-09-01' AS published_at,
+                       1::bigint AS prediction_id
             )
         """
         query = simulation.SEASON_GAMES_QUERY.replace("core.games", "fixture_games").replace(

--- a/tests/test_fitted_coverage_verification.py
+++ b/tests/test_fitted_coverage_verification.py
@@ -13,15 +13,25 @@ def warehouse():
     conn.executescript("""
         ATTACH DATABASE ':memory:' AS core;
         ATTACH DATABASE ':memory:' AS predictions;
-        CREATE TABLE core.games (id INTEGER PRIMARY KEY, season INTEGER, completed BOOLEAN);
-        CREATE TABLE predictions.game_predictions (game_id INTEGER, model_version TEXT);
+        CREATE TABLE core.games (
+            id INTEGER PRIMARY KEY,
+            season INTEGER,
+            completed BOOLEAN,
+            start_date TEXT
+        );
+        CREATE TABLE predictions.game_predictions (
+            game_id INTEGER,
+            model_version TEXT,
+            evaluation_mode TEXT,
+            published_at TEXT
+        );
     """)
     yield conn
     conn.close()
 
 
 def test_only_incomplete_superseded_original_is_empty_pending(warehouse, capsys):
-    warehouse.execute("INSERT INTO core.games VALUES (401866625, 2026, false)")
+    warehouse.execute("INSERT INTO core.games VALUES (401866625, 2026, false, NULL)")
     report = Report()
     check_fitted_coverage(warehouse.cursor(), report)
     assert report.failures == 0
@@ -30,10 +40,10 @@ def test_only_incomplete_superseded_original_is_empty_pending(warehouse, capsys)
 
 def test_superseded_completed_row_does_not_advance_pending_anchor(warehouse, capsys):
     warehouse.executemany(
-        "INSERT INTO core.games VALUES (?, ?, ?)",
+        "INSERT INTO core.games VALUES (?, ?, ?, ?)",
         [
-            (401866625, 2027, True),
-            (401917058, 2026, False),
+            (401866625, 2027, True, "2027-09-01T12:00:00Z"),
+            (401917058, 2026, False, "2026-09-01T12:00:00Z"),
         ],
     )
     report = Report()
@@ -44,13 +54,14 @@ def test_superseded_completed_row_does_not_advance_pending_anchor(warehouse, cap
 
 def test_large_covered_season_cannot_hide_empty_next_season(warehouse, capsys):
     warehouse.executemany(
-        "INSERT INTO core.games VALUES (?, 2026, false)", [(n,) for n in range(1, 1601)]
+        "INSERT INTO core.games VALUES (?, 2026, false, NULL)", [(n,) for n in range(1, 1601)]
     )
     warehouse.executemany(
-        "INSERT INTO core.games VALUES (?, 2027, false)", [(n,) for n in range(1601, 1621)]
+        "INSERT INTO core.games VALUES (?, 2027, false, NULL)", [(n,) for n in range(1601, 1621)]
     )
     warehouse.executemany(
-        "INSERT INTO predictions.game_predictions VALUES (?, 'fitted_v1')",
+        """INSERT INTO predictions.game_predictions
+           VALUES (?, 'fitted_v1', 'published_forecast', '2026-08-01T12:00:00Z')""",
         [(n,) for n in range(1, 1601)],
     )
     report = Report()
@@ -63,13 +74,72 @@ def test_large_covered_season_cannot_hide_empty_next_season(warehouse, capsys):
 
 def test_replacement_and_rematch_count_once_despite_prediction_snapshots(warehouse, capsys):
     warehouse.executemany(
-        "INSERT INTO core.games VALUES (?, 2026, false)", [(401866625,), (401917058,), (123,)]
+        "INSERT INTO core.games VALUES (?, 2026, false, NULL)",
+        [(401866625,), (401917058,), (123,)],
     )
     warehouse.executemany(
-        "INSERT INTO predictions.game_predictions VALUES (?, 'fitted_v1')",
+        """INSERT INTO predictions.game_predictions
+           VALUES (?, 'fitted_v1', 'published_forecast', '2026-08-01T12:00:00Z')""",
         [(401917058,), (401917058,), (123,)],
     )
     report = Report()
     check_fitted_coverage(warehouse.cursor(), report)
     assert report.failures == 0
     assert "covers 2/2" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    ("evaluation_mode", "published_at"),
+    [
+        ("legacy_unknown", "2026-08-01T12:00:00Z"),
+        ("walk_forward_reconstruction", None),
+        ("hindsight_experiment", None),
+        ("published_forecast", None),
+    ],
+)
+def test_nonpublished_or_unpublished_rows_do_not_satisfy_coverage(
+    warehouse, capsys, evaluation_mode, published_at
+):
+    warehouse.execute("INSERT INTO core.games VALUES (1, 2026, false, NULL)")
+    warehouse.execute(
+        "INSERT INTO predictions.game_predictions VALUES (1, 'fitted_v1', ?, ?)",
+        (evaluation_mode, published_at),
+    )
+
+    report = Report()
+    check_fitted_coverage(warehouse.cursor(), report)
+
+    assert report.failures == 1
+    assert "covers 0/1" in capsys.readouterr().out
+
+
+def test_at_or_after_known_kickoff_does_not_satisfy_coverage(warehouse, capsys):
+    kickoff = "2026-09-01T12:00:00Z"
+    warehouse.execute("INSERT INTO core.games VALUES (1, 2026, false, ?)", (kickoff,))
+    warehouse.executemany(
+        "INSERT INTO predictions.game_predictions VALUES (1, 'fitted_v1', ?, ?)",
+        [
+            ("published_forecast", kickoff),
+            ("published_forecast", "2026-09-01T12:00:01Z"),
+        ],
+    )
+
+    report = Report()
+    check_fitted_coverage(warehouse.cursor(), report)
+
+    assert report.failures == 1
+    assert "covers 0/1" in capsys.readouterr().out
+
+
+def test_strictly_prekickoff_published_row_satisfies_coverage(warehouse, capsys):
+    warehouse.execute("INSERT INTO core.games VALUES (1, 2026, false, '2026-09-01T12:00:00Z')")
+    warehouse.execute(
+        """INSERT INTO predictions.game_predictions
+           VALUES (1, 'fitted_v1', 'published_forecast', '2026-09-01T11:59:59Z')"""
+    )
+
+    report = Report()
+    check_fitted_coverage(warehouse.cursor(), report)
+
+    assert report.failures == 0
+    assert "covers 1/1" in capsys.readouterr().out

--- a/tests/test_prediction_provenance.py
+++ b/tests/test_prediction_provenance.py
@@ -1,0 +1,246 @@
+"""F04 regression coverage for immutable prediction writer provenance."""
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+
+from scripts import compute_predictions as closed_form
+from scripts import score_fitted as fitted
+from scripts import train_model as training
+from scripts.prediction_provenance import (
+    HINDSIGHT_EXPERIMENT,
+    PUBLISHED_FORECAST,
+    WALK_FORWARD_RECONSTRUCTION,
+    attach_prediction_provenance,
+    canonical_hash,
+    canonical_json,
+    identify_model_artifact,
+)
+
+
+def _closed_form_game(*, start_date=None):
+    return {
+        "game_id": 101,
+        "season": 2026,
+        "week": 3,
+        "season_type": "regular",
+        "start_date": start_date,
+        "neutral_site": False,
+        "home_team": "Alpha",
+        "away_team": "Bravo",
+        "home_pregame_elo": 1610.0,
+        "away_pregame_elo": 1490.0,
+    }
+
+
+def _fit(train_through=2025):
+    return {
+        "train_through": train_through,
+        "feature_means": dict.fromkeys(training.TEAM_WEEK_SOURCE_COLUMNS, 0.0),
+        "diff_means": dict.fromkeys(training.FEATURE_NAMES, 0.0),
+        "diff_stds": dict.fromkeys(training.FEATURE_NAMES, 1.0),
+        "beta_margin": np.arange(len(training.FEATURE_NAMES), dtype=float),
+        "beta_winprob": np.arange(len(training.FEATURE_NAMES), dtype=float) / 10,
+        "platt_a": 0.75,
+        "platt_b": -0.1,
+    }
+
+
+def test_canonical_hash_is_order_independent_and_lowercase_sha256():
+    first = {"b": [2, 3], "a": {"kickoff": datetime(2026, 9, 5, 17, tzinfo=UTC)}}
+    second = {"a": {"kickoff": datetime(2026, 9, 5, 17, tzinfo=UTC)}, "b": [2, 3]}
+    digest = canonical_hash(first)
+    assert digest == canonical_hash(second)
+    assert len(digest) == 64
+    assert digest == digest.lower()
+    assert set(digest) <= set("0123456789abcdef")
+
+
+def test_canonical_json_handles_arrays_and_preserves_decimal_precision():
+    value = {"vector": np.array([1, 2]), "numeric": Decimal("1.2300000000000000001")}
+    assert canonical_json(value) == '{"numeric":"1.2300000000000000001","vector":[1,2]}'
+
+
+def test_fit_id_addresses_model_version_and_exact_artifact():
+    fit_id, normalized = identify_model_artifact("elo_v1", {"weight": 0.6})
+    same_id, _ = identify_model_artifact("elo_v1", {"weight": 0.6})
+    changed_id, _ = identify_model_artifact("elo_v2", {"weight": 0.6})
+    assert fit_id == same_id
+    assert fit_id != changed_id
+    assert normalized == {"weight": 0.6}
+
+
+def test_mode_validation_and_input_hash_cover_exact_snapshot():
+    snapshot = {"market": {"spread": -3.5, "captured_at": "2026-09-01T12:00:00+00:00"}}
+    row = attach_prediction_provenance(
+        {"model_version": "elo_v1"},
+        evaluation_mode=PUBLISHED_FORECAST,
+        fit_id="a" * 64,
+        model_artifact={"parameters": {}},
+        input_snapshot=snapshot,
+    )
+    assert row["input_hash"] == canonical_hash(snapshot)
+    assert row["simulated_as_of_at"] is None
+    assert row["experiment_label"] is None
+
+    with pytest.raises(ValueError, match="known simulated_as_of_at"):
+        attach_prediction_provenance(
+            {},
+            evaluation_mode=WALK_FORWARD_RECONSTRUCTION,
+            fit_id="a" * 64,
+            model_artifact={},
+            input_snapshot={},
+        )
+    with pytest.raises(ValueError, match="nonempty label"):
+        attach_prediction_provenance(
+            {},
+            evaluation_mode=HINDSIGHT_EXPERIMENT,
+            fit_id="a" * 64,
+            model_artifact={},
+            input_snapshot={},
+            simulated_as_of_at=datetime(2026, 9, 1, tzinfo=UTC),
+            experiment_label="   ",
+        )
+
+
+def test_prediction_insert_is_append_only_and_omits_db_owned_timestamps():
+    sql = closed_form._INSERT_SQL.upper()
+    assert "ON CONFLICT" not in sql
+    assert "DO UPDATE" not in sql
+    columns = closed_form._INSERT_SQL.split(") VALUES", 1)[0]
+    assert "created_at" not in columns
+    assert "published_at" not in columns
+
+
+def test_upcoming_closed_form_rows_capture_consumed_inputs(monkeypatch):
+    game = _closed_form_game(start_date=datetime(2026, 9, 12, 18, tzinfo=UTC))
+    market_time = datetime(2026, 9, 6, 12, 30, tzinfo=UTC)
+    market = {"provider": "consensus", "spread": -4.5, "captured_at": market_time}
+    epa = {
+        ("Alpha", 2025): {
+            "team": "Alpha",
+            "season": 2025,
+            "off_coef": 0.2,
+            "def_coef": -0.1,
+            "hfa_coef": 0.03,
+        },
+        ("Bravo", 2025): {
+            "team": "Bravo",
+            "season": 2025,
+            "off_coef": 0.1,
+            "def_coef": -0.05,
+            "hfa_coef": 0.02,
+        },
+    }
+    write = Mock()
+    monkeypatch.setattr(closed_form, "fetch_target_games", lambda _conn: [game])
+    monkeypatch.setattr(
+        closed_form,
+        "fetch_elo_current",
+        lambda _conn: {"Alpha": (1610.0, 2026), "Bravo": (1490.0, 2026)},
+    )
+    monkeypatch.setattr(closed_form, "fetch_epa_coefs", lambda _conn: epa)
+    monkeypatch.setattr(closed_form, "table_exists", lambda *_args: True)
+    monkeypatch.setattr(
+        closed_form, "fetch_market_from_snapshots", lambda _conn, _ids: {101: market}
+    )
+    monkeypatch.setattr(closed_form, "write_upcoming", write)
+
+    closed_form.run_upcoming(object())
+
+    rows = write.call_args.args[1]
+    assert {row["evaluation_mode"] for row in rows} == {PUBLISHED_FORECAST}
+    assert all(len(row["fit_id"]) == 64 for row in rows)
+    elo = next(row for row in rows if row["model_version"] == closed_form.MODEL_ELO)
+    blend = next(row for row in rows if row["model_version"] == closed_form.MODEL_BLEND)
+    assert elo["input_snapshot"]["elo"] == {"home": 1610.0, "away": 1490.0}
+    assert elo["input_snapshot"]["market"]["captured_at"] == market_time.isoformat()
+    assert "epa" not in elo["input_snapshot"]
+    assert blend["input_snapshot"]["epa"]["home"]["off_coef"] == 0.2
+    assert blend["input_hash"] == canonical_hash(blend["input_snapshot"])
+
+
+def test_closed_form_backfill_defaults_to_reconstruction(monkeypatch):
+    kickoff = datetime(2026, 9, 5, 19, tzinfo=UTC)
+    game = _closed_form_game(start_date=kickoff)
+    write = Mock()
+    week = {
+        "Alpha": [(3, {"off_coef": 0.2, "def_coef": -0.1, "hfa_coef": 0.03, "plays": 200})],
+        "Bravo": [(3, {"off_coef": 0.1, "def_coef": -0.05, "hfa_coef": 0.02, "plays": 200})],
+    }
+    monkeypatch.setattr(closed_form, "fetch_backfill_games", lambda _conn, _season: [game])
+    monkeypatch.setattr(closed_form, "fetch_epa_week_coefs", lambda _conn, _season: week)
+    monkeypatch.setattr(closed_form, "fetch_epa_coefs", lambda _conn, season=None: {})
+    monkeypatch.setattr(closed_form, "fetch_market_from_lines", lambda _conn, _ids: {})
+    monkeypatch.setattr(closed_form, "write_backfill_season", write)
+
+    closed_form.run_backfill(object(), 2026, 2026)
+
+    rows = write.call_args.args[1]
+    assert {row["evaluation_mode"] for row in rows} == {WALK_FORWARD_RECONSTRUCTION}
+    assert {row["simulated_as_of_at"] for row in rows} == {kickoff}
+    assert {row["prediction_date"] for row in rows} == {kickoff.date()}
+
+
+def test_closed_form_hindsight_requires_label_and_is_explicit(monkeypatch):
+    kickoff = datetime(2026, 9, 5, 19, tzinfo=UTC)
+    game = _closed_form_game(start_date=kickoff)
+    write = Mock()
+    full = {
+        ("Alpha", 2026): {"off_coef": 0.2, "def_coef": -0.1, "hfa_coef": 0.03},
+        ("Bravo", 2026): {"off_coef": 0.1, "def_coef": -0.05, "hfa_coef": 0.02},
+    }
+    monkeypatch.setattr(closed_form, "fetch_backfill_games", lambda _conn, _season: [game])
+    monkeypatch.setattr(closed_form, "fetch_epa_coefs", lambda _conn, season=None: full)
+    monkeypatch.setattr(closed_form, "fetch_market_from_lines", lambda _conn, _ids: {})
+    monkeypatch.setattr(closed_form, "write_backfill_season", write)
+
+    closed_form.run_backfill(
+        object(), 2026, 2026, as_of_week=False, hindsight_experiment="full-season-v1"
+    )
+    assert {row["evaluation_mode"] for row in write.call_args.args[1]} == {HINDSIGHT_EXPERIMENT}
+    assert {row["experiment_label"] for row in write.call_args.args[1]} == {"full-season-v1"}
+
+    with pytest.raises(ValueError, match="requires --hindsight-experiment"):
+        closed_form.run_backfill(object(), 2026, 2026, as_of_week=False)
+
+
+def test_backfill_missing_kickoff_fails_before_any_write(monkeypatch):
+    write = Mock()
+    monkeypatch.setattr(
+        closed_form, "fetch_backfill_games", lambda _conn, _season: [_closed_form_game()]
+    )
+    monkeypatch.setattr(closed_form, "fetch_epa_week_coefs", lambda _conn, _season: {})
+    monkeypatch.setattr(closed_form, "fetch_epa_coefs", lambda _conn, season=None: {})
+    monkeypatch.setattr(closed_form, "fetch_market_from_lines", lambda _conn, _ids: {})
+    monkeypatch.setattr(closed_form, "write_backfill_season", write)
+    with pytest.raises(ValueError, match="has no kickoff"):
+        closed_form.run_backfill(object(), 2026, 2026)
+    write.assert_not_called()
+
+
+def test_fitted_artifact_captures_loaded_coefficients_scaling_and_calibration():
+    fit = _fit()
+    fit_id, artifact = fitted.fitted_model_artifact(fit)
+    assert len(fit_id) == 64
+    assert artifact["feature_means"] == fit["feature_means"]
+    assert artifact["feature_diff_stds"] == fit["diff_stds"]
+    assert artifact["calibration"] == {"platt_a": 0.75, "platt_b": -0.1}
+    assert artifact["coefficients"][3] == {
+        "feature_order": 3,
+        "feature_name": training.FEATURE_NAMES[3],
+        "margin": 3.0,
+        "winprob": 0.3,
+    }
+
+
+def test_fitted_fit_id_changes_when_consumed_runtime_constant_changes(monkeypatch):
+    fit = _fit()
+    original_id, _ = fitted.fitted_model_artifact(fit)
+    monkeypatch.setattr(training, "_MAX_LOGIT", 2.0)
+    changed_id, artifact = fitted.fitted_model_artifact(fit)
+    assert changed_id != original_id
+    assert artifact["implementation"]["runtime_constants"]["max_logit"] == 2.0

--- a/tests/test_prediction_provenance_sql.py
+++ b/tests/test_prediction_provenance_sql.py
@@ -1,0 +1,778 @@
+"""Executed PostgreSQL regressions for the F04 prediction-provenance cutover.
+
+These tests intentionally do not use ``db_conn``. They require an explicit
+``F04_TEST_DB_URL`` pointing at an empty PostgreSQL database on loopback, then
+build and remove their own minimal warehouse fixture there. This keeps schema
+and role mutations away from any configured warehouse credentials.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from decimal import Decimal
+from pathlib import Path
+from urllib.parse import urlparse
+
+import psycopg2
+import pytest
+
+from scripts import simulate_season
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+MIGRATIONS = PROJECT_ROOT / "src" / "schemas" / "migrations"
+MARTS = PROJECT_ROOT / "src" / "schemas" / "marts"
+API = PROJECT_ROOT / "src" / "schemas" / "api"
+
+FIT_ID = "a" * 64
+INPUT_HASH = "b" * 64
+MODEL = "f04_test_v1"
+
+
+@dataclass(frozen=True)
+class F04Database:
+    conn: psycopg2.extensions.connection
+    legacy_prediction_id: int
+    baseline_accuracy: tuple
+    accuracy_after_history: tuple
+    baseline_edges: tuple
+    edges_after_history: tuple
+
+
+def _execute_file(conn: psycopg2.extensions.connection, path: Path) -> None:
+    with conn.cursor() as cur:
+        cur.execute(path.read_text())
+
+
+def _fetchone(conn: psycopg2.extensions.connection, query: str, params=None) -> tuple:
+    with conn.cursor() as cur:
+        cur.execute(query, params)
+        return cur.fetchone()
+
+
+def _guard_disposable_database(conn: psycopg2.extensions.connection, dsn: str) -> None:
+    parsed = urlparse(dsn)
+    if parsed.scheme not in {"postgres", "postgresql"}:
+        pytest.fail("F04_TEST_DB_URL must be a postgresql:// URL")
+    if parsed.hostname not in {"127.0.0.1", "localhost", "::1"}:
+        pytest.fail("F04_TEST_DB_URL must point at a loopback PostgreSQL server")
+
+    if _fetchone(
+        conn,
+        """
+        SELECT COUNT(*) FROM pg_namespace
+        WHERE nspname IN ('api', 'marts', 'predictions', 'metrics', 'core')
+    """,
+    )[0]:
+        pytest.fail("F04 fixture refuses to own or remove any preexisting target schema")
+
+    current_database, user_relation_count = _fetchone(
+        conn,
+        """
+        SELECT
+            current_database(),
+            (
+                SELECT count(*)
+                FROM pg_class c
+                JOIN pg_namespace n ON n.oid = c.relnamespace
+                WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+                  AND n.nspname !~ '^pg_toast'
+                  AND c.relkind IN ('r', 'p', 'v', 'm', 'S', 'f')
+            )
+        """,
+    )
+    requested_database = parsed.path.removeprefix("/")
+    if requested_database and current_database != requested_database:
+        pytest.fail(
+            "F04_TEST_DB_URL database does not match the connected database "
+            f"({requested_database!r} != {current_database!r})"
+        )
+    if user_relation_count:
+        pytest.fail(
+            "F04_TEST_DB_URL must target an empty disposable database; "
+            f"found {user_relation_count} existing user relation(s)"
+        )
+
+
+def _create_roles_and_minimal_schema(conn: psycopg2.extensions.connection) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            DO $roles$
+            BEGIN
+                IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+                    CREATE ROLE anon NOLOGIN;
+                END IF;
+                IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+                    CREATE ROLE authenticated NOLOGIN;
+                END IF;
+                IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'analyst_ro') THEN
+                    CREATE ROLE analyst_ro NOLOGIN;
+                END IF;
+            END
+            $roles$;
+
+            CREATE SCHEMA core;
+            CREATE SCHEMA metrics;
+            CREATE SCHEMA marts;
+            CREATE SCHEMA api;
+
+            CREATE TABLE core.games (
+                id BIGINT PRIMARY KEY,
+                season BIGINT,
+                start_date TIMESTAMPTZ,
+                completed BOOLEAN,
+                home_points BIGINT,
+                away_points BIGINT
+            );
+            CREATE TABLE metrics.pregame_win_probability (
+                game_id BIGINT PRIMARY KEY,
+                home_win_probability NUMERIC
+            );
+
+            GRANT USAGE ON SCHEMA api TO anon, authenticated, analyst_ro;
+            """
+        )
+
+
+def _insert_prediction(
+    conn: psycopg2.extensions.connection,
+    *,
+    game_id: int,
+    mode: str,
+    expected_margin: Decimal | int,
+    published_at: str | None = None,
+    simulated_as_of_at: str | None = None,
+    experiment_label: str | None = None,
+    fit_id: str | None = FIT_ID,
+    input_hash: str | None = INPUT_HASH,
+    input_snapshot: str | None = '{"source":"fixture"}',
+    model_version: str = MODEL,
+    prediction_date: str = "2026-09-01",
+) -> tuple[int, object, object, bool]:
+    created_at = published_at or simulated_as_of_at or "2026-09-01 12:00:00+00"
+    edge = Decimal(expected_margin) - Decimal("3")
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO predictions.game_predictions (
+                computed_at, prediction_date, model_version, game_id, season, week,
+                season_type, home_team, away_team, neutral_site,
+                expected_home_margin, home_win_prob, market_provider,
+                market_home_margin, market_spread, market_captured_at, edge, edge_pick,
+                evaluation_mode, created_at, published_at, simulated_as_of_at,
+                experiment_label, fit_id, input_hash, input_snapshot
+            ) VALUES (
+                '2099-01-01 00:00:00+00', %s, %s, %s, 2026, 1,
+                'regular', 'Home', 'Away', false,
+                %s, CASE WHEN %s = 1004 THEN 0.4 ELSE 0.7 END, 'fixture',
+                3, -3, '2026-09-01 17:00:00+00', %s,
+                CASE WHEN %s >= 3 THEN 'home' ELSE 'away' END,
+                %s, %s, %s, %s, %s, %s, %s, %s::jsonb
+            )
+            RETURNING prediction_id, created_at, published_at,
+                      created_at = statement_timestamp()
+            """,
+            (
+                prediction_date,
+                model_version,
+                game_id,
+                expected_margin,
+                game_id,
+                edge,
+                edge,
+                mode,
+                created_at,
+                published_at,
+                simulated_as_of_at,
+                experiment_label,
+                fit_id,
+                input_hash,
+                input_snapshot,
+            ),
+        )
+        return cur.fetchone()
+
+
+def _accuracy_row(conn: psycopg2.extensions.connection) -> tuple:
+    return _fetchone(
+        conn,
+        """
+        SELECT n_games, margin_mae, brier, cfbd_brier, n_scored_win_prob
+        FROM marts.prediction_accuracy
+        WHERE model_version = %s AND season = 2026 AND edge_threshold = 0
+        """,
+        (MODEL,),
+    )
+
+
+def _edge_rows(conn: psycopg2.extensions.connection) -> tuple:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT game_id, expected_home_margin
+            FROM marts.scored_matchup_edges
+            WHERE model_version = %s
+            ORDER BY game_id
+            """,
+            (MODEL,),
+        )
+        return tuple(cur.fetchall())
+
+
+@pytest.fixture(scope="module")
+def f04_db() -> F04Database:
+    dsn = os.environ.get("F04_TEST_DB_URL")
+    if not dsn:
+        pytest.skip("set F04_TEST_DB_URL to an empty disposable local PostgreSQL database")
+
+    conn = psycopg2.connect(dsn)
+    conn.autocommit = True
+    cleanup_allowed = False
+    try:
+        _guard_disposable_database(conn, dsn)
+        # From here onward every schema named below belongs to this fixture.
+        cleanup_allowed = True
+        _create_roles_and_minimal_schema(conn)
+        _execute_file(conn, MIGRATIONS / "024_predictions_schema.sql")
+
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO core.games VALUES
+                    (1001, 2026, '2026-09-01 20:00:00+00', true, 30, 20),
+                    (1002, 2026, NULL, true, 24, 21),
+                    (1003, 2026, '2026-09-08 20:00:00+00', false, NULL, NULL),
+                    (1004, 2026, '2026-09-01 20:00:00+00', true, 17, 17);
+                INSERT INTO metrics.pregame_win_probability VALUES (1001, 0.8), (1004, 0.3);
+
+                INSERT INTO predictions.game_predictions (
+                    computed_at, prediction_date, model_version, game_id, season, week,
+                    season_type, home_team, away_team, neutral_site,
+                    expected_home_margin, home_win_prob, market_spread, edge, edge_pick
+                ) VALUES (
+                    '2099-12-31 00:00:00+00', '2099-12-31', %s, 1003, 2026, 1,
+                    'regular', 'Home', 'Away', false, 900, 0.99, -3, 897, 'home'
+                ) RETURNING prediction_id
+                """,
+                (MODEL,),
+            )
+            legacy_prediction_id = cur.fetchone()[0]
+
+        legacy_before = _fetchone(
+            conn,
+            """
+            SELECT prediction_id, computed_at, prediction_date, expected_home_margin
+            FROM predictions.game_predictions WHERE prediction_id = %s
+            """,
+            (legacy_prediction_id,),
+        )
+
+        # The actual upgrade is applied twice before any F04 fixture writes.
+        _execute_file(conn, MIGRATIONS / "063_prediction_provenance.sql")
+        _execute_file(conn, MIGRATIONS / "063_prediction_provenance.sql")
+
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO predictions.model_artifacts (fit_id, model_version, artifact)
+                VALUES (%s, %s, '{"kind":"closed_form","implementation":"fixture-v1"}')
+                """,
+                (FIT_ID, MODEL),
+            )
+
+            # Controlled publication history is allowed only because the guard
+            # above proved this is a dedicated empty loopback database.
+            cur.execute(
+                "ALTER TABLE predictions.game_predictions "
+                "DISABLE TRIGGER stamp_prediction_provenance"
+            )
+
+        _insert_prediction(
+            conn,
+            game_id=1001,
+            mode="published_forecast",
+            expected_margin=3,
+            published_at="2026-09-01 18:00:00+00",
+        )
+        _insert_prediction(
+            conn,
+            game_id=1001,
+            mode="published_forecast",
+            expected_margin=7,
+            published_at="2026-09-01 19:00:00+00",
+        )
+        _insert_prediction(
+            conn,
+            game_id=1001,
+            mode="published_forecast",
+            expected_margin=80,
+            published_at="2026-09-01 20:00:00+00",
+        )
+        _insert_prediction(
+            conn,
+            game_id=1001,
+            mode="published_forecast",
+            expected_margin=90,
+            published_at="2026-09-01 21:00:00+00",
+        )
+        _insert_prediction(
+            conn,
+            game_id=1002,
+            mode="published_forecast",
+            expected_margin=20,
+            published_at="2026-09-01 19:00:00+00",
+        )
+        _insert_prediction(
+            conn,
+            game_id=1003,
+            mode="published_forecast",
+            expected_margin=12,
+            published_at="2026-09-01 19:00:00+00",
+        )
+        _insert_prediction(
+            conn,
+            game_id=1004,
+            mode="published_forecast",
+            expected_margin=5,
+            published_at="2026-09-01 19:00:00+00",
+        )
+
+        with conn.cursor() as cur:
+            cur.execute(
+                "ALTER TABLE predictions.game_predictions "
+                "ENABLE TRIGGER stamp_prediction_provenance"
+            )
+
+        # First build creates the old dependent API views; the second build
+        # exercises DROP ... CASCADE followed by explicit API restoration.
+        for _ in range(2):
+            _execute_file(conn, MARTS / "037_scored_matchup_edges.sql")
+            _execute_file(conn, MARTS / "038_prediction_accuracy.sql")
+            _execute_file(conn, API / "030_scored_matchup_edges.sql")
+            _execute_file(conn, API / "031_prediction_accuracy.sql")
+            _execute_file(conn, API / "032_game_predictions.sql")
+
+        baseline_accuracy = _accuracy_row(conn)
+        baseline_edges = _edge_rows(conn)
+
+        # These rows have newer immutable IDs and intentionally extreme values.
+        # Neither may alter prospective API/mart outputs.
+        _insert_prediction(
+            conn,
+            game_id=1001,
+            mode="walk_forward_reconstruction",
+            expected_margin=700,
+            simulated_as_of_at="2026-09-01 19:59:00+00",
+        )
+        _insert_prediction(
+            conn,
+            game_id=1001,
+            mode="hindsight_experiment",
+            expected_margin=800,
+            simulated_as_of_at="2026-09-01 19:59:00+00",
+            experiment_label="full-season hindsight fixture",
+        )
+        _insert_prediction(
+            conn,
+            game_id=1003,
+            mode="walk_forward_reconstruction",
+            expected_margin=700,
+            simulated_as_of_at="2026-09-08 19:59:00+00",
+        )
+        _insert_prediction(
+            conn,
+            game_id=1003,
+            mode="hindsight_experiment",
+            expected_margin=800,
+            simulated_as_of_at="2026-09-08 19:59:00+00",
+            experiment_label="newer than publication",
+        )
+
+        with conn.cursor() as cur:
+            cur.execute("REFRESH MATERIALIZED VIEW marts.scored_matchup_edges")
+            cur.execute("REFRESH MATERIALIZED VIEW marts.prediction_accuracy")
+
+        legacy_after = _fetchone(
+            conn,
+            """
+            SELECT prediction_id, computed_at, prediction_date, expected_home_margin
+            FROM predictions.game_predictions WHERE prediction_id = %s
+            """,
+            (legacy_prediction_id,),
+        )
+        assert legacy_after == legacy_before
+
+        db = F04Database(
+            conn=conn,
+            legacy_prediction_id=legacy_prediction_id,
+            baseline_accuracy=baseline_accuracy,
+            accuracy_after_history=_accuracy_row(conn),
+            baseline_edges=baseline_edges,
+            edges_after_history=_edge_rows(conn),
+        )
+        yield db
+    finally:
+        try:
+            if cleanup_allowed:
+                with conn.cursor() as cur:
+                    cur.execute("RESET ROLE")
+                    cur.execute(
+                        "DROP SCHEMA IF EXISTS api, marts, predictions, metrics, core CASCADE"
+                    )
+        finally:
+            conn.close()
+
+
+def test_migration_is_idempotent_and_preserves_legacy_rows(f04_db: F04Database) -> None:
+    conn = f04_db.conn
+    row = _fetchone(
+        conn,
+        """
+        SELECT evaluation_mode, created_at, published_at, simulated_as_of_at,
+               experiment_label, fit_id, input_hash, input_snapshot
+        FROM predictions.game_predictions WHERE prediction_id = %s
+        """,
+        (f04_db.legacy_prediction_id,),
+    )
+    assert row == ("legacy_unknown", None, None, None, None, None, None, None)
+    assert _fetchone(
+        conn,
+        "SELECT to_regclass('predictions.game_predictions_daily_key')",
+    ) == (None,)
+    assert (
+        _fetchone(
+            conn,
+            """
+        SELECT count(*)
+        FROM predictions.game_predictions
+        WHERE game_id = 1001 AND model_version = %s AND prediction_date = '2026-09-01'
+        """,
+            (MODEL,),
+        )[0]
+        >= 6
+    )
+
+
+def test_provenance_trigger_stamps_database_write_time(f04_db: F04Database) -> None:
+    conn = f04_db.conn
+    before_insert = _fetchone(conn, "SELECT clock_timestamp()")[0]
+    prediction_id, created_at, published_at, used_statement_timestamp = _insert_prediction(
+        conn,
+        game_id=2001,
+        mode="published_forecast",
+        expected_margin=1,
+        published_at="2000-01-01 00:00:00+00",
+    )
+    after_insert = _fetchone(conn, "SELECT clock_timestamp()")[0]
+    assert created_at == published_at
+    assert used_statement_timestamp is True
+    assert before_insert <= created_at <= after_insert
+
+    before_reconstruction = _fetchone(conn, "SELECT clock_timestamp()")[0]
+    (
+        _,
+        reconstructed_created_at,
+        reconstructed_published_at,
+        reconstruction_used_statement_timestamp,
+    ) = _insert_prediction(
+        conn,
+        game_id=2002,
+        mode="walk_forward_reconstruction",
+        expected_margin=1,
+        published_at="2000-01-01 00:00:00+00",
+        simulated_as_of_at="2025-09-01 00:00:00+00",
+    )
+    after_reconstruction = _fetchone(conn, "SELECT clock_timestamp()")[0]
+    assert reconstruction_used_statement_timestamp is True
+    assert before_reconstruction <= reconstructed_created_at <= after_reconstruction
+    assert reconstructed_published_at is None
+    assert _fetchone(
+        conn,
+        """
+        SELECT published_at = created_at
+        FROM predictions.game_predictions
+        WHERE prediction_id = %s
+        """,
+        (prediction_id,),
+    ) == (True,)
+
+
+def test_constraints_enforce_modes_hashes_and_artifact_identity(f04_db: F04Database) -> None:
+    conn = f04_db.conn
+    modes = _fetchone(
+        conn,
+        """
+        SELECT array_agg(DISTINCT evaluation_mode ORDER BY evaluation_mode)
+        FROM predictions.game_predictions
+        """,
+    )[0]
+    assert modes == [
+        "hindsight_experiment",
+        "legacy_unknown",
+        "published_forecast",
+        "walk_forward_reconstruction",
+    ]
+
+    with pytest.raises(psycopg2.Error, match="explicit non-legacy provenance"):
+        _insert_prediction(
+            conn,
+            game_id=2101,
+            mode="legacy_unknown",
+            expected_margin=1,
+            fit_id=None,
+            input_hash=None,
+        )
+    with pytest.raises(psycopg2.IntegrityError):
+        _insert_prediction(
+            conn,
+            game_id=2102,
+            mode="walk_forward_reconstruction",
+            expected_margin=1,
+            simulated_as_of_at=None,
+        )
+    with pytest.raises(psycopg2.IntegrityError):
+        _insert_prediction(
+            conn,
+            game_id=2103,
+            mode="hindsight_experiment",
+            expected_margin=1,
+            simulated_as_of_at="2025-09-01 00:00:00+00",
+            experiment_label="   ",
+        )
+    with pytest.raises(psycopg2.IntegrityError):
+        _insert_prediction(
+            conn,
+            game_id=2104,
+            mode="published_forecast",
+            expected_margin=1,
+            published_at="2025-09-01 00:00:00+00",
+            input_hash="not-a-sha256",
+        )
+    with pytest.raises(psycopg2.IntegrityError):
+        _insert_prediction(
+            conn,
+            game_id=2105,
+            mode="published_forecast",
+            expected_margin=1,
+            published_at="2025-09-01 00:00:00+00",
+            fit_id=None,
+        )
+    with pytest.raises(psycopg2.IntegrityError):
+        _insert_prediction(
+            conn,
+            game_id=2106,
+            mode="published_forecast",
+            expected_margin=1,
+            published_at="2025-09-01 00:00:00+00",
+            input_hash=None,
+        )
+    with pytest.raises(psycopg2.IntegrityError):
+        _insert_prediction(
+            conn,
+            game_id=2107,
+            mode="published_forecast",
+            expected_margin=1,
+            published_at="2025-09-01 00:00:00+00",
+            input_snapshot=None,
+        )
+    with pytest.raises(psycopg2.IntegrityError):
+        _insert_prediction(
+            conn,
+            game_id=2108,
+            mode="published_forecast",
+            expected_margin=1,
+            published_at="2025-09-01 00:00:00+00",
+            model_version="wrong-model",
+        )
+    with pytest.raises(psycopg2.IntegrityError):
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO predictions.model_artifacts (fit_id, model_version, artifact)
+                VALUES ('short', 'bad-artifact', '{}')
+                """
+            )
+
+    assert re.fullmatch(
+        r"[0-9a-f]{64}",
+        _fetchone(conn, "SELECT fit_id FROM predictions.model_artifacts")[0],
+    )
+
+
+def test_prediction_and_artifact_snapshots_are_immutable(f04_db: F04Database) -> None:
+    conn = f04_db.conn
+    with pytest.raises(psycopg2.Error, match="immutable"):
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE predictions.game_predictions SET expected_home_margin = 0 "
+                "WHERE prediction_id = %s",
+                (f04_db.legacy_prediction_id,),
+            )
+    with pytest.raises(psycopg2.Error, match="immutable"):
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE predictions.model_artifacts SET artifact = '{}' WHERE fit_id = %s",
+                (FIT_ID,),
+            )
+
+
+def test_api_and_marts_keep_historical_modes_out_of_prospective_outputs(
+    f04_db: F04Database,
+) -> None:
+    conn = f04_db.conn
+    assert f04_db.accuracy_after_history == f04_db.baseline_accuracy
+    assert f04_db.edges_after_history == f04_db.baseline_edges
+    assert f04_db.accuracy_after_history == (
+        2,
+        Decimal("4.0000"),
+        Decimal("0.050000"),
+        Decimal("0.040000"),
+        2,
+    )
+    assert f04_db.edges_after_history == ((1003, Decimal("12.00")),)
+
+    # The general API shows the newest publication even when it was post-kickoff;
+    # the accuracy mart independently selects the newest strictly pre-kickoff row.
+    assert _fetchone(
+        conn,
+        """
+        SELECT expected_home_margin, evaluation_mode
+        FROM api.game_predictions WHERE game_id = 1001 AND model_version = %s
+        """,
+        (MODEL,),
+    ) == (Decimal("90.00"), "published_forecast")
+    assert _fetchone(
+        conn,
+        """
+        SELECT count(DISTINCT evaluation_mode), count(*)
+        FROM api.prediction_history
+        WHERE model_version = %s AND game_id BETWEEN 1001 AND 1004
+        """,
+        (MODEL,),
+    ) == (4, 12)
+    assert _fetchone(
+        conn,
+        """
+        SELECT to_regclass('api.scored_matchup_edges'),
+               to_regclass('api.prediction_accuracy'),
+               to_regclass('api.game_predictions'),
+               to_regclass('api.prediction_history')
+        """,
+    ) == (
+        "api.scored_matchup_edges",
+        "api.prediction_accuracy",
+        "api.game_predictions",
+        "api.prediction_history",
+    )
+
+
+@pytest.mark.parametrize("role", ["anon", "authenticated", "analyst_ro"])
+def test_api_roles_can_read_but_cannot_mutate(role: str, f04_db: F04Database) -> None:
+    conn = f04_db.conn
+    try:
+        with conn.cursor() as cur:
+            cur.execute(f"SET ROLE {role}")
+            cur.execute("SELECT count(*) FROM api.game_predictions")
+            assert cur.fetchone()[0] >= 1
+            cur.execute("SELECT count(*) FROM api.prediction_history")
+            assert cur.fetchone()[0] >= 1
+            with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+                cur.execute(
+                    "UPDATE api.prediction_history SET expected_home_margin = 0 "
+                    "WHERE prediction_id = %s",
+                    (f04_db.legacy_prediction_id,),
+                )
+    finally:
+        with conn.cursor() as cur:
+            cur.execute("RESET ROLE")
+
+    if role == "analyst_ro":
+        with conn.cursor() as cur:
+            cur.execute("SELECT has_schema_privilege('analyst_ro', 'predictions', 'USAGE')")
+            assert cur.fetchone()[0] is False
+
+
+def test_residual_sigma_uses_only_strictly_prekickoff_publications(
+    f04_db: F04Database,
+) -> None:
+    conn = f04_db.conn
+    with conn.cursor() as cur:
+        cur.execute(simulate_season.RESIDUAL_SIGMA_QUERY, {"model": MODEL})
+        sigma, count = cur.fetchone()
+    assert count == 2
+    assert sigma == pytest.approx(4.0)
+
+    with pytest.raises(RuntimeError, match=r"Only 2 completed game\(s\).+need >= 100"):
+        simulate_season.fetch_sigma(conn, MODEL)
+
+
+def test_python_writers_round_trip_same_day_snapshots_and_artifacts(f04_db):
+    """Execute shared writer SQL, JSON adaptation and artifact deduplication."""
+    from scripts import compute_predictions as writer
+    from scripts.prediction_provenance import (
+        attach_prediction_provenance,
+        canonical_hash,
+        identify_model_artifact,
+    )
+
+    conn = f04_db.conn
+    model = "writer_round_trip"
+    fit_id, artifact = identify_model_artifact(model, {"coefficient": 1.25})
+    kickoff = _fetchone(conn, "SELECT statement_timestamp() + interval '1 hour'")[0]
+    payload = dict.fromkeys(writer._ROW_COLUMNS)
+    payload.update(
+        model_version=model, game_id=9001, home_team="A", away_team="B", expected_home_margin=7.25
+    )
+    source = {"rating": 1700.125, "kickoff": kickoff}
+    published = attach_prediction_provenance(
+        payload,
+        evaluation_mode="published_forecast",
+        fit_id=fit_id,
+        model_artifact=artifact,
+        input_snapshot=source,
+    )
+    conn.autocommit = False
+    try:
+        transaction_start = _fetchone(conn, "SELECT transaction_timestamp(), pg_sleep(0.01)")[0]
+        writer.write_upcoming(conn, [published])
+        first = _fetchone(
+            conn,
+            """
+            SELECT prediction_id, created_at, published_at, prediction_date, input_snapshot
+            FROM predictions.game_predictions WHERE model_version = %s
+        """,
+            (model,),
+        )
+        assert first[1] == first[2] and first[1] > transaction_start
+        assert canonical_hash(first[4]) == published["input_hash"]
+        reconstructed = attach_prediction_provenance(
+            {**payload, "prediction_date": first[3]},
+            evaluation_mode="walk_forward_reconstruction",
+            fit_id=fit_id,
+            model_artifact=artifact,
+            input_snapshot=source,
+            simulated_as_of_at=kickoff,
+        )
+        writer.write_backfill_season(conn, [reconstructed])
+        writer.write_upcoming(conn, [published])
+        assert _fetchone(
+            conn,
+            """
+            SELECT COUNT(*), COUNT(DISTINCT prediction_id), COUNT(DISTINCT prediction_date)
+            FROM predictions.game_predictions WHERE model_version = %s
+        """,
+            (model,),
+        ) == (3, 3, 1)
+        assert _fetchone(
+            conn, "SELECT COUNT(*) FROM predictions.model_artifacts WHERE fit_id=%s", (fit_id,)
+        ) == (1,)
+        assert _fetchone(
+            conn,
+            "SELECT published_at FROM predictions.game_predictions WHERE prediction_id=%s",
+            (first[0],),
+        ) == (first[2],)
+    finally:
+        conn.rollback()
+        conn.autocommit = True

--- a/tests/test_simulate_season.py
+++ b/tests/test_simulate_season.py
@@ -30,6 +30,8 @@ from scripts.simulate_season import (  # noqa: E402
     BOWL_ELIGIBLE_WINS,
     DEFAULT_STRENGTH_SHARE,
     MIN_SLATE_COHORT,
+    RESIDUAL_SIGMA_QUERY,
+    SEASON_GAMES_QUERY,
     STANDARD_SLATE_GAMES,
     assign_sos_ranks,
     bowls_apply,
@@ -37,6 +39,7 @@ from scripts.simulate_season import (  # noqa: E402
     conference_title_probs,
     expected_slate_games,
     fetch_season_games,
+    fetch_sigma,
     normalize_strength_share,
     schedule_strength,
     select_projection_game_rows,
@@ -150,6 +153,44 @@ class TestSupersededProjectionGames:
 
         assert selected == rows
         assert selected is not rows
+
+
+class TestPublishedPredictionSelection:
+    @staticmethod
+    def _normalized(sql):
+        return " ".join(sql.split())
+
+    def test_season_query_filters_before_latest_published_selection(self):
+        sql = self._normalized(SEASON_GAMES_QUERY)
+        assert "gp.evaluation_mode = 'published_forecast'" in sql
+        assert "gp.published_at IS NOT NULL" in sql
+        assert "gp.published_at < g.start_date" in sql
+        assert "ORDER BY gp.published_at DESC, gp.prediction_id DESC" in sql
+        assert "prediction_date" not in sql
+        assert "computed_at" not in sql
+
+    def test_sigma_query_uses_only_strictly_prekickoff_published_rows(self):
+        sql = self._normalized(RESIDUAL_SIGMA_QUERY)
+        distinct_at = sql.index("SELECT DISTINCT ON")
+        published_filter_at = sql.index("p.evaluation_mode = 'published_forecast'")
+        order_at = sql.index("ORDER BY p.game_id, p.published_at DESC, p.prediction_id DESC")
+        assert published_filter_at > distinct_at
+        assert published_filter_at < order_at
+        assert "p.published_at IS NOT NULL" in sql
+        assert "g.start_date IS NOT NULL" in sql
+        assert "p.published_at < g.start_date" in sql
+        assert "prediction_date" not in sql
+        assert "computed_at" not in sql
+
+    def test_sigma_cold_start_stays_fail_closed_without_backfill_advice(self):
+        conn = MagicMock()
+        cursor = conn.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = (None, 0)
+
+        with pytest.raises(RuntimeError, match="prospective published forecasts") as exc:
+            fetch_sigma(conn, "fitted_v1")
+
+        assert "backfill" not in str(exc.value).lower()
 
 
 class TestSimulateWins:
@@ -1005,3 +1046,69 @@ class TestBowlEligibilityIsAnFbsRule:
         of-an-absence failure this file already has three tests about."""
         assert bowls_apply(None) is False
         assert bowls_apply("fbs") is True
+
+
+@pytest.mark.parametrize("allow", [False, True])
+def test_cli_calibration_cold_start_is_explicit_opt_in(monkeypatch, caplog, allow):
+    from unittest.mock import MagicMock
+
+    from scripts import simulate_season as simulation
+
+    conn = MagicMock()
+    monkeypatch.setattr("psycopg2.connect", lambda *_: conn)
+    monkeypatch.setattr(simulation, "get_db_url", lambda: "unused")
+    monkeypatch.setattr(
+        "sys.argv",
+        ["simulate_season.py", "--season", "2026"]
+        + (["--allow-calibration-cold-start"] if allow else []),
+    )
+
+    def cold_start(*_):
+        raise simulation.CalibrationColdStartError("insufficient published outcomes")
+
+    monkeypatch.setattr(simulation, "simulate_one_season", cold_start)
+    if allow:
+        simulation.main()
+        assert "no projections written" in caplog.text
+        assert "stored outlook retained" in caplog.text
+    else:
+        with pytest.raises(SystemExit) as exc:
+            simulation.main()
+        assert exc.value.code == 1
+    conn.commit.assert_not_called()
+    conn.close.assert_called_once()
+
+
+def test_cli_cold_start_option_does_not_hide_other_failures(monkeypatch):
+    from unittest.mock import MagicMock
+
+    from scripts import simulate_season as simulation
+
+    conn = MagicMock()
+    monkeypatch.setattr("psycopg2.connect", lambda *_: conn)
+    monkeypatch.setattr(simulation, "get_db_url", lambda: "unused")
+    monkeypatch.setattr(
+        "sys.argv", ["simulate_season.py", "--season", "2026", "--allow-calibration-cold-start"]
+    )
+
+    def broken(*_):
+        raise RuntimeError("invalid sigma or database failure")
+
+    monkeypatch.setattr(simulation, "simulate_one_season", broken)
+    with pytest.raises(SystemExit) as exc:
+        simulation.main()
+    assert exc.value.code == 1
+    conn.commit.assert_not_called()
+
+
+@pytest.mark.parametrize("sigma", [None, float("nan"), float("inf"), 0, -1])
+def test_invalid_sigma_is_not_an_ignorable_cold_start(sigma):
+    from unittest.mock import MagicMock
+
+    from scripts import simulate_season as simulation
+
+    conn = MagicMock()
+    conn.cursor.return_value.__enter__.return_value.fetchone.return_value = (sigma, 1000)
+    with pytest.raises(RuntimeError) as exc:
+        simulation.fetch_sigma(conn, "fitted_v1")
+    assert not isinstance(exc.value, simulation.CalibrationColdStartError)


### PR DESCRIPTION
Historical backfills could overwrite same-day forecasts and enter published accuracy and simulation calibration through a backdated prediction date. F04 makes new predictions append-only and records explicit published/reconstruction/hindsight modes, actual database publication time, immutable consumed model artifacts, and captured input snapshots. Existing rows retain their IDs and payloads as `legacy_unknown`.

Published accuracy and calibration now select only forecasts written strictly before a known kickoff. Upcoming APIs and simulation exclude historical experiments; a new history view retains every mode. Blend backfills default to as-of-week reconstruction, with labeled hindsight opt-in. Nightly simulation explicitly preserves stored outlooks during the initial published-sample cold start while continuing mart refresh and verification; other failures remain fatal.

Validation: 2,389 main tests passed (460 skipped, including live warehouse checks); 59 MCP tests passed; 10 actual PostgreSQL 16 tests passed, covering repeat migration, real writer inserts, strict intraday selection, invariant prospective metrics, and anon/authenticated/analyst access. Independent review findings resolved. Lint/format and agent setup checks pass for committed files. CI adds a disposable PostgreSQL provenance job; production F04 assertions remain deployment-aware.

Deployment is separate and not performed. The plan and ordered manifest require coordinated writer/schema cutover, production dependency/grant inspection, downstream API type regeneration, and explicit production authorization. Legacy history is never promoted; published accuracy can initially be empty and new outlook generation needs enough prospective outcomes. See `docs/plans/2026-09-07-f04-prediction-provenance.md` for the rollout and evidence.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

## Summary
- Separates prospective published forecasts from reconstructed prediction history.
- Preserves historical prediction records while limiting accuracy measurements to forecasts published before kickoff.
- Validated the migration and prediction API views against a disposable database fixture; no issues were identified.

<h3>Confidence Score: 5/5</h3>

Safe to merge.

No defects were identified. The database migration, accuracy calculation, and prediction API contract were exercised with pre-kickoff, post-kickoff, and reconstructed prediction records.

**Files Needing Attention:** No files need follow-up attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I created a disposable PostgreSQL fixture with pre-kickoff, post-kickoff, and reconstructed prediction records; I then applied the prediction-provenance migration and rebuilt the prediction accuracy and API views.
- I verified that accuracy uses exactly one forecast published before kickoff, the current prediction view returns the latest published forecast, and the history view retains reconstructed records.
- After the migration, marts.prediction\_accuracy scores exactly one strict pre-kickoff publication with margin\_mae=3.0000; api.game\_predictions returns the latest published 90.00; api.prediction\_history retains reconstruction, and the hypothesis that the migration/API contract fails to separate prospective scoring from published/history views was disproven.

<a href="https://app.greptile.com/trex/runs/22836162/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Separate published forecasts from histor..."](https://github.com/rstover-fo/cfb-database/commit/1b852c50239fe868edca832a3dd301e0e9c22ea7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61059880)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Knowledge Base — [Database platform and analytics layer](https://app.greptile.com/formentera-operations/-/custom-context/knowledge-base/rstover-fo/cfb-database/-/docs/database-platform.md)
- Knowledge Base — [Schema deployment and migrations](https://app.greptile.com/formentera-operations/-/custom-context/knowledge-base/rstover-fo/cfb-database/-/docs/schema-deployment.md)
- Knowledge Base — [Analytics marts and refreshes](https://app.greptile.com/formentera-operations/-/custom-context/knowledge-base/rstover-fo/cfb-database/-/docs/analytics-marts.md)
- Knowledge Base — [Public data views and functions](https://app.greptile.com/formentera-operations/-/custom-context/knowledge-base/rstover-fo/cfb-database/-/docs/public-data-interfaces.md)
- Knowledge Base — [Ratings and game predictions](https://app.greptile.com/formentera-operations/-/custom-context/knowledge-base/rstover-fo/cfb-database/-/docs/ratings-and-predictions.md)
</details>


<!-- /greptile_comment -->