### PR TITLE
F07: make mart rebuilds dependency-aware and atomic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - run: ./scripts/setup_dev.sh
       - name: Managed bootstrap and upgrade integration
-        run: .venv/bin/python -m pytest tests/test_warehouse_migrations_sql.py tests/test_warehouse_bootstrap_sql.py tests/test_adopt_warehouse_catalog_sql.py tests/test_f06_verification_transactions_sql.py -q --tb=short
+        run: .venv/bin/python -m pytest tests/test_warehouse_migrations_sql.py tests/test_warehouse_bootstrap_sql.py tests/test_adopt_warehouse_catalog_sql.py tests/test_f06_verification_transactions_sql.py tests/test_mart_release_sql.py -q --tb=short
         env:
           F06_TEST_DB_URL: postgresql://postgres:f06-disposable-ci@127.0.0.1:5432/postgres
           F06_REQUIRE_DB: "1"

--- a/.github/workflows/deploy-schema.yml
+++ b/.github/workflows/deploy-schema.yml
@@ -29,14 +29,15 @@ on:
           - backfill
           - compute
         default: presence_check
-      marts_from:
-        description: "run_marts.py --from value, e.g. 029 (apply only)"
+      mart_release:
+        description: "Reviewed dependency-aware mart release manifest (apply only)"
         required: false
         type: string
-      marts_only:
-        description: "run_marts.py --only value, e.g. 011 (apply only, takes precedence over marts_from)"
+      plan:
+        description: "Read-only mart release dependency preview (requires mart_release)"
         required: false
-        type: string
+        type: boolean
+        default: false
       files:
         description: "Comma-separated SQL files for run_migrations.py --file (apply only)"
         required: false
@@ -109,8 +110,8 @@ jobs:
         # unchanged; only where each value comes from moves.
         env:
           ACTION_INPUT: ${{ inputs.action }}
-          MARTS_FROM_INPUT: ${{ inputs.marts_from }}
-          MARTS_ONLY_INPUT: ${{ inputs.marts_only }}
+          MART_RELEASE_INPUT: ${{ inputs.mart_release }}
+          PLAN_INPUT: ${{ inputs.plan }}
           FILES_INPUT: ${{ inputs.files }}
           REFRESH_INPUT: ${{ inputs.refresh }}
           BACKFILL_START_INPUT: ${{ inputs.backfill_start }}
@@ -121,8 +122,8 @@ jobs:
         run: |
           set -euo pipefail
           ARGS=(--action "$ACTION_INPUT")
-          if [ -n "$MARTS_FROM_INPUT" ]; then ARGS+=(--marts-from "$MARTS_FROM_INPUT"); fi
-          if [ -n "$MARTS_ONLY_INPUT" ]; then ARGS+=(--marts-only "$MARTS_ONLY_INPUT"); fi
+          if [ -n "$MART_RELEASE_INPUT" ]; then ARGS+=(--mart-release "$MART_RELEASE_INPUT"); fi
+          if [ "$PLAN_INPUT" = "true" ]; then ARGS+=(--plan); fi
           if [ -n "$FILES_INPUT" ]; then ARGS+=(--files "$FILES_INPUT"); fi
           if [ "$REFRESH_INPUT" = "true" ]; then ARGS+=(--refresh); fi
           if [ -n "$BACKFILL_START_INPUT" ]; then ARGS+=(--backfill-start "$BACKFILL_START_INPUT"); fi

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ logs/
 # Subagent worktrees (Agent tool isolation: "worktree"). Transient checkouts of
 # this repo, auto-removed when the agent finishes; never project content.
 .claude/worktrees/
+
+# PR Lens writes its previews here. They are rebuilt on demand.
+.pr-lens/

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ catalog reconciliation and adoption. Do not point bootstrap at them.
 
 ### Ingestion and explicit operations
 
+Mart replacement uses an explicit [dependency-aware release](docs/mart-releases.md).
+Preview with `scripts/run_marts.py --release <manifest> --plan`, then apply the
+same reviewed manifest. Real bare/number-selected mart deployments and raw mart
+files through the per-file migration runner are rejected to preserve consumers.
+
 Schema construction does not load game/roster data or certify warehouse coverage.
 For an authorized ingestion target, configure `.dlt/secrets.toml` from its example
 with a CFBD key and Supabase session-pooler connection, then run the selected

--- a/deploys/mart-releases/trajectory-consumer.sql
+++ b/deploys/mart-releases/trajectory-consumer.sql
@@ -1,0 +1,7 @@
+-- Scoped consumer restoration for the trajectory mart release.
+CREATE OR REPLACE VIEW public.team_season_trajectory
+WITH (security_invoker = true) AS
+SELECT team, season, epa_per_play, success_rate, off_epa_rank, def_epa_rank,
+       win_pct, wins, games, recruiting_rank, era_code, era_name, prev_epa, epa_delta
+FROM marts.team_season_trajectory;
+GRANT SELECT ON public.team_season_trajectory TO anon, authenticated;

--- a/deploys/mart-releases/trajectory.json
+++ b/deploys/mart-releases/trajectory.json
@@ -40,13 +40,20 @@
       "name": "trajectory_rpc_anon",
       "role": "anon",
       "query": "SELECT count(*) >= 0 FROM public.get_trajectory_averages('SEC', 2020, 2025)",
-      "covers": []
+      "covers": [
+        "public.get_trajectory_averages(p_conference text, p_season_start integer, p_season_end integer)"
+      ]
     },
     {
       "name": "trajectory_rpc_authenticated",
       "role": "authenticated",
       "query": "SELECT count(*) >= 0 FROM public.get_trajectory_averages('SEC', 2020, 2025)",
-      "covers": []
+      "covers": [
+        "public.get_trajectory_averages(p_conference text, p_season_start integer, p_season_end integer)"
+      ]
     }
+  ],
+  "consumers": [
+    "public.get_trajectory_averages(p_conference text, p_season_start integer, p_season_end integer)"
   ]
 }

--- a/deploys/mart-releases/trajectory.json
+++ b/deploys/mart-releases/trajectory.json
@@ -1,0 +1,52 @@
+{
+  "version": 1,
+  "files": [
+    {
+      "path": "src/schemas/marts/013_team_season_trajectory.sql",
+      "sha256": "f9a2e14b7e199c696a23ddfed181f346d5388259a790f9bd7fea022dd248b117"
+    },
+    {
+      "path": "deploys/mart-releases/trajectory-consumer.sql",
+      "sha256": "c1e966ddd0c0dcddd34465adcb48b0845c64f53d23e0a478351a5185715e68d9"
+    }
+  ],
+  "roots": [
+    "marts.team_season_trajectory"
+  ],
+  "restores": [
+    {
+      "kind": "relation",
+      "identity": "marts.team_season_trajectory"
+    },
+    {
+      "kind": "relation",
+      "identity": "public.team_season_trajectory"
+    }
+  ],
+  "validations": [
+    {
+      "name": "trajectory_anon",
+      "role": "anon",
+      "query": "SELECT count(*) >= 0 FROM public.team_season_trajectory",
+      "covers": []
+    },
+    {
+      "name": "trajectory_authenticated",
+      "role": "authenticated",
+      "query": "SELECT count(*) >= 0 FROM public.team_season_trajectory",
+      "covers": []
+    },
+    {
+      "name": "trajectory_rpc_anon",
+      "role": "anon",
+      "query": "SELECT count(*) >= 0 FROM public.get_trajectory_averages('SEC', 2020, 2025)",
+      "covers": []
+    },
+    {
+      "name": "trajectory_rpc_authenticated",
+      "role": "authenticated",
+      "query": "SELECT count(*) >= 0 FROM public.get_trajectory_averages('SEC', 2020, 2025)",
+      "covers": []
+    }
+  ]
+}

--- a/docs/mart-releases.md
+++ b/docs/mart-releases.md
@@ -1,0 +1,84 @@
+# Dependency-aware mart releases
+
+Mart definitions that use CASCADE must run as an explicit release, with every
+affected consumer restored in the same transaction. Bare `run_marts.py`, real
+`--only`/`--from` selection, and mart files passed to `run_migrations.py --file`
+are rejected. Historical deployment manifests containing mart files need an
+explicit release conversion before reuse; their old per-file sequence is not
+an atomic recovery plan.
+
+## Prepare and preview
+
+Use `deploys/mart-releases/trajectory.json` as a bounded example. Its SQL files
+rebuild the trajectory mart and restore its public invoker-rights wrapper. The
+manifest pins exact file SHA256 checksums and declares relation roots, restoration
+identities, and caller-role boolean SELECT assertions.
+
+```bash
+export SUPABASE_DB_URL='postgresql://postgres:local-password@127.0.0.1:55437/postgres'
+.venv/bin/python scripts/run_marts.py --release deploys/mart-releases/trajectory.json --plan
+```
+
+The plan reads PostgreSQL catalog dependencies and reports the affected closure,
+missing restoration coverage, and unsupported objects. It executes no release
+SQL. A plan is a preview, not a reservation: execution must recheck the catalog
+under the shared migration lock. Review added consumers instead of simply
+appending their names to make preflight green; their definitions and permissions
+must survive the release as well.
+
+## Execute and verify
+
+```bash
+.venv/bin/python scripts/run_marts.py --release deploys/mart-releases/trajectory.json
+```
+
+The schema workflow exposes `mart_release` and `plan` for the same operation.
+Do not combine a release with extra per-file SQL or a separate refresh step.
+All required definitions, indexes, and caller assertions belong in the release.
+The engine uses one transaction and checks preserved contracts before committing.
+Failure rolls back the replacement and its downstream work together. Inspect
+the reported error and rerun the unchanged read-only plan after fixing the
+reviewed release; do not repair consumers with a partially applied file list.
+
+Existing consumer column types/order, object kinds, owner/security properties,
+and permissions are preservation contracts. Version 1 does not authorize a
+breaking API change. Prepare a separately reviewed compatible migration when
+the intended consumer contract must change.
+
+Version 1 accepts view and materialized-view roots and their supported view and
+function dependents. It rejects dependent stored tables and unsupported catalog
+objects such as composite types. Recreate existing indexes, comments, column
+grants, and other checked metadata in the release SQL; omitted metadata causes
+rollback. Object owners and relation/function grants are restored automatically.
+Multi-level grants delegated through other grantees may fail during replay; a
+failure rolls back the release. Such grant chains need a separately rehearsed
+restoration strategy before rollout.
+
+## Operational boundaries
+
+Production execution requires rollout authorization. Plan and rehearsal should
+use the disposable F06 warehouse first, with representative populated fixtures
+where behavior depends on data. The bundled trajectory example proves executable
+definitions and access on an empty fixture, not production rebuild duration.
+
+Transactional rebuilding can block readers and consume substantial storage or
+work memory. Use bounded timeouts and a maintenance window without other schema
+writers. The advisory lock coordinates managed tools, not unrelated admin DDL.
+For long builds, design a separate staged replacement and dependency cutover;
+renaming a new relation does not move views still bound to the old object.
+
+Catalog dependencies omit some string-bodied and dynamic SQL references.
+Explicit caller-role queries complement closure checks, but cannot prove every
+application query. Release SQL is reviewed migration code, not hostile input;
+these checks are not a general SQL security sandbox.
+
+Validation queries must be side-effect-free SELECT assertions. Each runs under
+its declared role inside a savepoint that is rolled back, so ordinary transactional
+writes cannot persist. This is not enforced read-only execution: sequence advances
+and external effects of called functions can survive a savepoint rollback. Review
+the functions invoked by assertions as well as the query text.
+
+The F06 production adoption receipt and immutable baseline remain unchanged.
+The release manifest's file checksums bind this release's reviewed SQL; they do
+not create historical migration entries or authorize changing already applied
+immutable files in the production migration manifest.

--- a/docs/mart-releases.md
+++ b/docs/mart-releases.md
@@ -14,6 +14,14 @@ rebuild the trajectory mart and restore its public invoker-rights wrapper. The
 manifest pins exact file SHA256 checksums and declares relation roots, restoration
 identities, and caller-role boolean SELECT assertions.
 
