### PR TITLE
Fix F09 plays index ownership validation and guarded repair

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - run: ./scripts/setup_dev.sh
       - name: Managed bootstrap and upgrade integration
-        run: .venv/bin/python -m pytest tests/test_warehouse_migrations_sql.py tests/test_warehouse_bootstrap_sql.py tests/test_adopt_warehouse_catalog_sql.py tests/test_f06_verification_transactions_sql.py tests/test_mart_release_sql.py tests/test_play_partitions.py -q --tb=short
+        run: .venv/bin/python -m pytest tests/test_warehouse_migrations_sql.py tests/test_warehouse_bootstrap_sql.py tests/test_adopt_warehouse_catalog_sql.py tests/test_f06_verification_transactions_sql.py tests/test_mart_release_sql.py tests/test_play_partitions.py tests/test_play_indexes_sql.py -q --tb=short
         env:
           F06_TEST_DB_URL: postgresql://postgres:f06-disposable-ci@127.0.0.1:5432/postgres
           F06_REQUIRE_DB: "1"

--- a/docs/plans/2026-09-04-main-codebase-audit.md
+++ b/docs/plans/2026-09-04-main-codebase-audit.md
@@ -188,6 +188,13 @@ Evidence: [partition creation](https://github.com/rstover-fo/cfb-database/blob/4
 
 ### F09 — The plays table swap can leave expected indexes on the old table
 
+Investigation and implementation: [F09 plays index ownership](2026-09-08-f09-plays-index-ownership.md).
+Read-only production inspection on 2026-09-08 found no `plays_old` table and all
+nine captured index families valid, ready, and attached to the correct parent
+and all 23 partitions. No production repair is needed for the ownership defect.
+The finding below records the historical migration-sequence flaw; index tuning
+and per-index write overhead remain separate, unmeasured work.
+
 **P1 to inspect; P2 remediation if affected · Confirmed migration-sequence flaw · M**
 
 Initial core DDL creates named plays indexes. The partition migration renames the original table to plays_old, then creates indexes on the new table using the same names and IF NOT EXISTS. Existing index names stay associated with the old relation, so the later statements can skip creating the intended indexes. Subsequent same-name statements are not a repair. Production may already have been repaired manually; its catalog must decide that.

--- a/docs/plans/2026-09-08-f09-plays-index-ownership.md
+++ b/docs/plans/2026-09-08-f09-plays-index-ownership.md
@@ -1,0 +1,102 @@
+# F09: plays index ownership and partition coverage
+
+F09 addresses the historical table-swap sequence that leaves an index name on
+`core.plays_old` while `CREATE INDEX IF NOT EXISTS` skips the new partitioned
+`core.plays`. Index names alone cannot establish the indexed table, definition,
+validity, or coverage of attached partitions.
+
+## Production finding, 2026-09-08
+
+Read-only inspection of the `cfbd-database` warehouse found **no current ownership
+defect**: `core.plays_old` is absent, and all nine index families in the reviewed
+2026-09-07 baseline belong to `core.plays`. Every parent is valid and ready and
+has 23 valid, ready child indexes on 23 distinct, correct attached partitions.
+No production DDL was applied. Partition provisioning for F08 remains separate.
+
+The inspected baseline is
+`src/schemas/baseline/20260907_pre_f05.sql`, not the union of index names in old
+002/011/016 migration files. Restoring that historical union would add indexes
+which are absent from the captured warehouse and have not been justified.
+
+| Index | Expected btree keys / predicate | Child-index bytes | Scans at inspection |
+|---|---|---:|---:|
+| `plays_dlt_id_unique` | **UNIQUE** `(_dlt_id, season)` | 171,433,984 | 0 |
+| `idx_plays_game_id` | `(game_id)` | 29,360,128 | 176,961 |
+| `idx_plays_offense` | `(offense)` | 33,316,864 | 937 |
+| `idx_plays_defense` | `(defense)` | 33,275,904 | 183 |
+| `idx_plays_offense_season` | `(offense, season)` | 33,939,456 | 1,287 |
+| `idx_plays_defense_season` | `(defense, season)` | 33,464,320 | 25 |
+| `idx_plays_play_type` | `(play_type)` | 34,676,736 | 20 |
+| `idx_plays_score_diff` | `(score_diff)` | 33,824,768 | 0 |
+| `idx_plays_competitive` | `(game_id, period) WHERE abs(offense_score - defense_score) <= 28` | 27,942,912 | 0 |
+
+Total child-index storage was 431,235,072 bytes (411.26 MiB). These are cumulative
+scan counters with an unknown observation interval (`pg_stat_database.stats_reset`
+returned NULL); they are not a controlled workload comparison. In particular,
+zero scans do not remove the need for uniqueness enforcement.
+
+## Executed read-only query evidence
+
+`EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)` ran ordinary SELECTs on season 2026,
+using observed game `401867684`, offense `UT Martin`, defense `Chicago State`,
+play type `Timeout`, and score difference `14`. These narrow examples were not
+forced to use an index and do not establish whole-warehouse latency or the
+incremental value of every overlapping index.
+
+| Query shape | Chosen child index | Rows read from index | Execution ms |
+|---|---|---:|---:|
+| Game lookup, `id, play_text` | `plays_y2026_game_id_idx` | 175 | 1.523 |
+| Offense-season count / average PPA | `plays_y2026_offense_idx` | 170 | 2.160 |
+| Defense-season count / average PPA | `plays_y2026_defense_idx` | 188 | 2.231 |
+| Count timeout plays | `plays_y2026_play_type_idx` | 1,837 | 11.601 |
+| Game + period <= 4 + competitive predicate | `plays_y2026_game_id_idx` | 175 (5 filtered) | 1.463 |
+| Count score difference = 14 | `plays_y2026_score_diff_idx` | 1,263 | 4.212 |
+
+The competitive query did not choose `idx_plays_competitive`. Its marginal value
+and that of the overlapping team/season indexes remain tuning questions. No
+production writes, index removals, or counter resets were authorized or performed;
+per-index write overhead is unmeasured. This change protects the captured
+structure and provides selected repair, not a claim that all nine indexes are
+optimal. Any future retention/removal decision needs a representative workload
+and write-cost evidence.
+
+## Implementation boundaries
+
+- Audit the nine reviewed definitions, their exact parent relation, and the full
+  set of valid/ready child targets. A matching count is insufficient.
+- Before fetching plays, require only the `plays_dlt_id_unique` family. Its
+  uniqueness and `(_dlt_id, season)` coverage protect loaded identity; missing
+  optional performance indexes are maintenance decisions.
+- Expose repair only through explicit index selection and `--apply`. Validate
+  every selected change before issuing DDL. Recognized old-heap collisions get
+  deterministic retained names; old rows and tables remain intact.
+- Run parent index creation in a bounded, atomic maintenance transaction. This
+  blocks writes during index construction and is not a concurrent online build.
+  Unexpected owners, definitions, rename collisions, or incomplete/invalid
+  index trees require investigation rather than automatic destructive repair.
+- Preserve immutable historical migrations and the captured baseline. No new
+  index set is silently installed by routine ingestion or bootstrap.
+
+PostgreSQL documents that `IF NOT EXISTS` does not verify equivalence, and that
+concurrent builds are unsupported directly on partitioned parents. Online builds
+would need a separate leaf-build/attach procedure. See the
+[PostgreSQL 17 CREATE INDEX documentation](https://www.postgresql.org/docs/17/sql-createindex.html).
+
+## Verification
+
+The executed regression suite is `tests/test_play_indexes_sql.py`, using an
+explicit disposable loopback PostgreSQL target through `F06_TEST_DB_URL`.
+It reproduces the old table swap, checks repair and repeated no-op behavior,
+and exercises invalid catalog state, rollback, inherited indexes on a future
+partition, uniqueness, unchanged caller access, concurrent index renaming, and
+builtin predicate identity under a shadowed search path. CI runs it alongside
+the warehouse upgrade tests.
+
+Final local checks passed: 532 focused unit/loader/source tests and all ten
+executed PostgreSQL 17 scenarios (the final positive predicate case was rerun
+after its test update). Ruff, formatting, whitespace checks, and agent setup
+validation passed. Independent review found no remaining material findings.
+Production evidence above came from read-only catalog/EXPLAIN queries through
+the connected database tool. The new CLI was not run against production because
+this environment has no local warehouse DSN. Live CFBD/dlt loading and production
+write overhead remain unverified; no production changes were made.

--- a/docs/warehouse-operations.md
+++ b/docs/warehouse-operations.md
@@ -29,6 +29,7 @@ These commands operate on an explicitly selected, authorized warehouse; use
 | Season ingestion | `scripts/load_season.py --weekly` (explicit `--season` for backfills) |
 | Post-load verification | `scripts/verify_load.py` |
 | Inspect / maintain plays partitions | `scripts/maintain_play_partitions.py` (read-only); `--apply` creates missing partitions |
+| Inspect / repair plays index ownership | `scripts/maintain_play_indexes.py` (read-only); explicit `--apply --index <name>` for a maintenance window |
 | Refresh existing marts | `scripts/refresh_marts.py` |
 | Apply definitions / migrations | [Atomic mart releases](mart-releases.md); `scripts/run_migrations.py` for explicit non-mart migrations |
 | One-off SQL application | `scripts/run_migrations.py --file <path>`; follow that file's application contract |
@@ -79,6 +80,50 @@ drift, and rollback after the first of two partition creations succeeds. The
 partition tests run in the CI PostgreSQL job. This verifies executed SQL and
 loader preflight ordering with fakes; it does not represent a live CFBD/dlt
 end-to-end load or a production deployment.
+
+## Plays index ownership (F09)
+
+The historical plays table swap could leave expected index names on `plays_old`.
+The current production catalog is already correct: read-only inspection on
+2026-09-08 found no old table and nine valid index families covering all 23
+partitions. See [the F09 evidence and scope](plans/2026-09-08-f09-plays-index-ownership.md)
+for definitions, executed query plans, and measurement limits.
+
+The plays runner now validates the `plays_dlt_id_unique` family after partition
+maintenance and before fetching data, on the same destination as dlt. Missing,
+misowned, structurally different, or incompletely attached identity indexes fail
+the load. This read-only check does not rebuild indexes during ingestion.
+
+To inspect all nine reviewed index families on an explicitly selected target:
+
+```bash
+WAREHOUSE_DB_URL='<authorized PostgreSQL URL>' \
+  .venv/bin/python scripts/maintain_play_indexes.py
+```
+
+For an affected warehouse, select each justified index explicitly:
+
+```bash
+WAREHOUSE_DB_URL='<authorized PostgreSQL URL>' \
+  .venv/bin/python scripts/maintain_play_indexes.py \
+  --apply --index plays_dlt_id_unique --index idx_plays_game_id
+```
+
+The command reads `WAREHOUSE_DB_URL` (or an explicit `--db-url`), not implicit dlt
+credentials. Inspection is read-only and returns a nonzero exit status for
+invalid selected state. Repair requires an idle dedicated connection and runs
+in one transaction with a 10-second lock timeout and 30-minute statement timeout.
+**Schedule repair for an authorized maintenance window:** ordinary parent index
+builds block writes while they run; this command does not claim concurrent online
+creation. It validates every selected repair first, renames recognized old-heap
+indexes to `plays_old_<index_name>`, creates missing selected parent indexes and
+their child indexes, and verifies the result before committing. Repeating a
+completed repair is a no-op. Any failure rolls back the selected batch.
+
+Unexpected targets or definitions, existing rename targets, equivalent differently
+named parent indexes, and invalid or incomplete index trees require separate investigation.
+The command does not drop old storage, alter consumer grants, recreate obsolete
+historical indexes, or choose which optional indexes are worth their write cost.
 
 ## Box-score and roster request failures
 

--- a/scripts/maintain_play_indexes.py
+++ b/scripts/maintain_play_indexes.py
@@ -1,0 +1,100 @@
+"""Audit or explicitly repair the managed ``core.plays`` indexes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import psycopg2  # noqa: E402
+
+from scripts.bootstrap_warehouse import _redact_error, validate_database_url  # noqa: E402
+from src.pipelines.utils.play_indexes import (  # noqa: E402
+    EXPECTED_PLAY_INDEXES,
+    inspect_play_indexes,
+    repair_play_indexes,
+)
+
+DATABASE_ENV = "WAREHOUSE_DB_URL"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Audit core.plays indexes or run an explicit transactional repair"
+    )
+    parser.add_argument(
+        "--db-url",
+        help=f"Explicit PostgreSQL URL (default: {DATABASE_ENV})",
+    )
+    parser.add_argument(
+        "--index",
+        action="append",
+        choices=tuple(EXPECTED_PLAY_INDEXES),
+        default=[],
+        help="Managed index to select; repeat for more than one",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply the selected safe repairs in one write-blocking maintenance transaction",
+    )
+    return parser
+
+
+def _database_url(explicit: str | None) -> str:
+    database_url = explicit or os.environ.get(DATABASE_ENV)
+    if not database_url:
+        raise RuntimeError(f"{DATABASE_ENV} is required when --db-url is omitted")
+    validate_database_url(database_url)
+    return database_url
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    database_url: str | None = None
+    conn = None
+    try:
+        if args.apply and not args.index:
+            raise ValueError("--apply requires at least one explicit --index selection")
+        database_url = _database_url(args.db_url)
+        conn = psycopg2.connect(database_url)
+        if args.apply:
+            report = repair_play_indexes(conn, args.index)
+        else:
+            with conn.cursor() as cur:
+                cur.execute("BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY")
+                report = inspect_play_indexes(cur, args.index or None)
+            conn.rollback()
+        print(json.dumps({"apply": args.apply, **report}, indent=2, sort_keys=True))
+        return 0 if report["valid"] else 1
+    except Exception as exc:
+        if conn is not None:
+            conn.rollback()
+        print(
+            json.dumps(
+                {
+                    "error": {
+                        "message": _redact_error(exc, database_url),
+                        "type": type(exc).__name__,
+                    },
+                    "valid": False,
+                },
+                indent=2,
+                sort_keys=True,
+            ),
+            file=sys.stderr,
+        )
+        return 1
+    finally:
+        if conn is not None:
+            conn.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/pipelines/run.py
+++ b/src/pipelines/run.py
@@ -355,6 +355,7 @@ def run_plays_pipeline(years: list[int] | None = None, mode: str = "incremental"
 
     from .config.years import YEAR_RANGES, get_current_season
     from .utils.partitions import ensure_play_partitions
+    from .utils.play_indexes import validate_play_indexes
 
     if years is None:
         years = [get_current_season()] if mode == "incremental" else YEAR_RANGES["plays"].to_list()
@@ -370,6 +371,11 @@ def run_plays_pipeline(years: list[int] | None = None, mode: str = "incremental"
     try:
         plan = ensure_play_partitions(conn, years, create=True)
         logger.info("Plays partition preflight: %s", plan)
+        # Missing performance indexes are maintenance decisions. The dlt identity
+        # index is a load invariant and must cover every attached partition.
+        conn.set_session(readonly=True, isolation_level="REPEATABLE READ")
+        with conn.cursor() as cur:
+            validate_play_indexes(cur, ["plays_dlt_id_unique"])
     finally:
         conn.close()
 

--- a/src/pipelines/run.py
+++ b/src/pipelines/run.py
@@ -352,6 +352,8 @@ def run_game_stats_weekly(
 def run_plays_pipeline(years: list[int] | None = None, mode: str = "incremental"):
     """Run the plays data pipeline."""
     import psycopg2
+    from dlt.common.configuration import inject_section
+    from dlt.common.configuration.specs import ConfigSectionContext
 
     from .config.years import YEAR_RANGES, get_current_season
     from .utils.partitions import ensure_play_partitions
@@ -366,8 +368,13 @@ def run_plays_pipeline(years: list[int] | None = None, mode: str = "incremental"
     )
     # Validate the actual destination catalog before fetching any provider data.
     # A dedicated connection commits maintenance before dlt starts its load.
-    destination_client = pipeline.destination_client()
-    conn = psycopg2.connect(destination_client.config.credentials.to_native_representation())
+    # Resolve credentials in the pipeline scope, including on a first-ever load.
+    # This also preserves scoped target selection on older supported dlt versions.
+    with inject_section(ConfigSectionContext(pipeline_name=pipeline.pipeline_name, sections=())):
+        initial_config = pipeline.destination.spec()
+        initial_config.dataset_name = pipeline.dataset_name
+        destination_config = pipeline.destination.configuration(initial_config)
+    conn = psycopg2.connect(destination_config.credentials.to_native_representation())
     try:
         plan = ensure_play_partitions(conn, years, create=True)
         logger.info("Plays partition preflight: %s", plan)

--- a/src/pipelines/utils/play_indexes.py
+++ b/src/pipelines/utils/play_indexes.py
@@ -1,0 +1,777 @@
+"""Catalog-safe audit and explicit repair for managed ``core.plays`` indexes.
+
+The repair path is intentionally a maintenance operation.  PostgreSQL builds a
+partitioned parent index and all missing leaf indexes non-concurrently, so writes
+to ``core.plays`` are blocked for the duration of the authorized transaction.
+Inspection is read only and is suitable for ingestion preflight checks.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import asdict, dataclass
+
+from psycopg2 import sql
+from psycopg2.extensions import TRANSACTION_STATUS_IDLE
+
+LOCK_TIMEOUT = "10s"
+STATEMENT_TIMEOUT = "30min"
+# Shared with play-partition maintenance so the two catalog operations serialize.
+ADVISORY_LOCK_KEYS = (1_128_677_364, 80_008)
+
+
+@dataclass(frozen=True)
+class PlayIndexSpec:
+    """Exact supported definition for one managed parent index."""
+
+    columns: tuple[str, ...]
+    unique: bool = False
+    predicate: str | None = None
+    method: str = "btree"
+
+
+EXPECTED_PLAY_INDEXES: dict[str, PlayIndexSpec] = {
+    "plays_dlt_id_unique": PlayIndexSpec(("_dlt_id", "season"), unique=True),
+    "idx_plays_game_id": PlayIndexSpec(("game_id",)),
+    "idx_plays_offense": PlayIndexSpec(("offense",)),
+    "idx_plays_defense": PlayIndexSpec(("defense",)),
+    "idx_plays_offense_season": PlayIndexSpec(("offense", "season")),
+    "idx_plays_defense_season": PlayIndexSpec(("defense", "season")),
+    "idx_plays_play_type": PlayIndexSpec(("play_type",)),
+    "idx_plays_score_diff": PlayIndexSpec(("score_diff",)),
+    "idx_plays_competitive": PlayIndexSpec(
+        ("game_id", "period"),
+        predicate="abs((offense_score - defense_score)) <= 28",
+    ),
+}
+
+
+class PlayIndexStateError(RuntimeError):
+    """The selected play-index catalog is unhealthy or unsafe to repair."""
+
+    def __init__(self, message: str, report: dict[str, object] | None = None):
+        super().__init__(message)
+        self.report = report
+
+
+def _selected_names(index_names: Iterable[str] | None) -> tuple[str, ...]:
+    if index_names is None:
+        return tuple(EXPECTED_PLAY_INDEXES)
+    requested = tuple(index_names)
+    unknown = sorted({name for name in requested if name not in EXPECTED_PLAY_INDEXES})
+    if unknown:
+        raise ValueError("unsupported core.plays index: " + ", ".join(unknown))
+    requested_set = set(requested)
+    return tuple(name for name in EXPECTED_PLAY_INDEXES if name in requested_set)
+
+
+def _fetch_relations(cur: object, names: tuple[str, ...]) -> list[tuple[object, ...]]:
+    cur.execute(
+        """
+        SELECT relation.oid, relation.relname, relation.relkind,
+               relation.relispartition, pg_catalog.pg_get_userbyid(relation.relowner),
+               partitioned.partstrat, partitioned.partnatts,
+               ARRAY(
+                   SELECT attribute.attname
+                   FROM unnest(partitioned.partattrs::smallint[]) WITH ORDINALITY
+                       AS partition_key(attnum, key_order)
+                   LEFT JOIN pg_catalog.pg_attribute attribute
+                     ON attribute.attrelid = relation.oid
+                    AND attribute.attnum = partition_key.attnum
+                   ORDER BY partition_key.key_order
+               )
+        FROM pg_catalog.pg_class relation
+        JOIN pg_catalog.pg_namespace namespace
+          ON namespace.oid = relation.relnamespace
+        LEFT JOIN pg_catalog.pg_partitioned_table partitioned
+          ON partitioned.partrelid = relation.oid
+        WHERE namespace.nspname = %s AND relation.relname = ANY(%s)
+        ORDER BY relation.relname
+        """,
+        ("core", ["plays", "plays_old", *names]),
+    )
+    return list(cur.fetchall())
+
+
+def _fetch_leaf_partitions(cur: object, parent_oid: int) -> list[tuple[object, ...]]:
+    cur.execute(
+        """
+        WITH RECURSIVE descendants(oid) AS (
+            SELECT inheritance.inhrelid
+            FROM pg_catalog.pg_inherits inheritance
+            WHERE inheritance.inhparent = %s
+          UNION ALL
+            SELECT inheritance.inhrelid
+            FROM pg_catalog.pg_inherits inheritance
+            JOIN descendants parent ON parent.oid = inheritance.inhparent
+        )
+        SELECT child.oid, namespace.nspname, child.relname, child.relkind,
+               child.relispartition,
+               pg_catalog.pg_get_expr(child.relpartbound, child.oid)
+        FROM descendants
+        JOIN pg_catalog.pg_class child ON child.oid = descendants.oid
+        JOIN pg_catalog.pg_namespace namespace ON namespace.oid = child.relnamespace
+        WHERE NOT EXISTS (
+            SELECT 1 FROM pg_catalog.pg_inherits nested
+            WHERE nested.inhparent = child.oid
+        )
+        ORDER BY namespace.nspname, child.relname
+        """,
+        (parent_oid,),
+    )
+    return list(cur.fetchall())
+
+
+def _fetch_indexes(
+    cur: object,
+    table_oids: tuple[int, ...],
+    named_index_oids: tuple[int, ...],
+) -> list[tuple[object, ...]]:
+    if not table_oids and not named_index_oids:
+        return []
+    cur.execute(
+        """
+        SELECT index_relation.oid, index_namespace.nspname, index_relation.relname,
+               index_relation.relkind,
+               pg_catalog.pg_get_userbyid(index_relation.relowner),
+               indexed_table.oid, table_namespace.nspname, indexed_table.relname,
+               indexed_table.relkind, pg_catalog.pg_get_userbyid(indexed_table.relowner),
+               access_method.amname,
+               catalog_index.indisunique, catalog_index.indisvalid,
+               catalog_index.indisready, catalog_index.indislive,
+               catalog_index.indisprimary, catalog_index.indisexclusion,
+               catalog_index.indimmediate,
+               catalog_index.indnullsnotdistinct,
+               catalog_index.indnatts, catalog_index.indnkeyatts,
+               pg_catalog.pg_get_expr(catalog_index.indexprs, catalog_index.indrelid),
+               pg_catalog.pg_get_expr(catalog_index.indpred, catalog_index.indrelid),
+               pg_catalog.pg_get_indexdef(index_relation.oid),
+               ARRAY(
+                   SELECT attribute.attname
+                   FROM generate_series(0, catalog_index.indnkeyatts - 1)
+                       AS key_position(position)
+                   LEFT JOIN pg_catalog.pg_attribute attribute
+                     ON attribute.attrelid = indexed_table.oid
+                    AND attribute.attnum = catalog_index.indkey[position]
+                   ORDER BY position
+               ),
+               ARRAY(
+                   SELECT catalog_index.indcollation[position] = attribute.attcollation
+                   FROM generate_series(0, catalog_index.indnkeyatts - 1)
+                       AS key_position(position)
+                   LEFT JOIN pg_catalog.pg_attribute attribute
+                     ON attribute.attrelid = indexed_table.oid
+                    AND attribute.attnum = catalog_index.indkey[position]
+                   ORDER BY position
+               ),
+               ARRAY(
+                   SELECT operator_class.opcdefault
+                   FROM generate_series(0, catalog_index.indnkeyatts - 1)
+                       AS key_position(position)
+                   LEFT JOIN pg_catalog.pg_opclass operator_class
+                     ON operator_class.oid = catalog_index.indclass[position]
+                    AND operator_class.opcmethod = index_relation.relam
+                   ORDER BY position
+               ),
+               ARRAY(
+                   SELECT catalog_index.indoption[position]
+                   FROM generate_series(0, catalog_index.indnkeyatts - 1)
+                       AS key_position(position)
+                   ORDER BY position
+               ),
+               ARRAY(
+                   SELECT inheritance.inhparent
+                   FROM pg_catalog.pg_inherits inheritance
+                   WHERE inheritance.inhrelid = index_relation.oid
+                   ORDER BY inheritance.inhparent
+               ),
+               ARRAY(
+                   SELECT dependency_namespace.nspname || '.' || dependency_proc.proname
+                   FROM pg_catalog.pg_depend dependency
+                   JOIN pg_catalog.pg_proc dependency_proc
+                     ON dependency.classid = 'pg_catalog.pg_class'::pg_catalog.regclass
+                    AND dependency.refclassid = 'pg_catalog.pg_proc'::pg_catalog.regclass
+                    AND dependency.refobjid = dependency_proc.oid
+                   JOIN pg_catalog.pg_namespace dependency_namespace
+                     ON dependency_namespace.oid = dependency_proc.pronamespace
+                   WHERE dependency.objid = index_relation.oid
+                   ORDER BY 1
+               ),
+               ARRAY(
+                   SELECT dependency_namespace.nspname || '.' || dependency_operator.oprname
+                   FROM pg_catalog.pg_depend dependency
+                   JOIN pg_catalog.pg_operator dependency_operator
+                     ON dependency.classid = 'pg_catalog.pg_class'::pg_catalog.regclass
+                    AND dependency.refclassid = 'pg_catalog.pg_operator'::pg_catalog.regclass
+                    AND dependency.refobjid = dependency_operator.oid
+                   JOIN pg_catalog.pg_namespace dependency_namespace
+                     ON dependency_namespace.oid = dependency_operator.oprnamespace
+                   WHERE dependency.objid = index_relation.oid
+                   ORDER BY 1
+               )
+        FROM pg_catalog.pg_index catalog_index
+        JOIN pg_catalog.pg_class index_relation
+          ON index_relation.oid = catalog_index.indexrelid
+        JOIN pg_catalog.pg_namespace index_namespace
+          ON index_namespace.oid = index_relation.relnamespace
+        JOIN pg_catalog.pg_class indexed_table
+          ON indexed_table.oid = catalog_index.indrelid
+        JOIN pg_catalog.pg_namespace table_namespace
+          ON table_namespace.oid = indexed_table.relnamespace
+        JOIN pg_catalog.pg_am access_method ON access_method.oid = index_relation.relam
+        WHERE indexed_table.oid = ANY(%s) OR index_relation.oid = ANY(%s)
+        ORDER BY index_namespace.nspname, index_relation.relname
+        """,
+        (list(table_oids), list(named_index_oids)),
+    )
+    return list(cur.fetchall())
+
+
+def _relation_payload(row: tuple[object, ...]) -> dict[str, object]:
+    oid, name, relkind, is_partition, owner, strategy, key_count, key_names = row
+    return {
+        "oid": int(oid),
+        "schema": "core",
+        "name": str(name),
+        "relkind": str(relkind),
+        "is_partition": bool(is_partition),
+        "role_owner": str(owner),
+        "partition_strategy": strategy,
+        "partition_key_count": key_count,
+        "partition_keys": list(key_names or []),
+    }
+
+
+def _index_payload(row: tuple[object, ...]) -> dict[str, object]:
+    (
+        oid,
+        schema_name,
+        name,
+        relkind,
+        role_owner,
+        table_oid,
+        table_schema,
+        table_name,
+        table_relkind,
+        table_role_owner,
+        method,
+        unique,
+        valid,
+        ready,
+        live,
+        primary,
+        exclusion,
+        immediate,
+        nulls_not_distinct,
+        attribute_count,
+        key_count,
+        expressions,
+        predicate,
+        definition,
+        keys,
+        default_collations,
+        default_operator_classes,
+        options,
+        parent_index_oids,
+        function_dependencies,
+        operator_dependencies,
+    ) = row
+    return {
+        "oid": int(oid),
+        "schema": str(schema_name),
+        "name": str(name),
+        "relkind": str(relkind),
+        "role_owner": str(role_owner),
+        "target": {
+            "oid": int(table_oid),
+            "schema": str(table_schema),
+            "name": str(table_name),
+            "relkind": str(table_relkind),
+            "role_owner": str(table_role_owner),
+        },
+        "method": str(method),
+        "unique": bool(unique),
+        "valid": bool(valid),
+        "ready": bool(ready),
+        "live": bool(live),
+        "primary": bool(primary),
+        "exclusion": bool(exclusion),
+        "immediate": bool(immediate),
+        "nulls_not_distinct": bool(nulls_not_distinct),
+        "attribute_count": int(attribute_count),
+        "key_count": int(key_count),
+        "expressions": expressions,
+        "predicate": predicate,
+        "definition": str(definition),
+        "keys": list(keys or []),
+        "default_collations": list(default_collations or []),
+        "default_operator_classes": list(default_operator_classes or []),
+        "options": list(options or []),
+        "parent_index_oids": [int(value) for value in (parent_index_oids or [])],
+        "function_dependencies": list(function_dependencies or []),
+        "operator_dependencies": list(operator_dependencies or []),
+    }
+
+
+def _normalized_predicate(value: object) -> str | None:
+    if value is None:
+        return None
+    normalized = "".join(str(value).split())
+    # pg_get_expr qualifies pinned built-ins when a caller's search_path contains a
+    # shadowing object.  Dependency checks below still reject the shadowing object.
+    normalized = normalized.replace("pg_catalog.abs", "abs")
+    normalized = normalized.replace("OPERATOR(pg_catalog.-)", "-")
+    normalized = normalized.replace("OPERATOR(pg_catalog.<=)", "<=")
+    while normalized.startswith("(") and normalized.endswith(")"):
+        depth = 0
+        encloses_all = True
+        for offset, character in enumerate(normalized):
+            if character == "(":
+                depth += 1
+            elif character == ")":
+                depth -= 1
+                if depth == 0 and offset != len(normalized) - 1:
+                    encloses_all = False
+                    break
+        if not encloses_all:
+            break
+        normalized = normalized[1:-1]
+    return normalized
+
+
+def _structure_problems(actual: dict[str, object], spec: PlayIndexSpec) -> list[str]:
+    problems: list[str] = []
+    if actual["method"] != spec.method:
+        problems.append(f"access method is {actual['method']!r}, expected {spec.method!r}")
+    if actual["unique"] is not spec.unique:
+        problems.append(f"unique is {actual['unique']!r}, expected {spec.unique!r}")
+    if tuple(actual["keys"]) != spec.columns:
+        problems.append(f"keys are {actual['keys']!r}, expected {list(spec.columns)!r}")
+    if actual["attribute_count"] != actual["key_count"]:
+        problems.append("INCLUDE columns are not allowed")
+    if actual["expressions"] is not None or any(key is None for key in actual["keys"]):
+        problems.append("index expressions are not allowed")
+    if _normalized_predicate(actual["predicate"]) != _normalized_predicate(spec.predicate):
+        problems.append(f"predicate is {actual['predicate']!r}, expected {spec.predicate!r}")
+    # Built-in pg_catalog functions/operators are pinned and do not produce pg_depend rows.
+    # Any row here therefore identifies a shadowed or otherwise non-built-in dependency.
+    expected_functions: list[str] = []
+    expected_operators: list[str] = []
+    if actual["function_dependencies"] != expected_functions:
+        problems.append(
+            "predicate function dependencies are "
+            f"{actual['function_dependencies']!r}, expected {expected_functions!r}"
+        )
+    if actual["operator_dependencies"] != expected_operators:
+        problems.append(
+            "predicate operator dependencies are "
+            f"{actual['operator_dependencies']!r}, expected {expected_operators!r}"
+        )
+    if not all(value is True for value in actual["default_collations"]):
+        problems.append("non-default collation is not allowed")
+    if not all(value is True for value in actual["default_operator_classes"]):
+        problems.append("non-default operator class is not allowed")
+    if any(value != 0 for value in actual["options"]):
+        problems.append("non-default sort or NULL ordering is not allowed")
+    if actual["nulls_not_distinct"]:
+        problems.append("NULLS NOT DISTINCT is not allowed")
+    if actual["primary"] or actual["exclusion"]:
+        problems.append("primary/exclusion constraint indexes are not managed here")
+    if not actual["immediate"]:
+        problems.append("deferred uniqueness semantics are not allowed")
+    return problems
+
+
+def _readiness_problems(actual: dict[str, object]) -> list[str]:
+    return [
+        label
+        for field, label in (
+            ("valid", "index is not valid"),
+            ("ready", "index is not ready"),
+            ("live", "index is not live"),
+        )
+        if not actual[field]
+    ]
+
+
+def inspect_play_indexes(
+    cur: object,
+    index_names: Iterable[str] | None = None,
+) -> dict[str, object]:
+    """Return a JSON-serializable catalog report for selected managed indexes."""
+
+    selected = _selected_names(index_names)
+    relation_rows = _fetch_relations(cur, selected)
+    relations = {str(row[1]): _relation_payload(row) for row in relation_rows}
+    plays = relations.get("plays")
+    old = relations.get("plays_old")
+    catalog_issues: list[str] = []
+    parent_oid: int | None = None
+    if plays is None:
+        catalog_issues.append("core.plays is missing")
+    elif (
+        plays["relkind"] != "p"
+        or plays["partition_strategy"] != "l"
+        or plays["partition_key_count"] != 1
+        or plays["partition_keys"] != ["season"]
+    ):
+        catalog_issues.append("core.plays must be partitioned by exactly LIST (season)")
+    else:
+        parent_oid = int(plays["oid"])
+
+    leaf_rows = _fetch_leaf_partitions(cur, parent_oid) if parent_oid is not None else []
+    partitions: list[dict[str, object]] = []
+    for oid, schema_name, name, relkind, is_partition, bound in leaf_rows:
+        partition = {
+            "oid": int(oid),
+            "schema": str(schema_name),
+            "name": str(name),
+            "relkind": str(relkind),
+            "is_partition": bool(is_partition),
+            "bound": bound,
+        }
+        partitions.append(partition)
+        if schema_name != "core" or relkind != "r" or not is_partition:
+            catalog_issues.append(
+                f"attached leaf {schema_name}.{name} is not an ordinary core partition"
+            )
+
+    table_oids = tuple(
+        dict.fromkeys(
+            [
+                *([int(plays["oid"])] if plays is not None else []),
+                *([int(old["oid"])] if old is not None else []),
+                *(int(partition["oid"]) for partition in partitions),
+            ]
+        )
+    )
+    named_index_oids = tuple(
+        int(relations[name]["oid"])
+        for name in selected
+        if name in relations and relations[name]["relkind"] in {"i", "I"}
+    )
+    all_indexes = [_index_payload(row) for row in _fetch_indexes(cur, table_oids, named_index_oids)]
+    indexes_by_name = {str(index["name"]): index for index in all_indexes}
+    partition_oids = {int(partition["oid"]): partition for partition in partitions}
+
+    reports: dict[str, dict[str, object]] = {}
+    issue_summary: dict[str, list[str]] = {}
+    for name in selected:
+        spec = EXPECTED_PLAY_INDEXES[name]
+        expected = {"name": name, **asdict(spec)}
+        expected["columns"] = list(spec.columns)
+        relation = relations.get(name)
+        actual = indexes_by_name.get(name)
+        issue_codes: list[str] = []
+        diagnostics: list[str] = []
+
+        if relation is not None and relation["relkind"] not in {"i", "I"}:
+            issue_codes.append("wrong_structure")
+            diagnostics.append(f"core.{name} is relkind={relation['relkind']!r}, not an index")
+        elif actual is None:
+            issue_codes.append("missing")
+            diagnostics.append(f"core.{name} is missing")
+        else:
+            target = actual["target"]
+            if target["schema"] != "core" or target["name"] != "plays":
+                issue_codes.append("wrong_owner")
+                diagnostics.append(
+                    f"core.{name} targets {target['schema']}.{target['name']}, expected core.plays"
+                )
+            structural = _structure_problems(actual, spec)
+            if actual["relkind"] != "I" and target["name"] == "plays":
+                structural.append(
+                    f"parent index relkind is {actual['relkind']!r}, expected partitioned index"
+                )
+            if structural:
+                issue_codes.append("wrong_structure")
+                diagnostics.extend(structural)
+            readiness = _readiness_problems(actual)
+            if readiness:
+                issue_codes.append("invalid")
+                diagnostics.extend(readiness)
+
+        coverage = {
+            "expected_partition_count": len(partitions),
+            "attached_partition_count": 0,
+            "missing_partitions": [],
+            "invalid_partitions": [],
+            "wrong_structure_partitions": [],
+            "unexpected_targets": [],
+        }
+        if actual is not None and actual["target"]["name"] == "plays":
+            parent_index_oid = int(actual["oid"])
+            attached = [
+                index for index in all_indexes if parent_index_oid in index["parent_index_oids"]
+            ]
+            attached_by_target: dict[int, list[dict[str, object]]] = {}
+            for child_index in attached:
+                target_oid = int(child_index["target"]["oid"])
+                attached_by_target.setdefault(target_oid, []).append(child_index)
+                if target_oid not in partition_oids:
+                    coverage["unexpected_targets"].append(child_index["target"])
+            for partition_oid, partition in partition_oids.items():
+                child_indexes = attached_by_target.get(partition_oid, [])
+                if len(child_indexes) != 1:
+                    coverage["missing_partitions"].append(partition["name"])
+                    if len(child_indexes) > 1:
+                        coverage["wrong_structure_partitions"].append(partition["name"])
+                    continue
+                child_index = child_indexes[0]
+                coverage["attached_partition_count"] += 1
+                child_structure = _structure_problems(child_index, spec)
+                if child_structure or child_index["relkind"] != "i":
+                    coverage["wrong_structure_partitions"].append(partition["name"])
+                if _readiness_problems(child_index):
+                    coverage["invalid_partitions"].append(partition["name"])
+            if any(
+                coverage[key]
+                for key in (
+                    "missing_partitions",
+                    "invalid_partitions",
+                    "wrong_structure_partitions",
+                    "unexpected_targets",
+                )
+            ):
+                issue_codes.append("missing_child_coverage")
+                diagnostics.append("attached child-index coverage is incomplete or unhealthy")
+
+        # A differently named equivalent live parent is never silently accepted or duplicated,
+        # including when the canonical name still belongs to the retained old heap.
+        if parent_oid is not None and (actual is None or actual["target"]["oid"] != parent_oid):
+            equivalent = [
+                index
+                for index in all_indexes
+                if index["target"]["oid"] == parent_oid
+                and not _structure_problems(index, spec)
+                and index["name"] != name
+            ]
+            if equivalent:
+                if "wrong_structure" not in issue_codes:
+                    issue_codes.append("wrong_structure")
+                diagnostics.append(
+                    "equivalent differently named parent index requires manual review: "
+                    + ", ".join(sorted(str(index["name"]) for index in equivalent))
+                )
+
+        deduped_codes = list(dict.fromkeys(issue_codes))
+        reports[name] = {
+            "healthy": not deduped_codes and not catalog_issues,
+            "expected": expected,
+            "actual": actual,
+            "issues": deduped_codes,
+            "diagnostics": diagnostics,
+            "child_coverage": coverage,
+        }
+        if deduped_codes:
+            issue_summary[name] = deduped_codes
+
+    return {
+        "valid": not catalog_issues and not issue_summary,
+        "selected_indexes": list(selected),
+        "catalog_issues": catalog_issues,
+        "plays": plays,
+        "plays_old": old,
+        "partition_count": len(partitions),
+        "partitions": partitions,
+        "issues": issue_summary,
+        "indexes": reports,
+    }
+
+
+def validate_play_indexes(
+    cur: object,
+    index_names: Iterable[str] | None = None,
+) -> dict[str, object]:
+    """Return the report or raise when any selected index is unhealthy."""
+
+    report = inspect_play_indexes(cur, index_names)
+    if not report["valid"]:
+        affected = ", ".join(report["issues"]) or "catalog"
+        raise PlayIndexStateError(f"unhealthy core.plays indexes: {affected}", report)
+    return report
+
+
+def _ensure_idle_connection(conn: object) -> None:
+    if getattr(conn, "autocommit", False):
+        raise RuntimeError("play-index maintenance requires autocommit=False")
+    get_status = getattr(conn, "get_transaction_status", None)
+    if get_status is not None and get_status() != TRANSACTION_STATUS_IDLE:
+        raise RuntimeError("play-index maintenance requires an idle connection")
+
+
+def _repair_kind(name: str, report: dict[str, object]) -> str:
+    if report["catalog_issues"]:
+        raise PlayIndexStateError(
+            "core.plays catalog is not safely repairable: " + "; ".join(report["catalog_issues"]),
+            report,
+        )
+    index_report = report["indexes"][name]
+    if index_report["healthy"]:
+        return "healthy"
+    issues = set(index_report["issues"])
+    actual = index_report["actual"]
+    if actual is None and issues == {"missing"}:
+        return "missing"
+    old = report["plays_old"]
+    if (
+        actual is not None
+        and issues == {"wrong_owner"}
+        and actual["target"]["schema"] == "core"
+        and actual["target"]["name"] == "plays_old"
+        and old is not None
+        and old["relkind"] == "r"
+        and not old["is_partition"]
+    ):
+        return "retained_old"
+    raise PlayIndexStateError(
+        f"core.{name} is not safely repairable: "
+        + ", ".join(index_report["issues"])
+        + (
+            "; " + "; ".join(index_report["diagnostics"][:4]) if index_report["diagnostics"] else ""
+        ),
+        report,
+    )
+
+
+def _fetch_collisions(cur: object, names: list[str]) -> list[tuple[object, ...]]:
+    if not names:
+        return []
+    cur.execute(
+        """
+        SELECT relation.relname, relation.relkind
+        FROM pg_catalog.pg_class relation
+        JOIN pg_catalog.pg_namespace namespace ON namespace.oid = relation.relnamespace
+        WHERE namespace.nspname = %s AND relation.relname = ANY(%s)
+        ORDER BY relation.relname
+        """,
+        ("core", names),
+    )
+    return list(cur.fetchall())
+
+
+def _fetch_named_index_identity(cur: object, name: str) -> tuple[int, int] | None:
+    cur.execute(
+        """
+        SELECT index_relation.oid, catalog_index.indrelid
+        FROM pg_catalog.pg_class index_relation
+        JOIN pg_catalog.pg_namespace namespace
+          ON namespace.oid = index_relation.relnamespace
+        JOIN pg_catalog.pg_index catalog_index
+          ON catalog_index.indexrelid = index_relation.oid
+        WHERE namespace.nspname = %s AND index_relation.relname = %s
+        """,
+        ("core", name),
+    )
+    rows = list(cur.fetchall())
+    if not rows:
+        return None
+    if len(rows) != 1:
+        raise PlayIndexStateError(f"expected exactly one core.{name} index")
+    return int(rows[0][0]), int(rows[0][1])
+
+
+def _create_parent_index(cur: object, name: str, spec: PlayIndexSpec) -> None:
+    unique = sql.SQL("UNIQUE ") if spec.unique else sql.SQL("")
+    predicate = (
+        sql.SQL(
+            " WHERE pg_catalog.abs((offense_score OPERATOR(pg_catalog.-) defense_score)) "
+            "OPERATOR(pg_catalog.<=) 28"
+        )
+        if spec.predicate is not None
+        else sql.SQL("")
+    )
+    cur.execute(
+        sql.SQL("CREATE {}INDEX {} ON {}.{} USING {} ({}){}").format(
+            unique,
+            sql.Identifier(name),
+            sql.Identifier("core"),
+            sql.Identifier("plays"),
+            sql.Identifier(spec.method),
+            sql.SQL(", ").join(sql.Identifier(column) for column in spec.columns),
+            predicate,
+        )
+    )
+
+
+def repair_play_indexes(conn: object, index_names: Iterable[str]) -> dict[str, object]:
+    """Atomically repair an explicit, nonempty selection of managed indexes.
+
+    Only a wholly missing expected index or an exact valid copy still targeting a
+    verified ``core.plays_old`` heap is repaired.  Every other state fails closed.
+    The non-concurrent parent builds block writes during this maintenance window.
+    """
+
+    if index_names is None:
+        raise ValueError("play-index repair requires an explicit index selection")
+    selected = _selected_names(index_names)
+    if not selected:
+        raise ValueError("play-index repair requires at least one explicit --index selection")
+    _ensure_idle_connection(conn)
+    cur = conn.cursor()
+    repaired: list[str] = []
+    renamed: dict[str, str] = {}
+    try:
+        cur.execute("BEGIN ISOLATION LEVEL READ COMMITTED")
+        cur.execute("SET LOCAL lock_timeout = %s", (LOCK_TIMEOUT,))
+        cur.execute("SET LOCAL statement_timeout = %s", (STATEMENT_TIMEOUT,))
+        cur.execute("SELECT pg_advisory_xact_lock(%s, %s)", ADVISORY_LOCK_KEYS)
+        # Locking without ONLY covers every current partition.  SHARE ROW EXCLUSIVE
+        # prevents writes and competing catalog DDL while permitting readers.
+        cur.execute("LOCK TABLE core.plays IN SHARE ROW EXCLUSIVE MODE")
+        before = inspect_play_indexes(cur, selected)
+        preliminary_kinds = {name: _repair_kind(name, before) for name in selected}
+        if "retained_old" in preliminary_kinds.values():
+            cur.execute("LOCK TABLE core.plays_old IN SHARE ROW EXCLUSIVE MODE")
+            # Lock acquisition may have waited.  Repeat the complete preflight afterward.
+            before = inspect_play_indexes(cur, selected)
+        kinds = {name: _repair_kind(name, before) for name in selected}
+        rename_targets = [
+            f"plays_old_{name}" for name, kind in kinds.items() if kind == "retained_old"
+        ]
+        collisions = _fetch_collisions(cur, rename_targets)
+        if collisions:
+            details = ", ".join(f"core.{name} (relkind={kind})" for name, kind in collisions)
+            raise PlayIndexStateError(
+                f"retained-old index rename target already exists: {details}", before
+            )
+
+        # All selected states and rename targets are validated before the first DDL.
+        for name in selected:
+            kind = kinds[name]
+            if kind == "healthy":
+                continue
+            if kind == "retained_old":
+                renamed_name = f"plays_old_{name}"
+                expected_index_oid = int(before["indexes"][name]["actual"]["oid"])
+                expected_old_oid = int(before["plays_old"]["oid"])
+                cur.execute(
+                    sql.SQL("ALTER INDEX {}.{} RENAME TO {}").format(
+                        sql.Identifier("core"),
+                        sql.Identifier(name),
+                        sql.Identifier(renamed_name),
+                    )
+                )
+                renamed_identity = _fetch_named_index_identity(cur, renamed_name)
+                if renamed_identity != (expected_index_oid, expected_old_oid):
+                    raise PlayIndexStateError(
+                        f"core.{name} changed identity during retained-old rename; "
+                        "rolling back maintenance",
+                        before,
+                    )
+                renamed[name] = renamed_name
+            _create_parent_index(cur, name, EXPECTED_PLAY_INDEXES[name])
+            repaired.append(name)
+
+        after = validate_play_indexes(cur, selected)
+        conn.commit()
+        after["repaired_indexes"] = repaired
+        after["renamed_old_indexes"] = renamed
+        after["lock_timeout"] = LOCK_TIMEOUT
+        after["statement_timeout"] = STATEMENT_TIMEOUT
+        return after
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        cur.close()

--- a/tests/test_play_indexes.py
+++ b/tests/test_play_indexes.py
@@ -1,0 +1,514 @@
+"""Unit tests for the catalog-safe ``core.plays`` index lifecycle."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import scripts.maintain_play_indexes as cli
+from src.pipelines.utils import play_indexes
+from src.pipelines.utils.play_indexes import (
+    EXPECTED_PLAY_INDEXES,
+    PlayIndexStateError,
+    inspect_play_indexes,
+    repair_play_indexes,
+    validate_play_indexes,
+)
+
+
+def relation(
+    oid: int,
+    name: str,
+    relkind: str,
+    *,
+    is_partition: bool = False,
+    strategy=None,
+    key_count=None,
+    keys=(),
+):
+    return (oid, name, relkind, is_partition, "postgres", strategy, key_count, list(keys))
+
+
+def index_row(
+    oid: int,
+    name: str,
+    table_oid: int,
+    table_name: str,
+    columns: tuple[str, ...],
+    *,
+    unique: bool = False,
+    predicate: str | None = None,
+    relkind: str = "I",
+    valid: bool = True,
+    ready: bool = True,
+    live: bool = True,
+    immediate: bool = True,
+    parent_oids=(),
+    method: str = "btree",
+    attribute_count: int | None = None,
+    collations=None,
+    operator_classes=None,
+    options=None,
+    function_dependencies=None,
+    operator_dependencies=None,
+):
+    key_count = len(columns)
+    return (
+        oid,
+        "core",
+        name,
+        relkind,
+        "postgres",
+        table_oid,
+        "core",
+        table_name,
+        "p" if table_name == "plays" else "r",
+        "postgres",
+        method,
+        unique,
+        valid,
+        ready,
+        live,
+        False,
+        False,
+        immediate,
+        False,
+        key_count if attribute_count is None else attribute_count,
+        key_count,
+        None,
+        predicate,
+        f"CREATE INDEX {name}",
+        list(columns),
+        [True] * key_count if collations is None else collations,
+        [True] * key_count if operator_classes is None else operator_classes,
+        [0] * key_count if options is None else options,
+        list(parent_oids),
+        function_dependencies or [],
+        operator_dependencies or [],
+    )
+
+
+class CatalogCursor:
+    def __init__(self, *, relations=(), leaves=(), indexes=(), collisions=()):
+        self.relations = list(relations)
+        self.leaves = list(leaves)
+        self.indexes = list(indexes)
+        self.collisions = list(collisions)
+        self.rows = []
+        self.executions = []
+        self.closed = False
+
+    def execute(self, statement, values=None):
+        text = " ".join(str(statement).split())
+        self.executions.append((text, values))
+        if "pg_catalog.pg_partitioned_table" in text:
+            self.rows = self.relations
+        elif "WITH RECURSIVE descendants" in text:
+            self.rows = self.leaves
+        elif "FROM pg_catalog.pg_index catalog_index" in text:
+            self.rows = self.indexes
+        elif "SELECT relation.relname, relation.relkind" in text:
+            self.rows = self.collisions
+        elif "SQL('CREATE ')" in text or text.startswith(
+            (
+                "BEGIN",
+                "SET LOCAL",
+                "SELECT pg_advisory_xact_lock",
+                "LOCK TABLE",
+                "CREATE",
+                "ALTER INDEX",
+            )
+        ):
+            self.rows = []
+        else:
+            raise AssertionError(f"unexpected SQL: {text}")
+
+    def fetchall(self):
+        return list(self.rows)
+
+    def close(self):
+        self.closed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        self.close()
+
+
+def healthy_catalog(name="idx_plays_game_id"):
+    spec = EXPECTED_PLAY_INDEXES[name]
+    parent_oid = 10
+    partition_oid = 20
+    parent_index_oid = 30
+    return CatalogCursor(
+        relations=[
+            relation(parent_oid, "plays", "p", strategy="l", key_count=1, keys=("season",)),
+            relation(parent_index_oid, name, "I"),
+        ],
+        leaves=[(partition_oid, "core", "plays_y2026", "r", True, "FOR VALUES IN (2026)")],
+        indexes=[
+            index_row(
+                parent_index_oid,
+                name,
+                parent_oid,
+                "plays",
+                spec.columns,
+                unique=spec.unique,
+                predicate=spec.predicate,
+            ),
+            index_row(
+                31,
+                "plays_y2026_index",
+                partition_oid,
+                "plays_y2026",
+                spec.columns,
+                unique=spec.unique,
+                predicate=spec.predicate,
+                relkind="i",
+                parent_oids=(parent_index_oid,),
+            ),
+        ],
+    )
+
+
+def test_expected_index_allowlist_is_exact_and_ordered():
+    assert list(EXPECTED_PLAY_INDEXES) == [
+        "plays_dlt_id_unique",
+        "idx_plays_game_id",
+        "idx_plays_offense",
+        "idx_plays_defense",
+        "idx_plays_offense_season",
+        "idx_plays_defense_season",
+        "idx_plays_play_type",
+        "idx_plays_score_diff",
+        "idx_plays_competitive",
+    ]
+    assert EXPECTED_PLAY_INDEXES["plays_dlt_id_unique"].unique
+    assert EXPECTED_PLAY_INDEXES["plays_dlt_id_unique"].columns == ("_dlt_id", "season")
+    assert EXPECTED_PLAY_INDEXES["idx_plays_competitive"].predicate == (
+        "abs((offense_score - defense_score)) <= 28"
+    )
+
+
+def test_inspection_reports_complete_actual_definition_and_child_coverage():
+    report = inspect_play_indexes(healthy_catalog(), ["idx_plays_game_id"])
+
+    assert report["valid"] is True
+    assert report["partition_count"] == 1
+    actual = report["indexes"]["idx_plays_game_id"]["actual"]
+    assert actual["target"]["name"] == "plays"
+    assert actual["keys"] == ["game_id"]
+    assert actual["valid"] and actual["ready"] and actual["live"]
+    assert report["indexes"]["idx_plays_game_id"]["child_coverage"] == {
+        "expected_partition_count": 1,
+        "attached_partition_count": 1,
+        "missing_partitions": [],
+        "invalid_partitions": [],
+        "wrong_structure_partitions": [],
+        "unexpected_targets": [],
+    }
+    json.dumps(report)
+
+
+@pytest.mark.parametrize(
+    ("change", "issue"),
+    [
+        ({"valid": False}, "invalid"),
+        ({"immediate": False}, "wrong_structure"),
+        ({"method": "hash"}, "wrong_structure"),
+        ({"attribute_count": 2}, "wrong_structure"),
+        ({"collations": [False]}, "wrong_structure"),
+        ({"operator_classes": [False]}, "wrong_structure"),
+        ({"options": [1]}, "wrong_structure"),
+    ],
+)
+def test_parent_structure_and_readiness_are_strict(change, issue):
+    cur = healthy_catalog()
+    kwargs = dict(change)
+    spec = EXPECTED_PLAY_INDEXES["idx_plays_game_id"]
+    cur.indexes[0] = index_row(
+        30,
+        "idx_plays_game_id",
+        10,
+        "plays",
+        spec.columns,
+        **kwargs,
+    )
+
+    report = inspect_play_indexes(cur, ["idx_plays_game_id"])
+
+    assert issue in report["issues"]["idx_plays_game_id"]
+
+
+def test_missing_or_invalid_child_is_reported_as_missing_child_coverage():
+    cur = healthy_catalog()
+    cur.indexes[1] = index_row(
+        31,
+        "plays_y2026_index",
+        20,
+        "plays_y2026",
+        ("game_id",),
+        relkind="i",
+        valid=False,
+        parent_oids=(30,),
+    )
+
+    report = inspect_play_indexes(cur, ["idx_plays_game_id"])
+
+    assert report["issues"]["idx_plays_game_id"] == ["missing_child_coverage"]
+    assert report["indexes"]["idx_plays_game_id"]["child_coverage"]["invalid_partitions"] == [
+        "plays_y2026"
+    ]
+    invalid = healthy_catalog()
+    invalid.indexes.pop()
+    with pytest.raises(PlayIndexStateError) as raised:
+        validate_play_indexes(invalid, ["idx_plays_game_id"])
+    assert raised.value.report is not None
+
+
+def test_builtin_predicate_qualification_is_accepted_but_shadow_dependency_is_not():
+    name = "idx_plays_competitive"
+    spec = EXPECTED_PLAY_INDEXES[name]
+    cur = healthy_catalog(name)
+    cur.indexes[0] = index_row(
+        30,
+        name,
+        10,
+        "plays",
+        spec.columns,
+        predicate=(
+            "pg_catalog.abs((offense_score OPERATOR(pg_catalog.-) defense_score)) "
+            "OPERATOR(pg_catalog.<=) 28"
+        ),
+    )
+
+    assert inspect_play_indexes(cur, [name])["valid"] is True
+
+    cur.indexes[0] = index_row(
+        30,
+        name,
+        10,
+        "plays",
+        spec.columns,
+        predicate=spec.predicate,
+        function_dependencies=["public.abs"],
+    )
+    report = inspect_play_indexes(cur, [name])
+    assert "wrong_structure" in report["issues"][name]
+
+
+def test_canonical_index_on_unrelated_table_is_wrong_owner_not_missing():
+    cur = CatalogCursor(
+        relations=[
+            relation(10, "plays", "p", strategy="l", key_count=1, keys=("season",)),
+            relation(40, "idx_plays_game_id", "i"),
+        ],
+        indexes=[index_row(40, "idx_plays_game_id", 99, "unrelated", ("game_id",), relkind="i")],
+    )
+
+    report = inspect_play_indexes(cur, ["idx_plays_game_id"])
+
+    assert "wrong_owner" in report["issues"]["idx_plays_game_id"]
+    assert "missing" not in report["issues"]["idx_plays_game_id"]
+
+
+def test_old_canonical_plus_equivalent_differently_named_live_parent_is_not_repairable():
+    cur = CatalogCursor(
+        relations=[
+            relation(10, "plays", "p", strategy="l", key_count=1, keys=("season",)),
+            relation(11, "plays_old", "r"),
+            relation(40, "idx_plays_game_id", "i"),
+        ],
+        indexes=[
+            index_row(40, "idx_plays_game_id", 11, "plays_old", ("game_id",), relkind="i"),
+            index_row(41, "live_game_id_other_name", 10, "plays", ("game_id",)),
+        ],
+    )
+
+    report = inspect_play_indexes(cur, ["idx_plays_game_id"])
+
+    assert report["issues"]["idx_plays_game_id"] == ["wrong_owner", "wrong_structure"]
+    assert "differently named" in " ".join(report["indexes"]["idx_plays_game_id"]["diagnostics"])
+
+
+def test_unknown_selection_is_rejected_before_catalog_queries():
+    cur = CatalogCursor()
+    with pytest.raises(ValueError, match="unsupported"):
+        inspect_play_indexes(cur, ["idx_plays_obsolete"])
+    assert cur.executions == []
+
+
+class Connection:
+    def __init__(self, cursor, *, autocommit=False, status=0):
+        self._cursor = cursor
+        self.autocommit = autocommit
+        self.status = status
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+
+    def get_transaction_status(self):
+        return self.status
+
+    def cursor(self):
+        return self._cursor
+
+    def commit(self):
+        self.commits += 1
+
+    def rollback(self):
+        self.rollbacks += 1
+
+    def close(self):
+        self.closed = True
+
+
+def state_report(name, *, issues, actual=None, old=None, catalog_issues=()):
+    return {
+        "valid": not issues and not catalog_issues,
+        "catalog_issues": list(catalog_issues),
+        "issues": {name: list(issues)} if issues else {},
+        "indexes": {
+            name: {
+                "healthy": not issues and not catalog_issues,
+                "issues": list(issues),
+                "actual": actual,
+                "diagnostics": [],
+            }
+        },
+        "plays_old": old,
+    }
+
+
+@pytest.mark.parametrize("selection", [None, []])
+def test_repair_requires_nonempty_explicit_selection(selection):
+    conn = Connection(CatalogCursor())
+    with pytest.raises(ValueError, match="explicit|at least one"):
+        repair_play_indexes(conn, selection)
+    assert conn._cursor.executions == []
+
+
+@pytest.mark.parametrize(("autocommit", "status"), [(True, 0), (False, 2)])
+def test_repair_requires_dedicated_idle_transactional_connection(autocommit, status):
+    conn = Connection(CatalogCursor(), autocommit=autocommit, status=status)
+    with pytest.raises(RuntimeError, match="autocommit=False|idle connection"):
+        repair_play_indexes(conn, ["idx_plays_game_id"])
+    assert conn._cursor.executions == []
+
+
+def test_missing_selected_index_is_built_and_postvalidated(monkeypatch):
+    name = "idx_plays_game_id"
+    before = state_report(name, issues=["missing"])
+    after = state_report(name, issues=[])
+    reports = iter((before, after))
+    monkeypatch.setattr(play_indexes, "inspect_play_indexes", lambda *_args: next(reports))
+    cur = CatalogCursor()
+    conn = Connection(cur)
+
+    result = repair_play_indexes(conn, [name])
+
+    statements = [statement for statement, _ in cur.executions]
+    assert statements[:5] == [
+        "BEGIN ISOLATION LEVEL READ COMMITTED",
+        "SET LOCAL lock_timeout = %s",
+        "SET LOCAL statement_timeout = %s",
+        "SELECT pg_advisory_xact_lock(%s, %s)",
+        "LOCK TABLE core.plays IN SHARE ROW EXCLUSIVE MODE",
+    ]
+    assert any("CREATE" in statement and "INDEX" in statement for statement in statements)
+    assert conn.commits == 1
+    assert conn.rollbacks == 0
+    assert result["repaired_indexes"] == [name]
+    assert result["lock_timeout"] == "10s"
+    assert result["statement_timeout"] == "30min"
+
+
+def test_all_selected_states_are_validated_before_first_ddl(monkeypatch):
+    selected = ["idx_plays_game_id", "idx_plays_offense"]
+    report = {
+        "valid": False,
+        "catalog_issues": [],
+        "issues": {
+            "idx_plays_game_id": ["missing"],
+            "idx_plays_offense": ["wrong_structure"],
+        },
+        "indexes": {
+            "idx_plays_game_id": {"healthy": False, "issues": ["missing"], "actual": None},
+            "idx_plays_offense": {
+                "healthy": False,
+                "issues": ["wrong_structure"],
+                "actual": None,
+                "diagnostics": [],
+            },
+        },
+        "plays_old": None,
+    }
+    monkeypatch.setattr(play_indexes, "inspect_play_indexes", lambda *_args: report)
+    cur = CatalogCursor()
+    conn = Connection(cur)
+
+    with pytest.raises(PlayIndexStateError, match="not safely repairable"):
+        repair_play_indexes(conn, selected)
+
+    assert not any(
+        "CREATE" in statement or "ALTER INDEX" in statement for statement, _ in cur.executions
+    )
+    assert conn.commits == 0
+    assert conn.rollbacks == 1
+
+
+def test_retained_old_rename_collision_fails_before_ddl(monkeypatch):
+    name = "idx_plays_game_id"
+    actual = {"target": {"schema": "core", "name": "plays_old"}}
+    old = {"relkind": "r", "is_partition": False}
+    report = state_report(name, issues=["wrong_owner"], actual=actual, old=old)
+    monkeypatch.setattr(play_indexes, "inspect_play_indexes", lambda *_args: report)
+    cur = CatalogCursor(collisions=[(f"plays_old_{name}", "i")])
+    conn = Connection(cur)
+
+    with pytest.raises(PlayIndexStateError, match="rename target already exists"):
+        repair_play_indexes(conn, [name])
+
+    statements = [statement for statement, _ in cur.executions]
+    assert "LOCK TABLE core.plays_old IN SHARE ROW EXCLUSIVE MODE" in statements
+    assert not any(
+        "ALTER INDEX" in statement or "CREATE INDEX" in statement for statement in statements
+    )
+    assert conn.rollbacks == 1
+
+
+def test_inspect_cli_uses_read_only_snapshot_and_returns_nonzero_for_issues(monkeypatch, capsys):
+    name = "idx_plays_game_id"
+    report = state_report(name, issues=["missing"])
+    cur = CatalogCursor()
+    conn = Connection(cur)
+    monkeypatch.setenv("WAREHOUSE_DB_URL", "postgresql://u:p@db.example:5432/warehouse")
+    monkeypatch.setattr(cli, "validate_database_url", lambda _url: None)
+    monkeypatch.setattr(cli.psycopg2, "connect", lambda _url: conn)
+    monkeypatch.setattr(cli, "inspect_play_indexes", lambda *_args: report)
+
+    assert cli.main([]) == 1
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["apply"] is False
+    assert payload["valid"] is False
+    assert cur.executions[0][0] == "BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY"
+    assert conn.rollbacks == 1
+    assert conn.closed
+
+
+def test_apply_cli_requires_an_explicit_index_without_connecting(monkeypatch, capsys):
+    monkeypatch.setenv("WAREHOUSE_DB_URL", "postgresql://u:p@db.example:5432/warehouse")
+    monkeypatch.setattr(
+        cli.psycopg2,
+        "connect",
+        lambda _url: pytest.fail("must not connect without an explicit repair selection"),
+    )
+
+    assert cli.main(["--apply"]) == 1
+
+    payload = json.loads(capsys.readouterr().err)
+    assert payload["error"]["type"] == "ValueError"
+    assert "--apply requires" in payload["error"]["message"]

--- a/tests/test_play_indexes_sql.py
+++ b/tests/test_play_indexes_sql.py
@@ -1,0 +1,623 @@
+"""Executed F09 regression tests for ``core.plays`` index ownership repair."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import psycopg2
+import pytest
+
+from src.pipelines.utils.partitions import ensure_play_partitions
+from src.pipelines.utils.play_indexes import (
+    EXPECTED_PLAY_INDEXES,
+    PlayIndexStateError,
+    repair_play_indexes,
+    validate_play_indexes,
+)
+from tests.test_warehouse_migrations_sql import warehouse_db as _warehouse_db_fixture  # noqa: F401
+
+EXPECTED_DEFINITIONS = {
+    "plays_dlt_id_unique": (True, ["_dlt_id", "season"], None),
+    "idx_plays_game_id": (False, ["game_id"], None),
+    "idx_plays_offense": (False, ["offense"], None),
+    "idx_plays_defense": (False, ["defense"], None),
+    "idx_plays_offense_season": (False, ["offense", "season"], None),
+    "idx_plays_defense_season": (False, ["defense", "season"], None),
+    "idx_plays_play_type": (False, ["play_type"], None),
+    "idx_plays_score_diff": (False, ["score_diff"], None),
+    "idx_plays_competitive": (
+        False,
+        ["game_id", "period"],
+        "(abs((offense_score - defense_score)) <= 28)",
+    ),
+}
+
+PLAY_COLUMNS = """
+    _dlt_id text NOT NULL,
+    season bigint NOT NULL,
+    game_id bigint,
+    offense text,
+    defense text,
+    play_type text,
+    score_diff bigint,
+    period bigint,
+    offense_score bigint,
+    defense_score bigint
+"""
+
+CREATE_EXPECTED_INDEXES = {
+    "plays_dlt_id_unique": (
+        "CREATE UNIQUE INDEX plays_dlt_id_unique ON core.plays(_dlt_id, season)"
+    ),
+    "idx_plays_game_id": "CREATE INDEX idx_plays_game_id ON core.plays(game_id)",
+    "idx_plays_offense": "CREATE INDEX idx_plays_offense ON core.plays(offense)",
+    "idx_plays_defense": "CREATE INDEX idx_plays_defense ON core.plays(defense)",
+    "idx_plays_offense_season": (
+        "CREATE INDEX idx_plays_offense_season ON core.plays(offense, season)"
+    ),
+    "idx_plays_defense_season": (
+        "CREATE INDEX idx_plays_defense_season ON core.plays(defense, season)"
+    ),
+    "idx_plays_play_type": "CREATE INDEX idx_plays_play_type ON core.plays(play_type)",
+    "idx_plays_score_diff": "CREATE INDEX idx_plays_score_diff ON core.plays(score_diff)",
+    "idx_plays_competitive": (
+        "CREATE INDEX idx_plays_competitive ON core.plays(game_id, period) "
+        "WHERE abs(offense_score - defense_score) <= 28"
+    ),
+}
+
+HISTORICALLY_COLLIDING_INDEXES = (
+    "idx_plays_game_id",
+    "idx_plays_offense",
+    "idx_plays_defense",
+    "idx_plays_play_type",
+)
+
+
+@pytest.fixture(name="warehouse_db")
+def _play_index_warehouse_db(request):
+    return request.getfixturevalue("_warehouse_db_fixture")
+
+
+def _execute(conn, statement: str, values=None):
+    with conn.cursor() as cur:
+        cur.execute(statement, values)
+        rows = cur.fetchall() if cur.description else None
+    conn.commit()
+    return rows
+
+
+def _create_roles_and_schema(conn):
+    _execute(
+        conn,
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'anon') THEN
+                CREATE ROLE anon NOLOGIN;
+            END IF;
+            IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticated') THEN
+                CREATE ROLE authenticated NOLOGIN;
+            END IF;
+        END $$;
+        CREATE SCHEMA core;
+        GRANT USAGE ON SCHEMA core TO anon, authenticated;
+        """,
+    )
+
+
+def _create_partitioned_plays(conn, years: Iterable[int] = (2025, 2026)):
+    _create_roles_and_schema(conn)
+    with conn.cursor() as cur:
+        cur.execute(f"CREATE TABLE core.plays ({PLAY_COLUMNS}) PARTITION BY LIST (season)")
+        for year in years:
+            cur.execute(
+                f"CREATE TABLE core.plays_y{year} PARTITION OF core.plays FOR VALUES IN ({year})"
+            )
+    conn.commit()
+
+
+def _create_historical_swap(conn):
+    """Reproduce the old heap-to-partitioned-table index-name collision."""
+
+    _create_roles_and_schema(conn)
+    with conn.cursor() as cur:
+        cur.execute(f"CREATE TABLE core.plays ({PLAY_COLUMNS})")
+        cur.execute(
+            """
+            INSERT INTO core.plays VALUES
+                ('old-a', 2025, 1, 'Alpha', 'Beta', 'Rush', 7, 1, 14, 7),
+                ('old-b', 2026, 2, 'Gamma', 'Delta', 'Pass', -3, 2, 10, 13)
+            """
+        )
+        for name in HISTORICALLY_COLLIDING_INDEXES:
+            cur.execute(CREATE_EXPECTED_INDEXES[name])
+        cur.execute(
+            f"CREATE TABLE core.plays_partitioned ({PLAY_COLUMNS}) PARTITION BY LIST (season)"
+        )
+        for year in (2025, 2026):
+            cur.execute(
+                f"CREATE TABLE core.plays_y{year} PARTITION OF core.plays_partitioned "
+                f"FOR VALUES IN ({year})"
+            )
+        cur.execute("INSERT INTO core.plays_partitioned SELECT * FROM core.plays")
+        cur.execute("ALTER TABLE core.plays RENAME TO plays_old")
+        cur.execute("ALTER TABLE core.plays_partitioned RENAME TO plays")
+        for statement in CREATE_EXPECTED_INDEXES.values():
+            # This is the historical bug: the schema-level old index name makes every
+            # supposedly idempotent parent-index creation silently skip.
+            cur.execute(
+                statement.replace("CREATE ", "CREATE ", 1).replace(
+                    " INDEX ", " INDEX IF NOT EXISTS ", 1
+                )
+            )
+        cur.execute("GRANT SELECT ON core.plays TO anon, authenticated")
+    conn.commit()
+
+
+def _index_targets(conn, names=None):
+    names = list(names or EXPECTED_DEFINITIONS)
+    return dict(
+        _execute(
+            conn,
+            """
+            SELECT index_class.relname, table_class.relname
+            FROM pg_catalog.pg_index index_state
+            JOIN pg_catalog.pg_class index_class
+              ON index_class.oid = index_state.indexrelid
+            JOIN pg_catalog.pg_class table_class
+              ON table_class.oid = index_state.indrelid
+            WHERE index_class.relnamespace = 'core'::regnamespace
+              AND index_class.relname = ANY(%s)
+            ORDER BY index_class.relname
+            """,
+            (names,),
+        )
+    )
+
+
+def _parent_index_definitions(conn):
+    rows = _execute(
+        conn,
+        """
+        SELECT index_class.relname,
+               index_state.indisunique,
+               ARRAY(
+                   SELECT attribute.attname
+                   FROM unnest(index_state.indkey::smallint[]) WITH ORDINALITY
+                        AS key_column(attnum, position)
+                   JOIN pg_catalog.pg_attribute attribute
+                     ON attribute.attrelid = index_state.indrelid
+                    AND attribute.attnum = key_column.attnum
+                   WHERE key_column.position <= index_state.indnkeyatts
+                   ORDER BY key_column.position
+               ),
+               pg_get_expr(index_state.indpred, index_state.indrelid),
+               index_state.indisvalid,
+               index_state.indisready
+        FROM pg_catalog.pg_index index_state
+        JOIN pg_catalog.pg_class index_class
+          ON index_class.oid = index_state.indexrelid
+        JOIN pg_catalog.pg_class table_class
+          ON table_class.oid = index_state.indrelid
+        WHERE index_class.relnamespace = 'core'::regnamespace
+          AND table_class.relname = 'plays'
+          AND index_class.relname = ANY(%s)
+        ORDER BY index_class.relname
+        """,
+        (list(EXPECTED_DEFINITIONS),),
+    )
+    return {name: values for name, *values in rows}
+
+
+def _attached_child_indexes(conn, *, child_name: str | None = None):
+    child_filter = "AND child_table.relname = %s" if child_name else ""
+    values = (
+        (list(EXPECTED_DEFINITIONS), child_name) if child_name else (list(EXPECTED_DEFINITIONS),)
+    )
+    return _execute(
+        conn,
+        f"""
+        SELECT parent_index.relname, child_table.relname,
+               child_state.indisvalid, child_state.indisready
+        FROM pg_catalog.pg_inherits inheritance
+        JOIN pg_catalog.pg_class parent_index
+          ON parent_index.oid = inheritance.inhparent
+        JOIN pg_catalog.pg_index child_state
+          ON child_state.indexrelid = inheritance.inhrelid
+        JOIN pg_catalog.pg_class child_table
+          ON child_table.oid = child_state.indrelid
+        WHERE parent_index.relnamespace = 'core'::regnamespace
+          AND parent_index.relname = ANY(%s)
+          {child_filter}
+        ORDER BY parent_index.relname, child_table.relname
+        """,
+        values,
+    )
+
+
+def _index_snapshot(conn):
+    return _execute(
+        conn,
+        """
+        SELECT index_class.oid, index_class.relname, table_class.relname,
+               pg_get_indexdef(index_class.oid),
+               index_state.indisvalid, index_state.indisready
+        FROM pg_catalog.pg_index index_state
+        JOIN pg_catalog.pg_class index_class
+          ON index_class.oid = index_state.indexrelid
+        JOIN pg_catalog.pg_class table_class
+          ON table_class.oid = index_state.indrelid
+        WHERE index_class.relnamespace = 'core'::regnamespace
+        ORDER BY index_class.oid
+        """,
+    )
+
+
+def _assert_caller_can_read(conn, role: str):
+    try:
+        with conn.cursor() as cur:
+            cur.execute(f"SET LOCAL ROLE {role}")
+            cur.execute("SELECT _dlt_id, season FROM core.plays ORDER BY season")
+            assert cur.fetchall() == [("old-a", 2025), ("old-b", 2026)]
+    finally:
+        conn.rollback()
+
+
+def test_historical_swap_repair_builds_exact_covered_indexes_and_is_idempotent(warehouse_db):
+    conn, _ = warehouse_db
+    _create_historical_swap(conn)
+    names = list(EXPECTED_PLAY_INDEXES)
+
+    expected_initial_targets = {
+        name: "plays_old" if name in HISTORICALLY_COLLIDING_INDEXES else "plays" for name in names
+    }
+    assert _index_targets(conn, names) == expected_initial_targets
+    with conn.cursor() as cur:
+        with pytest.raises(PlayIndexStateError):
+            validate_play_indexes(cur)
+    conn.rollback()
+
+    report = repair_play_indexes(conn, names)
+
+    assert set(report["indexes"]) == set(names)
+    assert _index_targets(conn, names) == {name: "plays" for name in names}
+    definitions = _parent_index_definitions(conn)
+    assert set(definitions) == set(EXPECTED_DEFINITIONS)
+    for name, (unique, columns, predicate) in EXPECTED_DEFINITIONS.items():
+        assert definitions[name] == [unique, columns, predicate, True, True]
+    coverage = _attached_child_indexes(conn)
+    assert len(coverage) == len(names) * 2
+    assert {(child, valid, ready) for _, child, valid, ready in coverage} == {
+        ("plays_y2025", True, True),
+        ("plays_y2026", True, True),
+    }
+    assert _execute(conn, "SELECT * FROM core.plays_old ORDER BY season") == _execute(
+        conn, "SELECT * FROM core.plays ORDER BY season"
+    )
+    renamed = [f"plays_old_{name}" for name in HISTORICALLY_COLLIDING_INDEXES]
+    old_targets = _index_targets(conn, renamed)
+    assert old_targets == {name: "plays_old" for name in renamed}
+    _assert_caller_can_read(conn, "anon")
+    _assert_caller_can_read(conn, "authenticated")
+
+    before = _index_snapshot(conn)
+    repair_play_indexes(conn, names)
+    assert _index_snapshot(conn) == before
+
+
+def test_explicit_selection_uses_builtin_predicate_under_shadowed_search_path(warehouse_db):
+    conn, _ = warehouse_db
+    _create_historical_swap(conn)
+    _execute(
+        conn,
+        """
+        DROP INDEX core.idx_plays_competitive;
+        CREATE FUNCTION public.abs(bigint) RETURNS bigint
+        LANGUAGE sql IMMUTABLE STRICT
+        AS 'SELECT -1::bigint';
+        SET search_path = public, pg_catalog;
+        """,
+    )
+
+    repair_play_indexes(conn, ["idx_plays_competitive"])
+
+    assert _index_targets(conn, ["idx_plays_competitive"]) == {"idx_plays_competitive": "plays"}
+    assert _index_targets(conn, ["idx_plays_offense"]) == {"idx_plays_offense": "plays_old"}
+    assert "pg_catalog.abs" in _parent_index_definitions(conn)["idx_plays_competitive"][2]
+    assert _execute(
+        conn,
+        """
+        SELECT count(*)
+        FROM pg_catalog.pg_depend dependency
+        WHERE dependency.objid = 'core.idx_plays_competitive'::regclass
+          AND dependency.refobjid = 'public.abs(bigint)'::regprocedure
+        """,
+    ) == [(0,)]
+    with conn.cursor() as cur:
+        validate_play_indexes(cur, ["idx_plays_competitive"])
+        with pytest.raises(PlayIndexStateError):
+            validate_play_indexes(cur)
+    conn.rollback()
+
+
+def test_same_name_wrong_key_predicate_uniqueness_and_order_are_rejected(warehouse_db):
+    conn, _ = warehouse_db
+    _create_partitioned_plays(conn)
+    _execute(
+        conn,
+        """
+        CREATE FUNCTION public.abs(bigint) RETURNS bigint
+        LANGUAGE sql IMMUTABLE STRICT
+        AS 'SELECT -1::bigint';
+        SET search_path = public, pg_catalog;
+        """,
+    )
+    wrong_definitions = {
+        "idx_plays_game_id": "CREATE INDEX idx_plays_game_id ON core.plays(defense)",
+        "idx_plays_offense": (
+            "CREATE INDEX idx_plays_offense ON core.plays(offense) WHERE offense IS NOT NULL"
+        ),
+        "idx_plays_defense": (
+            "CREATE UNIQUE INDEX idx_plays_defense ON core.plays(defense, season)"
+        ),
+        "plays_dlt_id_unique": (
+            "CREATE UNIQUE INDEX plays_dlt_id_unique ON core.plays(season, _dlt_id)"
+        ),
+        "idx_plays_score_diff": (
+            "CREATE INDEX idx_plays_score_diff ON ONLY core.plays(score_diff)"
+        ),
+        "idx_plays_competitive": (
+            "CREATE INDEX idx_plays_competitive ON core.plays(game_id, period) "
+            "WHERE abs(offense_score - defense_score) <= 28"
+        ),
+    }
+    with conn.cursor() as cur:
+        for statement in wrong_definitions.values():
+            cur.execute(statement)
+    conn.commit()
+    with conn.cursor() as cur:
+        with pytest.raises(PlayIndexStateError):
+            validate_play_indexes(cur, ["plays_dlt_id_unique"])
+    conn.rollback()
+    _execute(
+        conn,
+        """
+        DROP INDEX core.plays_dlt_id_unique;
+        ALTER TABLE core.plays
+            ADD CONSTRAINT plays_dlt_id_unique
+            UNIQUE (_dlt_id, season) DEFERRABLE INITIALLY DEFERRED
+        """,
+    )
+    assert _execute(
+        conn,
+        """
+        SELECT NOT index_state.indimmediate
+        FROM pg_catalog.pg_index index_state
+        WHERE index_state.indexrelid = 'core.plays_dlt_id_unique'::regclass
+        """,
+    ) == [(True,)]
+    before = _index_snapshot(conn)
+
+    for name in wrong_definitions:
+        with conn.cursor() as cur:
+            with pytest.raises(PlayIndexStateError):
+                validate_play_indexes(cur, [name])
+        conn.rollback()
+    with pytest.raises(PlayIndexStateError):
+        repair_play_indexes(conn, list(wrong_definitions))
+    assert _index_snapshot(conn) == before
+    assert not any(parent == "idx_plays_score_diff" for parent, *_ in _attached_child_indexes(conn))
+
+
+def test_expected_name_on_unsupported_table_fails_before_index_mutation(warehouse_db):
+    conn, _ = warehouse_db
+    _create_partitioned_plays(conn)
+    _execute(
+        conn,
+        "CREATE TABLE core.unrelated(id bigint); "
+        "CREATE INDEX idx_plays_game_id ON core.unrelated(id)",
+    )
+    before = _index_snapshot(conn)
+
+    with pytest.raises(PlayIndexStateError, match="unrelated|owner|target"):
+        repair_play_indexes(conn, ["idx_plays_game_id"])
+
+    assert _index_snapshot(conn) == before
+    assert _index_targets(conn, ["idx_plays_game_id"]) == {"idx_plays_game_id": "unrelated"}
+
+
+def test_retained_index_rename_collision_fails_before_any_rename(warehouse_db):
+    conn, _ = warehouse_db
+    _create_historical_swap(conn)
+    _execute(conn, "CREATE INDEX plays_old_idx_plays_game_id ON core.plays_old(period)")
+    before = _index_snapshot(conn)
+
+    with pytest.raises(PlayIndexStateError, match="plays_old_idx_plays_game_id"):
+        repair_play_indexes(conn, ["idx_plays_game_id"])
+
+    assert _index_snapshot(conn) == before
+    assert _index_targets(conn, ["idx_plays_game_id"]) == {"idx_plays_game_id": "plays_old"}
+
+
+def test_equivalent_live_parent_index_blocks_duplicate_repair(warehouse_db):
+    conn, _ = warehouse_db
+    _create_historical_swap(conn)
+    _execute(conn, "CREATE INDEX equivalent_game_id ON core.plays(game_id)")
+    before = _index_snapshot(conn)
+
+    with pytest.raises(PlayIndexStateError, match="equivalent|duplicate"):
+        repair_play_indexes(conn, ["idx_plays_game_id"])
+
+    assert _index_snapshot(conn) == before
+    assert _index_targets(conn, ["idx_plays_game_id"]) == {"idx_plays_game_id": "plays_old"}
+
+
+def test_injected_build_failure_rolls_back_old_index_rename(warehouse_db):
+    conn, _ = warehouse_db
+    _create_historical_swap(conn)
+    before = _index_snapshot(conn)
+
+    class FailingCursor:
+        def __init__(self, wrapped):
+            self.wrapped = wrapped
+
+        def execute(self, statement, values=None):
+            rendered = str(statement)
+            if "CREATE" in rendered and "INDEX" in rendered:
+                raise RuntimeError("injected index build failure")
+            return self.wrapped.execute(statement, values)
+
+        def __getattr__(self, name):
+            return getattr(self.wrapped, name)
+
+    class FailingConnection:
+        autocommit = False
+
+        def __init__(self, wrapped):
+            self.wrapped = wrapped
+
+        def cursor(self):
+            return FailingCursor(self.wrapped.cursor())
+
+        def __getattr__(self, name):
+            return getattr(self.wrapped, name)
+
+    with pytest.raises(RuntimeError, match="injected index build failure"):
+        repair_play_indexes(FailingConnection(conn), ["idx_plays_game_id"])
+
+    assert _index_snapshot(conn) == before
+    assert _index_targets(conn, ["idx_plays_game_id"]) == {"idx_plays_game_id": "plays_old"}
+
+
+def test_index_name_swap_after_preflight_cannot_rename_the_wrong_index(warehouse_db):
+    conn, target = warehouse_db
+    _create_historical_swap(conn)
+    _execute(
+        conn,
+        "CREATE TABLE core.unrelated(id bigint); CREATE INDEX race_unrelated ON core.unrelated(id)",
+    )
+    identities = dict(
+        _execute(
+            conn,
+            """
+            SELECT index_class.relname, index_class.oid
+            FROM pg_catalog.pg_class index_class
+            WHERE index_class.relnamespace = 'core'::regnamespace
+              AND index_class.relname IN ('idx_plays_game_id', 'race_unrelated')
+            """,
+        )
+    )
+    contender = psycopg2.connect(target, options="-c lock_timeout=2s")
+
+    class RacingCursor:
+        def __init__(self, wrapped):
+            self.wrapped = wrapped
+            self.raced = False
+
+        def execute(self, statement, values=None):
+            rendered = str(statement)
+            if not self.raced and "ALTER INDEX" in rendered:
+                self.raced = True
+                with contender.cursor() as race_cur:
+                    race_cur.execute(
+                        "ALTER INDEX core.idx_plays_game_id RENAME TO raced_old_game_id"
+                    )
+                    race_cur.execute("ALTER INDEX core.race_unrelated RENAME TO idx_plays_game_id")
+                contender.commit()
+            return self.wrapped.execute(statement, values)
+
+        def __getattr__(self, name):
+            return getattr(self.wrapped, name)
+
+    class RacingConnection:
+        autocommit = False
+
+        def __init__(self, wrapped):
+            self.wrapped = wrapped
+            self.cursor_instance = None
+
+        def cursor(self):
+            self.cursor_instance = RacingCursor(self.wrapped.cursor())
+            return self.cursor_instance
+
+        def __getattr__(self, name):
+            return getattr(self.wrapped, name)
+
+    racing = RacingConnection(conn)
+    try:
+        with pytest.raises(PlayIndexStateError, match="changed|identity|race"):
+            repair_play_indexes(racing, ["idx_plays_game_id"])
+        assert racing.cursor_instance.raced
+    finally:
+        contender.close()
+
+    after = dict(
+        _execute(
+            conn,
+            """
+            SELECT index_class.relname, index_class.oid
+            FROM pg_catalog.pg_class index_class
+            WHERE index_class.relnamespace = 'core'::regnamespace
+              AND index_class.relname IN (
+                  'idx_plays_game_id', 'raced_old_game_id',
+                  'plays_old_idx_plays_game_id'
+              )
+            """,
+        )
+    )
+    assert after == {
+        "idx_plays_game_id": identities["race_unrelated"],
+        "raced_old_game_id": identities["idx_plays_game_id"],
+    }
+    assert _index_targets(conn, ["idx_plays_game_id", "raced_old_game_id"]) == {
+        "idx_plays_game_id": "unrelated",
+        "raced_old_game_id": "plays_old",
+    }
+
+
+def test_duplicate_unique_keys_roll_back_rename_and_leave_data_intact(warehouse_db):
+    conn, _ = warehouse_db
+    _create_partitioned_plays(conn)
+    _execute(
+        conn,
+        """
+        CREATE TABLE core.plays_old (LIKE core.plays);
+        INSERT INTO core.plays_old VALUES
+            ('old', 2025, 1, 'Alpha', 'Beta', 'Rush', 7, 1, 14, 7);
+        CREATE UNIQUE INDEX plays_dlt_id_unique
+            ON core.plays_old(_dlt_id, season);
+        INSERT INTO core.plays VALUES
+            ('duplicate', 2026, 3, 'One', 'Two', 'Rush', 0, 1, 7, 7),
+            ('duplicate', 2026, 4, 'Three', 'Four', 'Pass', 0, 2, 7, 7)
+        """,
+    )
+    before = _index_snapshot(conn)
+
+    with pytest.raises(
+        psycopg2.errors.UniqueViolation,
+        match="could not create unique index|duplicated|duplicate key",
+    ):
+        repair_play_indexes(conn, ["plays_dlt_id_unique"])
+
+    assert _index_snapshot(conn) == before
+    assert _index_targets(conn, ["plays_dlt_id_unique"]) == {"plays_dlt_id_unique": "plays_old"}
+    assert _execute(
+        conn,
+        "SELECT _dlt_id, season, count(*) FROM core.plays "
+        "GROUP BY _dlt_id, season HAVING count(*) > 1",
+    ) == [("duplicate", 2026, 2)]
+
+
+def test_f08_future_partition_inherits_every_repaired_index(warehouse_db):
+    conn, _ = warehouse_db
+    _create_historical_swap(conn)
+    names = list(EXPECTED_PLAY_INDEXES)
+    repair_play_indexes(conn, names)
+
+    plan = ensure_play_partitions(conn, [2027], create=True, calendar_year=2026)
+
+    assert plan.created_years == (2027,)
+    coverage = _attached_child_indexes(conn, child_name="plays_y2027")
+    assert len(coverage) == len(names)
+    assert {parent for parent, _, _, _ in coverage} == set(names)
+    assert all(valid and ready for _, _, valid, ready in coverage)

--- a/tests/test_plays_preflight.py
+++ b/tests/test_plays_preflight.py
@@ -1,27 +1,34 @@
 """Loader and post-load verification must use the catalog before claiming success."""
 
 from types import SimpleNamespace
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
 from scripts.verify_load import Report, check_partition
 from src.pipelines import run
 from src.pipelines.utils.partitions import PartitionStateError
+from src.pipelines.utils.play_indexes import PlayIndexStateError
 
 
-@pytest.mark.parametrize("fails", [False, True])
+@pytest.mark.parametrize("fails", [None, "partition", "index"])
 def test_loader_preflight_precedes_source_and_load(fails):
     events = []
-    conn = Mock()
+    conn = MagicMock()
 
     def preflight(connection, years, create):
         assert connection is conn
         assert years == [2027]
         assert create is True
         events.append("preflight")
-        if fails:
+        if fails == "partition":
             raise PartitionStateError("unattached partition")
+
+    def validate(cur, index_names):
+        assert index_names == ["plays_dlt_id_unique"]
+        events.append("index-check")
+        if fails == "index":
+            raise PlayIndexStateError("wrong index owner")
 
     def source(**kwargs):
         events.append("source")
@@ -36,16 +43,21 @@ def test_loader_preflight_precedes_source_and_load(fails):
         patch("psycopg2.connect", return_value=conn) as connect,
         patch.object(run, "_metrics_wp_db_url", side_effect=AssertionError("wrong target")),
         patch("src.pipelines.utils.partitions.ensure_play_partitions", side_effect=preflight),
+        patch("src.pipelines.utils.play_indexes.validate_play_indexes", side_effect=validate),
         patch.object(run, "plays_source", side_effect=source),
         patch.object(run.dlt, "pipeline", return_value=pipeline),
     ):
-        if fails:
+        if fails == "partition":
             with pytest.raises(PartitionStateError):
                 run.run_plays_pipeline([2027])
             assert events == ["preflight"]
+        elif fails == "index":
+            with pytest.raises(PlayIndexStateError):
+                run.run_plays_pipeline([2027])
+            assert events == ["preflight", "index-check"]
         else:
             run.run_plays_pipeline([2027])
-            assert events == ["preflight", "source", "load"]
+            assert events == ["preflight", "index-check", "source", "load"]
     connect.assert_called_once_with("pipeline-scoped-target")
     conn.close.assert_called_once()
 

--- a/tests/test_plays_preflight.py
+++ b/tests/test_plays_preflight.py
@@ -36,7 +36,8 @@ def test_loader_preflight_precedes_source_and_load(fails):
         return "source"
 
     pipeline = Mock()
-    credentials = pipeline.destination_client.return_value.config.credentials
+    pipeline.pipeline_name = "cfbd_plays"
+    credentials = pipeline.destination.configuration.return_value.credentials
     credentials.to_native_representation.return_value = "pipeline-scoped-target"
     pipeline.run.side_effect = lambda source: events.append("load")
     with (
@@ -81,3 +82,59 @@ def test_verifier_fails_invalid_partition():
     ):
         check_partition(Mock(), 2027, report)
     assert report.failures == 1
+
+
+@pytest.mark.parametrize("pipeline_scoped", [False, True])
+def test_fresh_pipeline_resolves_credentials_before_fetch(tmp_path, monkeypatch, pipeline_scoped):
+    """Exercise real dlt configuration with no stored schema or destination sync."""
+    import dlt
+    from psycopg2.extensions import parse_dsn
+
+    general = "postgresql://test_user:test_password@localhost:5432/general_target"
+    scoped = "postgresql://test_user:test_password@localhost:5432/plays_target"
+    monkeypatch.setenv("DESTINATION__POSTGRES__CREDENTIALS", general)
+    monkeypatch.delenv("CFBD_PLAYS__DESTINATION__POSTGRES__CREDENTIALS", raising=False)
+    if pipeline_scoped:
+        monkeypatch.setenv("CFBD_PLAYS__DESTINATION__POSTGRES__CREDENTIALS", scoped)
+    pipeline = dlt.pipeline(
+        pipeline_name="cfbd_plays",
+        pipelines_dir=str(tmp_path),
+        destination="postgres",
+        dataset_name="core",
+    )
+    assert pipeline.default_schema_name is None
+    assert list(pipeline.schemas) == []
+    events = []
+    conn = MagicMock()
+
+    def preflight(connection, years, create):
+        assert connection is conn
+        events.append("partition")
+
+    def validate(cur, names):
+        assert names == ["plays_dlt_id_unique"]
+        events.append("index")
+
+    def source(**kwargs):
+        events.append("fetch")
+        return "source"
+
+    try:
+        with (
+            patch.object(run.dlt, "pipeline", return_value=pipeline),
+            patch("psycopg2.connect", return_value=conn) as connect,
+            patch("src.pipelines.utils.partitions.ensure_play_partitions", side_effect=preflight),
+            patch("src.pipelines.utils.play_indexes.validate_play_indexes", side_effect=validate),
+            patch.object(run, "plays_source", side_effect=source),
+            patch.object(pipeline, "run", side_effect=lambda _: events.append("load")),
+        ):
+            run.run_plays_pipeline([2027])
+        assert events == ["partition", "index", "fetch", "load"]
+        assert parse_dsn(connect.call_args.args[0])["dbname"] == (
+            "plays_target" if pipeline_scoped else "general_target"
+        )
+        assert pipeline.default_schema_name is None
+        assert list(pipeline.schemas) == []
+        conn.close.assert_called_once()
+    finally:
+        pipeline.deactivate()


### PR DESCRIPTION
The historical plays table swap can leave an index name on `core.plays_old`, causing `CREATE INDEX IF NOT EXISTS` to skip the new parent. Add a catalog audit that verifies the indexed relation, exact structure, validity/readiness, and complete child-index coverage; stop plays fetching if the dlt identity index family is unhealthy.

**F09 architecture — PR Lens**

![F09 architecture: identity validation gates ingestion; separate CLI audits and repairs selected indexes](https://github.com/user-attachments/assets/b8d2f59d-5094-4c67-b503-a6f12c7ef29b)

The new load gate checks only `plays_dlt_id_unique`; the maintenance audit covers all nine baseline families. F08 partition preparation and CFBD/dlt behavior remain unchanged.

**Explicit repair transaction — PR Lens**

![F09 repair flow: explicit selection, locks, catalog validation, conditional rename, rebuild, validation and commit or rollback](https://github.com/user-attachments/assets/e14d90b5-5af1-421d-80e4-b2718d53b192)

This maintenance flow applies only to selected safe repairs: a missing expected index or an exact valid index retained on the verified `plays_old` heap. Healthy selections are no-ops; failures roll back the batch. Production inspection found all nine families healthy, so no production DDL was applied.

Read-only production inspection found no active ownership defect: `plays_old` is absent and all nine captured index families cover the correct 23 partitions. No production repair was applied. [Investigation and executed query evidence](docs/plans/2026-09-08-f09-plays-index-ownership.md) distinguish the reviewed baseline from obsolete historical index names and record the remaining performance limits.

For affected warehouses, `maintain_play_indexes.py` audits an explicit database target by default. `--apply` requires an explicit index selection and runs an atomic maintenance transaction that preserves old rows, renames recognized old-table indexes, and creates missing selected index families. It rejects ambiguous definitions, incomplete trees, duplicate equivalent parents, rename collisions, and concurrent identity changes. Parent builds block writes during an authorized maintenance window; ordinary ingestion never rebuilds indexes.

Validation: 532 focused unit/loader/source tests and ten PostgreSQL 17 scenarios passed (542 total), including the historical four-index collision, repeated no-op, caller access, uniqueness, future-partition inheritance, rollback, a real two-connection rename race, and builtin predicate identity under a shadowed search path. Ruff, formatting, whitespace, and agent setup checks passed. Independent review findings were resolved. CI includes the SQL suite.

The new CLI was not executed against production because no local warehouse DSN is available; production catalog/EXPLAIN evidence was collected through the connected database tool. Live CFBD/dlt loading and per-index production write overhead remain unverified. This PR does not claim that all retained baseline indexes are optimal or authorize dropping old storage.




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This update ensures the plays loader resolves its configured PostgreSQL destination before checking required partitions and identity-index coverage. It also adds coverage for fresh installations using either general or plays-specific destination credentials.

<h3>Confidence Score: 5/5</h3>

Safe to merge; no blocking issues remain.

No accepted new findings or outstanding previous findings require changes.

<sub>Reviews (2): Last reviewed commit: ["Resolve plays preflight credentials in p..."](https://github.com/rstover-fo/cfb-database/commit/b2e17fa1dcd5b49bb70f4b5e9e80d83e15da818a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61621699)</sub>

**Context used:**

- Knowledge Base — [College football data ingestion](https://app.greptile.com/formentera-operations/-/custom-context/knowledge-base/rstover-fo/cfb-database/-/docs/data-ingestion.md)

<!-- /greptile_comment -->