### PR TITLE
Fix F10 workflow refresh dependencies

### DIFF
--- a/.github/workflows/backfill-sources.yml
+++ b/.github/workflows/backfill-sources.yml
@@ -14,11 +14,12 @@ name: Backfill Sources
 # below, which shells out to load_season.py and validates sources against
 # that same SOURCE_ORDER. Dispatching with `runner: pipeline_run` bypasses
 # that validation on purpose and calls src/pipelines/run.py directly for a
-# single `--source` once, with no per-season loop -- and, because that path
-# skips the trailing mart refresh, its `sources` input is restricted by an
-# in-step allowlist to exactly coach_tenures and metrics_ppa_predicted;
-# anything in load_season's SOURCE_ORDER (ratings, recruiting, stats, wepa,
-# ...) must go through the default runner so its mart refresh still runs.
+# single `--source` once, with no per-season loop. Its `sources` input is
+# restricted by an in-step allowlist to exactly coach_tenures and
+# metrics_ppa_predicted: coach_tenures refreshes its dependent mart after a
+# successful load, while metrics_ppa_predicted has no affected mart. Anything
+# in load_season's SOURCE_ORDER (ratings, recruiting, stats, wepa, ...) must go
+# through the default runner so its full trailing mart refresh still runs.
 #
 # Requires repo secrets:
 #   CFBD_API_KEY    - collegefootballdata.com API key
@@ -40,7 +41,7 @@ on:
         required: true
         type: string
       runner:
-        description: "load_season: per-season loop via scripts/load_season.py (default). pipeline_run: single src.pipelines.run --source call, allowlisted to run.py-only sources not in load_season's SOURCE_ORDER (coach_tenures, metrics_ppa_predicted) -- any other source is rejected since this path skips the mart refresh."
+        description: "load_season: per-season loop via scripts/load_season.py (default). pipeline_run: single src.pipelines.run --source call, allowlisted to run.py-only sources not in load_season's SOURCE_ORDER (coach_tenures, metrics_ppa_predicted); coach_tenures refreshes its mart, while metrics_ppa_predicted has no affected mart."
         required: false
         type: choice
         default: load_season
@@ -135,13 +136,12 @@ jobs:
           # has a correct dispatch path through the default runner (loops
           # seasons, refreshes marts at the end); letting one of those
           # sources through here would load data and leave its dependent
-          # matviews silently stale, since this path skips the refresh
-          # step unconditionally. Only coach_tenures and
-          # metrics_ppa_predicted are run.py-only with no SOURCE_ORDER
-          # slot -- and neither feeds any mart, which is what makes
-          # skipping the refresh on this path safe, as long as this
-          # allowlist holds. A future run.py-only source gets added here
-          # deliberately, not implicitly.
+          # matviews silently stale. Only coach_tenures and
+          # metrics_ppa_predicted are run.py-only with no SOURCE_ORDER slot;
+          # coach_tenures gets its targeted refresh below, and
+          # metrics_ppa_predicted has no affected mart. A future run.py-only
+          # source gets added here deliberately, with its refresh contract,
+          # not implicitly.
           case "$SOURCES_INPUT" in
             coach_tenures|metrics_ppa_predicted) ;;
             *)
@@ -162,9 +162,14 @@ jobs:
           else
             python -m src.pipelines.run --source "$SOURCES_INPUT"
           fi
+          # Keep the refresh in this same fail-fast step: a failed pipeline
+          # command exits before the mart can publish a mixed generation.
+          if [ "$SOURCES_INPUT" = "coach_tenures" ]; then
+            python scripts/refresh_marts.py --views marts.coach_tenures
+          fi
       - name: Refresh marts
-        # Neither run.py-only source (coach_tenures, metrics_ppa_predicted)
-        # feeds any mart, so skip the refresh entirely on that path rather
-        # than pay for a no-op refresh.
+        # The default load_season path may affect any mart, so retain its full
+        # refresh. The allowlisted pipeline_run path handles its only affected
+        # mart (marts.coach_tenures) directly after that source succeeds.
         if: ${{ inputs.runner != 'pipeline_run' }}
         run: python scripts/refresh_marts.py

--- a/.github/workflows/daily-load.yml
+++ b/.github/workflows/daily-load.yml
@@ -48,7 +48,7 @@ env:
 
 jobs:
   load:
