### PR TITLE
Fix F08 season rollover and plays partition preflight

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - run: ./scripts/setup_dev.sh
       - name: Managed bootstrap and upgrade integration
-        run: .venv/bin/python -m pytest tests/test_warehouse_migrations_sql.py tests/test_warehouse_bootstrap_sql.py tests/test_adopt_warehouse_catalog_sql.py tests/test_f06_verification_transactions_sql.py tests/test_mart_release_sql.py -q --tb=short
+        run: .venv/bin/python -m pytest tests/test_warehouse_migrations_sql.py tests/test_warehouse_bootstrap_sql.py tests/test_adopt_warehouse_catalog_sql.py tests/test_f06_verification_transactions_sql.py tests/test_mart_release_sql.py tests/test_play_partitions.py -q --tb=short
         env:
           F06_TEST_DB_URL: postgresql://postgres:f06-disposable-ci@127.0.0.1:5432/postgres
           F06_REQUIRE_DB: "1"

--- a/docs/plans/2026-09-04-main-codebase-audit.md
+++ b/docs/plans/2026-09-04-main-codebase-audit.md
@@ -170,6 +170,12 @@ Evidence: [mart runner](https://github.com/rstover-fo/cfb-database/blob/4a798fde
 
 ### F08 — Partition and historical-year configuration stops at 2026
 
+Implemented in the plays runner preflight, `scripts/maintain_play_partitions.py`,
+and rolling year configuration. Operational behavior and read-only production
+catalog evidence: [warehouse operations](../warehouse-operations.md#plays-partition-rollover-f08).
+Production provisioning remains a separate authorized operation. The finding
+below records the original audit state.
+
 **P1 before 2027 ingestion · Confirmed repository limit; validate live catalog · M**
 
 The plays partition migration creates years 2004–2026. No automated future-partition lifecycle was found. Configured historical year ranges also end at 2026. The load verifier checks a partition's name after ingestion, rather than ensuring an attached partition with correct bounds exists before loading.

--- a/docs/warehouse-operations.md
+++ b/docs/warehouse-operations.md
@@ -28,6 +28,7 @@ These commands operate on an explicitly selected, authorized warehouse; use
 | Inspect a season load plan and estimate | `scripts/load_season.py --dry-run` |
 | Season ingestion | `scripts/load_season.py --weekly` (explicit `--season` for backfills) |
 | Post-load verification | `scripts/verify_load.py` |
+| Inspect / maintain plays partitions | `scripts/maintain_play_partitions.py` (read-only); `--apply` creates missing partitions |
 | Refresh existing marts | `scripts/refresh_marts.py` |
 | Apply definitions / migrations | [Atomic mart releases](mart-releases.md); `scripts/run_migrations.py` for explicit non-mart migrations |
 | One-off SQL application | `scripts/run_migrations.py --file <path>`; follow that file's application contract |
@@ -40,6 +41,44 @@ transaction pooling does not accept all startup/session options these jobs use.
 Secrets belong in ignored config or the host's credential mechanism, never docs.
 The request budget is configured in `.dlt/config.toml`; historical estimates do
 not establish the cost of today's source/resource selection.
+
+## Plays partition rollover (F08)
+
+`run_plays_pipeline()` performs catalog preflight before constructing the source
+or fetching plays. It validates `core.plays` as `LIST (season)`, each child's
+attachment and single-season bound, and conflicting partition names. On an
+authorized ingestion run it creates missing partitions for the requested years
+and the current calendar year plus one following year, in a separate atomic
+transaction before dlt starts loading. Maintenance uses bounded lock waits;
+catalog inconsistencies fail the load rather than being silently repaired.
+
+Preview a target's catalog with
+`.venv/bin/python scripts/maintain_play_partitions.py`; use `--apply` only for an
+authorized target. An explicit historical `--years 2004` includes that partition
+in the required set. Existing historical partitions remain in place, so late
+records continue to route by their requested season; this does not change
+provider correction or re-fetch policy. Years before 2004 or beyond the next
+calendar year are rejected. No default partition is added, so NULL or unsupported
+season values cannot silently accumulate in catch-all storage. The parent must
+already be partitioned; this command does not replay the old table-swap migration.
+
+Historical source ranges keep fixed coverage starts and resolve their upper end
+to the calendar year on each lookup. This includes preseason data before August;
+incremental selection retains the existing August season boundary. Post-load
+verification checks catalog attachment/bounds and required horizon coverage.
+
+Read-only production inspection on 2026-09-08 found `core.plays` partitioned by
+`LIST (season)` with exactly 23 correctly attached, single-season partitions,
+`core.plays_y2004` through `core.plays_y2026`, and no detached names matching that
+pattern. The 2027 partition is absent. F08 development did not apply production
+DDL; the first authorized maintenance or ingestion run must provision it.
+
+Validation on disposable PostgreSQL 17 passed rollover and historical-row
+routing, inherited partition-index creation, idempotence, rejection of catalog
+drift, and rollback after the first of two partition creations succeeds. The
+partition tests run in the CI PostgreSQL job. This verifies executed SQL and
+loader preflight ordering with fakes; it does not represent a live CFBD/dlt
+end-to-end load or a production deployment.
 
 ## Box-score and roster request failures
 

--- a/scripts/maintain_play_partitions.py
+++ b/scripts/maintain_play_partitions.py
@@ -1,0 +1,80 @@
+"""Inspect or create the bounded ``core.plays`` season partition horizon."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import psycopg2  # noqa: E402
+
+from src.pipelines.utils import load_ledger  # noqa: E402
+from src.pipelines.utils.partitions import ensure_play_partitions  # noqa: E402
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate core.plays partitions and optionally create the bounded horizon"
+    )
+    parser.add_argument(
+        "--years",
+        type=int,
+        nargs="*",
+        default=(),
+        help="Additional historical seasons to require (default: rolling current/next years)",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Atomically create missing partitions after full catalog validation",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    conn = None
+    try:
+        conn = psycopg2.connect(load_ledger.get_db_url())
+        plan = ensure_play_partitions(conn, args.years, create=args.apply)
+        print(
+            json.dumps(
+                {
+                    "apply": args.apply,
+                    "created_years": list(plan.created_years),
+                    "existing_years": list(plan.existing_years),
+                    "missing_years": list(plan.missing_years),
+                    "required_years": list(plan.required_years),
+                    "valid": True,
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
+    except Exception as exc:
+        print(
+            json.dumps(
+                {
+                    "error": {
+                        "message": str(exc) or type(exc).__name__,
+                        "type": type(exc).__name__,
+                    },
+                    "valid": False,
+                },
+                sort_keys=True,
+            ),
+            file=sys.stderr,
+        )
+        return 1
+    finally:
+        if conn is not None:
+            conn.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_load.py
+++ b/scripts/verify_load.py
@@ -11,7 +11,7 @@ Usage:
     python scripts/verify_load.py --strict          # Treat staleness as failure year-round
 
 Checks:
-    1. plays partition for the season exists (core.plays_yNNNN)
+    1. plays partitions have correct attachment/bounds and cover the load horizon
     2. core.games row count for the season matches the CFBD /games count (1 API call)
     3. completed FBS-involved games have game_team_stats rows (lower-division
        games are excluded -- CFBD only reliably publishes box scores for games
@@ -91,12 +91,17 @@ class Report:
 
 
 def check_partition(cur, season: int, report: Report) -> None:
-    cur.execute("SELECT to_regclass(%s)", (f"core.plays_y{season}",))
-    exists = cur.fetchone()[0] is not None
+    from src.pipelines.utils.partitions import PartitionStateError, inspect_play_partitions
+
+    try:
+        plan = inspect_play_partitions(cur, [season])
+    except PartitionStateError as exc:
+        report.record(FAIL, "plays_partition", str(exc))
+        return
     report.record(
-        PASS if exists else FAIL,
+        FAIL if plan.missing_years else PASS,
         "plays_partition",
-        f"core.plays_y{season} {'exists' if exists else 'MISSING'}",
+        f"validated catalog; missing seasons: {list(plan.missing_years)}",
     )
 
 

--- a/src/pipelines/config/years.py
+++ b/src/pipelines/config/years.py
@@ -1,8 +1,11 @@
 """Year range configuration for CFBD API endpoints.
 
-Different data types have different available year ranges.
+Different data types have different available start years. Historical loads run
+through the current calendar year so preseason data for the upcoming season is
+reachable before August.
 """
 
+from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 
 
@@ -27,26 +30,59 @@ class YearRange:
         return list(range(self.start, self.end + 1))
 
 
-# Year ranges by data category
-YEAR_RANGES = {
+# Fixed provider-coverage starts by data category. The end is resolved when a
+# range is requested so a long-lived loader process crosses New Year cleanly.
+YEAR_RANGE_STARTS = {
     # Games go back to 1869 but we'll start with modern era for most uses
-    "games": YearRange(start=1869, end=2026),
-    "games_modern": YearRange(start=2000, end=2026),
+    "games": 1869,
+    "games_modern": 2000,
     # Play-by-play only available from 2004
-    "plays": YearRange(start=2004, end=2026),
+    "plays": 2004,
     # Most stats available from 2004
-    "stats": YearRange(start=2004, end=2026),
+    "stats": 2004,
     # Advanced ratings from 2004 (FPI starts 2005)
-    "ratings": YearRange(start=2004, end=2026),
+    "ratings": 2004,
     # Recruiting from 2000
-    "recruiting": YearRange(start=2000, end=2026),
+    "recruiting": 2000,
     # Betting lines from 2013
-    "betting": YearRange(start=2013, end=2026),
+    "betting": 2013,
     # Draft from 2000
-    "draft": YearRange(start=2000, end=2026),
+    "draft": 2000,
     # Advanced metrics from 2014
-    "metrics": YearRange(start=2014, end=2026),
+    "metrics": 2014,
 }
+
+
+def get_historical_end_year() -> int:
+    """Return the rolling upper bound for historical ingestion.
+
+    Historical endpoints can publish upcoming-season data before the season
+    starts, so this intentionally uses the calendar year rather than
+    :func:`get_current_season`, which remains on the prior season until August.
+    """
+    from datetime import datetime
+
+    return datetime.now().year
+
+
+class _YearRanges(Mapping[str, YearRange]):
+    """Read-only ranges with a calendar-year end resolved on every lookup."""
+
+    def __getitem__(self, category: str) -> YearRange:
+        return YearRange(
+            start=YEAR_RANGE_STARTS[category],
+            end=get_historical_end_year(),
+        )
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(YEAR_RANGE_STARTS)
+
+    def __len__(self) -> int:
+        return len(YEAR_RANGE_STARTS)
+
+
+# Dict-like compatibility for existing source configuration lookups.
+YEAR_RANGES: Mapping[str, YearRange] = _YearRanges()
 
 
 def get_current_season() -> int:

--- a/src/pipelines/run.py
+++ b/src/pipelines/run.py
@@ -351,14 +351,30 @@ def run_game_stats_weekly(
 
 def run_plays_pipeline(years: list[int] | None = None, mode: str = "incremental"):
     """Run the plays data pipeline."""
-    years_str = f"years={years}" if years else f"mode={mode}"
-    print(f"\n=== Loading Plays Data ({years_str}) ===\n")
+    import psycopg2
 
+    from .config.years import YEAR_RANGES, get_current_season
+    from .utils.partitions import ensure_play_partitions
+
+    if years is None:
+        years = [get_current_season()] if mode == "incremental" else YEAR_RANGES["plays"].to_list()
     pipeline = dlt.pipeline(
         pipeline_name="cfbd_plays",
         destination="postgres",
         dataset_name="core",
     )
+    # Validate the actual destination catalog before fetching any provider data.
+    # A dedicated connection commits maintenance before dlt starts its load.
+    destination_client = pipeline.destination_client()
+    conn = psycopg2.connect(destination_client.config.credentials.to_native_representation())
+    try:
+        plan = ensure_play_partitions(conn, years, create=True)
+        logger.info("Plays partition preflight: %s", plan)
+    finally:
+        conn.close()
+
+    years_str = f"years={years}" if years else f"mode={mode}"
+    print(f"\n=== Loading Plays Data ({years_str}) ===\n")
 
     source = plays_source(years=years, mode=mode)
     info = pipeline.run(source)

--- a/src/pipelines/utils/partitions.py
+++ b/src/pipelines/utils/partitions.py
@@ -1,0 +1,272 @@
+"""Catalog-safe lifecycle for ``core.plays`` season partitions.
+
+The helper validates the complete live partition set before it emits DDL.  This
+is intentionally stricter than ``CREATE TABLE IF NOT EXISTS``: an orphaned
+same-name table, a default partition, or a child whose name disagrees with its
+bound must stop ingestion rather than silently route plays to the wrong table.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import date
+
+from psycopg2 import sql
+from psycopg2.extensions import TRANSACTION_STATUS_IDLE
+
+MIN_PLAY_SEASON = 2004
+LOCK_TIMEOUT = "10s"
+ADVISORY_LOCK_KEYS = (1_128_677_364, 80_008)
+
+_PARTITION_NAME_RE = re.compile(r"plays_y([0-9]+)\Z")
+_PARTITION_BOUND_RE = re.compile(r"FOR VALUES IN \(('?)([0-9]+)\1\)\Z")
+
+
+class PartitionStateError(RuntimeError):
+    """The live ``core.plays`` partition catalog is unsafe to maintain."""
+
+
+@dataclass(frozen=True)
+class PlayPartitionPlan:
+    """Validated partition state and the bounded work requested by the caller."""
+
+    required_years: tuple[int, ...]
+    existing_years: tuple[int, ...]
+    missing_years: tuple[int, ...]
+    created_years: tuple[int, ...] = ()
+
+
+def _required_years(years: Iterable[int], calendar_year: int) -> tuple[int, ...]:
+    maximum = calendar_year + 1
+    requested: set[int] = set()
+    for year in years:
+        # bool is an int subclass but accepting it as season 0/1 makes caller bugs obscure.
+        if isinstance(year, bool) or not isinstance(year, int):
+            raise ValueError(f"play partition year must be an integer, got {year!r}")
+        if not MIN_PLAY_SEASON <= year <= maximum:
+            raise ValueError(f"play partition year {year} is outside {MIN_PLAY_SEASON}..{maximum}")
+        requested.add(year)
+    requested.update((calendar_year, maximum))
+    return tuple(sorted(requested))
+
+
+def _fetch_parent(cur: object) -> int:
+    cur.execute(
+        """
+        SELECT parent.oid, parent.relkind, partitioned.partstrat,
+               partitioned.partnatts,
+               ARRAY(
+                   SELECT attribute.attname
+                   FROM unnest(partitioned.partattrs::smallint[]) WITH ORDINALITY
+                       AS partition_key(attnum, key_order)
+                   LEFT JOIN pg_catalog.pg_attribute attribute
+                     ON attribute.attrelid = parent.oid
+                    AND attribute.attnum = partition_key.attnum
+                   ORDER BY partition_key.key_order
+               )
+        FROM pg_catalog.pg_class parent
+        JOIN pg_catalog.pg_namespace namespace
+          ON namespace.oid = parent.relnamespace
+        LEFT JOIN pg_catalog.pg_partitioned_table partitioned
+          ON partitioned.partrelid = parent.oid
+        WHERE namespace.nspname = %s AND parent.relname = %s
+        """,
+        ("core", "plays"),
+    )
+    rows = cur.fetchall()
+    if len(rows) != 1:
+        raise PartitionStateError("expected exactly one core.plays relation")
+    oid, relkind, strategy, key_count, key_names = rows[0]
+    if relkind != "p" or strategy != "l" or key_count != 1 or key_names != ["season"]:
+        raise PartitionStateError(
+            "core.plays must be partitioned by exactly LIST (season); "
+            f"found relkind={relkind!r}, strategy={strategy!r}, keys={key_names!r}"
+        )
+    return int(oid)
+
+
+def _fetch_children(cur: object, parent_oid: int) -> list[tuple[object, ...]]:
+    cur.execute(
+        """
+        SELECT child.oid, child_namespace.nspname, child.relname,
+               child.relkind, child.relispartition,
+               pg_catalog.pg_get_expr(child.relpartbound, child.oid)
+        FROM pg_catalog.pg_inherits inheritance
+        JOIN pg_catalog.pg_class child ON child.oid = inheritance.inhrelid
+        JOIN pg_catalog.pg_namespace child_namespace
+          ON child_namespace.oid = child.relnamespace
+        WHERE inheritance.inhparent = %s
+        ORDER BY child_namespace.nspname, child.relname
+        """,
+        (parent_oid,),
+    )
+    return list(cur.fetchall())
+
+
+def _fetch_reserved_relations(cur: object) -> list[tuple[object, ...]]:
+    cur.execute(
+        """
+        SELECT relation.oid, relation.relname, relation.relkind
+        FROM pg_catalog.pg_class relation
+        JOIN pg_catalog.pg_namespace namespace
+          ON namespace.oid = relation.relnamespace
+        WHERE namespace.nspname = %s AND relation.relname ~ %s
+        ORDER BY relation.relname
+        """,
+        ("core", r"^plays_y[0-9]+$"),
+    )
+    return list(cur.fetchall())
+
+
+def inspect_play_partitions(
+    cur: object,
+    years: Iterable[int] = (),
+    *,
+    calendar_year: int | None = None,
+) -> PlayPartitionPlan:
+    """Validate the full catalog and report missing requested/rolling partitions.
+
+    Existing correctly named single-season partitions beyond the rolling horizon
+    are retained and accepted.  The upper bound applies to newly requested years,
+    preventing accidental unbounded future creation.
+    """
+
+    resolved_calendar_year = date.today().year if calendar_year is None else calendar_year
+    if isinstance(resolved_calendar_year, bool) or not isinstance(resolved_calendar_year, int):
+        raise ValueError("calendar_year must be an integer")
+    if resolved_calendar_year < MIN_PLAY_SEASON:
+        raise ValueError(f"calendar_year must be at least {MIN_PLAY_SEASON}")
+    required = _required_years(years, resolved_calendar_year)
+
+    parent_oid = _fetch_parent(cur)
+    children = _fetch_children(cur, parent_oid)
+    child_oids: set[int] = set()
+    existing: set[int] = set()
+    problems: list[str] = []
+
+    for raw_oid, schema_name, relation_name, relkind, is_partition, bound in children:
+        oid = int(raw_oid)
+        child_oids.add(oid)
+        name_match = _PARTITION_NAME_RE.fullmatch(str(relation_name))
+        bound_match = _PARTITION_BOUND_RE.fullmatch(str(bound)) if bound is not None else None
+        if schema_name != "core":
+            problems.append(f"attached child {schema_name}.{relation_name} is outside core")
+            continue
+        if relkind != "r" or not is_partition:
+            problems.append(
+                f"core.{relation_name} is not an ordinary attached partition "
+                f"(relkind={relkind!r}, relispartition={is_partition!r})"
+            )
+            continue
+        if name_match is None:
+            problems.append(f"unexpected attached child core.{relation_name}")
+            continue
+        if bound == "DEFAULT":
+            problems.append(f"default partition core.{relation_name} is not allowed")
+            continue
+        if bound_match is None:
+            problems.append(f"core.{relation_name} has unsupported bound {bound!r}")
+            continue
+        name_year = int(name_match.group(1))
+        bound_year = int(bound_match.group(2))
+        if relation_name != f"plays_y{name_year}":
+            problems.append(f"core.{relation_name} is not a canonical partition name")
+            continue
+        if name_year < MIN_PLAY_SEASON:
+            problems.append(
+                f"core.{relation_name} precedes the play coverage floor {MIN_PLAY_SEASON}"
+            )
+            continue
+        if name_year != bound_year:
+            problems.append(
+                f"core.{relation_name} has bound for {bound_year}, expected {name_year}"
+            )
+            continue
+        if name_year in existing:
+            problems.append(f"more than one core.plays child covers season {name_year}")
+            continue
+        existing.add(name_year)
+
+    for raw_oid, relation_name, relkind in _fetch_reserved_relations(cur):
+        if int(raw_oid) not in child_oids:
+            problems.append(
+                f"reserved relation core.{relation_name} exists but is not attached to "
+                f"core.plays (relkind={relkind!r})"
+            )
+
+    if problems:
+        raise PartitionStateError("invalid core.plays partition catalog: " + "; ".join(problems))
+
+    missing = tuple(year for year in required if year not in existing)
+    return PlayPartitionPlan(
+        required_years=required,
+        existing_years=tuple(sorted(existing)),
+        missing_years=missing,
+    )
+
+
+def _ensure_idle_connection(conn: object) -> None:
+    if getattr(conn, "autocommit", False):
+        raise RuntimeError("partition maintenance requires autocommit=False")
+    get_status = getattr(conn, "get_transaction_status", None)
+    if get_status is not None and get_status() != TRANSACTION_STATUS_IDLE:
+        raise RuntimeError("partition maintenance requires an idle connection")
+
+
+def ensure_play_partitions(
+    conn: object,
+    years: Iterable[int] = (),
+    *,
+    create: bool = False,
+    calendar_year: int | None = None,
+) -> PlayPartitionPlan:
+    """Inspect or atomically create the requested and rolling play partitions."""
+
+    resolved_calendar_year = date.today().year if calendar_year is None else calendar_year
+    # Validate caller input before opening a transaction or taking locks.
+    required = _required_years(years, resolved_calendar_year)
+    _ensure_idle_connection(conn)
+    cur = conn.cursor()
+    try:
+        cur.execute("BEGIN" if create else "BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY")
+        if not create:
+            plan = inspect_play_partitions(cur, required, calendar_year=resolved_calendar_year)
+            conn.rollback()
+            return plan
+
+        cur.execute("SET LOCAL lock_timeout = %s", (LOCK_TIMEOUT,))
+        cur.execute("SELECT pg_advisory_xact_lock(%s, %s)", ADVISORY_LOCK_KEYS)
+        # The advisory lock coordinates this helper; the table lock also excludes
+        # direct external partition DDL between validation and creation.
+        cur.execute("LOCK TABLE ONLY core.plays IN SHARE UPDATE EXCLUSIVE MODE")
+        before = inspect_play_partitions(cur, required, calendar_year=resolved_calendar_year)
+        for year in before.missing_years:
+            cur.execute(
+                sql.SQL("CREATE TABLE {}.{} PARTITION OF {}.{} FOR VALUES IN (%s)").format(
+                    sql.Identifier("core"),
+                    sql.Identifier(f"plays_y{year}"),
+                    sql.Identifier("core"),
+                    sql.Identifier("plays"),
+                ),
+                (year,),
+            )
+        after = inspect_play_partitions(cur, required, calendar_year=resolved_calendar_year)
+        if after.missing_years:
+            raise PartitionStateError(
+                "partition creation completed without satisfying: "
+                + ", ".join(str(year) for year in after.missing_years)
+            )
+        conn.commit()
+        return PlayPartitionPlan(
+            required_years=after.required_years,
+            existing_years=after.existing_years,
+            missing_years=(),
+            created_years=before.missing_years,
+        )
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        cur.close()

--- a/tests/test_play_partitions.py
+++ b/tests/test_play_partitions.py
@@ -1,0 +1,434 @@
+"""Catalog and SQL tests for the bounded ``core.plays`` partition lifecycle."""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from urllib.parse import urlparse
+
+import psycopg2
+import pytest
+from psycopg2 import sql
+from psycopg2.extensions import make_dsn
+
+import scripts.maintain_play_partitions as cli
+from src.pipelines.utils import partitions
+from src.pipelines.utils.partitions import (
+    PartitionStateError,
+    PlayPartitionPlan,
+    ensure_play_partitions,
+    inspect_play_partitions,
+)
+
+
+class CatalogCursor:
+    def __init__(
+        self,
+        *,
+        parent=(42, "p", "l", 1, ["season"]),
+        children=(),
+        reserved=(),
+    ):
+        self.parent = parent
+        self.children = list(children)
+        self.reserved = list(reserved)
+        self.rows = []
+        self.executions = []
+
+    def execute(self, statement, values=None):
+        text = " ".join(str(statement).split())
+        self.executions.append((text, values))
+        if "pg_catalog.pg_partitioned_table" in text:
+            self.rows = [] if self.parent is None else [self.parent]
+        elif "pg_catalog.pg_inherits" in text:
+            self.rows = self.children
+        elif "relation.relname ~" in text:
+            self.rows = self.reserved
+        else:
+            raise AssertionError(f"unexpected catalog query: {text}")
+
+    def fetchall(self):
+        return list(self.rows)
+
+
+def child(year: int, *, name: str | None = None, bound: str | None = None, oid: int | None = None):
+    relation_name = name or f"plays_y{year}"
+    partition_bound = bound or f"FOR VALUES IN ('{year}')"
+    return (oid or year, "core", relation_name, "r", True, partition_bound)
+
+
+def reserved(year: int, *, oid: int | None = None, relkind: str = "r"):
+    return (oid or year, f"plays_y{year}", relkind)
+
+
+def test_inspection_reports_rolling_horizon_and_explicit_historical_years():
+    rows = [child(2004), child(2026)]
+    cur = CatalogCursor(children=rows, reserved=[reserved(2004), reserved(2026)])
+
+    plan = inspect_play_partitions(cur, [2004], calendar_year=2026)
+
+    assert plan.required_years == (2004, 2026, 2027)
+    assert plan.existing_years == (2004, 2026)
+    assert plan.missing_years == (2027,)
+
+
+@pytest.mark.parametrize("year", [2003, 2028, True, 2026.0, "2026"])
+def test_requested_years_are_bounded_and_strictly_typed(year):
+    with pytest.raises(ValueError, match="year"):
+        inspect_play_partitions(CatalogCursor(), [year], calendar_year=2026)
+
+
+@pytest.mark.parametrize(
+    ("parent", "message"),
+    [
+        (None, "exactly one"),
+        ((42, "r", None, None, []), "LIST"),
+        ((42, "p", "r", 1, ["season"]), "LIST"),
+        ((42, "p", "l", 2, ["season", "game_id"]), "LIST"),
+        ((42, "p", "l", 1, [None]), "LIST"),
+    ],
+)
+def test_parent_must_be_list_partitioned_on_the_season_column(parent, message):
+    with pytest.raises(PartitionStateError, match=message):
+        inspect_play_partitions(CatalogCursor(parent=parent), calendar_year=2026)
+
+
+@pytest.mark.parametrize(
+    ("bad_child", "message"),
+    [
+        (child(2027, name="plays_future"), "unexpected attached child"),
+        (child(2027, name="plays_y02027"), "canonical partition name"),
+        (child(2027, bound="FOR VALUES IN ('2028')"), "expected 2027"),
+        (child(2027, bound="FOR VALUES IN ('2027', '2028')"), "unsupported bound"),
+        (child(2027, bound="DEFAULT"), "default partition"),
+        ((2027, "other", "plays_y2027", "r", True, "FOR VALUES IN ('2027')"), "outside core"),
+        ((2027, "core", "plays_y2027", "p", True, "FOR VALUES IN ('2027')"), "ordinary"),
+        ((2027, "core", "plays_y2027", "r", False, "FOR VALUES IN ('2027')"), "ordinary"),
+    ],
+)
+def test_every_attached_child_must_have_the_canonical_single_year_shape(bad_child, message):
+    cur = CatalogCursor(children=[bad_child], reserved=[reserved(2027)])
+
+    with pytest.raises(PartitionStateError, match=message):
+        inspect_play_partitions(cur, calendar_year=2026)
+
+
+def test_valid_precreated_future_partition_beyond_creation_horizon_is_accepted():
+    rows = [child(2026), child(2027), child(2028)]
+    cur = CatalogCursor(children=rows, reserved=[reserved(year) for year in (2026, 2027, 2028)])
+
+    plan = inspect_play_partitions(cur, calendar_year=2026)
+
+    assert plan.existing_years == (2026, 2027, 2028)
+    assert not plan.missing_years
+
+
+def test_unquoted_integral_catalog_bound_is_accepted():
+    cur = CatalogCursor(
+        children=[child(2026, bound="FOR VALUES IN (2026)")],
+        reserved=[reserved(2026)],
+    )
+
+    assert inspect_play_partitions(cur, calendar_year=2026).existing_years == (2026,)
+
+
+def test_same_name_relation_unattached_from_actual_parent_is_rejected():
+    cur = CatalogCursor(children=[child(2026)], reserved=[reserved(2026), reserved(2027)])
+
+    with pytest.raises(PartitionStateError, match="plays_y2027.*not attached"):
+        inspect_play_partitions(cur, calendar_year=2026)
+
+
+def test_reserved_catalog_query_matches_exact_partition_names_only():
+    cur = CatalogCursor(children=[child(2026)], reserved=[reserved(2026)])
+
+    inspect_play_partitions(cur, calendar_year=2026)
+
+    reserved_query, values = cur.executions[-1]
+    assert "relation.relname ~" in reserved_query
+    assert values == ("core", r"^plays_y[0-9]+$")
+
+
+class RecordingCursor:
+    def __init__(self):
+        self.executions = []
+        self.closed = False
+
+    def execute(self, statement, values=None):
+        self.executions.append((str(statement), values))
+
+    def close(self):
+        self.closed = True
+
+
+class RecordingConnection:
+    autocommit = False
+
+    def __init__(self):
+        self.cursor_instance = RecordingCursor()
+        self.commits = 0
+        self.rollbacks = 0
+
+    def get_transaction_status(self):
+        return 0
+
+    def cursor(self):
+        return self.cursor_instance
+
+    def commit(self):
+        self.commits += 1
+
+    def rollback(self):
+        self.rollbacks += 1
+
+
+def test_create_validates_before_any_ddl_and_rolls_back_on_drift(monkeypatch):
+    conn = RecordingConnection()
+
+    def reject(*args, **kwargs):
+        raise PartitionStateError("wrong bound")
+
+    monkeypatch.setattr(partitions, "inspect_play_partitions", reject)
+
+    with pytest.raises(PartitionStateError, match="wrong bound"):
+        ensure_play_partitions(conn, [2027], create=True, calendar_year=2026)
+
+    statements = [statement for statement, _ in conn.cursor_instance.executions]
+    assert not any("CREATE TABLE" in statement for statement in statements)
+    assert any("SHARE UPDATE EXCLUSIVE" in statement for statement in statements)
+    assert ("SET LOCAL lock_timeout = %s", ("10s",)) in conn.cursor_instance.executions
+    assert (
+        "SELECT pg_advisory_xact_lock(%s, %s)",
+        partitions.ADVISORY_LOCK_KEYS,
+    ) in conn.cursor_instance.executions
+    assert conn.commits == 0
+    assert conn.rollbacks == 1
+    assert conn.cursor_instance.closed
+
+
+def test_inspection_uses_read_only_transaction_and_rolls_it_back(monkeypatch):
+    conn = RecordingConnection()
+    expected = PlayPartitionPlan((2026, 2027), (2026,), (2027,))
+    monkeypatch.setattr(partitions, "inspect_play_partitions", lambda *a, **k: expected)
+
+    result = ensure_play_partitions(conn, create=False, calendar_year=2026)
+
+    assert result == expected
+    assert conn.cursor_instance.executions[0] == (
+        "BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY",
+        None,
+    )
+    assert conn.commits == 0
+    assert conn.rollbacks == 1
+
+
+def test_autocommit_and_nonidle_connections_are_rejected_before_sql():
+    conn = RecordingConnection()
+    conn.autocommit = True
+    with pytest.raises(RuntimeError, match="autocommit"):
+        ensure_play_partitions(conn, calendar_year=2026)
+    conn.autocommit = False
+    conn.get_transaction_status = lambda: 2
+    with pytest.raises(RuntimeError, match="idle"):
+        ensure_play_partitions(conn, calendar_year=2026)
+    assert conn.cursor_instance.executions == []
+
+
+class ClosingConnection:
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+def test_cli_defaults_to_inspection_and_resolves_dsn_through_load_ledger(monkeypatch, capsys):
+    conn = ClosingConnection()
+    captured = []
+    monkeypatch.setattr(cli.load_ledger, "get_db_url", lambda: "postgresql://resolved")
+    monkeypatch.setattr(cli.psycopg2, "connect", lambda dsn: captured.append(dsn) or conn)
+    monkeypatch.setattr(
+        cli,
+        "ensure_play_partitions",
+        lambda connection, years, *, create: PlayPartitionPlan((2026, 2027), (2004, 2026), (2027,)),
+    )
+
+    assert cli.main([]) == 0
+
+    assert captured == ["postgresql://resolved"]
+    assert conn.closed
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["apply"] is False
+    assert payload["missing_years"] == [2027]
+
+
+def test_cli_apply_passes_explicit_years(monkeypatch, capsys):
+    conn = ClosingConnection()
+    calls = []
+    monkeypatch.setattr(cli.load_ledger, "get_db_url", lambda: "postgresql://resolved")
+    monkeypatch.setattr(cli.psycopg2, "connect", lambda dsn: conn)
+
+    def ensure(connection, years, *, create):
+        calls.append((connection, years, create))
+        return PlayPartitionPlan((2004, 2026, 2027), (2004, 2026, 2027), (), (2027,))
+
+    monkeypatch.setattr(cli, "ensure_play_partitions", ensure)
+
+    assert cli.main(["--years", "2004", "--apply"]) == 0
+    assert calls == [(conn, [2004], True)]
+    assert json.loads(capsys.readouterr().out)["created_years"] == [2027]
+
+
+@pytest.fixture
+def partition_db():
+    """Isolated database on the explicitly selected disposable F06 cluster."""
+
+    dsn = os.environ.get("F06_TEST_DB_URL")
+    if not dsn:
+        if os.environ.get("F06_REQUIRE_DB") == "1":
+            pytest.fail("F06_TEST_DB_URL is required for mandatory partition integration")
+        pytest.skip("set F06_TEST_DB_URL to a disposable loopback PostgreSQL cluster")
+    parsed = urlparse(dsn)
+    if parsed.scheme not in {"postgres", "postgresql"} or parsed.hostname not in {
+        "localhost",
+        "127.0.0.1",
+        "::1",
+    }:
+        pytest.fail("F06_TEST_DB_URL must select a disposable loopback PostgreSQL cluster")
+    name = "f08_test_" + uuid.uuid4().hex
+    admin = psycopg2.connect(dsn)
+    admin.autocommit = True
+    with admin.cursor() as cur:
+        cur.execute(sql.SQL("CREATE DATABASE {} TEMPLATE template0").format(sql.Identifier(name)))
+    conn = psycopg2.connect(make_dsn(dsn, dbname=name))
+    try:
+        yield conn
+    finally:
+        conn.close()
+        with admin.cursor() as cur:
+            cur.execute(sql.SQL("DROP DATABASE {} WITH (FORCE)").format(sql.Identifier(name)))
+        admin.close()
+
+
+def _create_play_parent(conn, *, indexed: bool = False):
+    with conn.cursor() as cur:
+        cur.execute("CREATE SCHEMA core")
+        cur.execute("CREATE TABLE core.games (id bigint PRIMARY KEY, season bigint NOT NULL)")
+        cur.execute(
+            "CREATE TABLE core.plays (id bigint, game_id bigint, season bigint NOT NULL) "
+            "PARTITION BY LIST (season)"
+        )
+        cur.execute("CREATE TABLE core.plays_y2004 PARTITION OF core.plays FOR VALUES IN (2004)")
+        cur.execute("CREATE TABLE core.plays_y2026 PARTITION OF core.plays FOR VALUES IN (2026)")
+        if indexed:
+            cur.execute("CREATE INDEX idx_plays_game_id ON core.plays(game_id)")
+    conn.commit()
+
+
+def _relation_exists(conn, name: str) -> bool:
+    with conn.cursor() as cur:
+        cur.execute("SELECT to_regclass(%s) IS NOT NULL", (f"core.{name}",))
+        return bool(cur.fetchone()[0])
+
+
+def test_sql_rollover_late_history_idempotence_and_parent_indexes(partition_db):
+    conn = partition_db
+    _create_play_parent(conn, indexed=True)
+
+    first = ensure_play_partitions(conn, [2004], create=True, calendar_year=2026)
+    second = ensure_play_partitions(conn, [2004], create=True, calendar_year=2026)
+
+    assert first.created_years == (2027,)
+    assert not second.created_years
+    with conn.cursor() as cur:
+        cur.execute("INSERT INTO core.games VALUES (1, 2027)")
+        cur.execute("INSERT INTO core.plays VALUES (1, 1, 2027), (2, 1, 2004)")
+        cur.execute("SELECT tableoid::regclass::text, season FROM core.plays ORDER BY season DESC")
+        assert cur.fetchall() == [("core.plays_y2027", 2027), ("core.plays_y2004", 2004)]
+        cur.execute(
+            """
+            SELECT parent_index.relname, child_index.relname
+            FROM pg_catalog.pg_inherits inheritance
+            JOIN pg_catalog.pg_class child_index ON child_index.oid = inheritance.inhrelid
+            JOIN pg_catalog.pg_class parent_index ON parent_index.oid = inheritance.inhparent
+            WHERE parent_index.relname = 'idx_plays_game_id'
+              AND child_index.relnamespace = 'core'::regnamespace
+              AND child_index.relname LIKE 'plays_y2027%'
+            """
+        )
+        assert len(cur.fetchall()) == 1
+    conn.commit()
+
+
+@pytest.mark.parametrize(
+    "bad_ddl",
+    [
+        "CREATE TABLE core.plays_y2025 PARTITION OF core.plays FOR VALUES IN (2024)",
+        "CREATE TABLE core.plays_y2027 (LIKE core.plays)",
+        "CREATE TABLE core.plays_misc PARTITION OF core.plays DEFAULT",
+    ],
+)
+def test_sql_catalog_drift_never_creates_any_missing_partition(partition_db, bad_ddl):
+    conn = partition_db
+    with conn.cursor() as cur:
+        cur.execute("CREATE SCHEMA core")
+        cur.execute(
+            "CREATE TABLE core.plays (id bigint, season bigint NOT NULL) PARTITION BY LIST (season)"
+        )
+        cur.execute(bad_ddl)
+    conn.commit()
+
+    with pytest.raises(PartitionStateError):
+        ensure_play_partitions(conn, create=True, calendar_year=2026)
+
+    assert not _relation_exists(conn, "plays_y2026")
+    if "plays_y2027 (" not in bad_ddl:
+        assert not _relation_exists(conn, "plays_y2027")
+
+
+def test_sql_second_create_failure_rolls_back_first_partition(partition_db):
+    conn = partition_db
+    with conn.cursor() as cur:
+        cur.execute("CREATE SCHEMA core")
+        cur.execute(
+            "CREATE TABLE core.plays (id bigint, season bigint NOT NULL) PARTITION BY LIST (season)"
+        )
+    conn.commit()
+
+    class FailSecondCreateCursor:
+        def __init__(self, wrapped):
+            self.wrapped = wrapped
+            self.creates = 0
+
+        def execute(self, statement, values=None):
+            if "CREATE TABLE" in str(statement):
+                self.creates += 1
+                if self.creates == 2:
+                    raise RuntimeError("injected second partition failure")
+            return self.wrapped.execute(statement, values)
+
+        def __getattr__(self, name):
+            return getattr(self.wrapped, name)
+
+    class FailSecondCreateConnection:
+        autocommit = False
+
+        def __init__(self, wrapped):
+            self.wrapped = wrapped
+            self.cursor_instance = None
+
+        def cursor(self):
+            self.cursor_instance = FailSecondCreateCursor(self.wrapped.cursor())
+            return self.cursor_instance
+
+        def __getattr__(self, name):
+            return getattr(self.wrapped, name)
+
+    failing = FailSecondCreateConnection(conn)
+    with pytest.raises(RuntimeError, match="injected second partition failure"):
+        ensure_play_partitions(failing, create=True, calendar_year=2026)
+
+    assert failing.cursor_instance.creates == 2
+    assert not _relation_exists(conn, "plays_y2026")
+    assert not _relation_exists(conn, "plays_y2027")

--- a/tests/test_plays_preflight.py
+++ b/tests/test_plays_preflight.py
@@ -1,0 +1,71 @@
+"""Loader and post-load verification must use the catalog before claiming success."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from scripts.verify_load import Report, check_partition
+from src.pipelines import run
+from src.pipelines.utils.partitions import PartitionStateError
+
+
+@pytest.mark.parametrize("fails", [False, True])
+def test_loader_preflight_precedes_source_and_load(fails):
+    events = []
+    conn = Mock()
+
+    def preflight(connection, years, create):
+        assert connection is conn
+        assert years == [2027]
+        assert create is True
+        events.append("preflight")
+        if fails:
+            raise PartitionStateError("unattached partition")
+
+    def source(**kwargs):
+        events.append("source")
+        assert kwargs["years"] == [2027]
+        return "source"
+
+    pipeline = Mock()
+    credentials = pipeline.destination_client.return_value.config.credentials
+    credentials.to_native_representation.return_value = "pipeline-scoped-target"
+    pipeline.run.side_effect = lambda source: events.append("load")
+    with (
+        patch("psycopg2.connect", return_value=conn) as connect,
+        patch.object(run, "_metrics_wp_db_url", side_effect=AssertionError("wrong target")),
+        patch("src.pipelines.utils.partitions.ensure_play_partitions", side_effect=preflight),
+        patch.object(run, "plays_source", side_effect=source),
+        patch.object(run.dlt, "pipeline", return_value=pipeline),
+    ):
+        if fails:
+            with pytest.raises(PartitionStateError):
+                run.run_plays_pipeline([2027])
+            assert events == ["preflight"]
+        else:
+            run.run_plays_pipeline([2027])
+            assert events == ["preflight", "source", "load"]
+    connect.assert_called_once_with("pipeline-scoped-target")
+    conn.close.assert_called_once()
+
+
+@pytest.mark.parametrize("missing", [(), (2027,)])
+def test_verifier_reports_missing_catalog_coverage(missing):
+    report = Report()
+    with patch(
+        "src.pipelines.utils.partitions.inspect_play_partitions",
+        return_value=SimpleNamespace(missing_years=missing),
+    ):
+        check_partition(Mock(), 2027, report)
+    assert report.failures == bool(missing)
+
+
+def test_verifier_fails_invalid_partition():
+    report = Report()
+    with patch(
+        "src.pipelines.utils.partitions.inspect_play_partitions",
+        side_effect=PartitionStateError("wrong bounds"),
+    ):
+        check_partition(Mock(), 2027, report)
+    assert report.failures == 1

--- a/tests/test_years.py
+++ b/tests/test_years.py
@@ -3,9 +3,11 @@
 from unittest.mock import patch
 
 from src.pipelines.config.years import (
+    YEAR_RANGE_STARTS,
     YEAR_RANGES,
     YearRange,
     get_current_season,
+    get_historical_end_year,
     get_projection_seasons,
 )
 
@@ -68,6 +70,15 @@ class TestYearRange:
         assert yr.to_list() == [2024]
         assert 2024 in yr
 
+    def test_explicit_range_stays_fixed_across_calendar_rollover(self):
+        from datetime import datetime
+
+        yr = YearRange(start=2020, end=2026)
+        with patch("datetime.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2027, 1, 1)
+            assert yr.end == 2026
+            assert yr.to_list()[0] == 2026
+
 
 class TestYearRangesConfig:
     def test_all_categories_exist(self):
@@ -90,9 +101,36 @@ class TestYearRangesConfig:
     def test_ratings_start_2004(self):
         assert YEAR_RANGES["ratings"].start == 2004
 
-    def test_all_ranges_end_2026(self):
-        for name, yr in YEAR_RANGES.items():
-            assert yr.end == 2026, f"{name} should end at 2026, got {yr.end}"
+    def test_config_starts_are_fixed(self):
+        assert YEAR_RANGE_STARTS["games"] == 1869
+        assert YEAR_RANGE_STARTS["metrics"] == 2014
+
+    def test_all_ranges_end_at_current_calendar_year(self):
+        from datetime import datetime
+
+        with patch("datetime.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2027, 3, 15)
+            for name, yr in YEAR_RANGES.items():
+                assert yr.end == 2027, f"{name} should end at 2027, got {yr.end}"
+
+    def test_long_lived_import_resolves_end_on_each_lookup(self):
+        from datetime import datetime
+
+        with patch("datetime.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 12, 31)
+            assert YEAR_RANGES["plays"].end == 2026
+
+            mock_dt.now.return_value = datetime(2027, 1, 1)
+            assert YEAR_RANGES["plays"].end == 2027
+
+    def test_offseason_historical_range_includes_upcoming_season(self):
+        from datetime import datetime
+
+        with patch("datetime.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2027, 3, 15)
+            assert get_current_season() == 2026
+            assert get_historical_end_year() == 2027
+            assert YEAR_RANGES["stats"].end == 2027
 
 
 class TestGetCurrentSeason:


### PR DESCRIPTION
Historical source ranges stopped at 2026 and the plays loader only checked partition names after ingestion. Resolve historical end years at lookup time and validate the actual plays partition catalog before fetching data, creating only missing requested seasons and the current/next calendar-year horizon.

![F08 architecture: rolling year ranges and partition preflight before CFBD fetching and dlt loading](https://github.com/user-attachments/assets/e8a7d6b3-1bf3-4c95-88a3-22b1b6430b50)

![F08 load sequence: validate the catalog, atomically create missing partitions, then fetch and merge plays](https://github.com/user-attachments/assets/9fdd3861-2ee3-493e-bbda-fdb3e8b5821c)

The preflight uses dlt's resolved destination credentials, checks attachment and bounds, rejects conflicting catalog state, and creates partitions atomically with bounded locking. Add a read-only maintenance preview with explicit `--apply`, strengthen post-load verification, and include partition integration tests in CI.

Validation: 541 focused tests passed, including five executed PostgreSQL 17 cases covering 2027 and historical routing, inherited indexes, idempotence, malformed catalogs, and partial-creation rollback. Ruff, formatting, whitespace checks, and agent setup validation passed. Independent review findings were resolved.

Read-only production inspection confirmed valid partitions for 2004–2026 and no 2027 partition. No production DDL or live CFBD/dlt end-to-end load was performed; provisioning remains an authorized maintenance or ingestion operation.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change updates historical year resolution and adds safe maintenance for `core.plays` partitions. The partition behavior was exercised against PostgreSQL 17: required partitions were created, inserted rows were routed correctly, invalid catalog state was rejected before changes, and a forced creation failure rolled back cleanly.

<h3>Confidence Score: 5/5</h3>

Safe to merge; no correctness, security, or repository-requirement issues were found.

No final findings remain. The database behavior most central to this change was exercised using a disposable PostgreSQL 17 instance.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- - Before capture, the validator recorded the PostgreSQL 17 catalog expression and the expected missing 2027 partition.
- - After capture, the validator confirmed successful creation and routing, and verified no partitions leaked for both invalid-catalog and injected-failure paths.
- - The container was removed after validation, and no production credentials or external databases were used.
- - Artifacts were produced to document the validation: a Python artifact and two log artifacts linked to the general-contract-validation-proof.

<a href="https://app.greptile.com/trex/runs/23100689/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Handle F08 season rollover with validate..."](https://github.com/rstover-fo/cfb-database/commit/ddba3517550e9aa1617fed31640ca7d28d7f4975) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61606392)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [College football data ingestion](https://app.greptile.com/formentera-operations/-/custom-context/knowledge-base/rstover-fo/cfb-database/-/docs/data-ingestion.md)
- Knowledge Base — [Data quality and verification](https://app.greptile.com/formentera-operations/-/custom-context/knowledge-base/rstover-fo/cfb-database/-/docs/data-quality-and-verification.md)
- Knowledge Base — [Harden freshness checks after PostgreSQL restarts](https://app.greptile.com/formentera-operations/-/custom-context/knowledge-base/rstover-fo/cfb-database/-/reverts/incident-mitigation_106-20260903-freshness-after-restart-3aa92a3.md)
</details>


<!-- /greptile_comment -->