+List known textual or dynamic function readers in the optional `consumers`
+array, using the exact qualified identity reported by
+`pg_get_function_identity_arguments` (including argument names). Each must
+exist and be named in an assertion's `covers` array. These declarations add
+validation coverage; they do not authorize recreating an unrelated function.
+The trajectory example declares its RPC this way. Catalog inspection cannot
+discover every such reader, so the release author must identify them.
+
 ```bash
 export SUPABASE_DB_URL='postgresql://postgres:local-password@127.0.0.1:55437/postgres'
 .venv/bin/python scripts/run_marts.py --release deploys/mart-releases/trajectory.json --plan
@@ -41,7 +49,7 @@ the reported error and rerun the unchanged read-only plan after fixing the
 reviewed release; do not repair consumers with a partially applied file list.
 
 Existing consumer column types/order, object kinds, owner/security properties,
-and permissions are preservation contracts. Version 1 does not authorize a
+population state, and permissions are preservation contracts. Version 1 does not authorize a
 breaking API change. Prepare a separately reviewed compatible migration when
 the intended consumer contract must change.
 

--- a/docs/plans/2026-09-04-main-codebase-audit.md
+++ b/docs/plans/2026-09-04-main-codebase-audit.md
@@ -156,6 +156,8 @@ Evidence: [migration runner](https://github.com/rstover-fo/cfb-database/blob/4a7
 
 ### F07 — Generic mart deployment can remove consumer objects through CASCADE
 
+Implementation plan: [F07 dependency-aware mart releases](2026-09-08-f07-dependency-aware-marts.md).
+
 **P1 · Confirmed · L; shares work with F06**
 
 Many mart definition files drop materialized views with CASCADE. The generic runner applies sorted mart files with per-file commits and does not recreate dependent api/public objects. An individual --only deployment can remove a dependency closure beyond its requested file. Handwritten deployment manifests sometimes restore that closure, but the generic command does not enforce it.

--- a/docs/plans/2026-09-08-f07-dependency-aware-marts.md
+++ b/docs/plans/2026-09-08-f07-dependency-aware-marts.md
@@ -1,8 +1,9 @@
 # F07 — dependency-aware mart releases
 
-Status: implemented and locally verified from merged PR #130 (`4291e88`), pending
-PR checks and review. Production rollout requires separate authorization; this
-goal uses disposable PostgreSQL.
+Status: implemented and locally verified in PR #131 from merged PR #130
+(`4291e88`). Initial CI passed; all four automated findings have verified fixes
+and independent review, pending CI on the follow-up commit. Production rollout
+requires separate authorization; this goal uses disposable PostgreSQL.
 
 ## Outcome
 
@@ -59,18 +60,23 @@ files remain immutable. Unrelated film/tracking work is preserved.
 
 ## Verification evidence
 
-- Executed PostgreSQL 17/pgvector: 12 F07 cases pass, including rollback after
+- Executed PostgreSQL 17/pgvector: 16 F07 cases pass, including rollback after
   downstream failure, successful/repeated populated rebuild, incomplete/new
   dependencies, incompatible columns, lost indexes/comments/column grants/view
   rules, public consumer changes, default-grant isolation, composite-type rejection,
   row-type function coverage, and the existing trajectory release/RPC caller roles.
+  PR regressions additionally cover population state, numeric assertions, and
+  explicitly declared dynamic consumers.
 - Combined F06 compatibility and F07 SQL suite: 26 passed before the final extra
   view-rule case; the final F07 suite was rerun successfully afterward.
-- Main suite: 2,563 passed, 527 skipped (database-dependent tests opt in separately).
-  MCP suite: 59 passed.
+- Main suite: 2,578 passed, 531 skipped (database-dependent tests opt in separately).
+  MCP suite: 59 passed. Final engine/CLI checks after the Unicode identifier
+  guard regression: 39 passed.
 - Ruff check and format pass for tracked/project changes. Whole-workspace lint
   also finds existing untracked `scripts/film/update_storage_uri.py` issues; that
   unrelated user work is unchanged and excluded from this PR.
 - Independent review findings on dependency closure, public objects, metadata,
   transaction parsing, and validation boundaries were addressed. See the release
   operations guide for remaining dynamic-SQL, grant-chain, and runtime limits.
+- PR Lens architecture and transaction SVGs are attached to PR #131. Generated
+  diagrams stay local in the ignored `.pr-lens/` directory.

--- a/docs/plans/2026-09-08-f07-dependency-aware-marts.md
+++ b/docs/plans/2026-09-08-f07-dependency-aware-marts.md
@@ -1,0 +1,76 @@
+# F07 — dependency-aware mart releases
+
+Status: implemented and locally verified from merged PR #130 (`4291e88`), pending
+PR checks and review. Production rollout requires separate authorization; this
+goal uses disposable PostgreSQL.
+
+## Outcome
+
+A mart rebuild must not silently remove consumers through CASCADE. The supported
+release path previews the live PostgreSQL dependency closure, requires explicit
+restoration coverage, executes the ordered release in one transaction, and checks
+consumer contracts and access before commit. A downstream SQL failure rolls back
+the upstream replacement, leaving the prior API/public objects and grants intact.
+
+## Delegation and ownership
+
+- Lead: release design, representative catalog fixtures, executed integration,
+  workflow wiring, documentation, integration, and PR publication.
+- Explorer: read-only tracing of existing runners, dependency closure, and bypasses.
+- Implementer: strict release manifest, catalog preflight, transactional engine,
+  and focused engine tests.
+- Implementer: mart CLI and schema deployer integration, fail-closed legacy paths,
+  and CLI regression tests.
+- Independent reviewer: substantive engine/access changes and executed failure
+  scenarios after implementation; the explorer slot is reused for review.
+
+## Scope and acceptance
+
+1. Explicit manifests identify upstream roots, objects restored, ordered SQL files
+   with exact checksums, and caller-role validation queries. Read-only planning
+   lists the live closure and rejects missing/unsupported restoration coverage.
+2. Execution rechecks under the shared migration lock and performs all release
+   work in one transaction. Preserve existing consumer columns, object kinds,
+   owners, security settings, and privileges; reject unexplained contract loss.
+3. Bare mart deployment and real `--only`/`--from` calls fail before connecting.
+   Raw mart files cannot pass through the old per-file migration/deploy route.
+   Diagnostic listing and SQL previews remain available.
+4. Disposable PostgreSQL tests cover an upstream mart, downstream materialized
+   and regular views, public/API consumers and actual roles. Inject failure after
+   the upstream DROP, then prove prior object identities, data and grants survive.
+   Test incomplete closure, newly added unmanaged dependents, lost permissions,
+   and incompatible replacement columns as failures rather than partial success.
+5. Exercise a representative existing mart release on the F06 warehouse fixture.
+   Add mandatory CI coverage, document recovery and blocking/long-build limits,
+   resolve independent/PR findings, and publish the completed change.
+
+## Limits to keep explicit
+
+PostgreSQL catalog dependencies do not discover arbitrary dynamic SQL or every
+string-bodied function reference. Explicit caller assertions complement catalog
+closure checks. Reviewed SQL is trusted migration code; this is not a sandbox for
+hostile arbitrary SQL. Long rebuilds can hold locks and consume resources; test
+rollback correctness without claiming unmeasured production downtime or cost.
+Renaming a staged object does not repoint existing dependencies. Specialized
+staged rebuilds need their own reviewed dependency and cutover plan.
+
+The F06 immutable baseline, adopted production receipt, and historical migration
+files remain immutable. Unrelated film/tracking work is preserved.
+
+## Verification evidence
+
+- Executed PostgreSQL 17/pgvector: 12 F07 cases pass, including rollback after
+  downstream failure, successful/repeated populated rebuild, incomplete/new
+  dependencies, incompatible columns, lost indexes/comments/column grants/view
+  rules, public consumer changes, default-grant isolation, composite-type rejection,
+  row-type function coverage, and the existing trajectory release/RPC caller roles.
+- Combined F06 compatibility and F07 SQL suite: 26 passed before the final extra
+  view-rule case; the final F07 suite was rerun successfully afterward.
+- Main suite: 2,563 passed, 527 skipped (database-dependent tests opt in separately).
+  MCP suite: 59 passed.
+- Ruff check and format pass for tracked/project changes. Whole-workspace lint
+  also finds existing untracked `scripts/film/update_storage_uri.py` issues; that
+  unrelated user work is unchanged and excluded from this PR.
+- Independent review findings on dependency closure, public objects, metadata,
+  transaction parsing, and validation boundaries were addressed. See the release
+  operations guide for remaining dynamic-SQL, grant-chain, and runtime limits.

--- a/docs/warehouse-operations.md
+++ b/docs/warehouse-operations.md
@@ -29,7 +29,7 @@ These commands operate on an explicitly selected, authorized warehouse; use
 | Season ingestion | `scripts/load_season.py --weekly` (explicit `--season` for backfills) |
 | Post-load verification | `scripts/verify_load.py` |
 | Refresh existing marts | `scripts/refresh_marts.py` |
-| Apply definitions / migrations | `scripts/run_marts.py`; `scripts/run_migrations.py` |
+| Apply definitions / migrations | [Atomic mart releases](mart-releases.md); `scripts/run_migrations.py` for explicit non-mart migrations |
 | One-off SQL application | `scripts/run_migrations.py --file <path>`; follow that file's application contract |
 | Flat-file ingestion | `scripts/load_flat_files.py --due` |
 | Check upstream preseason availability | `scripts/probe_offseason_availability.py` |

--- a/scripts/deploy_schema.py
+++ b/scripts/deploy_schema.py
@@ -10,8 +10,8 @@ run_migrations.py, refresh_marts.py, load_season.py, and check_presence.py.
 Manifest schema:
     {
       "action": "presence_check" | "apply" | "backfill" | "compute",
-      "marts_from": "029",
-      "marts_only": "011",
+      "mart_release": "src/schemas/mart-releases/example.json",
+      "plan": false,
       "files": ["src/schemas/api/019_x.sql", ...],
       "refresh": true,
       "refresh_views": ["marts.team_week_features", "marts.adjusted_epa_week"],
@@ -19,13 +19,16 @@ Manifest schema:
       "compute": {"script": "compute_house_elo", "args": ["--full"]}
     }
 
-All fields besides "action" are optional and only consulted by the action
-that uses them (e.g. an "apply" manifest never looks at "backfill").
+All fields besides "action" are optional. A mart release is exclusive: it
+cannot be combined with legacy mart selectors, per-file SQL, refresh, backfill,
+or compute fields.
 
 Usage:
     python scripts/deploy_schema.py --manifest deploy-manifest.json
     python scripts/deploy_schema.py --action presence_check --strict
-    python scripts/deploy_schema.py --action apply --marts-only 011 \\
+    python scripts/deploy_schema.py --action apply \\
+        --mart-release src/schemas/mart-releases/example.json --plan
+    python scripts/deploy_schema.py --action apply \\
         --files src/schemas/functions/get_player_game_log.sql --refresh
     python scripts/deploy_schema.py --action backfill \\
         --backfill-start 2014 --backfill-end 2025 --sources stats,betting
@@ -50,6 +53,8 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(mess
 logger = logging.getLogger(__name__)
 
 SCRIPTS_DIR = Path(__file__).parent
+REPO_ROOT = SCRIPTS_DIR.parent.resolve()
+MARTS_DIR = (REPO_ROOT / "src" / "schemas" / "marts").resolve()
 RUN_MARTS = SCRIPTS_DIR / "run_marts.py"
 RUN_MIGRATIONS = SCRIPTS_DIR / "run_migrations.py"
 REFRESH_MARTS = SCRIPTS_DIR / "refresh_marts.py"
@@ -136,6 +141,8 @@ class ComputeSpec:
 @dataclass
 class Plan:
     action: str
+    mart_release: str | None = None
+    plan: bool = False
     marts_from: str | None = None
     marts_only: str | None = None
     files: list[str] = field(default_factory=list)
@@ -176,6 +183,58 @@ def validate_plan(plan: Plan) -> None:
                 f"must be one of {sorted(COMPUTE_SCRIPTS)}"
             )
 
+    if not isinstance(plan.plan, bool):
+        raise ValueError("plan must be a boolean")
+    if plan.mart_release is not None and (
+        not isinstance(plan.mart_release, str) or not plan.mart_release.strip()
+    ):
+        raise ValueError("mart_release must be a nonempty manifest path")
+
+    if plan.plan and plan.mart_release is None:
+        raise ValueError("--plan requires a mart_release manifest")
+
+    if plan.mart_release is not None:
+        if plan.action != "apply":
+            raise ValueError("mart_release is valid only for the apply action")
+        conflicts = []
+        if plan.marts_from:
+            conflicts.append("marts_from")
+        if plan.marts_only:
+            conflicts.append("marts_only")
+        if plan.files:
+            conflicts.append("files")
+        if plan.refresh:
+            conflicts.append("refresh")
+        if plan.refresh_views:
+            conflicts.append("refresh_views")
+        if plan.backfill is not None:
+            conflicts.append("backfill")
+        if plan.compute is not None:
+            conflicts.append("compute")
+        if plan.strict:
+            conflicts.append("strict")
+        if conflicts:
+            raise ValueError(
+                "mart_release cannot be combined with legacy deploy fields: " + ", ".join(conflicts)
+            )
+
+    if plan.action == "apply" and (plan.marts_from or plan.marts_only):
+        raise ValueError(
+            "legacy mart selectors cannot execute real changes; "
+            "use mart_release with a dependency-complete release manifest"
+        )
+
+    for sql_file in plan.files:
+        candidate = Path(sql_file)
+        if not candidate.is_absolute():
+            candidate = REPO_ROOT / candidate
+        resolved = candidate.resolve()
+        if resolved == MARTS_DIR or MARTS_DIR in resolved.parents:
+            raise ValueError(
+                f"mart SQL file {sql_file!r} cannot use the per-file migration route; "
+                "use mart_release with a dependency-complete release manifest"
+            )
+
     if plan.refresh_views:
         for view in plan.refresh_views:
             if view.count(".") != 1:
@@ -189,6 +248,10 @@ def load_manifest(path: str) -> dict:
 
 def plan_from_manifest(manifest: dict) -> Plan:
     """Build and validate a Plan from a parsed deploy-manifest.json dict."""
+    raw_release_plan = manifest.get("plan", False)
+    if not isinstance(raw_release_plan, bool):
+        raise ValueError("plan must be a boolean")
+
     backfill = None
     bf = manifest.get("backfill")
     if bf:
@@ -208,6 +271,8 @@ def plan_from_manifest(manifest: dict) -> Plan:
 
     plan = Plan(
         action=manifest.get("action"),
+        mart_release=manifest.get("mart_release"),
+        plan=raw_release_plan,
         marts_from=manifest.get("marts_from"),
         marts_only=manifest.get("marts_only"),
         files=list(manifest.get("files") or []),
@@ -229,6 +294,8 @@ def plan_from_manifest(manifest: dict) -> Plan:
 def plan_from_cli(
     *,
     action: str,
+    mart_release: str | None = None,
+    plan: bool = False,
     marts_from: str | None = None,
     marts_only: str | None = None,
     files: str | None = None,
@@ -267,6 +334,8 @@ def plan_from_cli(
 
     plan = Plan(
         action=action,
+        mart_release=mart_release,
+        plan=plan,
         marts_from=marts_from,
         marts_only=marts_only,
         files=file_list,
@@ -301,21 +370,12 @@ def run_presence_check(plan: Plan) -> int:
 
 
 def run_apply(plan: Plan) -> int:
-    # --only takes precedence over --from, mirroring run_marts.py's own logic.
-    if plan.marts_only:
-        rc = run_cmd(
-            [sys.executable, str(RUN_MARTS), "--only", plan.marts_only],
-            f"run_marts --only {plan.marts_only}",
-        )
-        if rc:
-            return rc
-    elif plan.marts_from:
-        rc = run_cmd(
-            [sys.executable, str(RUN_MARTS), "--from", plan.marts_from],
-            f"run_marts --from {plan.marts_from}",
-        )
-        if rc:
-            return rc
+    validate_plan(plan)
+    if plan.mart_release:
+        cmd = [sys.executable, str(RUN_MARTS), "--release", plan.mart_release]
+        if plan.plan:
+            cmd.append("--plan")
+        return run_cmd(cmd, f"run_marts --release {plan.mart_release}")
 
     for sql_file in plan.files:
         rc = run_cmd(
@@ -419,8 +479,26 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Schema deploy driver")
     parser.add_argument("--manifest", help="Path to a JSON deploy manifest (see module docstring)")
     parser.add_argument("--action", choices=sorted(VALID_ACTIONS), help="Action to run")
-    parser.add_argument("--marts-from", dest="marts_from", help="run_marts.py --from value")
-    parser.add_argument("--marts-only", dest="marts_only", help="run_marts.py --only value")
+    parser.add_argument(
+        "--mart-release",
+        dest="mart_release",
+        help="Dependency-complete mart release manifest (apply only)",
+    )
+    parser.add_argument(
+        "--plan",
+        action="store_true",
+        help="Preview --mart-release through a read-only transaction",
+    )
+    parser.add_argument(
+        "--marts-from",
+        dest="marts_from",
+        help="unsupported legacy selector; use --mart-release",
+    )
+    parser.add_argument(
+        "--marts-only",
+        dest="marts_only",
+        help="unsupported legacy selector; use --mart-release",
+    )
     parser.add_argument("--files", help="Comma-separated SQL files to apply via run_migrations.py")
     parser.add_argument("--refresh", action="store_true", help="Refresh marts schema after apply")
     parser.add_argument(
@@ -463,6 +541,8 @@ def main(argv: list[str] | None = None) -> None:
             parser.error("--action is required when --manifest is not given")
         plan = plan_from_cli(
             action=args.action,
+            mart_release=args.mart_release,
+            plan=args.plan,
             marts_from=args.marts_from,
             marts_only=args.marts_only,
             files=args.files,

--- a/scripts/mart_release.py
+++ b/scripts/mart_release.py
@@ -1,0 +1,892 @@
+"""Dependency-complete, transactional mart releases.
+
+Version 1 deliberately supports only contract-preserving releases.  A manifest names every
+existing relation or function in the PostgreSQL downstream dependency closure.  Planning is
+read-only; execution repeats the plan under the warehouse migration advisory lock before any
+manifest SQL is run.
+
+PostgreSQL records parsed dependencies for views and SQL functions.  PL/pgSQL bodies can contain
+textual relation references which are not catalog dependencies, so affected PL/pgSQL functions
+also require role-scoped validation queries declared by the manifest.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Literal
+
+from scripts.warehouse_migrations import (
+    ADVISORY_LOCK_KEYS,
+    PROJECT_SCHEMAS,
+    _statement_words,
+    _validate_no_transaction_control,
+)
+
+ObjectKind = Literal["relation", "function"]
+
+LOCK_TIMEOUT = "10s"
+STATEMENT_TIMEOUT = "15min"
+
+_IDENTIFIER_RE = re.compile(r"[a-z_][a-z0-9_$]*\Z")
+_RELATION_RE = re.compile(r"[a-z_][a-z0-9_$]*\.[a-z_][a-z0-9_$]*\Z")
+_SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
+
+
+class ReleaseManifestError(ValueError):
+    """The release manifest or one of its files is malformed or unsafe."""
+
+
+class ReleaseExecutionError(RuntimeError):
+    """A release failed a validation or post-execution invariant."""
+
+
+class ReleaseBlockedError(RuntimeError):
+    """The live dependency closure does not permit this release."""
+
+    def __init__(self, plan: ReleasePlan):
+        self.plan = plan
+        super().__init__("; ".join(plan.blockers) or "mart release is blocked")
+
+
+@dataclass(frozen=True, order=True)
+class ObjectIdentity:
+    kind: ObjectKind
+    identity: str
+
+
+@dataclass(frozen=True)
+class ReleaseFile:
+    path: str
+    sha256: str
+    absolute_path: Path
+    sql: str
+
+
+@dataclass(frozen=True)
+class ValidationQuery:
+    name: str
+    role: str
+    query: str
+    covers: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ReleaseManifest:
+    version: int
+    files: tuple[ReleaseFile, ...]
+    roots: tuple[str, ...]
+    restores: tuple[ObjectIdentity, ...]
+    validations: tuple[ValidationQuery, ...]
+    source_path: Path
+    root: Path
+
+
+@dataclass(frozen=True)
+class ReleasePlan:
+    files: tuple[ReleaseFile, ...]
+    roots: tuple[str, ...]
+    declared_restores: tuple[ObjectIdentity, ...]
+    live_closure: tuple[ObjectIdentity, ...]
+    blockers: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
+
+    @property
+    def valid(self) -> bool:
+        return not self.blockers
+
+
+@dataclass(frozen=True)
+class _CatalogSnapshot:
+    identity: ObjectIdentity
+    object_type: str
+    definition: str
+    contract: tuple[object, ...]
+    owner: str
+    acl: tuple[tuple[str, str, str, bool], ...]
+
+
+def _reject_duplicate_json_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ReleaseManifestError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def _load_json(path: Path) -> object:
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        raise ReleaseManifestError(f"cannot read release manifest {path}: {exc}") from exc
+    try:
+        return json.loads(raw.decode("utf-8"), object_pairs_hook=_reject_duplicate_json_keys)
+    except UnicodeDecodeError as exc:
+        raise ReleaseManifestError(f"release manifest is not UTF-8: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ReleaseManifestError(f"invalid JSON release manifest {path}: {exc}") from exc
+
+
+def _resolve_sql_path(value: object, root: Path) -> tuple[str, Path]:
+    if not isinstance(value, str) or not value or "\\" in value:
+        raise ReleaseManifestError("release file path must be repository-relative POSIX syntax")
+    relative = PurePosixPath(value)
+    if (
+        relative.is_absolute()
+        or value != relative.as_posix()
+        or any(part in {"", ".", ".."} for part in relative.parts)
+        or relative.suffix.lower() != ".sql"
+    ):
+        raise ReleaseManifestError(f"unsafe or non-canonical release file path: {value!r}")
+    try:
+        resolved = root.joinpath(*relative.parts).resolve(strict=True)
+        resolved.relative_to(root)
+    except (OSError, ValueError) as exc:
+        raise ReleaseManifestError(
+            f"release file is missing or outside repository: {value!r}"
+        ) from exc
+    if not resolved.is_file():
+        raise ReleaseManifestError(f"release path is not a file: {value!r}")
+    return value, resolved
+
+
+def _validate_release_sql(sql: str, path: str) -> None:
+    _validate_no_transaction_control(sql, path)
+    for words in _statement_words(sql):
+        if not words:
+            continue
+        forbidden = words[0] in {"CALL", "VACUUM"}
+        forbidden = forbidden or words[:2] in (
+            ["ALTER", "SYSTEM"],
+            ["CREATE", "DATABASE"],
+            ["CREATE", "TABLESPACE"],
+            ["DROP", "DATABASE"],
+            ["DROP", "TABLESPACE"],
+        )
+        # A file-level GUC change can weaken the parser assumptions or remove the bounded
+        # timeouts for later statements in the same protocol message. Function-clause SETs are
+        # part of a CREATE statement and therefore remain supported.
+        forbidden = forbidden or words[0] in {"SET", "RESET"}
+        forbidden = forbidden or (
+            "CONCURRENTLY" in words and words[0] in {"CREATE", "DROP", "REINDEX", "REFRESH"}
+        )
+        if forbidden:
+            raise ReleaseManifestError(
+                f"release file {path!r} contains nontransactional or unsafe SQL: "
+                f"{' '.join(words[:4])}"
+            )
+
+
+def _require_exact_keys(value: object, keys: set[str], context: str) -> dict[str, object]:
+    if not isinstance(value, dict) or set(value) != keys:
+        raise ReleaseManifestError(f"{context} keys must be exactly: {', '.join(sorted(keys))}")
+    return value
+
+
+def load_release(path: str | Path, root: str | Path) -> ReleaseManifest:
+    """Load and strictly validate a version-1 release manifest and its exact-byte hashes."""
+
+    try:
+        root_path = Path(root).resolve(strict=True)
+    except OSError as exc:
+        raise ReleaseManifestError(f"cannot resolve repository root {root}: {exc}") from exc
+    if not root_path.is_dir():
+        raise ReleaseManifestError(f"repository root is not a directory: {root_path}")
+    source_path = Path(path).resolve(strict=False)
+    payload = _require_exact_keys(
+        _load_json(source_path),
+        {"version", "files", "roots", "restores", "validations"},
+        "release manifest",
+    )
+    if type(payload["version"]) is not int or payload["version"] != 1:
+        raise ReleaseManifestError("release manifest version must be integer 1")
+
+    entries = payload["files"]
+    if not isinstance(entries, list) or not entries:
+        raise ReleaseManifestError("release manifest files must be a non-empty list")
+    files: list[ReleaseFile] = []
+    seen_paths: set[str] = set()
+    seen_resolved: set[Path] = set()
+    for index, raw_entry in enumerate(entries, start=1):
+        entry = _require_exact_keys(raw_entry, {"path", "sha256"}, f"release file {index}")
+        relative, absolute = _resolve_sql_path(entry["path"], root_path)
+        checksum = entry["sha256"]
+        if not isinstance(checksum, str) or not _SHA256_RE.fullmatch(checksum):
+            raise ReleaseManifestError(f"release file {relative!r} has invalid sha256")
+        if relative in seen_paths or absolute in seen_resolved:
+            raise ReleaseManifestError(f"duplicate release file: {relative}")
+        sql_bytes = absolute.read_bytes()
+        actual = hashlib.sha256(sql_bytes).hexdigest()
+        if actual != checksum:
+            raise ReleaseManifestError(
+                f"release file checksum mismatch for {relative}: expected {checksum}, "
+                f"found {actual}"
+            )
+        try:
+            sql = sql_bytes.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise ReleaseManifestError(f"release file is not UTF-8: {relative}") from exc
+        _validate_release_sql(sql, relative)
+        files.append(ReleaseFile(relative, checksum, absolute, sql))
+        seen_paths.add(relative)
+        seen_resolved.add(absolute)
+
+    roots_raw = payload["roots"]
+    if not isinstance(roots_raw, list) or not roots_raw:
+        raise ReleaseManifestError("release roots must be a non-empty list")
+    roots: list[str] = []
+    for value in roots_raw:
+        if not isinstance(value, str) or not _RELATION_RE.fullmatch(value):
+            raise ReleaseManifestError(f"root must be a fully qualified relation name: {value!r}")
+        if value in roots:
+            raise ReleaseManifestError(f"duplicate release root: {value}")
+        roots.append(value)
+
+    restores_raw = payload["restores"]
+    if not isinstance(restores_raw, list) or not restores_raw:
+        raise ReleaseManifestError("release restores must be a non-empty list")
+    restores: list[ObjectIdentity] = []
+    for index, raw_restore in enumerate(restores_raw, start=1):
+        restore = _require_exact_keys(raw_restore, {"kind", "identity"}, f"restore {index}")
+        kind = restore["kind"]
+        identity = restore["identity"]
+        if kind not in {"relation", "function"} or not isinstance(identity, str) or not identity:
+            raise ReleaseManifestError(f"invalid restore {index}: {raw_restore!r}")
+        if kind == "relation" and not _RELATION_RE.fullmatch(identity):
+            raise ReleaseManifestError(f"invalid relation restore identity: {identity!r}")
+        item = ObjectIdentity(kind, identity)
+        if item in restores:
+            raise ReleaseManifestError(f"duplicate restore identity: {kind} {identity}")
+        restores.append(item)
+    missing_roots = set(roots) - {item.identity for item in restores if item.kind == "relation"}
+    if missing_roots:
+        raise ReleaseManifestError(
+            f"release roots must also be declared as restores: {', '.join(sorted(missing_roots))}"
+        )
+
+    validations_raw = payload["validations"]
+    if not isinstance(validations_raw, list):
+        raise ReleaseManifestError("release validations must be a list")
+    validations: list[ValidationQuery] = []
+    names: set[str] = set()
+    for index, raw_validation in enumerate(validations_raw, start=1):
+        validation = _require_exact_keys(
+            raw_validation, {"name", "role", "query", "covers"}, f"validation {index}"
+        )
+        name, role, query, covers = (
+            validation["name"],
+            validation["role"],
+            validation["query"],
+            validation["covers"],
+        )
+        if not isinstance(name, str) or not name or name in names:
+            raise ReleaseManifestError(f"validation {index} has missing or duplicate name")
+        if not isinstance(role, str) or not _IDENTIFIER_RE.fullmatch(role):
+            raise ReleaseManifestError(f"validation {name!r} has invalid role")
+        if not isinstance(query, str) or not query.strip():
+            raise ReleaseManifestError(f"validation {name!r} has an empty query")
+        statements = _statement_words(query)
+        if len(statements) != 1 or statements[0][0] != "SELECT":
+            raise ReleaseManifestError(f"validation {name!r} must be one SELECT assertion")
+        _validate_no_transaction_control(query, f"validation {name}")
+        if not isinstance(covers, list) or any(
+            not isinstance(item, str) or not item for item in covers
+        ):
+            raise ReleaseManifestError(f"validation {name!r} covers must be a list of identities")
+        validations.append(ValidationQuery(name, role, query, tuple(covers)))
+        names.add(name)
+
+    return ReleaseManifest(
+        1,
+        tuple(files),
+        tuple(roots),
+        tuple(restores),
+        tuple(validations),
+        source_path,
+        root_path,
+    )
+
+
+def _ensure_idle_connection(conn: object) -> None:
+    if getattr(conn, "autocommit", False) is True:
+        raise RuntimeError("mart release connection must have autocommit disabled")
+    get_status = getattr(conn, "get_transaction_status", None)
+    if callable(get_status):
+        status = get_status()
+        if isinstance(status, int) and status != 0:
+            raise RuntimeError("mart release connection must not already be in a transaction")
+
+
+def _execute(cur: object, sql: str, params: object = None) -> None:
+    if params is None:
+        cur.execute(sql)
+    else:
+        cur.execute(sql, params)
+
+
+def _start_transaction(cur: object, *, read_only: bool) -> None:
+    _execute(cur, "BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY" if read_only else "BEGIN")
+    _execute(cur, "SET LOCAL standard_conforming_strings = on")
+    _execute(cur, "SET LOCAL lock_timeout = %s", (LOCK_TIMEOUT,))
+    _execute(cur, "SET LOCAL statement_timeout = %s", (STATEMENT_TIMEOUT,))
+    _execute(cur, "SELECT pg_advisory_xact_lock(%s, %s)", ADVISORY_LOCK_KEYS)
+
+
+def _resolve_roots(cur: object, roots: tuple[str, ...]) -> tuple[tuple[int, str], ...]:
+    _execute(
+        cur,
+        """
+        /* mart_release:roots */
+        SELECT c.oid, format('%%I.%%I', n.nspname, c.relname), c.relkind
+        FROM unnest(%s::text[]) WITH ORDINALITY AS requested(identity, position)
+        LEFT JOIN pg_catalog.pg_class c ON c.oid = pg_catalog.to_regclass(requested.identity)
+        LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        ORDER BY requested.position
+        """,
+        (list(roots),),
+    )
+    rows = cur.fetchall()
+    resolved: list[tuple[int, str]] = []
+    for requested, row in zip(roots, rows, strict=True):
+        oid, identity, relkind = row
+        if oid is None:
+            raise ReleaseExecutionError(f"release root does not exist: {requested}")
+        if relkind not in {"v", "m"}:
+            raise ReleaseExecutionError(
+                f"release root has unsupported relation kind {relkind!r}: {requested}"
+            )
+        resolved.append((int(oid), str(identity)))
+    return tuple(resolved)
+
+
+_CLOSURE_SQL = """
+WITH RECURSIVE dependency_graph(classid, objid, objsubid) AS (
+    SELECT 'pg_catalog.pg_class'::pg_catalog.regclass::oid, root_oid, 0
+    FROM unnest(%s::oid[]) AS roots(root_oid)
+    UNION
+    SELECT
+        CASE WHEN dependency.classid = 'pg_catalog.pg_rewrite'::pg_catalog.regclass
+             THEN 'pg_catalog.pg_class'::pg_catalog.regclass::oid
+             ELSE dependency.classid END,
+        CASE WHEN dependency.classid = 'pg_catalog.pg_rewrite'::pg_catalog.regclass
+             THEN rewrite.ev_class
+             ELSE dependency.objid END,
+        CASE WHEN dependency.classid = 'pg_catalog.pg_rewrite'::pg_catalog.regclass
+             THEN 0 ELSE dependency.objsubid END
+    FROM dependency_graph AS upstream
+    JOIN pg_catalog.pg_depend AS dependency
+      ON dependency.refclassid = upstream.classid
+     AND dependency.refobjid = upstream.objid
+     AND (upstream.objsubid = 0 OR dependency.refobjsubid = upstream.objsubid)
+    LEFT JOIN pg_catalog.pg_rewrite AS rewrite
+      ON dependency.classid = 'pg_catalog.pg_rewrite'::pg_catalog.regclass
+     AND rewrite.oid = dependency.objid
+    WHERE dependency.deptype <> 'p'
+), visible AS (
+    SELECT 'object'::text AS category, 'relation'::text AS kind,
+           format('%%I.%%I', namespace.nspname, relation.relname) AS identity,
+           NULL::text AS language, relation.relkind::text AS detail
+    FROM dependency_graph AS graph
+    JOIN pg_catalog.pg_class AS relation
+      ON graph.classid = 'pg_catalog.pg_class'::pg_catalog.regclass AND relation.oid = graph.objid
+    JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = relation.relnamespace
+    WHERE relation.relkind IN ('v', 'm')
+    UNION
+    SELECT 'object', 'function',
+           format('%%I.%%I(%%s)', namespace.nspname, procedure.proname,
+                  pg_catalog.pg_get_function_identity_arguments(procedure.oid)),
+           language.lanname,
+           procedure.prokind::text
+    FROM dependency_graph AS graph
+    JOIN pg_catalog.pg_proc AS procedure
+      ON graph.classid = 'pg_catalog.pg_proc'::pg_catalog.regclass AND procedure.oid = graph.objid
+    JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = procedure.pronamespace
+    JOIN pg_catalog.pg_language AS language ON language.oid = procedure.prolang
+), unsupported AS (
+    SELECT DISTINCT 'unsupported'::text, graph.classid::pg_catalog.regclass::text,
+           graph.objid::text, NULL::text, 'catalog class'::text
+    FROM dependency_graph AS graph
+    LEFT JOIN pg_catalog.pg_class AS relation
+      ON graph.classid = 'pg_catalog.pg_class'::pg_catalog.regclass AND relation.oid = graph.objid
+    LEFT JOIN pg_catalog.pg_type AS type_info
+      ON graph.classid = 'pg_catalog.pg_type'::pg_catalog.regclass
+     AND type_info.oid = graph.objid
+    WHERE (graph.classid = 'pg_catalog.pg_type'::pg_catalog.regclass
+           AND NOT EXISTS (
+               SELECT 1 FROM dependency_graph AS relation_graph
+               WHERE relation_graph.classid = 'pg_catalog.pg_class'::pg_catalog.regclass
+                 AND relation_graph.objid = type_info.typrelid
+           )
+           AND NOT (type_info.typelem <> 0 AND EXISTS (
+               SELECT 1 FROM dependency_graph AS element_graph
+               WHERE element_graph.classid = 'pg_catalog.pg_type'::pg_catalog.regclass
+                 AND element_graph.objid = type_info.typelem
+           )))
+       OR graph.classid NOT IN (
+              'pg_catalog.pg_class'::pg_catalog.regclass,
+              'pg_catalog.pg_proc'::pg_catalog.regclass,
+              'pg_catalog.pg_type'::pg_catalog.regclass,
+              'pg_catalog.pg_constraint'::pg_catalog.regclass,
+              'pg_catalog.pg_attrdef'::pg_catalog.regclass,
+              'pg_catalog.pg_trigger'::pg_catalog.regclass,
+              'pg_catalog.pg_rewrite'::pg_catalog.regclass
+          )
+       OR (graph.classid = 'pg_catalog.pg_class'::pg_catalog.regclass
+           AND relation.relkind NOT IN ('v','m','i','I','t'))
+)
+SELECT * FROM visible
+UNION ALL
+SELECT * FROM unsupported
+ORDER BY 1, 2, 3
+"""
+
+
+def _read_closure(
+    cur: object, root_oids: tuple[int, ...]
+) -> tuple[tuple[ObjectIdentity, str | None, str], tuple[str, ...]]:
+    _execute(cur, "/* mart_release:closure */\n" + _CLOSURE_SQL, (list(root_oids),))
+    objects: list[tuple[ObjectIdentity, str | None, str]] = []
+    unsupported: list[str] = []
+    for category, kind, identity, language, detail in cur.fetchall():
+        if category == "unsupported":
+            unsupported.append(f"unsupported downstream catalog object {kind} OID {identity}")
+        else:
+            objects.append((ObjectIdentity(kind, identity), language, detail))
+    return tuple(objects), tuple(unsupported)
+
+
+_SNAPSHOT_SQL = """
+/* mart_release:snapshot */
+SELECT 'relation'::text,
+       format('%%I.%%I', namespace.nspname, relation.relname),
+       relation.relkind::text,
+       pg_catalog.pg_get_userbyid(relation.relowner),
+       COALESCE(pg_catalog.pg_get_viewdef(relation.oid, false), ''),
+       relation.relkind::text,
+       COALESCE(relation.reloptions::text, ''),
+       relation.relreplident::text,
+       relation.relrowsecurity::text,
+       relation.relforcerowsecurity::text,
+       COALESCE(pg_catalog.obj_description(relation.oid, 'pg_class'), ''),
+       COALESCE((
+           SELECT string_agg(format('%%s:%%I:%%s:%%s:%%s:%%s:%%s:%%s:%%s', attribute.attnum,
+                     attribute.attname, pg_catalog.format_type(attribute.atttypid,
+                     attribute.atttypmod), attribute.attnotnull, attribute.attidentity,
+                     attribute.attgenerated, COALESCE(pg_catalog.pg_get_expr(definition.adbin,
+                     definition.adrelid), ''), COALESCE(attribute.attacl::text, ''),
+                     COALESCE(pg_catalog.col_description(attribute.attrelid,
+                     attribute.attnum), '')), '|' ORDER BY attribute.attnum)
+           FROM pg_catalog.pg_attribute AS attribute
+           LEFT JOIN pg_catalog.pg_attrdef AS definition
+             ON definition.adrelid = attribute.attrelid
+            AND definition.adnum = attribute.attnum
+           WHERE attribute.attrelid = relation.oid
+             AND attribute.attnum > 0 AND NOT attribute.attisdropped
+       ), ''),
+       COALESCE((
+           SELECT string_agg(format('%%I=%%s', index_relation.relname,
+                                    pg_catalog.pg_get_indexdef(index_relation.oid)),
+                             '|' ORDER BY index_relation.relname)
+           FROM pg_catalog.pg_index AS index_info
+           JOIN pg_catalog.pg_class AS index_relation ON index_relation.oid = index_info.indexrelid
+           WHERE index_info.indrelid = relation.oid
+       ), ''),
+       COALESCE((
+           SELECT string_agg(format('%%I:%%s:%%s:%%s', role.rolname,
+                     pg_catalog.has_table_privilege(role.oid, relation.oid, 'SELECT'),
+                     pg_catalog.has_table_privilege(role.oid, relation.oid, 'INSERT,UPDATE,DELETE'),
+                     pg_catalog.has_table_privilege(role.oid, relation.oid,
+                                                    'TRUNCATE,REFERENCES,TRIGGER')),
+                     '|' ORDER BY role.rolname)
+           FROM pg_catalog.pg_roles AS role
+           WHERE NOT role.rolsuper AND role.rolname !~ '^pg_'
+       ), ''),
+       COALESCE((SELECT string_agg(pg_catalog.pg_get_constraintdef(constraint_info.oid),
+                                  '|' ORDER BY constraint_info.conname)
+                 FROM pg_catalog.pg_constraint AS constraint_info
+                 WHERE constraint_info.conrelid = relation.oid), ''),
+       COALESCE((SELECT string_agg(trigger_info.tgenabled::text || ':' ||
+                                  pg_catalog.pg_get_triggerdef(trigger_info.oid),
+                                  '|' ORDER BY trigger_info.tgname)
+                 FROM pg_catalog.pg_trigger AS trigger_info
+                 WHERE trigger_info.tgrelid = relation.oid
+                   AND NOT trigger_info.tgisinternal), ''),
+       COALESCE((SELECT string_agg(pg_catalog.concat_ws(':', policy_info.polname,
+                                      policy_info.polcmd, policy_info.polpermissive::text,
+                                      policy_info.polroles::text,
+                                      pg_catalog.pg_get_expr(policy_info.polqual,
+                                                             policy_info.polrelid),
+                                      pg_catalog.pg_get_expr(policy_info.polwithcheck,
+                                                             policy_info.polrelid)),
+                                  '|' ORDER BY policy_info.polname)
+                 FROM pg_catalog.pg_policy AS policy_info
+                 WHERE policy_info.polrelid = relation.oid), ''),
+       COALESCE((SELECT string_agg(rule_info.ev_enabled::text || ':' ||
+                                  pg_catalog.pg_get_ruledef(rule_info.oid),
+                                  '|' ORDER BY rule_info.rulename)
+                 FROM pg_catalog.pg_rewrite AS rule_info
+                 WHERE rule_info.ev_class = relation.oid
+                   AND rule_info.rulename <> '_RETURN'), '')
+FROM pg_catalog.pg_class AS relation
+JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = relation.relnamespace
+WHERE namespace.nspname = ANY(%s)
+  AND relation.relkind IN ('r','p','v','m','f','S')
+  AND NOT EXISTS (
+      SELECT 1 FROM pg_catalog.pg_depend AS extension_dependency
+      WHERE extension_dependency.classid = 'pg_catalog.pg_class'::pg_catalog.regclass
+        AND extension_dependency.objid = relation.oid
+        AND extension_dependency.deptype = 'e'
+  )
+UNION ALL
+SELECT 'function',
+       format('%%I.%%I(%%s)', namespace.nspname, procedure.proname,
+              pg_catalog.pg_get_function_identity_arguments(procedure.oid)),
+       CASE procedure.prokind WHEN 'p' THEN 'procedure' ELSE 'function' END,
+       pg_catalog.pg_get_userbyid(procedure.proowner),
+       pg_catalog.pg_get_functiondef(procedure.oid),
+       procedure.prokind::text,
+       procedure.prosecdef::text,
+       COALESCE(procedure.proconfig::text, ''),
+       procedure.provolatile::text,
+       procedure.proparallel::text,
+       procedure.proleakproof::text,
+       procedure.proisstrict::text,
+       pg_catalog.pg_get_function_result(procedure.oid),
+       pg_catalog.pg_get_function_arguments(procedure.oid),
+       COALESCE(pg_catalog.obj_description(procedure.oid, 'pg_proc'), ''),
+       COALESCE((
+           SELECT string_agg(format('%%I:%%s', role.rolname,
+                     pg_catalog.has_function_privilege(role.oid, procedure.oid, 'EXECUTE')),
+                     '|' ORDER BY role.rolname)
+           FROM pg_catalog.pg_roles AS role
+           WHERE NOT role.rolsuper AND role.rolname !~ '^pg_'
+       ), ''),
+       ''::text,
+       ''::text
+FROM pg_catalog.pg_proc AS procedure
+JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = procedure.pronamespace
+WHERE namespace.nspname = ANY(%s)
+  AND procedure.prokind IN ('f', 'p')
+  AND NOT EXISTS (
+      SELECT 1 FROM pg_catalog.pg_depend AS extension_dependency
+      WHERE extension_dependency.classid = 'pg_catalog.pg_proc'::pg_catalog.regclass
+        AND extension_dependency.objid = procedure.oid
+        AND extension_dependency.deptype = 'e'
+  )
+ORDER BY 1, 2
+"""
+
+
+_ACL_SQL = """
+/* mart_release:acl */
+SELECT 'relation'::text,
+       format('%%I.%%I', namespace.nspname, relation.relname),
+       pg_catalog.pg_get_userbyid(relation.relowner),
+       COALESCE(pg_catalog.pg_get_userbyid(acl.grantor), ''),
+       CASE WHEN acl.grantee = 0 THEN 'PUBLIC' ELSE pg_catalog.pg_get_userbyid(acl.grantee) END,
+       acl.privilege_type,
+       acl.is_grantable
+FROM pg_catalog.pg_class AS relation
+JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = relation.relnamespace
+LEFT JOIN LATERAL pg_catalog.aclexplode(
+    COALESCE(relation.relacl, pg_catalog.acldefault(
+        CASE WHEN relation.relkind = 'S' THEN 's'::"char" ELSE 'r'::"char" END,
+        relation.relowner))) AS acl ON true
+WHERE namespace.nspname = ANY(%s)
+  AND relation.relkind IN ('r','p','v','m','f','S')
+  AND NOT EXISTS (
+      SELECT 1 FROM pg_catalog.pg_depend AS extension_dependency
+      WHERE extension_dependency.classid = 'pg_catalog.pg_class'::pg_catalog.regclass
+        AND extension_dependency.objid = relation.oid
+        AND extension_dependency.deptype = 'e'
+  )
+UNION ALL
+SELECT 'function',
+       format('%%I.%%I(%%s)', namespace.nspname, procedure.proname,
+              pg_catalog.pg_get_function_identity_arguments(procedure.oid)),
+       pg_catalog.pg_get_userbyid(procedure.proowner),
+       COALESCE(pg_catalog.pg_get_userbyid(acl.grantor), ''),
+       CASE WHEN acl.grantee = 0 THEN 'PUBLIC' ELSE pg_catalog.pg_get_userbyid(acl.grantee) END,
+       acl.privilege_type,
+       acl.is_grantable
+FROM pg_catalog.pg_proc AS procedure
+JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = procedure.pronamespace
+LEFT JOIN LATERAL pg_catalog.aclexplode(
+    COALESCE(procedure.proacl, pg_catalog.acldefault('f', procedure.proowner))) AS acl ON true
+WHERE namespace.nspname = ANY(%s)
+  AND procedure.prokind IN ('f', 'p')
+  AND NOT EXISTS (
+      SELECT 1 FROM pg_catalog.pg_depend AS extension_dependency
+      WHERE extension_dependency.classid = 'pg_catalog.pg_proc'::pg_catalog.regclass
+        AND extension_dependency.objid = procedure.oid
+        AND extension_dependency.deptype = 'e'
+  )
+ORDER BY 1, 2, 5, 6, 7
+"""
+
+
+def _read_snapshot(cur: object) -> dict[ObjectIdentity, _CatalogSnapshot]:
+    schemas = [*PROJECT_SCHEMAS, "public"]
+    _execute(cur, _SNAPSHOT_SQL, (schemas, schemas))
+    base_rows = cur.fetchall()
+    _execute(cur, _ACL_SQL, (schemas, schemas))
+    acl_by_identity: dict[ObjectIdentity, list[tuple[str, str, str, bool]]] = {}
+    owner_by_identity: dict[ObjectIdentity, str] = {}
+    for kind, identity, owner, grantor, grantee, privilege, grantable in cur.fetchall():
+        item = ObjectIdentity(kind, identity)
+        owner_by_identity[item] = owner
+        if privilege is not None:
+            acl_by_identity.setdefault(item, []).append(
+                (str(grantor), str(grantee), str(privilege), bool(grantable))
+            )
+    snapshots: dict[ObjectIdentity, _CatalogSnapshot] = {}
+    for kind, identity, object_type, owner, definition, *contract in base_rows:
+        item = ObjectIdentity(kind, identity)
+        snapshots[item] = _CatalogSnapshot(
+            item,
+            object_type,
+            definition,
+            tuple(contract),
+            owner_by_identity.get(item, owner),
+            tuple(acl_by_identity.get(item, ())),
+        )
+    return snapshots
+
+
+def _build_plan(
+    cur: object, manifest: ReleaseManifest
+) -> tuple[ReleasePlan, dict[ObjectIdentity, _CatalogSnapshot]]:
+    resolved = _resolve_roots(cur, manifest.roots)
+    closure_rows, unsupported = _read_closure(cur, tuple(row[0] for row in resolved))
+    live = tuple(sorted({row[0] for row in closure_rows}))
+    declared = set(manifest.restores)
+    actual = set(live)
+    blockers = list(unsupported)
+    missing = actual - declared
+    extra = declared - actual
+    if missing:
+        blockers.append(
+            "manifest omits live downstream closure objects: "
+            + ", ".join(f"{item.kind} {item.identity}" for item in sorted(missing))
+        )
+    if extra:
+        blockers.append(
+            "manifest declares restore objects outside the live closure: "
+            + ", ".join(f"{item.kind} {item.identity}" for item in sorted(extra))
+        )
+    plpgsql = {row[0].identity for row in closure_rows if row[1] == "plpgsql"}
+    covered = {identity for validation in manifest.validations for identity in validation.covers}
+    missing_validation = plpgsql - covered
+    unknown_coverage = covered - {item.identity for item in actual if item.kind == "function"}
+    if missing_validation:
+        blockers.append(
+            "affected PL/pgSQL functions require caller-role validations: "
+            + ", ".join(sorted(missing_validation))
+        )
+    if unknown_coverage:
+        blockers.append(
+            "validation covers identities outside the live function closure: "
+            + ", ".join(sorted(unknown_coverage))
+        )
+    snapshot = _read_snapshot(cur)
+    unsnapshotted = actual - set(snapshot)
+    if unsnapshotted:
+        blockers.append(
+            "live closure contains objects outside supported project/public namespaces: "
+            + ", ".join(f"{item.kind} {item.identity}" for item in sorted(unsnapshotted))
+        )
+    warnings = (
+        "PostgreSQL catalog dependencies do not include dynamic SQL or textual PL/pgSQL "
+        "references; declared caller-role validations cover affected PL/pgSQL functions.",
+        "Version 1 permits contract-preserving releases only and does not write the F06 "
+        "warehouse migration ledger.",
+    )
+    return (
+        ReleasePlan(
+            manifest.files,
+            tuple(identity for _, identity in resolved),
+            manifest.restores,
+            live,
+            tuple(blockers),
+            warnings,
+        ),
+        snapshot,
+    )
+
+
+def plan_release(conn: object, manifest: ReleaseManifest) -> ReleasePlan:
+    """Return a read-only dependency and blocker preview, leaving no transaction open."""
+
+    _ensure_idle_connection(conn)
+    cur = conn.cursor()
+    try:
+        _start_transaction(cur, read_only=True)
+        plan, _ = _build_plan(cur, manifest)
+        conn.rollback()
+        return plan
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        cur.close()
+
+
+def _quote_ident(value: str) -> str:
+    return '"' + value.replace('"', '""') + '"'
+
+
+def _restore_security(
+    cur: object,
+    before: dict[ObjectIdentity, _CatalogSnapshot],
+    affected: set[ObjectIdentity],
+) -> None:
+    current = _read_snapshot(cur)
+    for identity in sorted(affected):
+        original = before[identity]
+        if identity not in current:
+            raise ReleaseExecutionError(
+                f"manifest did not recreate {identity.kind} {identity.identity}"
+            )
+        owner = _quote_ident(original.owner)
+        if identity.kind == "relation":
+            alter_kind = {
+                "r": "TABLE",
+                "p": "TABLE",
+                "v": "VIEW",
+                "m": "MATERIALIZED VIEW",
+                "f": "FOREIGN TABLE",
+                "S": "SEQUENCE",
+            }[original.object_type]
+            _execute(cur, f"ALTER {alter_kind} {identity.identity} OWNER TO {owner}")
+            target = (
+                f"TABLE {identity.identity}"
+                if original.object_type != "S"
+                else f"SEQUENCE {identity.identity}"
+            )
+        else:
+            alter_kind = "PROCEDURE" if original.object_type == "procedure" else "FUNCTION"
+            _execute(cur, f"ALTER {alter_kind} {identity.identity} OWNER TO {owner}")
+            target = f"{alter_kind} {identity.identity}"
+
+        old_grantees = {entry[1] for entry in original.acl}
+        new_grantees = {entry[1] for entry in current[identity].acl}
+        for grantee in sorted((old_grantees | new_grantees) - {original.owner}):
+            recipient = "PUBLIC" if grantee == "PUBLIC" else _quote_ident(grantee)
+            _execute(cur, f"REVOKE ALL PRIVILEGES ON {target} FROM {recipient}")
+        for grantor, grantee, privilege, grantable in original.acl:
+            if grantee == original.owner:
+                continue
+            _execute(cur, f"SET LOCAL ROLE {_quote_ident(grantor)}")
+            recipient = "PUBLIC" if grantee == "PUBLIC" else _quote_ident(grantee)
+            suffix = " WITH GRANT OPTION" if grantable else ""
+            _execute(cur, f"GRANT {privilege} ON {target} TO {recipient}{suffix}")
+            _execute(cur, "RESET ROLE")
+
+
+def _run_validations(cur: object, validations: tuple[ValidationQuery, ...]) -> None:
+    for validation in validations:
+        _execute(cur, "SAVEPOINT mart_release_validation")
+        try:
+            _execute(cur, "SET LOCAL standard_conforming_strings = on")
+            _execute(cur, f"SET LOCAL ROLE {_quote_ident(validation.role)}")
+            _execute(cur, validation.query)
+            row = cur.fetchone()
+            if row != (True,):
+                raise ReleaseExecutionError(
+                    f"release validation {validation.name!r} must return exactly one true boolean"
+                )
+            if cur.fetchone() is not None:
+                raise ReleaseExecutionError(
+                    f"release validation {validation.name!r} returned more than one row"
+                )
+        except Exception:
+            _execute(cur, "ROLLBACK TO SAVEPOINT mart_release_validation")
+            _execute(cur, "RELEASE SAVEPOINT mart_release_validation")
+            raise
+        _execute(cur, "ROLLBACK TO SAVEPOINT mart_release_validation")
+        _execute(cur, "RELEASE SAVEPOINT mart_release_validation")
+
+
+def _verify_post_snapshot(
+    before: dict[ObjectIdentity, _CatalogSnapshot],
+    after: dict[ObjectIdentity, _CatalogSnapshot],
+    affected: set[ObjectIdentity],
+) -> None:
+    lost = set(before) - set(after)
+    if lost:
+        raise ReleaseExecutionError(
+            "release removed undeclared project objects: "
+            + ", ".join(f"{item.kind} {item.identity}" for item in sorted(lost))
+        )
+    added = set(after) - set(before)
+    undeclared_added = added - affected
+    if undeclared_added:
+        raise ReleaseExecutionError(
+            "release added objects outside its declared closure: "
+            + ", ".join(f"{item.kind} {item.identity}" for item in sorted(undeclared_added))
+        )
+    changed_outside = {
+        item for item in set(before) & set(after) - affected if before[item] != after[item]
+    }
+    if changed_outside:
+        raise ReleaseExecutionError(
+            "release changed project objects outside its declared closure: "
+            + ", ".join(f"{item.kind} {item.identity}" for item in sorted(changed_outside))
+        )
+    changed_contract = {
+        item
+        for item in affected
+        if item in before
+        and item in after
+        and (
+            before[item].object_type != after[item].object_type
+            or before[item].contract != after[item].contract
+            or before[item].owner != after[item].owner
+            or before[item].acl != after[item].acl
+        )
+    }
+    if changed_contract:
+        raise ReleaseExecutionError(
+            "release changed an existing object contract; version 1 has no reviewed "
+            "contract-change escape hatch: "
+            + ", ".join(f"{item.kind} {item.identity}" for item in sorted(changed_contract))
+        )
+
+
+def execute_release(conn: object, manifest: ReleaseManifest) -> ReleasePlan:
+    """Atomically execute a valid release and its validations, or roll everything back."""
+
+    for release_file in manifest.files:
+        sql_bytes = release_file.absolute_path.read_bytes()
+        actual = hashlib.sha256(sql_bytes).hexdigest()
+        if actual != release_file.sha256:
+            raise ReleaseManifestError(
+                f"release file changed after manifest load: {release_file.path}"
+            )
+        _validate_release_sql(release_file.sql, release_file.path)
+    _ensure_idle_connection(conn)
+    cur = conn.cursor()
+    try:
+        _start_transaction(cur, read_only=False)
+        plan, before = _build_plan(cur, manifest)
+        if not plan.valid:
+            raise ReleaseBlockedError(plan)
+        affected = set(plan.live_closure)
+        for release_file in manifest.files:
+            _execute(cur, "SET LOCAL standard_conforming_strings = on")
+            _execute(cur, release_file.sql)
+        _restore_security(cur, before, affected)
+        _run_validations(cur, manifest.validations)
+        after = _read_snapshot(cur)
+        _verify_post_snapshot(before, after, affected)
+        conn.commit()
+        return plan
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        cur.close()

--- a/scripts/mart_release.py
+++ b/scripts/mart_release.py
@@ -5,9 +5,10 @@ existing relation or function in the PostgreSQL downstream dependency closure.  
 read-only; execution repeats the plan under the warehouse migration advisory lock before any
 manifest SQL is run.
 
-PostgreSQL records parsed dependencies for views and SQL functions.  PL/pgSQL bodies can contain
-textual relation references which are not catalog dependencies, so affected PL/pgSQL functions
-also require role-scoped validation queries declared by the manifest.
+PostgreSQL records parsed dependencies for views and SQL functions. PL/pgSQL bodies and dynamic
+SQL can contain textual relation references which are not catalog dependencies, so manifests can
+declare existing function consumers which, like affected PL/pgSQL functions, require role-scoped
+validation queries.
 """
 
 from __future__ import annotations
@@ -80,6 +81,7 @@ class ReleaseManifest:
     files: tuple[ReleaseFile, ...]
     roots: tuple[str, ...]
     restores: tuple[ObjectIdentity, ...]
+    consumers: tuple[str, ...]
     validations: tuple[ValidationQuery, ...]
     source_path: Path
     root: Path
@@ -89,6 +91,7 @@ class ReleaseManifest:
 class ReleasePlan:
     files: tuple[ReleaseFile, ...]
     roots: tuple[str, ...]
+    declared_consumers: tuple[str, ...]
     declared_restores: tuple[ObjectIdentity, ...]
     live_closure: tuple[ObjectIdentity, ...]
     blockers: tuple[str, ...] = ()
@@ -179,6 +182,109 @@ def _validate_release_sql(sql: str, path: str) -> None:
                 f"release file {path!r} contains nontransactional or unsafe SQL: "
                 f"{' '.join(words[:4])}"
             )
+    _validate_no_set_config(sql, f"release file {path!r}")
+
+
+def _skip_sql_space_and_comments(sql: str, index: int) -> int:
+    """Skip whitespace and PostgreSQL comments starting at ``index``."""
+
+    length = len(sql)
+    while index < length:
+        if sql[index].isspace():
+            index += 1
+            continue
+        if sql.startswith("--", index):
+            newline = sql.find("\n", index + 2)
+            index = length if newline < 0 else newline + 1
+            continue
+        if sql.startswith("/*", index):
+            depth = 1
+            index += 2
+            while index < length and depth:
+                if sql.startswith("/*", index):
+                    depth += 1
+                    index += 2
+                elif sql.startswith("*/", index):
+                    depth -= 1
+                    index += 2
+                else:
+                    index += 1
+            continue
+        break
+    return index
+
+
+def _validate_no_set_config(sql: str, context: str) -> None:
+    """Reject direct set_config calls without matching text inside inert SQL regions."""
+
+    index = 0
+    length = len(sql)
+    while index < length:
+        skipped = _skip_sql_space_and_comments(sql, index)
+        if skipped != index:
+            index = skipped
+            continue
+        if index >= length:
+            break
+        char = sql[index]
+        if char == "'":
+            escape_string = (
+                index > 0
+                and sql[index - 1] in {"e", "E"}
+                and (index < 2 or not (sql[index - 2].isalnum() or sql[index - 2] in {"_", "$"}))
+            )
+            index += 1
+            while index < length:
+                if sql[index] == "'":
+                    if index + 1 < length and sql[index + 1] == "'":
+                        index += 2
+                        continue
+                    index += 1
+                    break
+                if escape_string and sql[index] == "\\" and index + 1 < length:
+                    index += 2
+                else:
+                    index += 1
+            continue
+        if char == "$":
+            tag_match = re.match(r"\$[A-Za-z_][A-Za-z0-9_]*\$|\$\$", sql[index:])
+            if tag_match:
+                tag = tag_match.group(0)
+                end = sql.find(tag, index + len(tag))
+                index = length if end < 0 else end + len(tag)
+                continue
+        identifier = ""
+        if char == '"':
+            if sql[max(0, index - 2) : index].lower() == "u&":
+                raise ReleaseManifestError(
+                    f"{context} does not support Unicode-escaped identifiers"
+                )
+            index += 1
+            pieces: list[str] = []
+            while index < length:
+                if sql[index] == '"':
+                    if index + 1 < length and sql[index + 1] == '"':
+                        pieces.append('"')
+                        index += 2
+                        continue
+                    index += 1
+                    break
+                pieces.append(sql[index])
+                index += 1
+            identifier = "".join(pieces)
+        elif char.isalpha() or char == "_":
+            end = index + 1
+            while end < length and (sql[end].isalnum() or sql[end] in {"_", "$"}):
+                end += 1
+            identifier = sql[index:end]
+            index = end
+        else:
+            index += 1
+            continue
+        if identifier.lower() == "set_config":
+            following = _skip_sql_space_and_comments(sql, index)
+            if following < length and sql[following] == "(":
+                raise ReleaseManifestError(f"{context} may not call set_config")
 
 
 def _require_exact_keys(value: object, keys: set[str], context: str) -> dict[str, object]:
@@ -197,11 +303,19 @@ def load_release(path: str | Path, root: str | Path) -> ReleaseManifest:
     if not root_path.is_dir():
         raise ReleaseManifestError(f"repository root is not a directory: {root_path}")
     source_path = Path(path).resolve(strict=False)
-    payload = _require_exact_keys(
-        _load_json(source_path),
-        {"version", "files", "roots", "restores", "validations"},
-        "release manifest",
-    )
+    raw_payload = _load_json(source_path)
+    if not isinstance(raw_payload, dict):
+        raise ReleaseManifestError("release manifest must be a JSON object")
+    required_keys = {"version", "files", "roots", "restores", "validations"}
+    if frozenset(raw_payload) not in {
+        frozenset(required_keys),
+        frozenset(required_keys | {"consumers"}),
+    }:
+        raise ReleaseManifestError(
+            "release manifest keys must be exactly: consumers (optional), files, restores, "
+            "roots, validations, version"
+        )
+    payload = raw_payload
     if type(payload["version"]) is not int or payload["version"] != 1:
         raise ReleaseManifestError("release manifest version must be integer 1")
 
@@ -268,6 +382,24 @@ def load_release(path: str | Path, root: str | Path) -> ReleaseManifest:
             f"release roots must also be declared as restores: {', '.join(sorted(missing_roots))}"
         )
 
+    consumers_raw = payload.get("consumers", [])
+    if not isinstance(consumers_raw, list):
+        raise ReleaseManifestError("release consumers must be a list")
+    consumers: list[str] = []
+    for identity in consumers_raw:
+        if (
+            not isinstance(identity, str)
+            or "\n" in identity
+            or "\r" in identity
+            or not re.fullmatch(r"[a-z_][a-z0-9_$]*\.[a-z_][a-z0-9_$]*\([^()]*\)", identity)
+        ):
+            raise ReleaseManifestError(
+                f"consumer must be an exact fully qualified function identity: {identity!r}"
+            )
+        if identity in consumers:
+            raise ReleaseManifestError(f"duplicate release consumer: {identity}")
+        consumers.append(identity)
+
     validations_raw = payload["validations"]
     if not isinstance(validations_raw, list):
         raise ReleaseManifestError("release validations must be a list")
@@ -293,6 +425,7 @@ def load_release(path: str | Path, root: str | Path) -> ReleaseManifest:
         if len(statements) != 1 or statements[0][0] != "SELECT":
             raise ReleaseManifestError(f"validation {name!r} must be one SELECT assertion")
         _validate_no_transaction_control(query, f"validation {name}")
+        _validate_no_set_config(query, f"validation {name!r}")
         if not isinstance(covers, list) or any(
             not isinstance(item, str) or not item for item in covers
         ):
@@ -305,6 +438,7 @@ def load_release(path: str | Path, root: str | Path) -> ReleaseManifest:
         tuple(files),
         tuple(roots),
         tuple(restores),
+        tuple(consumers),
         tuple(validations),
         source_path,
         root_path,
@@ -467,6 +601,7 @@ SELECT 'relation'::text,
        pg_catalog.pg_get_userbyid(relation.relowner),
        COALESCE(pg_catalog.pg_get_viewdef(relation.oid, false), ''),
        relation.relkind::text,
+       relation.relispopulated::text,
        COALESCE(relation.reloptions::text, ''),
        relation.relreplident::text,
        relation.relrowsecurity::text,
@@ -565,6 +700,7 @@ SELECT 'function',
            FROM pg_catalog.pg_roles AS role
            WHERE NOT role.rolsuper AND role.rolname !~ '^pg_'
        ), ''),
+       ''::text,
        ''::text,
        ''::text
 FROM pg_catalog.pg_proc AS procedure
@@ -678,21 +814,32 @@ def _build_plan(
             "manifest declares restore objects outside the live closure: "
             + ", ".join(f"{item.kind} {item.identity}" for item in sorted(extra))
         )
+    snapshot = _read_snapshot(cur)
+    declared_consumers = set(manifest.consumers)
+    existing_functions = {item.identity for item in snapshot if item.kind == "function"}
+    missing_consumers = declared_consumers - existing_functions
+    if missing_consumers:
+        blockers.append(
+            "declared textual/dynamic consumer functions do not exist: "
+            + ", ".join(sorted(missing_consumers))
+        )
     plpgsql = {row[0].identity for row in closure_rows if row[1] == "plpgsql"}
     covered = {identity for validation in manifest.validations for identity in validation.covers}
-    missing_validation = plpgsql - covered
-    unknown_coverage = covered - {item.identity for item in actual if item.kind == "function"}
+    missing_validation = (plpgsql | declared_consumers) - covered
+    permitted_coverage = {item.identity for item in actual if item.kind == "function"} | (
+        declared_consumers & existing_functions
+    )
+    unknown_coverage = covered - permitted_coverage
     if missing_validation:
         blockers.append(
-            "affected PL/pgSQL functions require caller-role validations: "
-            + ", ".join(sorted(missing_validation))
+            "affected PL/pgSQL and declared textual/dynamic consumers require "
+            "caller-role validations: " + ", ".join(sorted(missing_validation))
         )
     if unknown_coverage:
         blockers.append(
-            "validation covers identities outside the live function closure: "
-            + ", ".join(sorted(unknown_coverage))
+            "validation covers identities outside the live function closure or declared "
+            "existing consumers: " + ", ".join(sorted(unknown_coverage))
         )
-    snapshot = _read_snapshot(cur)
     unsnapshotted = actual - set(snapshot)
     if unsnapshotted:
         blockers.append(
@@ -701,7 +848,8 @@ def _build_plan(
         )
     warnings = (
         "PostgreSQL catalog dependencies do not include dynamic SQL or textual PL/pgSQL "
-        "references; declared caller-role validations cover affected PL/pgSQL functions.",
+        "references; manifests must declare those existing function consumers and cover them "
+        "with caller-role validations.",
         "Version 1 permits contract-preserving releases only and does not write the F06 "
         "warehouse migration ledger.",
     )
@@ -709,6 +857,7 @@ def _build_plan(
         ReleasePlan(
             manifest.files,
             tuple(identity for _, identity in resolved),
+            manifest.consumers,
             manifest.restores,
             live,
             tuple(blockers),
@@ -792,10 +941,12 @@ def _run_validations(cur: object, validations: tuple[ValidationQuery, ...]) -> N
         _execute(cur, "SAVEPOINT mart_release_validation")
         try:
             _execute(cur, "SET LOCAL standard_conforming_strings = on")
+            _execute(cur, "SET LOCAL lock_timeout = %s", (LOCK_TIMEOUT,))
+            _execute(cur, "SET LOCAL statement_timeout = %s", (STATEMENT_TIMEOUT,))
             _execute(cur, f"SET LOCAL ROLE {_quote_ident(validation.role)}")
             _execute(cur, validation.query)
             row = cur.fetchone()
-            if row != (True,):
+            if row is None or len(row) != 1 or row[0] is not True:
                 raise ReleaseExecutionError(
                     f"release validation {validation.name!r} must return exactly one true boolean"
                 )
@@ -878,6 +1029,8 @@ def execute_release(conn: object, manifest: ReleaseManifest) -> ReleasePlan:
         affected = set(plan.live_closure)
         for release_file in manifest.files:
             _execute(cur, "SET LOCAL standard_conforming_strings = on")
+            _execute(cur, "SET LOCAL lock_timeout = %s", (LOCK_TIMEOUT,))
+            _execute(cur, "SET LOCAL statement_timeout = %s", (STATEMENT_TIMEOUT,))
             _execute(cur, release_file.sql)
         _restore_security(cur, before, affected)
         _run_validations(cur, manifest.validations)

--- a/scripts/run_marts.py
+++ b/scripts/run_marts.py
@@ -1,50 +1,41 @@
 #!/usr/bin/env python3
-"""Deploy mart SQL files to Supabase Postgres.
+"""Plan or deploy a dependency-complete mart release.
 
-Runs CREATE/DROP statements for materialized views and regular views in
-src/schemas/marts/. This is separate from run_migrations.py which handles
-core schema DDL.
+Real mart changes require a checksum-verified release manifest so the engine can
+validate the live dependency closure and execute the full release atomically.
+The legacy file selectors remain available only for listing and SQL inspection.
 
 Usage:
-    python scripts/run_marts.py                    # Run all marts
-    python scripts/run_marts.py --from 017         # Run from 017 onwards
-    python scripts/run_marts.py --only 017         # Run only files starting with 017
-    python scripts/run_marts.py --dry-run          # Print SQL without executing
-    python scripts/run_marts.py --list             # List available mart files
+    python scripts/run_marts.py --release path/to/release.json
+    python scripts/run_marts.py --release path/to/release.json --plan
+    python scripts/run_marts.py --dry-run
+    python scripts/run_marts.py --only 017 --dry-run
+    python scripts/run_marts.py --list
 """
 
 import argparse
+import json
 import logging
+import os
 import sys
 from pathlib import Path
 
-import dlt
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.bootstrap_warehouse import _redact_error, validate_database_url  # noqa: E402
+from scripts.mart_release import execute_release, load_release, plan_release  # noqa: E402
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
 
-MARTS_DIR = Path(__file__).parent.parent / "src" / "schemas" / "marts"
-
-
-def get_db_url() -> str:
-    """Get database URL from dlt secrets or environment."""
-    import os
-
-    try:
-        creds = dlt.secrets.get("destination.postgres.credentials")
-        if creds:
-            return str(creds)
-    except Exception:
-        pass
-
-    url = os.environ.get("SUPABASE_DB_URL") or os.environ.get("DATABASE_URL")
-    if url:
-        return url
-
-    raise RuntimeError(
-        "No database URL found. Set destination.postgres.credentials in "
-        ".dlt/secrets.toml or SUPABASE_DB_URL environment variable."
-    )
+MARTS_DIR = REPO_ROOT / "src" / "schemas" / "marts"
+DATABASE_ENV = "SUPABASE_DB_URL"
+MANAGED_RELEASE_GUIDANCE = (
+    "real mart deployment requires --release <manifest>; "
+    "use --plan to preview the dependency closure or --dry-run to inspect legacy SQL"
+)
 
 
 def get_mart_files() -> list[Path]:
@@ -62,38 +53,101 @@ def get_mart_files() -> list[Path]:
 
 
 def run_mart(sql_file: Path, conn, dry_run: bool = False) -> None:
-    """Execute a single mart SQL file."""
+    """Display legacy SQL; real single-file mart execution is unsupported."""
+    if not dry_run:
+        raise RuntimeError(MANAGED_RELEASE_GUIDANCE)
+
     sql = sql_file.read_text()
     logger.info(f"{'[DRY RUN] ' if dry_run else ''}Running {sql_file.name}")
 
-    if dry_run:
-        print(f"\n-- {sql_file.name}")
-        print(sql[:500] + "..." if len(sql) > 500 else sql)
-        return
+    print(f"\n-- {sql_file.name}")
+    print(sql[:500] + "..." if len(sql) > 500 else sql)
 
-    cursor = conn.cursor()
+
+def get_release_db_url() -> str:
+    """Return the explicit release database URI; never consult dlt/libpq fallbacks."""
+    database_url = os.environ.get(DATABASE_ENV)
+    if not database_url:
+        raise RuntimeError(f"{DATABASE_ENV} is required; no other credential source is used")
     try:
-        cursor.execute(sql)
-        conn.commit()
-        logger.info(f"  {sql_file.name} completed successfully")
-    except Exception as e:
-        conn.rollback()
-        logger.error(f"  {sql_file.name} FAILED: {e}")
-        raise
+        validate_database_url(database_url)
+    except Exception as exc:
+        # Reuse the bootstrap validator while naming this command's supported env var.
+        message = str(exc).replace("WAREHOUSE_DB_URL", DATABASE_ENV)
+        raise ValueError(message) from exc
+    return database_url
+
+
+def _plan_payload(plan, *, read_only: bool) -> dict[str, object]:
+    """Build stable JSON output without serializing Path or connection objects."""
+    return {
+        "read_only": read_only,
+        "valid": plan.valid,
+        "roots": list(plan.roots),
+        "live_closure": [{"kind": obj.kind, "identity": obj.identity} for obj in plan.live_closure],
+        "declared_restores": [
+            {"kind": obj.kind, "identity": obj.identity} for obj in plan.declared_restores
+        ],
+        "files": [
+            {"path": str(release_file.path), "sha256": release_file.sha256}
+            for release_file in plan.files
+        ],
+        "warnings": list(plan.warnings),
+        "blockers": list(plan.blockers),
+    }
+
+
+def run_release(release_path: Path, *, read_only: bool) -> int:
+    """Validate first, then plan or atomically execute one managed release."""
+    database_url: str | None = None
+    conn = None
+    try:
+        manifest = load_release(release_path, REPO_ROOT)
+        database_url = get_release_db_url()
+
+        import psycopg2
+
+        conn = psycopg2.connect(database_url)
+        plan = plan_release(conn, manifest) if read_only else execute_release(conn, manifest)
+        print(json.dumps(_plan_payload(plan, read_only=read_only), indent=2, sort_keys=True))
+        return 0 if plan.valid else 1
+    except Exception as exc:
+        logger.error(_redact_error(exc, database_url))
+        return 1
     finally:
-        cursor.close()
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception as exc:
+                logger.error(_redact_error(exc, database_url))
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(description="Deploy mart SQL files")
-    parser.add_argument(
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Plan or deploy a managed mart release")
+    selectors = parser.add_mutually_exclusive_group()
+    selectors.add_argument(
         "--from",
         dest="from_num",
-        help="Start from mart number (e.g., 017)",
+        help="Select legacy SQL from this mart number (inspection only)",
+    )
+    selectors.add_argument(
+        "--only",
+        help="Select legacy SQL starting with this number (inspection only)",
+    )
+    selectors.add_argument(
+        "--all",
+        action="store_true",
+        help="Select all legacy mart files (inspection only)",
     )
     parser.add_argument(
-        "--only",
-        help="Run only marts starting with this number (e.g., 017)",
+        "--release",
+        type=Path,
+        help="Checksum-verified dependency-complete mart release manifest",
+    )
+    parser.add_argument(
+        "--plan",
+        action="store_true",
+        help="Preview a release in a read-only transaction",
     )
     parser.add_argument(
         "--dry-run",
@@ -105,7 +159,17 @@ def main() -> None:
         action="store_true",
         help="List available mart files and exit",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
+
+    legacy_options = args.from_num or args.only or args.all or args.dry_run or args.list
+    if args.release and legacy_options:
+        parser.error("--release cannot be combined with legacy selectors, --dry-run, or --list")
+    if args.plan and not args.release:
+        parser.error("--plan requires --release <manifest>")
+    if args.release:
+        return run_release(args.release, read_only=args.plan)
+    if not args.dry_run and not args.list:
+        parser.error(MANAGED_RELEASE_GUIDANCE)
 
     all_files = get_mart_files()
 
@@ -114,7 +178,7 @@ def main() -> None:
         for f in all_files:
             print(f"  {f.name}")
         print(f"\nTotal: {len(all_files)} files")
-        return
+        return 0
 
     # Filter files
     files = all_files
@@ -131,21 +195,11 @@ def main() -> None:
     if args.dry_run:
         for f in files:
             run_mart(f, conn=None, dry_run=True)
-        return
+        return 0
 
-    # Connect and run
-    import psycopg2
-
-    db_url = get_db_url()
-    conn = psycopg2.connect(db_url)
-
-    try:
-        for f in files:
-            run_mart(f, conn)
-        logger.info("All marts deployed successfully")
-    finally:
-        conn.close()
+    # Guarded above: all non-release legacy paths are read-only diagnostics.
+    raise AssertionError("unreachable real legacy mart execution")
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/scripts/run_marts.py
+++ b/scripts/run_marts.py
@@ -84,6 +84,7 @@ def _plan_payload(plan, *, read_only: bool) -> dict[str, object]:
         "read_only": read_only,
         "valid": plan.valid,
         "roots": list(plan.roots),
+        "declared_consumers": list(plan.declared_consumers),
         "live_closure": [{"kind": obj.kind, "identity": obj.identity} for obj in plan.live_closure],
         "declared_restores": [
             {"kind": obj.kind, "identity": obj.identity} for obj in plan.declared_restores

--- a/scripts/run_migrations.py
+++ b/scripts/run_migrations.py
@@ -27,6 +27,7 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(mess
 logger = logging.getLogger(__name__)
 
 SCHEMAS_DIR = Path(__file__).parent.parent / "src" / "schemas"
+MARTS_DIR = (SCHEMAS_DIR / "marts").resolve()
 
 MIGRATION_ORDER = [
     "001_reference.sql",
@@ -111,6 +112,12 @@ def run_migration(sql_file: Path, conn, dry_run: bool = False) -> None:
         cursor.close()
 
 
+def _is_mart_sql_path(sql_path: Path) -> bool:
+    """Return whether a canonical path targets the managed marts directory."""
+    resolved = sql_path.resolve()
+    return resolved == MARTS_DIR or MARTS_DIR in resolved.parents
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Run schema migrations")
     selectors = parser.add_mutually_exclusive_group()
@@ -147,6 +154,12 @@ def main() -> None:
         if not sql_path.exists():
             logger.error(f"SQL file not found: {sql_path}")
             sys.exit(1)
+
+        if not args.dry_run and _is_mart_sql_path(sql_path):
+            parser.error(
+                "mart SQL cannot use the per-file migration route; "
+                "use scripts/run_marts.py --release <manifest>"
+            )
 
         if args.dry_run:
             run_migration(sql_path, conn=None, dry_run=True)

--- a/tests/test_deploy_schema.py
+++ b/tests/test_deploy_schema.py
@@ -1,9 +1,11 @@
 """Unit tests for deploy_schema's pure plan-building (no DB, no subprocess)."""
 
 import json
+import sys
 
 import pytest
 
+import scripts.deploy_schema as deploy_schema
 from scripts.deploy_schema import (
     COMPUTE_SCRIPTS,
     VALID_ACTIONS,
@@ -82,20 +84,15 @@ class TestPlanFromManifestPresenceCheck:
 
 
 class TestPlanFromManifestApply:
-    def test_apply_fields(self):
+    def test_legacy_mart_selectors_are_rejected(self):
         manifest = {
             "action": "apply",
             "marts_from": "029",
-            "marts_only": "011",
             "files": ["src/schemas/api/019_x.sql", "src/schemas/functions/y.sql"],
             "refresh": True,
         }
-        plan = plan_from_manifest(manifest)
-        assert plan.action == "apply"
-        assert plan.marts_from == "029"
-        assert plan.marts_only == "011"
-        assert plan.files == ["src/schemas/api/019_x.sql", "src/schemas/functions/y.sql"]
-        assert plan.refresh is True
+        with pytest.raises(ValueError, match="legacy mart selectors"):
+            plan_from_manifest(manifest)
 
     def test_apply_defaults(self):
         plan = plan_from_manifest({"action": "apply"})
@@ -242,17 +239,13 @@ class TestPlanFromCli:
         plan = plan_from_cli(action="presence_check", strict=True)
         assert plan.strict is True
 
-    def test_apply_flags_mapped(self):
+    def test_apply_fields_mapped_without_legacy_mart_selector(self):
         plan = plan_from_cli(
             action="apply",
-            marts_from="029",
-            marts_only="011",
             files="src/schemas/api/019_x.sql, src/schemas/functions/y.sql",
             refresh=True,
         )
         assert plan.action == "apply"
-        assert plan.marts_from == "029"
-        assert plan.marts_only == "011"
         # Comma-separated CLI string is split and whitespace-stripped.
         assert plan.files == ["src/schemas/api/019_x.sql", "src/schemas/functions/y.sql"]
         assert plan.refresh is True
@@ -350,3 +343,116 @@ class TestLoadManifest:
         manifest_path.write_text(json.dumps({"action": "presence_check"}))
         manifest = load_manifest(str(manifest_path))
         assert manifest == {"action": "presence_check"}
+
+
+class TestMartReleasePlans:
+    def test_manifest_maps_release_and_read_only_plan(self):
+        plan = plan_from_manifest(
+            {
+                "action": "apply",
+                "mart_release": "src/schemas/mart-releases/example.json",
+                "plan": True,
+            }
+        )
+        assert plan.mart_release == "src/schemas/mart-releases/example.json"
+        assert plan.plan is True
+
+    def test_cli_maps_release_execution_by_default(self):
+        plan = plan_from_cli(action="apply", mart_release="release.json")
+        assert plan.mart_release == "release.json"
+        assert plan.plan is False
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("marts_from", "029"),
+            ("marts_only", "011"),
+            ("files", ["src/schemas/api/example.sql"]),
+            ("refresh", True),
+            ("refresh_views", ["marts.example"]),
+            ("backfill", BackfillSpec(start=2025, end=2025, sources="stats")),
+            ("compute", ComputeSpec(script="compute_house_elo")),
+        ],
+    )
+    def test_release_rejects_legacy_deploy_fields(self, field, value):
+        plan = Plan(action="apply", mart_release="release.json")
+        setattr(plan, field, value)
+        with pytest.raises(ValueError, match=field):
+            validate_plan(plan)
+
+    def test_plan_requires_release(self):
+        with pytest.raises(ValueError, match="requires a mart_release"):
+            plan_from_cli(action="apply", plan=True)
+
+    def test_manifest_plan_must_be_boolean(self):
+        with pytest.raises(ValueError, match="plan must be a boolean"):
+            plan_from_manifest({"action": "apply", "mart_release": "release.json", "plan": "false"})
+
+    def test_release_requires_apply_action(self):
+        with pytest.raises(ValueError, match="only for the apply action"):
+            plan_from_cli(action="presence_check", mart_release="release.json")
+
+    @pytest.mark.parametrize("selector", [{"marts_from": "029"}, {"marts_only": "011"}])
+    def test_real_apply_rejects_legacy_mart_selectors(self, selector):
+        with pytest.raises(ValueError, match="dependency-complete"):
+            plan_from_cli(action="apply", **selector)
+
+    @pytest.mark.parametrize(
+        "files",
+        [
+            "src/schemas/marts/001_example.sql",
+            "src/schemas/api/001_ok.sql,src/schemas/marts/002_blocked.sql",
+            "src/schemas/api/../marts/003_traversal.sql",
+        ],
+    )
+    def test_apply_rejects_mart_file_in_any_position_or_spelling(self, files):
+        with pytest.raises(ValueError, match="per-file migration route"):
+            plan_from_cli(action="apply", files=files)
+
+    def test_release_execute_dispatches_exactly_one_atomic_runner(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            deploy_schema,
+            "run_cmd",
+            lambda cmd, label: calls.append((cmd, label)) or 0,
+        )
+
+        rc = deploy_schema.execute_plan(
+            Plan(action="apply", mart_release="src/schemas/mart-releases/example.json")
+        )
+
+        assert rc == 0
+        assert calls == [
+            (
+                [
+                    sys.executable,
+                    str(deploy_schema.RUN_MARTS),
+                    "--release",
+                    "src/schemas/mart-releases/example.json",
+                ],
+                "run_marts --release src/schemas/mart-releases/example.json",
+            )
+        ]
+
+    def test_release_plan_dispatches_read_only_flag(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            deploy_schema,
+            "run_cmd",
+            lambda cmd, label: calls.append(cmd) or 0,
+        )
+
+        rc = deploy_schema.execute_plan(
+            Plan(action="apply", mart_release="release.json", plan=True)
+        )
+
+        assert rc == 0
+        assert calls == [
+            [
+                sys.executable,
+                str(deploy_schema.RUN_MARTS),
+                "--release",
+                "release.json",
+                "--plan",
+            ]
+        ]

--- a/tests/test_mart_release.py
+++ b/tests/test_mart_release.py
@@ -1,0 +1,292 @@
+"""Unit tests for the bounded dependency-aware mart release engine."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.mart_release import (
+    ReleaseBlockedError,
+    ReleaseExecutionError,
+    ReleaseManifestError,
+    execute_release,
+    load_release,
+    plan_release,
+)
+
+
+def _write_release(
+    root: Path,
+    sql: str,
+    *,
+    restores: list[dict[str, str]] | None = None,
+    validations: list[dict[str, object]] | None = None,
+):
+    root.mkdir(parents=True, exist_ok=True)
+    sql_path = root / "release.sql"
+    sql_path.write_bytes(sql.encode())
+    manifest_path = root / "release.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "files": [
+                    {
+                        "path": "release.sql",
+                        "sha256": hashlib.sha256(sql_path.read_bytes()).hexdigest(),
+                    }
+                ],
+                "roots": ["marts.parent"],
+                "restores": restores
+                or [
+                    {"kind": "relation", "identity": "marts.parent"},
+                    {"kind": "relation", "identity": "api.consumer"},
+                ],
+                "validations": validations
+                or [
+                    {
+                        "name": "anon consumer",
+                        "role": "anon",
+                        "query": "SELECT true",
+                        "covers": [],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return load_release(manifest_path, root)
+
+
+def _snapshot_rows(*, changed_definition: bool = False):
+    # kind, identity, object type, owner, mutable implementation definition, then the eleven
+    # contract fields selected by _SNAPSHOT_SQL.
+    parent_definition = "SELECT 2" if changed_definition else "SELECT 1"
+    return [
+        (
+            "relation",
+            "api.consumer",
+            "v",
+            "owner",
+            "SELECT * FROM marts.parent",
+            "v",
+            "",
+            "false",
+            "false",
+            "",
+            "1:id:integer:false:::data::",
+            "",
+            "anon:true:false:false",
+            "",
+            "",
+            "",
+        ),
+        (
+            "relation",
+            "marts.parent",
+            "m",
+            "owner",
+            parent_definition,
+            "m",
+            "",
+            "false",
+            "false",
+            "",
+            "1:id:integer:false:::data::",
+            "parent_id=CREATE UNIQUE INDEX parent_id ON marts.parent USING btree (id)",
+            "anon:false:false:false",
+            "",
+            "",
+            "",
+        ),
+    ]
+
+
+def _acl_rows():
+    return [
+        ("relation", "api.consumer", "owner", "owner", "owner", "SELECT", False),
+        ("relation", "api.consumer", "owner", "owner", "anon", "SELECT", False),
+        ("relation", "marts.parent", "owner", "owner", "owner", "SELECT", False),
+    ]
+
+
+class FakeCursor:
+    def __init__(self, conn):
+        self.conn = conn
+        self.results = []
+        self.closed = False
+
+    def execute(self, sql, params=None):
+        normalized = " ".join(sql.split())
+        self.conn.executions.append((normalized, params))
+        if "mart_release:roots" in sql:
+            self.results = [(42, "marts.parent", "m")]
+        elif "mart_release:closure" in sql:
+            self.results = list(self.conn.closure)
+        elif "mart_release:snapshot" in sql:
+            self.results = _snapshot_rows(changed_definition=self.conn.release_ran)
+        elif "mart_release:acl" in sql:
+            self.results = _acl_rows()
+        elif sql == "SELECT true":
+            self.results = [(True,)]
+        else:
+            self.results = []
+        if "RELEASE BODY" in sql:
+            self.conn.release_ran = True
+        if "INJECT FAILURE" in sql:
+            raise ReleaseExecutionError("injected failure")
+
+    def fetchall(self):
+        rows, self.results = self.results, []
+        return rows
+
+    def fetchone(self):
+        return self.results.pop(0) if self.results else None
+
+    def close(self):
+        self.closed = True
+
+
+class FakeConnection:
+    autocommit = False
+
+    def __init__(self, *, closure=None):
+        self.closure = closure or [
+            ("object", "relation", "api.consumer", None, "v"),
+            ("object", "relation", "marts.parent", None, "m"),
+        ]
+        self.executions = []
+        self.commits = 0
+        self.rollbacks = 0
+        self.release_ran = False
+        self.cursor_instance = None
+
+    def get_transaction_status(self):
+        return 0
+
+    def cursor(self):
+        self.cursor_instance = FakeCursor(self)
+        return self.cursor_instance
+
+    def commit(self):
+        self.commits += 1
+
+    def rollback(self):
+        self.rollbacks += 1
+
+
+def test_load_release_hashes_exact_bytes_and_preserves_file_order(tmp_path: Path):
+    release = _write_release(tmp_path, "SELECT 1;\r\n")
+
+    assert release.files[0].sha256 == hashlib.sha256(b"SELECT 1;\r\n").hexdigest()
+    assert release.files[0].path == "release.sql"
+    assert release.roots == ("marts.parent",)
+
+
+def test_load_release_rejects_hash_mismatch_and_nontransactional_sql(tmp_path: Path):
+    _write_release(tmp_path / "hash", "SELECT 1;")
+    manifest_path = tmp_path / "hash" / "release.json"
+    payload = json.loads(manifest_path.read_text())
+    payload["files"][0]["sha256"] = "0" * 64
+    manifest_path.write_text(json.dumps(payload))
+    with pytest.raises(ReleaseManifestError, match="checksum mismatch"):
+        load_release(manifest_path, tmp_path / "hash")
+
+    with pytest.raises(ReleaseManifestError, match="nontransactional"):
+        _write_release(tmp_path / "ddl", "CREATE INDEX CONCURRENTLY x ON y(z);")
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        'SET "standard_conforming_strings" = off;',
+        "RESET ALL;",
+        "SET statement_timeout = '30min';",
+    ],
+)
+def test_load_release_rejects_top_level_guc_changes(tmp_path: Path, sql: str):
+    with pytest.raises(ReleaseManifestError, match="unsafe SQL"):
+        _write_release(tmp_path, sql)
+
+
+def test_plan_fails_closed_on_unsupported_catalog_objects(tmp_path: Path):
+    release = _write_release(tmp_path, "SELECT 1;")
+    conn = FakeConnection(
+        closure=[
+            ("object", "relation", "api.consumer", None, "v"),
+            ("object", "relation", "marts.parent", None, "m"),
+            ("unsupported", "pg_class", "73", None, "catalog class"),
+        ]
+    )
+
+    plan = plan_release(conn, release)
+
+    assert not plan.valid
+    assert "unsupported downstream catalog object" in " ".join(plan.blockers)
+
+
+def test_plan_is_read_only_and_reports_incomplete_live_closure(tmp_path: Path):
+    release = _write_release(
+        tmp_path,
+        "SELECT 1;",
+        restores=[{"kind": "relation", "identity": "marts.parent"}],
+    )
+    conn = FakeConnection()
+
+    plan = plan_release(conn, release)
+
+    assert not plan.valid
+    assert "api.consumer" in " ".join(plan.blockers)
+    assert conn.commits == 0
+    assert conn.rollbacks == 1
+    assert any(
+        sql.startswith("BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY")
+        for sql, _ in conn.executions
+    )
+
+
+def test_execute_rejects_incomplete_closure_before_release_sql(tmp_path: Path):
+    release = _write_release(
+        tmp_path,
+        "/* RELEASE BODY */ SELECT 1;",
+        restores=[{"kind": "relation", "identity": "marts.parent"}],
+    )
+    conn = FakeConnection()
+
+    with pytest.raises(ReleaseBlockedError):
+        execute_release(conn, release)
+
+    assert not conn.release_ran
+    assert conn.commits == 0
+    assert conn.rollbacks == 1
+
+
+def test_execute_rolls_back_file_failure(tmp_path: Path):
+    release = _write_release(tmp_path, "/* RELEASE BODY INJECT FAILURE */ SELECT 1;")
+    conn = FakeConnection()
+
+    with pytest.raises(ReleaseExecutionError, match="injected"):
+        execute_release(conn, release)
+
+    assert conn.release_ran
+    assert conn.commits == 0
+    assert conn.rollbacks == 1
+
+
+def test_execute_allows_definition_change_with_same_contract_and_rolls_back_validation_writes(
+    tmp_path: Path,
+):
+    release = _write_release(tmp_path, "/* RELEASE BODY */ SELECT 1;")
+    conn = FakeConnection()
+
+    plan = execute_release(conn, release)
+
+    assert plan.valid
+    assert conn.commits == 1
+    assert conn.rollbacks == 0
+    queries = [sql for sql, _ in conn.executions]
+    assert "ROLLBACK TO SAVEPOINT mart_release_validation" in queries
+    assert "RELEASE SAVEPOINT mart_release_validation" in queries

--- a/tests/test_mart_release.py
+++ b/tests/test_mart_release.py
@@ -23,49 +23,53 @@ def _write_release(
     sql: str,
     *,
     restores: list[dict[str, str]] | None = None,
+    consumers: list[str] | None = None,
     validations: list[dict[str, object]] | None = None,
 ):
     root.mkdir(parents=True, exist_ok=True)
     sql_path = root / "release.sql"
     sql_path.write_bytes(sql.encode())
     manifest_path = root / "release.json"
-    manifest_path.write_text(
-        json.dumps(
+    payload = {
+        "version": 1,
+        "files": [
             {
-                "version": 1,
-                "files": [
-                    {
-                        "path": "release.sql",
-                        "sha256": hashlib.sha256(sql_path.read_bytes()).hexdigest(),
-                    }
-                ],
-                "roots": ["marts.parent"],
-                "restores": restores
-                or [
-                    {"kind": "relation", "identity": "marts.parent"},
-                    {"kind": "relation", "identity": "api.consumer"},
-                ],
-                "validations": validations
-                or [
-                    {
-                        "name": "anon consumer",
-                        "role": "anon",
-                        "query": "SELECT true",
-                        "covers": [],
-                    }
-                ],
+                "path": "release.sql",
+                "sha256": hashlib.sha256(sql_path.read_bytes()).hexdigest(),
             }
-        ),
-        encoding="utf-8",
-    )
+        ],
+        "roots": ["marts.parent"],
+        "restores": restores
+        or [
+            {"kind": "relation", "identity": "marts.parent"},
+            {"kind": "relation", "identity": "api.consumer"},
+        ],
+        "validations": validations
+        or [
+            {
+                "name": "anon consumer",
+                "role": "anon",
+                "query": "SELECT true",
+                "covers": [],
+            }
+        ],
+    }
+    if consumers is not None:
+        payload["consumers"] = consumers
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
     return load_release(manifest_path, root)
 
 
-def _snapshot_rows(*, changed_definition: bool = False):
-    # kind, identity, object type, owner, mutable implementation definition, then the eleven
+def _snapshot_rows(
+    *,
+    changed_definition: bool = False,
+    parent_populated: bool = True,
+    function_consumer: bool = False,
+):
+    # kind, identity, object type, owner, mutable implementation definition, then the fourteen
     # contract fields selected by _SNAPSHOT_SQL.
     parent_definition = "SELECT 2" if changed_definition else "SELECT 1"
-    return [
+    rows = [
         (
             "relation",
             "api.consumer",
@@ -73,13 +77,16 @@ def _snapshot_rows(*, changed_definition: bool = False):
             "owner",
             "SELECT * FROM marts.parent",
             "v",
+            "true",
             "",
+            "d",
             "false",
             "false",
             "",
             "1:id:integer:false:::data::",
             "",
             "anon:true:false:false",
+            "",
             "",
             "",
             "",
@@ -91,7 +98,9 @@ def _snapshot_rows(*, changed_definition: bool = False):
             "owner",
             parent_definition,
             "m",
+            str(parent_populated).lower(),
             "",
+            "d",
             "false",
             "false",
             "",
@@ -101,8 +110,34 @@ def _snapshot_rows(*, changed_definition: bool = False):
             "",
             "",
             "",
+            "",
         ),
     ]
+    if function_consumer:
+        rows.append(
+            (
+                "function",
+                "public.dynamic_consumer(integer)",
+                "function",
+                "owner",
+                "CREATE FUNCTION public.dynamic_consumer(integer) RETURNS boolean ...",
+                "f",
+                "false",
+                "",
+                "v",
+                "u",
+                "false",
+                "false",
+                "boolean",
+                "integer",
+                "",
+                "anon:true",
+                "",
+                "",
+                "",
+            )
+        )
+    return rows
 
 
 def _acl_rows():
@@ -127,11 +162,15 @@ class FakeCursor:
         elif "mart_release:closure" in sql:
             self.results = list(self.conn.closure)
         elif "mart_release:snapshot" in sql:
-            self.results = _snapshot_rows(changed_definition=self.conn.release_ran)
+            self.results = _snapshot_rows(
+                changed_definition=self.conn.release_ran,
+                parent_populated=not (self.conn.release_ran and self.conn.unpopulate_after_release),
+                function_consumer=self.conn.function_consumer,
+            )
         elif "mart_release:acl" in sql:
             self.results = _acl_rows()
         elif sql == "SELECT true":
-            self.results = [(True,)]
+            self.results = [(self.conn.validation_result,)]
         else:
             self.results = []
         if "RELEASE BODY" in sql:
@@ -153,7 +192,14 @@ class FakeCursor:
 class FakeConnection:
     autocommit = False
 
-    def __init__(self, *, closure=None):
+    def __init__(
+        self,
+        *,
+        closure=None,
+        unpopulate_after_release: bool = False,
+        function_consumer: bool = False,
+        validation_result=True,
+    ):
         self.closure = closure or [
             ("object", "relation", "api.consumer", None, "v"),
             ("object", "relation", "marts.parent", None, "m"),
@@ -162,6 +208,9 @@ class FakeConnection:
         self.commits = 0
         self.rollbacks = 0
         self.release_ran = False
+        self.unpopulate_after_release = unpopulate_after_release
+        self.function_consumer = function_consumer
+        self.validation_result = validation_result
         self.cursor_instance = None
 
     def get_transaction_status(self):
@@ -184,6 +233,7 @@ def test_load_release_hashes_exact_bytes_and_preserves_file_order(tmp_path: Path
     assert release.files[0].sha256 == hashlib.sha256(b"SELECT 1;\r\n").hexdigest()
     assert release.files[0].path == "release.sql"
     assert release.roots == ("marts.parent",)
+    assert release.consumers == ()
 
 
 def test_load_release_rejects_hash_mismatch_and_nontransactional_sql(tmp_path: Path):
@@ -212,6 +262,35 @@ def test_load_release_rejects_top_level_guc_changes(tmp_path: Path, sql: str):
         _write_release(tmp_path, sql)
 
 
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT set_config('statement_timeout', '0', false);",
+        "SELECT pg_catalog.\"set_config\"('lock_timeout', '0', false);",
+        "SELECT \"pg_catalog\".\"set_config\"('statement_timeout', '0', false);",
+    ],
+)
+def test_load_release_rejects_direct_set_config_calls(tmp_path: Path, sql: str):
+    with pytest.raises(ReleaseManifestError, match="may not call set_config"):
+        _write_release(tmp_path, sql)
+
+
+def test_set_config_text_in_inert_regions_is_allowed(tmp_path: Path):
+    release = _write_release(
+        tmp_path,
+        "SELECT 'set_config('';' AS text; /* set_config(...) */",
+    )
+    assert release.files[0].sql.startswith("SELECT")
+
+
+def test_unicode_escaped_configuration_call_is_rejected(tmp_path: Path):
+    with pytest.raises(ReleaseManifestError, match="Unicode-escaped identifiers"):
+        _write_release(
+            tmp_path,
+            r"""SELECT pg_catalog.U&"set\005fconfig"('statement_timeout', '0', false);""",
+        )
+
+
 def test_plan_fails_closed_on_unsupported_catalog_objects(tmp_path: Path):
     release = _write_release(tmp_path, "SELECT 1;")
     conn = FakeConnection(
@@ -226,6 +305,37 @@ def test_plan_fails_closed_on_unsupported_catalog_objects(tmp_path: Path):
 
     assert not plan.valid
     assert "unsupported downstream catalog object" in " ".join(plan.blockers)
+
+
+def test_declared_dynamic_consumer_must_exist_and_have_validation_coverage(tmp_path: Path):
+    consumer = "public.dynamic_consumer(integer)"
+    validation = {
+        "name": "dynamic consumer",
+        "role": "anon",
+        "query": "SELECT true",
+        "covers": [consumer],
+    }
+    release = _write_release(
+        tmp_path / "existing",
+        "SELECT 1;",
+        consumers=[consumer],
+        validations=[validation],
+    )
+    assert plan_release(FakeConnection(function_consumer=True), release).valid
+
+    missing = plan_release(FakeConnection(), release)
+    assert not missing.valid
+    assert "consumer functions do not exist" in " ".join(missing.blockers)
+
+    uncovered = _write_release(
+        tmp_path / "uncovered",
+        "SELECT 1;",
+        consumers=[consumer],
+        validations=[{**validation, "covers": []}],
+    )
+    plan = plan_release(FakeConnection(function_consumer=True), uncovered)
+    assert not plan.valid
+    assert "require caller-role validations" in " ".join(plan.blockers)
 
 
 def test_plan_is_read_only_and_reports_incomplete_live_closure(tmp_path: Path):
@@ -290,3 +400,42 @@ def test_execute_allows_definition_change_with_same_contract_and_rolls_back_vali
     queries = [sql for sql, _ in conn.executions]
     assert "ROLLBACK TO SAVEPOINT mart_release_validation" in queries
     assert "RELEASE SAVEPOINT mart_release_validation" in queries
+
+
+def test_execute_rejects_recreated_unpopulated_materialized_view(tmp_path: Path):
+    release = _write_release(tmp_path, "/* RELEASE BODY */ SELECT 1;")
+    conn = FakeConnection(unpopulate_after_release=True)
+
+    with pytest.raises(ReleaseExecutionError, match="changed an existing object contract"):
+        execute_release(conn, release)
+
+    assert conn.commits == 0
+    assert conn.rollbacks == 1
+
+
+@pytest.mark.parametrize("result", [1, 1.0, "true", None])
+def test_validation_requires_literal_boolean_true(tmp_path: Path, result):
+    release = _write_release(tmp_path, "/* RELEASE BODY */ SELECT 1;")
+    conn = FakeConnection(validation_result=result)
+
+    with pytest.raises(ReleaseExecutionError, match="exactly one true boolean"):
+        execute_release(conn, release)
+
+    assert conn.commits == 0
+    assert conn.rollbacks == 1
+
+
+def test_validation_rejects_direct_set_config_call(tmp_path: Path):
+    with pytest.raises(ReleaseManifestError, match="may not call set_config"):
+        _write_release(
+            tmp_path,
+            "SELECT 1;",
+            validations=[
+                {
+                    "name": "timeout bypass",
+                    "role": "anon",
+                    "query": "SELECT pg_catalog.set_config('statement_timeout', '0', false)",
+                    "covers": [],
+                }
+            ],
+        )

--- a/tests/test_mart_release_cli.py
+++ b/tests/test_mart_release_cli.py
@@ -1,0 +1,274 @@
+"""Regression coverage for the managed mart release CLI boundaries."""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import scripts.run_marts as run_marts
+import scripts.run_migrations as run_migrations
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [[], ["--all"], ["--from", "029"], ["--only", "029"]],
+)
+def test_real_legacy_mart_paths_fail_before_credentials(monkeypatch, arguments):
+    monkeypatch.setattr(
+        run_marts,
+        "get_release_db_url",
+        lambda: pytest.fail("release credential lookup must not run"),
+    )
+
+    with pytest.raises(SystemExit, match="2"):
+        run_marts.main(arguments)
+
+
+def test_run_mart_public_helper_rejects_real_unmanaged_execution(tmp_path):
+    sql_path = tmp_path / "mart.sql"
+    sql_path.write_text("select 1;")
+
+    with pytest.raises(RuntimeError, match="requires --release"):
+        run_marts.run_mart(sql_path, conn=SimpleNamespace(), dry_run=False)
+
+
+def test_legacy_dry_run_still_displays_selected_sql(monkeypatch, tmp_path, capsys):
+    first = tmp_path / "001_first.sql"
+    second = tmp_path / "002_second.sql"
+    first.write_text("select 1;")
+    second.write_text("select 2;")
+    monkeypatch.setattr(run_marts, "get_mart_files", lambda: [first, second])
+
+    assert run_marts.main(["--only", "002", "--dry-run"]) == 0
+
+    output = capsys.readouterr().out
+    assert "002_second.sql" in output
+    assert "select 2;" in output
+    assert "001_first.sql" not in output
+
+
+def test_list_remains_read_only_without_credentials(monkeypatch, tmp_path, capsys):
+    sql_path = tmp_path / "001_example.sql"
+    sql_path.write_text("select 1;")
+    monkeypatch.setattr(run_marts, "get_mart_files", lambda: [sql_path])
+    monkeypatch.setattr(
+        run_marts,
+        "get_release_db_url",
+        lambda: pytest.fail("listing must not inspect credentials"),
+    )
+
+    assert run_marts.main(["--list"]) == 0
+    assert "001_example.sql" in capsys.readouterr().out
+
+
+def _valid_plan():
+    return SimpleNamespace(
+        valid=True,
+        roots=("marts.upstream",),
+        live_closure=(SimpleNamespace(kind="view", identity="api.consumer"),),
+        declared_restores=(SimpleNamespace(kind="view", identity="api.consumer"),),
+        files=(SimpleNamespace(path=Path("src/schemas/marts/001.sql"), sha256="a" * 64),),
+        warnings=(),
+        blockers=(),
+    )
+
+
+class _Connection:
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+def test_plan_calls_only_read_only_engine_path(monkeypatch, capsys):
+    manifest = object()
+    conn = _Connection()
+    calls = []
+    monkeypatch.setattr(run_marts, "load_release", lambda path, root: manifest)
+    monkeypatch.setattr(run_marts, "get_release_db_url", lambda: "postgresql://complete")
+    monkeypatch.setattr("psycopg2.connect", lambda database_url: conn)
+    monkeypatch.setattr(
+        run_marts,
+        "plan_release",
+        lambda actual_conn, actual_manifest: (
+            calls.append(("plan", actual_conn, actual_manifest)) or _valid_plan()
+        ),
+    )
+    monkeypatch.setattr(
+        run_marts,
+        "execute_release",
+        lambda *_: pytest.fail("read-only preview must not execute the release"),
+    )
+
+    assert run_marts.main(["--release", "release.json", "--plan"]) == 0
+
+    assert calls == [("plan", conn, manifest)]
+    assert conn.closed is True
+    assert '"read_only": true' in capsys.readouterr().out
+
+
+def test_release_execution_calls_atomic_engine_once(monkeypatch):
+    manifest = object()
+    conn = _Connection()
+    calls = []
+    monkeypatch.setattr(run_marts, "load_release", lambda path, root: manifest)
+    monkeypatch.setattr(run_marts, "get_release_db_url", lambda: "postgresql://complete")
+    monkeypatch.setattr("psycopg2.connect", lambda database_url: conn)
+    monkeypatch.setattr(
+        run_marts,
+        "execute_release",
+        lambda actual_conn, actual_manifest: (
+            calls.append((actual_conn, actual_manifest)) or _valid_plan()
+        ),
+    )
+    monkeypatch.setattr(
+        run_marts,
+        "plan_release",
+        lambda *_: pytest.fail("execution must use the engine's single atomic call"),
+    )
+
+    assert run_marts.main(["--release", "release.json"]) == 0
+    assert calls == [(conn, manifest)]
+    assert conn.closed is True
+
+
+def test_invalid_release_manifest_fails_before_credentials_and_redacts(monkeypatch, caplog):
+    leaked_url = "postgresql://alice:secret@example.test:5432/warehouse"
+    monkeypatch.setattr(
+        run_marts,
+        "load_release",
+        lambda path, root: (_ for _ in ()).throw(ValueError(f"invalid source {leaked_url}")),
+    )
+    monkeypatch.setattr(
+        run_marts,
+        "get_release_db_url",
+        lambda: pytest.fail("invalid manifests must fail before credentials"),
+    )
+
+    with caplog.at_level(logging.ERROR):
+        assert run_marts.main(["--release", "invalid.json"]) == 1
+
+    assert leaked_url not in caplog.text
+    assert "secret" not in caplog.text
+    assert "[REDACTED_DATABASE_URL]" in caplog.text
+
+
+def test_connection_error_redacts_explicit_database_url(monkeypatch, caplog):
+    leaked_url = "postgresql://alice:secret@example.test:5432/warehouse"
+    monkeypatch.setattr(run_marts, "load_release", lambda path, root: object())
+    monkeypatch.setattr(run_marts, "get_release_db_url", lambda: leaked_url)
+    monkeypatch.setattr(
+        "psycopg2.connect",
+        lambda database_url: (_ for _ in ()).throw(
+            RuntimeError(f"cannot connect to {database_url}")
+        ),
+    )
+
+    with caplog.at_level(logging.ERROR):
+        assert run_marts.main(["--release", "release.json"]) == 1
+
+    assert leaked_url not in caplog.text
+    assert "secret" not in caplog.text
+    assert "[REDACTED]" in caplog.text
+
+
+def test_empty_release_manifest_fails_before_credentials(monkeypatch, tmp_path, caplog):
+    release_path = tmp_path / "empty-release.json"
+    release_path.write_text(
+        json.dumps({"version": 1, "files": [], "roots": [], "restores": [], "validations": []})
+    )
+    monkeypatch.setattr(
+        run_marts,
+        "get_release_db_url",
+        lambda: pytest.fail("an empty manifest must fail before credentials"),
+    )
+
+    with caplog.at_level(logging.ERROR):
+        assert run_marts.main(["--release", str(release_path)]) == 1
+
+    assert "files must be a non-empty list" in caplog.text
+
+
+def test_release_credentials_require_explicit_supabase_url(monkeypatch):
+    monkeypatch.delenv("SUPABASE_DB_URL", raising=False)
+    monkeypatch.setenv("DATABASE_URL", "postgresql://fallback:unused@example.test:5432/db")
+
+    with pytest.raises(RuntimeError, match="SUPABASE_DB_URL is required"):
+        run_marts.get_release_db_url()
+
+
+def test_release_credentials_use_complete_uri_validator(monkeypatch):
+    monkeypatch.setenv("SUPABASE_DB_URL", "postgresql://example.test/warehouse")
+
+    with pytest.raises(ValueError, match="SUPABASE_DB_URL.*explicitly include"):
+        run_marts.get_release_db_url()
+
+
+def test_run_migrations_rejects_canonical_mart_file_before_credentials(monkeypatch, tmp_path):
+    schemas_dir = tmp_path / "src" / "schemas"
+    marts_dir = schemas_dir / "marts"
+    api_dir = schemas_dir / "api"
+    marts_dir.mkdir(parents=True)
+    api_dir.mkdir()
+    mart_file = marts_dir / "999_cli_boundary_test.sql"
+    # The canonical-path check must also catch traversal through a non-mart parent.
+    spelled_path = api_dir / ".." / "marts" / mart_file.name
+    mart_file.write_text("select 1;")
+    monkeypatch.setattr(run_migrations, "MARTS_DIR", marts_dir.resolve())
+    monkeypatch.setattr(sys, "argv", ["run_migrations.py", "--file", str(spelled_path)])
+    monkeypatch.setattr(
+        run_migrations,
+        "get_db_url",
+        lambda: pytest.fail("blocked mart files must fail before credentials"),
+    )
+
+    with pytest.raises(SystemExit, match="2"):
+        run_migrations.main()
+
+
+def test_run_migrations_allows_mart_file_sql_preview(monkeypatch, tmp_path):
+    mart_file = tmp_path / "preview.sql"
+    mart_file.write_text("select 1;")
+    monkeypatch.setattr(run_migrations, "MARTS_DIR", tmp_path.resolve())
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["run_migrations.py", "--file", str(mart_file), "--dry-run"],
+    )
+    calls = []
+    monkeypatch.setattr(
+        run_migrations,
+        "run_migration",
+        lambda path, conn, dry_run: calls.append((path, conn, dry_run)),
+    )
+
+    run_migrations.main()
+
+    assert calls == [(mart_file, None, True)]
+
+
+def test_run_migrations_preserves_real_nonmart_file_route(monkeypatch, tmp_path):
+    sql_path = tmp_path / "diagnostic.sql"
+    sql_path.write_text("select 1;")
+    conn = _Connection()
+    monkeypatch.setattr(sys, "argv", ["run_migrations.py", "--file", str(sql_path)])
+    monkeypatch.setattr(run_migrations, "get_db_url", lambda: "postgresql://fixture")
+    monkeypatch.setattr("psycopg2.connect", lambda database_url: conn)
+    monkeypatch.setattr(run_migrations, "_disable_statement_timeout", lambda actual_conn: None)
+    calls = []
+    monkeypatch.setattr(
+        run_migrations,
+        "run_migration",
+        lambda path, actual_conn: calls.append((path, actual_conn)),
+    )
+
+    run_migrations.main()
+
+    assert calls == [(sql_path, conn)]
+    assert conn.closed is True

--- a/tests/test_mart_release_cli.py
+++ b/tests/test_mart_release_cli.py
@@ -70,6 +70,7 @@ def _valid_plan():
     return SimpleNamespace(
         valid=True,
         roots=("marts.upstream",),
+        declared_consumers=("api.dynamic_reader()",),
         live_closure=(SimpleNamespace(kind="view", identity="api.consumer"),),
         declared_restores=(SimpleNamespace(kind="view", identity="api.consumer"),),
         files=(SimpleNamespace(path=Path("src/schemas/marts/001.sql"), sha256="a" * 64),),
@@ -110,7 +111,9 @@ def test_plan_calls_only_read_only_engine_path(monkeypatch, capsys):
 
     assert calls == [("plan", conn, manifest)]
     assert conn.closed is True
-    assert '"read_only": true' in capsys.readouterr().out
+    output = capsys.readouterr().out
+    assert '"read_only": true' in output
+    assert '"api.dynamic_reader()"' in output
 
 
 def test_release_execution_calls_atomic_engine_once(monkeypatch):

--- a/tests/test_mart_release_sql.py
+++ b/tests/test_mart_release_sql.py
@@ -19,7 +19,7 @@ def _release_warehouse_db(request):
     return request.getfixturevalue("_warehouse_db_fixture")
 
 
-def write_release(root, sources, *, restores=None, validations=None):
+def write_release(root, sources, *, restores=None, validations=None, consumers=None):
     root.mkdir(exist_ok=True)
     files = []
     for index, source in enumerate(sources):
@@ -45,6 +45,8 @@ def write_release(root, sources, *, restores=None, validations=None):
             }
         ],
     }
+    if consumers is not None:
+        data["consumers"] = consumers
     path = root / "release.json"
     path.write_text(json.dumps(data))
     from scripts.mart_release import load_release
@@ -177,6 +179,83 @@ def test_missing_index_rolls_back(warehouse_db, tmp_path):
         execute_release(conn, release)
     assert snapshot(conn) == before
     assert consumer_read(conn) == [(1, 7)]
+
+
+def test_unpopulated_replacement_rolls_back_without_consumer_assertion(warehouse_db, tmp_path):
+    from scripts.mart_release import ReleaseExecutionError, execute_release, plan_release
+
+    conn, _ = warehouse_db
+    query(conn, SETUP)
+    before = snapshot(conn)
+    parent = PARENT.replace(
+        "FROM public.release_source;", "FROM public.release_source WITH NO DATA;"
+    )
+    child = CHILD.replace("FROM marts.release_parent;", "FROM marts.release_parent WITH NO DATA;")
+    release = write_release(
+        tmp_path,
+        [parent, child],
+        validations=[{"name": "trivial", "role": "anon", "query": "SELECT true", "covers": []}],
+    )
+    assert plan_release(conn, release).valid
+    with pytest.raises(ReleaseExecutionError, match="contract"):
+        execute_release(conn, release)
+    assert snapshot(conn) == before
+    assert consumer_read(conn) == [(1, 7)]
+
+
+@pytest.mark.parametrize("assertion", ["SELECT 1", "SELECT 1::numeric"])
+def test_numeric_assertion_is_not_boolean_success(warehouse_db, tmp_path, assertion):
+    from scripts.mart_release import ReleaseExecutionError, execute_release
+
+    conn, _ = warehouse_db
+    query(conn, SETUP)
+    before = snapshot(conn)
+    release = write_release(
+        tmp_path,
+        [PARENT, CHILD],
+        validations=[{"name": "numeric", "role": "anon", "query": assertion, "covers": []}],
+    )
+    with pytest.raises(ReleaseExecutionError, match="boolean"):
+        execute_release(conn, release)
+    assert snapshot(conn) == before
+    assert consumer_read(conn) == [(1, 7)]
+
+
+def test_declared_dynamic_consumer_requires_and_runs_assertion(warehouse_db, tmp_path):
+    from scripts.mart_release import ReleaseBlockedError, execute_release, plan_release
+
+    conn, _ = warehouse_db
+    query(conn, SETUP)
+    query(
+        conn,
+        """
+        CREATE FUNCTION api.dynamic_release_value() RETURNS integer LANGUAGE plpgsql AS $$
+        DECLARE result integer;
+        BEGIN EXECUTE 'SELECT value FROM api.release_view' INTO result; RETURN result; END $$;
+        GRANT EXECUTE ON FUNCTION api.dynamic_release_value() TO anon;
+    """,
+    )
+    consumer = "api.dynamic_release_value()"
+    uncovered = write_release(tmp_path / "uncovered", [PARENT, CHILD], consumers=[consumer])
+    assert not plan_release(conn, uncovered).valid
+    with pytest.raises(ReleaseBlockedError):
+        execute_release(conn, uncovered)
+    covered = write_release(
+        tmp_path / "covered",
+        [PARENT, CHILD],
+        consumers=[consumer],
+        validations=[
+            {
+                "name": "dynamic",
+                "role": "anon",
+                "query": "SELECT api.dynamic_release_value() = 8",
+                "covers": [consumer],
+            }
+        ],
+    )
+    assert plan_release(conn, covered).valid
+    assert execute_release(conn, covered).valid
+    assert consumer_read(conn) == [(1, 8)]
 
 
 def test_unrelated_public_consumer_change_rolls_back(warehouse_db, tmp_path):

--- a/tests/test_mart_release_sql.py
+++ b/tests/test_mart_release_sql.py
@@ -1,0 +1,300 @@
+"""Executed F07 dependency coverage, consumer contracts, and atomic rollback."""
+
+import hashlib
+import json
+from pathlib import Path
+
+import psycopg2
+import pytest
+
+from scripts.warehouse_migrations import apply_manifest, load_manifest
+from tests.test_warehouse_migrations_sql import query
+from tests.test_warehouse_migrations_sql import warehouse_db as _warehouse_db_fixture  # noqa: F401
+
+ROOT = Path(__file__).parents[1]
+
+
+@pytest.fixture(name="warehouse_db")
+def _release_warehouse_db(request):
+    return request.getfixturevalue("_warehouse_db_fixture")
+
+
+def write_release(root, sources, *, restores=None, validations=None):
+    root.mkdir(exist_ok=True)
+    files = []
+    for index, source in enumerate(sources):
+        path = root / f"{index:02}.sql"
+        path.write_text(source)
+        files.append({"path": path.name, "sha256": hashlib.sha256(path.read_bytes()).hexdigest()})
+    data = {
+        "version": 1,
+        "files": files,
+        "roots": ["marts.release_parent"],
+        "restores": [
+            {"kind": "relation", "identity": name}
+            for name in restores
+            or ["marts.release_parent", "marts.release_child", "api.release_view"]
+        ],
+        "validations": validations
+        or [
+            {
+                "name": "consumer",
+                "role": "anon",
+                "query": "SELECT count(*) = 1 FROM api.release_view",
+                "covers": [],
+            }
+        ],
+    }
+    path = root / "release.json"
+    path.write_text(json.dumps(data))
+    from scripts.mart_release import load_release
+
+    return load_release(path, root)
+
+
+SETUP = """
+DO $$ BEGIN CREATE ROLE anon NOLOGIN; EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+CREATE SCHEMA marts;
+CREATE SCHEMA api;
+GRANT USAGE ON SCHEMA api TO anon;
+CREATE TABLE public.release_source(id integer PRIMARY KEY, value integer);
+INSERT INTO public.release_source VALUES (1, 7);
+CREATE MATERIALIZED VIEW marts.release_parent AS SELECT * FROM public.release_source;
+CREATE UNIQUE INDEX release_parent_id ON marts.release_parent(id);
+CREATE MATERIALIZED VIEW marts.release_child AS SELECT * FROM marts.release_parent;
+CREATE UNIQUE INDEX release_child_id ON marts.release_child(id);
+CREATE VIEW api.release_view AS SELECT * FROM marts.release_child;
+GRANT SELECT ON api.release_view TO anon;
+"""
+PARENT = """
+DROP MATERIALIZED VIEW marts.release_parent CASCADE;
+CREATE MATERIALIZED VIEW marts.release_parent AS
+SELECT id, value + 1 AS value FROM public.release_source;
+CREATE UNIQUE INDEX release_parent_id ON marts.release_parent(id);
+"""
+CHILD = """
+CREATE MATERIALIZED VIEW marts.release_child AS SELECT * FROM marts.release_parent;
+CREATE UNIQUE INDEX release_child_id ON marts.release_child(id);
+CREATE VIEW api.release_view AS SELECT * FROM marts.release_child;
+"""
+
+
+def snapshot(conn):
+    return query(
+        conn,
+        """
+        SELECT c.oid, n.nspname, c.relname, pg_get_viewdef(c.oid),
+               pg_get_userbyid(c.relowner), c.relacl::text
+        FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
+        WHERE n.nspname IN ('marts','api') AND c.relkind IN ('m','v') ORDER BY 2,3
+    """,
+    )
+
+
+def consumer_read(conn):
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SET LOCAL ROLE anon")
+            cur.execute("SELECT * FROM api.release_view")
+            return cur.fetchall()
+    finally:
+        conn.rollback()
+
+
+def test_release_atomic_failure_then_success(warehouse_db, tmp_path):
+    from scripts.mart_release import execute_release, plan_release
+
+    conn, _ = warehouse_db
+    query(conn, SETUP)
+    before = snapshot(conn)
+    broken = write_release(tmp_path / "broken", [PARENT, CHILD, "SELECT 1/0;"])
+    assert plan_release(conn, broken).valid
+    assert snapshot(conn) == before  # planning executes no DDL
+    with pytest.raises(psycopg2.errors.DivisionByZero):
+        execute_release(conn, broken)
+    assert snapshot(conn) == before
+    assert consumer_read(conn) == [(1, 7)]
+    good = write_release(tmp_path / "good", [PARENT, CHILD])
+    assert execute_release(conn, good).valid
+    assert consumer_read(conn) == [(1, 8)]
+    assert execute_release(conn, good).valid
+    assert consumer_read(conn) == [(1, 8)]
+
+
+def test_incomplete_and_new_dependency_fail_before_mutation(warehouse_db, tmp_path):
+    from scripts.mart_release import ReleaseBlockedError, execute_release, plan_release
+
+    conn, _ = warehouse_db
+    query(conn, SETUP)
+    before = snapshot(conn)
+    incomplete = write_release(tmp_path / "incomplete", [PARENT], restores=["marts.release_parent"])
+    assert not plan_release(conn, incomplete).valid
+    with pytest.raises(ReleaseBlockedError):
+        execute_release(conn, incomplete)
+    assert snapshot(conn) == before
+    complete = write_release(tmp_path / "complete", [PARENT, CHILD])
+    assert plan_release(conn, complete).valid
+    query(conn, "CREATE VIEW api.unplanned_consumer AS SELECT * FROM marts.release_child")
+    changed = snapshot(conn)
+    assert not plan_release(conn, complete).valid
+    with pytest.raises(ReleaseBlockedError):
+        execute_release(conn, complete)
+    assert snapshot(conn) == changed
+
+
+def test_incompatible_columns_roll_back(warehouse_db, tmp_path):
+    from scripts.mart_release import ReleaseExecutionError, execute_release, plan_release
+
+    conn, _ = warehouse_db
+    query(conn, SETUP)
+    before = snapshot(conn)
+    altered = PARENT.replace("value + 1 AS value", "(value + 1)::bigint AS value")
+    release = write_release(tmp_path, [altered, CHILD])
+    assert plan_release(conn, release).valid
+    with pytest.raises(ReleaseExecutionError, match="contract"):
+        execute_release(conn, release)
+    assert snapshot(conn) == before
+    assert consumer_read(conn) == [(1, 7)]
+
+
+def test_missing_index_rolls_back(warehouse_db, tmp_path):
+    from scripts.mart_release import ReleaseExecutionError, execute_release, plan_release
+
+    conn, _ = warehouse_db
+    query(conn, SETUP)
+    before = snapshot(conn)
+    release = write_release(
+        tmp_path,
+        [
+            PARENT.replace(
+                "CREATE UNIQUE INDEX release_parent_id ON marts.release_parent(id);", ""
+            ),
+            CHILD,
+        ],
+    )
+    assert plan_release(conn, release).valid
+    with pytest.raises(ReleaseExecutionError, match="contract"):
+        execute_release(conn, release)
+    assert snapshot(conn) == before
+    assert consumer_read(conn) == [(1, 7)]
+
+
+def test_unrelated_public_consumer_change_rolls_back(warehouse_db, tmp_path):
+    from scripts.mart_release import ReleaseExecutionError, execute_release, plan_release
+
+    conn, _ = warehouse_db
+    query(conn, SETUP)
+    query(conn, "CREATE VIEW public.unrelated_consumer AS SELECT 17 AS value")
+    before = snapshot(conn)
+    release = write_release(
+        tmp_path,
+        [PARENT, CHILD, "CREATE OR REPLACE VIEW public.unrelated_consumer AS SELECT 19 AS value"],
+    )
+    assert plan_release(conn, release).valid
+    with pytest.raises(ReleaseExecutionError, match="outside"):
+        execute_release(conn, release)
+    assert snapshot(conn) == before
+    assert query(conn, "SELECT * FROM public.unrelated_consumer") == [(17,)]
+
+
+def test_recreation_does_not_leak_new_default_grants(warehouse_db, tmp_path):
+    from scripts.mart_release import execute_release, plan_release
+
+    conn, _ = warehouse_db
+    query(conn, SETUP)
+    query(conn, "ALTER DEFAULT PRIVILEGES IN SCHEMA marts GRANT SELECT ON TABLES TO PUBLIC")
+    release = write_release(tmp_path, [PARENT, CHILD])
+    assert plan_release(conn, release).valid
+    assert execute_release(conn, release).valid
+    assert consumer_read(conn) == [(1, 8)]
+    assert query(conn, "SELECT has_table_privilege('anon', 'marts.release_parent', 'SELECT')") == [
+        (False,)
+    ]
+
+
+def test_composite_dependent_type_blocks_release(warehouse_db, tmp_path):
+    from scripts.mart_release import ReleaseBlockedError, execute_release, plan_release
+
+    conn, _ = warehouse_db
+    query(conn, SETUP)
+    query(conn, "CREATE TYPE public.release_payload AS (item marts.release_parent)")
+    before = snapshot(conn)
+    release = write_release(tmp_path, [PARENT, CHILD])
+    plan = plan_release(conn, release)
+    assert not plan.valid, plan
+    with pytest.raises(ReleaseBlockedError):
+        execute_release(conn, release)
+    assert snapshot(conn) == before
+    assert query(conn, "SELECT to_regtype('public.release_payload') IS NOT NULL") == [(True,)]
+
+
+def test_row_type_function_requires_explicit_restoration(warehouse_db, tmp_path):
+    from scripts.mart_release import (
+        ObjectIdentity,
+        ReleaseBlockedError,
+        execute_release,
+        plan_release,
+    )
+
+    conn, _ = warehouse_db
+    query(conn, SETUP)
+    query(
+        conn,
+        "CREATE FUNCTION api.release_fn(x marts.release_parent) RETURNS integer "
+        "LANGUAGE sql IMMUTABLE AS 'SELECT ($1).id'",
+    )
+    before = snapshot(conn)
+    release = write_release(tmp_path, [PARENT, CHILD])
+    plan = plan_release(conn, release)
+    assert not plan.valid, plan
+    assert ObjectIdentity("function", "api.release_fn(x marts.release_parent)") in plan.live_closure
+    with pytest.raises(ReleaseBlockedError):
+        execute_release(conn, release)
+    assert snapshot(conn) == before
+    assert query(conn, "SELECT api.release_fn(ROW(1,7)::marts.release_parent)") == [(1,)]
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        "COMMENT ON MATERIALIZED VIEW marts.release_parent IS 'preserve mart documentation'",
+        "GRANT SELECT (id) ON marts.release_parent TO anon",
+        "CREATE RULE release_no_delete AS ON DELETE TO api.release_view DO INSTEAD NOTHING",
+    ],
+)
+def test_omitted_metadata_rolls_back(warehouse_db, tmp_path, metadata):
+    from scripts.mart_release import ReleaseExecutionError, execute_release, plan_release
+
+    conn, _ = warehouse_db
+    query(conn, SETUP)
+    query(conn, metadata)
+    before = snapshot(conn)
+    release = write_release(tmp_path, [PARENT, CHILD])
+    assert plan_release(conn, release).valid
+    with pytest.raises(ReleaseExecutionError, match="contract"):
+        execute_release(conn, release)
+    assert snapshot(conn) == before
+    assert consumer_read(conn) == [(1, 7)]
+
+
+def test_real_trajectory_release_preserves_invoker_contract(warehouse_db):
+    from scripts.mart_release import execute_release, load_release, plan_release
+
+    conn, _ = warehouse_db
+    apply_manifest(
+        conn, load_manifest(ROOT / "src/schemas/warehouse-manifest.json", ROOT), mode="bootstrap"
+    )
+    release = load_release(ROOT / "deploys/mart-releases/trajectory.json", ROOT)
+    plan = plan_release(conn, release)
+    assert plan.valid, plan
+    assert execute_release(conn, release).valid
+    for role in ("anon", "authenticated"):
+        try:
+            with conn.cursor() as cur:
+                cur.execute(f"SET LOCAL ROLE {role}")
+                cur.execute("SELECT * FROM public.team_season_trajectory LIMIT 1")
+                assert cur.fetchall() == []
+                with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+                    cur.execute("SELECT * FROM scouting.players LIMIT 1")
+        finally:
+            conn.rollback()


### PR DESCRIPTION
Mart rebuilds using DROP ... CASCADE could previously commit one file at a time and leave API/public consumers missing after a partial deployment. F07 introduces a checksum-bound release manifest that previews the live PostgreSQL dependency closure, rejects incomplete or unsupported releases, and executes the full rebuild with contract checks and caller assertions in one transaction.

![PR Lens architecture: one atomic release replaces per-file mart commits and preserves existing warehouse consumers](https://github.com/user-attachments/assets/fd2e4179-344e-4ce1-8707-85190067def4)

![PR Lens transaction flow: checksum validation, dependency checks, rebuild, grant restoration and commit or rollback](https://github.com/user-attachments/assets/bb888258-c4ab-45c7-bc7a-7c5f87afa4bf)

The CLI and Deploy Schema workflow use the same release engine. Legacy real mart selectors and mart files through the per-file migration route now fail before connecting. Existing owners and grants are restored, unexpected definition/metadata changes roll back, and a reviewed trajectory release provides a concrete example.

Validation:
- 16 executed PostgreSQL 17/pgvector F07 cases pass: populated success/repeat, downstream-failure rollback, missing/new dependencies, metadata/index/column preservation, public consumers, default grants, unsupported composite dependencies, function dependencies, and trajectory RPC access under anon/authenticated.
- Combined F06 compatibility/F07 integration passed 26 tests before the final view-rule regression; final F07 coverage passed afterward.
- Main suite: 2,578 passed, 531 skipped; MCP: 59 passed; 39 final engine/CLI cases pass.
- Ruff and agent setup checks pass for PR files; independent review findings resolved. Unrelated untracked film-script lint issues are excluded from this PR.

Review follow-up (`66b4383`): preserves materialized-view population state, requires literal boolean success, blocks direct timeout configuration calls, and validates declared dynamic consumers. All four bot review threads are resolved with regression evidence.

Production has not been changed. Version 1 requires contract-preserving view/matview releases; stored-table dependents and unsupported catalog objects are rejected. Dynamic SQL needs explicit caller assertions, validation functions must be side-effect-free, delegated grant chains may fail closed, and long rebuilds still require a rehearsed maintenance window. F06's immutable baseline and production adoption receipt are unchanged.






<!-- greptile_comment -->

<h3>Greptile Summary</h3>

## Summary
- The release engine enforces strict boolean validation results, prevents validation queries from removing release timeouts, and supports declared dynamic or textual consumers.
- Deployment adapters and focused test coverage continue to use the common mart-release path.

No new actionable issues were identified.

<h3>Confidence Score: 5/5</h3>

Safe to merge.

PRRC_kwDORDTOL87rqyAF was resolved by greptile-apps[bot] without explanation. PRRC_kwDORDTOL87rqyAK was resolved by greptile-apps[bot] without explanation. PRRC_kwDORDTOL87rqyAS was resolved by greptile-apps[bot] without explanation. The current implementation addresses each reported behavior: validation results require the singleton boolean True, direct set_config calls are rejected, and declared dynamic or textual consumers require validation coverage.

<sub>Reviews (2): Last reviewed commit: ["Close release validation and consumer co..."](https://github.com/rstover-fo/cfb-database/commit/66b4383531e6595b922f6235c55e4d8b2527857f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61433717)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Schema deployment and migrations](https://app.greptile.com/formentera-operations/-/custom-context/knowledge-base/rstover-fo/cfb-database/-/docs/schema-deployment.md)
- Knowledge Base — [Analytics marts and refreshes](https://app.greptile.com/formentera-operations/-/custom-context/knowledge-base/rstover-fo/cfb-database/-/docs/analytics-marts.md)
- Knowledge Base — [Database platform and analytics layer](https://app.greptile.com/formentera-operations/-/custom-context/knowledge-base/rstover-fo/cfb-database/-/docs/database-platform.md)
</details>


<!-- /greptile_comment -->