-    name: Load season, refresh marts, verify
+    name: Load season and refresh marts
     runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:
@@ -116,10 +116,59 @@ jobs:
       - name: Backtest season projections
         run: python scripts/backtest_preseason.py
       - name: Refresh Tier 2 + Tier 3 marts
-        run: python scripts/refresh_marts.py --views marts.house_elo,marts.house_elo_game,marts.team_adjusted_epa,marts.scored_matchup_edges,marts.prediction_accuracy,marts.team_week_features,marts.adjusted_epa_week
+        run: python scripts/refresh_marts.py --views marts.house_elo,marts.house_elo_game,marts.team_adjusted_epa,marts.epa_crossvalidation,marts.scored_matchup_edges,marts.prediction_accuracy,marts.team_week_features,marts.adjusted_epa_week
+      - name: Open or update failure issue
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = "Daily season load failing";
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const { data } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+            });
+            const existing = data.find((i) => i.title === title);
+            const body = `Run failed: ${runUrl} (${new Date().toISOString()})`;
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+              });
+            }
+
+  flat_files:
+    name: Load flat-file sources
+    needs: load
+    uses: ./.github/workflows/flat-files.yml
+    secrets: inherit
+
+  verify:
+    name: Verify daily load
+    needs: flat_files
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+      - run: pip install -e ".[compute]"
       - name: Verify load
-        # Hardening (PR #75 review finding C): see the "Load season data"
-        # step above for the env-indirection rationale.
+        # Hardening (PR #75 review finding C): route the workflow_dispatch
+        # input through a step-level env var instead of interpolating it into
+        # the shell command directly.
         env:
           SEASON_INPUT: ${{ inputs.season }}
         run: |
@@ -160,7 +209,7 @@ jobs:
 
   recaps:
     name: Generate nightly game recaps
-    needs: load
+    needs: verify
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:

--- a/.github/workflows/daily-load.yml
+++ b/.github/workflows/daily-load.yml
@@ -151,7 +151,8 @@ jobs:
     name: Load flat-file sources
     needs: load
     uses: ./.github/workflows/flat-files.yml
-    secrets: inherit
+    secrets:
+      SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
 
   verify:
     name: Verify daily load

--- a/.github/workflows/flat-files.yml
+++ b/.github/workflows/flat-files.yml
@@ -82,6 +82,7 @@ jobs:
         # dlt requires the postgres:// scheme (see .dlt/secrets.toml.example)
         run: echo "DESTINATION__POSTGRES__CREDENTIALS=$(printf '%s' "$SUPABASE_DB_URL" | sed 's/^postgresql:/postgres:/')" >> "$GITHUB_ENV"
       - name: Load flat-file sources
+        id: load_flat_files
         # Hardening (PR #75 review finding C): route the workflow_dispatch
         # `source` input through a step-level env: var (probe-endpoints.yml's
         # pattern) instead of interpolating ${{ inputs.source }} directly
@@ -117,8 +118,11 @@ jobs:
             python scripts/load_flat_files.py --due
           fi
       - name: Refresh external-rating consumers
-        # Also run after hash-skips or an empty due plan: a previous run may
-        # have committed the imports and then failed its refresh.
+        # A failed multi-source load may still have committed new ratings.
+        # Refresh those rows, but preserve the failed load/job status. Skip
+        # cancellation and setup failures where the import step never ran.
+        if: ${{ !cancelled() && (steps.load_flat_files.outcome == 'success' || steps.load_flat_files.outcome == 'failure') }}
+        # Also retry after hash-skips or an empty due plan.
         run: python scripts/refresh_marts.py --views marts.epa_crossvalidation
       - name: Open or update failure issue
         if: failure()

--- a/.github/workflows/flat-files.yml
+++ b/.github/workflows/flat-files.yml
@@ -8,11 +8,24 @@ name: Flat File Load
 #   SUPABASE_DB_URL   - Supabase SESSION pooler URL (IPv4)
 #
 # Flat-file freshness verification is handled by scripts/verify_load.py inside the
-# existing daily-load workflow; this workflow does not run verify_load.py.
+# existing daily-load workflow, after this reusable workflow succeeds.
 
 on:
-  schedule:
-    - cron: "0 11 * * *" # 11:00 UTC, 1 hour after daily-load completes
+  workflow_call:
+    inputs:
+      source:
+        description: "Registry source names, space-separated; empty runs --due"
+        required: false
+        type: string
+        default: ""
+      seasons:
+        description: "Season years, space-separated; empty uses the current loader target"
+        required: false
+        type: string
+        default: ""
+    secrets:
+      SUPABASE_DB_URL:
+        required: true
   workflow_dispatch:
     inputs:
       source:
@@ -103,6 +116,10 @@ jobs:
           else
             python scripts/load_flat_files.py --due
           fi
+      - name: Refresh external-rating consumers
+        # Also run after hash-skips or an empty due plan: a previous run may
+        # have committed the imports and then failed its refresh.
+        run: python scripts/refresh_marts.py --views marts.epa_crossvalidation
       - name: Open or update failure issue
         if: failure()
         uses: actions/github-script@v7

--- a/docs/plans/2026-09-04-main-codebase-audit.md
+++ b/docs/plans/2026-09-04-main-codebase-audit.md
@@ -207,6 +207,10 @@ Evidence: [original indexes](https://github.com/rstover-fo/cfb-database/blob/4a7
 
 ### F10 — Workflow dependencies drift even though the full mart order is valid
 
+Immediate correction plan: [F10 workflow dependencies](2026-09-08-f10-workflow-dependencies.md).
+The missing refreshes and workflow completion ordering are addressed there; the
+broader shared dependency planner remains in the F10/F28 orchestration work.
+
 **P1 · Confirmed · L**
 
 Daily loading refreshes the full mart set before computing new model inputs, then refreshes a manually selected subset. That subset omits epa_crossvalidation, which depends on newly computed team-adjusted EPA. Flat-file loading runs on a separate time-based schedule with no completion dependency or downstream refresh, so external-rating consumers can lag. The coach-tenure backfill path explicitly skips refresh because its comment says it feeds no mart, while the new coach_tenures mart reads that table.

--- a/docs/plans/2026-09-08-f10-workflow-dependencies.md
+++ b/docs/plans/2026-09-08-f10-workflow-dependencies.md
@@ -1,0 +1,64 @@
+# F10 immediate workflow dependency corrections
+
+## Scope
+
+This change addresses the three concrete refresh gaps in F10. It does not claim
+completion of the broader source-to-API dependency planner shared with F28, or
+F11's generation tracking and descendant failure propagation inside the Python
+refresher. No SQL definitions or grants change.
+
+## Dependency paths
+
+| Successful producer | Required consumer refresh |
+|---|---|
+| Daily adjusted-EPA recompute | `marts.team_adjusted_epa`, then `marts.epa_crossvalidation` |
+| `sdv_fpi_weekly` / `ratings.espn_fpi_weekly` | `marts.epa_crossvalidation` |
+| `sdv_ratings_weekly` / `ratings.sdv_ratings_weekly` | `marts.epa_crossvalidation` |
+| `coach_tenures` / `ref.coach_tenures` | `marts.coach_tenures` |
+
+The crossvalidation definition also reads `marts.team_epa_season`, refreshed by
+the daily full refresh before the compute chain. Massey ratings currently have
+no SQL mart consumer; their freshness is checked by `verify_load.py`.
+`metrics_ppa_predicted` has no materialized-view consumer and retains its
+explicit pipeline-only dispatch path.
+
+## Workflow behavior
+
+Daily automation runs load/compute and its final selected refresh, then calls
+the reusable flat-file workflow, then verifies the combined result. Recaps wait
+for verification. GitHub job dependencies replace the independent 11:00 UTC
+flat-file schedule; delayed or failed upstream work cannot be bypassed by the
+verification job. The existing 10:00 UTC daily trigger remains.
+
+The flat-file workflow retains manual `source` and `seasons` inputs and its
+separate `flat-file-load` concurrency group. Reusing the caller's
+`daily-season-load` group would deadlock the nested call. After a successful
+import step it refreshes crossvalidation, including when the loader reports an
+empty due plan, hash-skips, or expected no-data. This is deliberate: imported
+rows may already be committed when a prior refresh fails. Retrying must refresh
+consumers even if the next import has no new bytes. An import or refresh failure
+fails the reusable job. The daily job retains its own concurrency group for the
+entire chain; this is not a warehouse-wide lock across arbitrary CLI callers.
+
+Coach-tenure backfills refresh their mart only after the pipeline command
+succeeds. The normal season-loop path still refreshes all marts after all
+selected seasons succeed. Neither provider selection nor source merge behavior
+changes.
+
+## Verification and limits
+
+Workflow shell tests use the actual YAML commands with a stubbed Python command
+to exercise source/season arguments, refresh ordering, and failure exit codes.
+They do not invoke providers, database refreshes, or the GitHub scheduler.
+Reusable-workflow wiring is checked against GitHub's
+[documented workflow-call contract](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows).
+
+Local validation: **162 tests passed** across the two F10 workflow suites and
+the existing season-loader and flat-file suites. Ruff lint/format and
+`git diff --check` passed. Actionlint 1.7.12 validated all three changed workflows.
+Independent review found no actionable issues.
+
+This PR does not dispatch warehouse workflows or apply production changes.
+Successful production refresh and scheduler execution remain post-merge
+verification. The full mart list and refresh engine are unchanged; existing
+within-job partial refresh/generation risks remain F11 work.

--- a/docs/plans/2026-09-08-f10-workflow-dependencies.md
+++ b/docs/plans/2026-09-08-f10-workflow-dependencies.md
@@ -32,13 +32,16 @@ verification job. The existing 10:00 UTC daily trigger remains.
 
 The flat-file workflow retains manual `source` and `seasons` inputs and its
 separate `flat-file-load` concurrency group. Reusing the caller's
-`daily-season-load` group would deadlock the nested call. After a successful
-import step it refreshes crossvalidation, including when the loader reports an
-empty due plan, hash-skips, or expected no-data. This is deliberate: imported
+`daily-season-load` group would deadlock the nested call. After a completed
+import step (success or failure) it refreshes crossvalidation, including when
+the loader reports an empty due plan, hash-skips, or expected no-data. This is deliberate: imported
 rows may already be committed when a prior refresh fails. Retrying must refresh
 consumers even if the next import has no new bytes. An import or refresh failure
-fails the reusable job. The daily job retains its own concurrency group for the
-entire chain; this is not a warehouse-wide lock across arbitrary CLI callers.
+fails the reusable job. Refresh is skipped on cancellation or when setup fails
+before imports run. A partially failed multi-source load can commit ratings, so
+refreshing those rows must not depend on unrelated sources succeeding. The
+reusable call receives only `SUPABASE_DB_URL`, not other caller secrets.
+The daily job retains its own concurrency group for the entire chain; this is not a warehouse-wide lock across arbitrary CLI callers.
 
 Coach-tenure backfills refresh their mart only after the pipeline command
 succeeds. The normal season-loop path still refreshes all marts after all

--- a/docs/warehouse-operations.md
+++ b/docs/warehouse-operations.md
@@ -43,6 +43,22 @@ Secrets belong in ignored config or the host's credential mechanism, never docs.
 The request budget is configured in `.dlt/config.toml`; historical estimates do
 not establish the cost of today's source/resource selection.
 
+## Workflow refresh dependencies (F10)
+
+The daily workflow runs load/compute, calls the reusable flat-file workflow,
+then verifies the combined result. Recaps wait for verification. The flat-file
+workflow remains manually dispatchable, but its former independent 11:00 UTC
+schedule is removed. A successful import step refreshes `marts.epa_crossvalidation`
+even after hash-skips or an empty due plan, allowing a failed refresh to be
+retried without reloading unchanged files.
+
+The final daily refresh includes crossvalidation after `marts.team_adjusted_epa`.
+The `pipeline_run` coach-tenure backfill refreshes `marts.coach_tenures` after
+loading; `metrics_ppa_predicted` still has no mart refresh. Direct script calls
+do not acquire these workflow dependencies automatically. See the
+[F10 plan](plans/2026-09-08-f10-workflow-dependencies.md) for scope and verification
+limits; historical schedule descriptions later in this document predate F10.
+
 ## Plays partition rollover (F08)
 
 `run_plays_pipeline()` performs catalog preflight before constructing the source

--- a/docs/warehouse-operations.md
+++ b/docs/warehouse-operations.md
@@ -48,8 +48,10 @@ not establish the cost of today's source/resource selection.
 The daily workflow runs load/compute, calls the reusable flat-file workflow,
 then verifies the combined result. Recaps wait for verification. The flat-file
 workflow remains manually dispatchable, but its former independent 11:00 UTC
-schedule is removed. A successful import step refreshes `marts.epa_crossvalidation`
-even after hash-skips or an empty due plan, allowing a failed refresh to be
+schedule is removed. A completed import step refreshes `marts.epa_crossvalidation`
+even after partial failure, while preserving the failed job status; cancellation
+and setup failures skip the refresh. Hash-skips and empty due plans also trigger
+refresh, allowing a failed refresh to be
 retried without reloading unchanged files.
 
 The final daily refresh includes crossvalidation after `marts.team_adjusted_epa`.

--- a/tests/test_f10_daily_backfill.py
+++ b/tests/test_f10_daily_backfill.py
@@ -1,0 +1,173 @@
+"""Regression coverage for the immediate F10 workflow dependencies."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+
+import yaml
+
+ROOT = pathlib.Path(__file__).parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+
+def _workflow(name: str) -> dict:
+    return yaml.safe_load((WORKFLOWS / name).read_text())
+
+
+def _step(workflow: dict, job: str, name: str) -> dict:
+    return next(step for step in workflow["jobs"][job]["steps"] if step.get("name") == name)
+
+
+def _fake_python(tmp_path: pathlib.Path) -> tuple[pathlib.Path, pathlib.Path]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    call_log = tmp_path / "python-calls.log"
+    executable = bin_dir / "python"
+    executable.write_text(
+        "#!/usr/bin/env bash\n"
+        'printf \'%s\\n\' "$*" >> "$PYTHON_CALL_LOG"\n'
+        'if [[ -n "$FAIL_PYTHON_CALL" && "$*" == *"$FAIL_PYTHON_CALL"* ]]; then\n'
+        "  exit 23\n"
+        "fi\n"
+    )
+    executable.chmod(0o755)
+    return bin_dir, call_log
+
+
+def _run_script(
+    script: str,
+    tmp_path: pathlib.Path,
+    *,
+    seasons: str = "",
+    sources: str,
+    fail_call: str = "",
+    player_overview_max: str = "",
+) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    bin_dir, call_log = _fake_python(tmp_path)
+    env = {
+        **os.environ,
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+        "PYTHON_CALL_LOG": str(call_log),
+        "FAIL_PYTHON_CALL": fail_call,
+        "SEASONS_INPUT": seasons,
+        "SOURCES_INPUT": sources,
+        "PLAYER_OVERVIEW_MAX_PER_RUN": player_overview_max,
+    }
+    result = subprocess.run(
+        ["bash", "--noprofile", "--norc", "-e", "-o", "pipefail", "-c", script],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    calls = call_log.read_text().splitlines() if call_log.exists() else []
+    return result, calls
+
+
+def test_daily_verification_waits_for_load_and_flat_files() -> None:
+    workflow = _workflow("daily-load.yml")
+
+    assert workflow["jobs"]["flat_files"] == {
+        "name": "Load flat-file sources",
+        "needs": "load",
+        "uses": "./.github/workflows/flat-files.yml",
+        "secrets": "inherit",
+    }
+    assert "needs" not in workflow["jobs"]["load"]
+    assert workflow["jobs"]["verify"]["needs"] == "flat_files"
+    assert workflow["jobs"]["recaps"]["needs"] == "verify"
+    assert _step(workflow, "verify", "Verify load")["env"] == {
+        "SEASON_INPUT": "${{ inputs.season }}"
+    }
+
+
+def test_daily_refreshes_crossvalidation_after_adjusted_epa() -> None:
+    workflow = _workflow("daily-load.yml")
+    steps = workflow["jobs"]["load"]["steps"]
+    refresh_index = next(
+        index
+        for index, step in enumerate(steps)
+        if step.get("name") == "Refresh Tier 2 + Tier 3 marts"
+    )
+    refresh = steps[refresh_index]["run"]
+    views = refresh.split("--views ", 1)[1].split(",")
+
+    assert views.index("marts.epa_crossvalidation") == views.index("marts.team_adjusted_epa") + 1
+    adjusted_epa_index = next(
+        index for index, step in enumerate(steps) if step.get("name") == "Refit adjusted EPA"
+    )
+    assert adjusted_epa_index < refresh_index
+    assert not any(step.get("name") == "Verify load" for step in steps)
+
+
+def test_coach_tenure_pipeline_refreshes_after_successful_load(tmp_path: pathlib.Path) -> None:
+    workflow = _workflow("backfill-sources.yml")
+    script = _step(workflow, "backfill", "Run pipeline source")["run"]
+
+    result, calls = _run_script(
+        script,
+        tmp_path,
+        seasons="2024 2025",
+        sources="coach_tenures",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert calls == [
+        "-m src.pipelines.run --source coach_tenures --years 2024 2025",
+        "scripts/refresh_marts.py --views marts.coach_tenures",
+    ]
+
+
+def test_failed_coach_tenure_load_blocks_refresh(tmp_path: pathlib.Path) -> None:
+    workflow = _workflow("backfill-sources.yml")
+    script = _step(workflow, "backfill", "Run pipeline source")["run"]
+
+    result, calls = _run_script(
+        script,
+        tmp_path,
+        seasons="2025",
+        sources="coach_tenures",
+        fail_call="src.pipelines.run",
+    )
+
+    assert result.returncode == 23
+    assert calls == ["-m src.pipelines.run --source coach_tenures --years 2025"]
+
+
+def test_metrics_pipeline_preserves_bare_invocation_without_refresh(
+    tmp_path: pathlib.Path,
+) -> None:
+    workflow = _workflow("backfill-sources.yml")
+    script = _step(workflow, "backfill", "Run pipeline source")["run"]
+
+    result, calls = _run_script(script, tmp_path, sources="metrics_ppa_predicted")
+
+    assert result.returncode == 0, result.stderr
+    assert calls == ["-m src.pipelines.run --source metrics_ppa_predicted"]
+
+
+def test_load_season_keeps_selected_sources_and_year_loop(tmp_path: pathlib.Path) -> None:
+    workflow = _workflow("backfill-sources.yml")
+    script = _step(workflow, "backfill", "Load seasons")["run"]
+
+    result, calls = _run_script(
+        script,
+        tmp_path,
+        seasons="2022 2023",
+        sources="ratings,stats:player_returning",
+        player_overview_max="9000",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert calls == [
+        "scripts/load_season.py --season 2022 "
+        "--sources ratings,stats:player_returning --skip-refresh",
+        "scripts/load_season.py --season 2023 "
+        "--sources ratings,stats:player_returning --skip-refresh",
+    ]
+    refresh = _step(workflow, "backfill", "Refresh marts")
+    assert refresh["if"] == "${{ inputs.runner != 'pipeline_run' }}"
+    assert refresh["run"] == "python scripts/refresh_marts.py"

--- a/tests/test_f10_daily_backfill.py
+++ b/tests/test_f10_daily_backfill.py
@@ -74,7 +74,7 @@ def test_daily_verification_waits_for_load_and_flat_files() -> None:
         "name": "Load flat-file sources",
         "needs": "load",
         "uses": "./.github/workflows/flat-files.yml",
-        "secrets": "inherit",
+        "secrets": {"SUPABASE_DB_URL": "${{ secrets.SUPABASE_DB_URL }}"},
     }
     assert "needs" not in workflow["jobs"]["load"]
     assert workflow["jobs"]["verify"]["needs"] == "flat_files"

--- a/tests/test_f10_flat_file_workflow.py
+++ b/tests/test_f10_flat_file_workflow.py
@@ -62,7 +62,8 @@ def test_workflow_propagates_failures(tmp_path, failed_script):
     assert result == 17
     if failed_script == "scripts/load_flat_files.py":
         assert calls == [
-            ["scripts/load_flat_files.py", "--source", "sdv_fpi_weekly", "--season", "2024"]
+            ["scripts/load_flat_files.py", "--source", "sdv_fpi_weekly", "--season", "2024"],
+            ["scripts/refresh_marts.py", "--views", "marts.epa_crossvalidation"],
         ]
     else:
         assert len(calls) == 3
@@ -70,7 +71,7 @@ def test_workflow_propagates_failures(tmp_path, failed_script):
 
 
 def run_steps(tmp_path, sources, seasons, failed_script=""):
-    """Run the actual success-path shell steps with a logging command stub."""
+    """Run completed import and refresh commands while preserving failed status."""
     calls_path = tmp_path / "calls.jsonl"
     fake_python = tmp_path / "python"
     fake_python.write_text(
@@ -91,9 +92,15 @@ def run_steps(tmp_path, sources, seasons, failed_script=""):
         "Load flat-file sources",
         "Refresh external-rating consumers",
     ]
-    # GitHub's implicit success() must guard both, so a failed import cannot
-    # refresh its consumers or make the reusable job report success.
-    assert all("if" not in step and not step.get("continue-on-error") for step in selected)
+    assert selected[0]["id"] == "load_flat_files"
+    assert "if" not in selected[0]
+    assert selected[1]["if"] == (
+        "${{ !cancelled() && (steps.load_flat_files.outcome == 'success' "
+        "|| steps.load_flat_files.outcome == 'failure') }}"
+    )
+    # Refresh can recover committed rows after a partial import failure, but
+    # neither step may mask a failure from the reusable job's caller.
+    assert all(not step.get("continue-on-error") for step in selected)
     env = {
         **os.environ,
         "PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}",
@@ -111,7 +118,7 @@ def run_steps(tmp_path, sources, seasons, failed_script=""):
             text=True,
             check=False,
         )
-        status = result.returncode
-        if status:
-            break
+        # Both success and failure outcomes of the completed import step
+        # satisfy the refresh condition; retain the first failing exit code.
+        status = status or result.returncode
     return status, [json.loads(line) for line in calls_path.read_text().splitlines()]

--- a/tests/test_f10_flat_file_workflow.py
+++ b/tests/test_f10_flat_file_workflow.py
@@ -1,0 +1,117 @@
+"""Exercise flat-file workflow commands without provider or database access."""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOW = Path(__file__).resolve().parents[1] / ".github/workflows/flat-files.yml"
+
+
+def workflow():
+    return yaml.safe_load(WORKFLOW.read_text())
+
+
+def test_flat_file_workflow_is_reusable_and_keeps_manual_backfills():
+    triggers = workflow()[True]  # PyYAML's YAML 1.1 spelling of `on`.
+    assert "schedule" not in triggers
+    assert set(triggers) == {"workflow_call", "workflow_dispatch"}
+    for name in ("source", "seasons"):
+        assert triggers["workflow_call"]["inputs"][name]["type"] == "string"
+        assert triggers["workflow_call"]["inputs"][name]["default"] == ""
+        assert triggers["workflow_dispatch"]["inputs"][name]["required"] is False
+    assert triggers["workflow_call"]["secrets"]["SUPABASE_DB_URL"]["required"] is True
+    # The caller owns daily-season-load for its entire run; reusing that group
+    # here would make the called workflow wait for its own parent to finish.
+    assert workflow()["concurrency"]["group"] == "flat-file-load"
+
+
+@pytest.mark.parametrize(
+    "sources,seasons,expected",
+    [
+        ("", "", [["--due"]]),
+        ("sdv_fpi_weekly", "", [["--source", "sdv_fpi_weekly"]]),
+        ("", "2024 2025", [["--due", "--season", "2024"], ["--due", "--season", "2025"]]),
+        (
+            "sdv_fpi_weekly sdv_ratings_weekly",
+            "2024 2025",
+            [
+                ["--source", "sdv_fpi_weekly", "--source", "sdv_ratings_weekly", "--season", year]
+                for year in ("2024", "2025")
+            ],
+        ),
+    ],
+)
+def test_imports_finish_before_refresh(tmp_path, sources, seasons, expected):
+    result, calls = run_steps(tmp_path, sources, seasons)
+    assert result == 0
+    assert calls == [["scripts/load_flat_files.py", *args] for args in expected] + [
+        ["scripts/refresh_marts.py", "--views", "marts.epa_crossvalidation"]
+    ]
+
+
+@pytest.mark.parametrize(
+    "failed_script", ["scripts/load_flat_files.py", "scripts/refresh_marts.py"]
+)
+def test_workflow_propagates_failures(tmp_path, failed_script):
+    result, calls = run_steps(tmp_path, "sdv_fpi_weekly", "2024 2025", failed_script)
+    assert result == 17
+    if failed_script == "scripts/load_flat_files.py":
+        assert calls == [
+            ["scripts/load_flat_files.py", "--source", "sdv_fpi_weekly", "--season", "2024"]
+        ]
+    else:
+        assert len(calls) == 3
+        assert calls[-1][0] == "scripts/refresh_marts.py"
+
+
+def run_steps(tmp_path, sources, seasons, failed_script=""):
+    """Run the actual success-path shell steps with a logging command stub."""
+    calls_path = tmp_path / "calls.jsonl"
+    fake_python = tmp_path / "python"
+    fake_python.write_text(
+        f"#!{sys.executable}\n"
+        "import json, os, sys\n"
+        "with open(os.environ['TEST_CALLS'], 'a') as log:\n"
+        "    log.write(json.dumps(sys.argv[1:]) + '\\n')\n"
+        "sys.exit(17 if sys.argv[1] == os.environ.get('TEST_FAIL_SCRIPT') else 0)\n"
+    )
+    fake_python.chmod(0o755)
+    steps = workflow()["jobs"]["load"]["steps"]
+    selected = [
+        step
+        for step in steps
+        if step.get("name") in {"Load flat-file sources", "Refresh external-rating consumers"}
+    ]
+    assert [step["name"] for step in selected] == [
+        "Load flat-file sources",
+        "Refresh external-rating consumers",
+    ]
+    # GitHub's implicit success() must guard both, so a failed import cannot
+    # refresh its consumers or make the reusable job report success.
+    assert all("if" not in step and not step.get("continue-on-error") for step in selected)
+    env = {
+        **os.environ,
+        "PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}",
+        "SOURCE_INPUT": sources,
+        "SEASONS_INPUT": seasons,
+        "TEST_CALLS": str(calls_path),
+        "TEST_FAIL_SCRIPT": failed_script,
+    }
+    status = 0
+    for step in selected:
+        result = subprocess.run(
+            ["bash", "--noprofile", "--norc", "-eo", "pipefail", "-c", step["run"]],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        status = result.returncode
+        if status:
+            break
+    return status, [json.loads(line) for line in calls_path.read_text().splitlines()]


### PR DESCRIPTION
Warehouse workflows could finish with stale EPA crossvalidation or coach-tenure marts, and the separate flat-file cron provided no completion guarantee. Add the missing refreshes and make daily verification wait for successful load/compute and flat-file imports.

**F10 workflow dependencies — PR Lens**

![F10 architecture: load and compute lead to flat-file imports, verification and recaps; added EPA and coach-tenure refreshes](https://github.com/user-attachments/assets/44cc742c-b54a-4636-86d6-24f741329d4e)

**Daily sequence — PR Lens**

![F10 daily sequence: successful producer jobs gate verification and recaps, with EPA crossvalidation refreshed after compute and after imports](https://github.com/user-attachments/assets/53ddc3af-f5f7-4265-96df-ead6d4688965)

Flat-file refresh runs after any completed import step, including partial failures, hash-skips and empty due plans. Failed imports still fail the job and block verification; cancellation and setup failures skip refresh.

- Sequence daily jobs as `load → flat_files → verify → recaps`. Reuse the flat-file workflow after compute, retaining its manual source/season inputs and separate concurrency group while removing the independent 11:00 UTC cron.
- Refresh `marts.epa_crossvalidation` after adjusted EPA and after completed flat-file imports, including partial failure. Preserve the failed job status while refreshing committed ratings; hash-skips and empty due plans also retry refresh.
- Refresh `marts.coach_tenures` after its successful pipeline backfill. Preserve the metrics-only path and the ordinary season backfill's full refresh.

Validation: 162 tests passed across the new workflow-command tests and existing season-loader/flat-file suites. Tests execute the YAML shell commands with a fake Python command to check ordering, arguments and failure propagation. Actionlint 1.7.12, Ruff lint/format, and whitespace checks passed. Independent review found no actionable issues. Review follow-ups passed all 13 workflow tests and actionlint: partial imports now refresh committed ratings without masking failure, and the reusable call passes only `SUPABASE_DB_URL`.

These are F10's immediate corrections. The shared dependency planner (F10/F28) and F11 generation/failure semantics remain separate work. No production workflows were dispatched or database changes applied; live scheduler and refresh verification remain post-merge. Details: [F10 scope and evidence](https://github.com/rstover-fo/cfb-database/blob/codex/f10-workflow-dependencies/docs/plans/2026-09-08-f10-workflow-dependencies.md).






<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61656839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/formentera-operations/-/pull-requests/rstover-fo/cfb-database/134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge.

<details><summary><h3>Summary</h3></summary>

- This update sequences the daily warehouse workflow so downstream flat-file imports, verification, and recap generation wait for their required producer jobs. It also limits the reusable flat-file workflow to the database secret it declares and uses.
</details>

<!-- /greptile_comment -->