### PR TITLE
Fix F18 flat-file retry delays and terminal errors

### DIFF
--- a/docs/plans/2026-09-08-f18-flat-file-retries.md
+++ b/docs/plans/2026-09-08-f18-flat-file-retries.md
@@ -1,0 +1,34 @@
+# F18 flat-file retry hardening
+
+## Problem
+
+The flat-file HTTP fetcher converted `Retry-After` directly with `int()`, so
+valid HTTP-dates and malformed values escaped from the rate-limit handler. It
+also accepted arbitrarily large delays and slept after the final 429 before
+raising an unrelated `RuntimeError`. This made a remote header capable of
+parking the job and discarded the terminal HTTP response needed for diagnosis.
+
+## Implementation
+
+- Put RFC 9110 `Retry-After` parsing in a provider-neutral utility shared by
+  the flat-file fetcher and `CFBDClient`.
+- Accept integer seconds and HTTP-dates, treat past dates as zero, use the
+  configured default for missing, malformed, and negative values, and cap all
+  outcomes at 120 seconds.
+- Keep the flat-file fetcher's existing three-retry budget and 1/2/3-second
+  transient backoff. Its default maximum 429 wait is therefore 360 seconds.
+- Check the flat-file attempt budget before parsing or sleeping, then re-raise
+  the terminal `httpx.HTTPStatusError` with its response intact.
+- Keep CFBD's separate rate-limit and transient retry budgets, circuit breaker,
+  exception types, and public compatibility methods unchanged.
+
+## Verification
+
+Unit tests use `httpx.MockTransport` and a fake clock to cover successful and
+terminal retries without network access or real sleeping. Cases include
+numeric, HTTP-date, past, negative, malformed, and excessive headers; terminal
+429 error preservation; the 360-second default wait bound; and unchanged 5xx
+and connection-error attempt and backoff budgets. Existing CFBD retry tests
+exercise the shared parser through `CFBDClient`.
+
+No provider requests or database operations are required for this change.

--- a/src/pipelines/utils/api_client.py
+++ b/src/pipelines/utils/api_client.py
@@ -4,11 +4,12 @@ import logging
 import threading
 import time
 from datetime import UTC, datetime
-from email.utils import parsedate_to_datetime
 from typing import Any
 
 import dlt
 import httpx
+
+from . import http_retries
 
 logger = logging.getLogger(__name__)
 
@@ -204,7 +205,7 @@ class CFBDClient:
 
     # Upper bound on a server-supplied Retry-After. Without it a hostile or
     # mistaken header could park the pipeline for hours inside one sleep.
-    MAX_RETRY_AFTER_SECONDS = 120
+    MAX_RETRY_AFTER_SECONDS = http_retries.MAX_RETRY_AFTER_SECONDS
 
     def __init__(self, api_key: str | None = None, breaker: RateLimitBreaker | None = None):
         """Initialize the client.
@@ -253,17 +254,8 @@ class CFBDClient:
 
         Never negative: a date already in the past means "retry now".
         """
-        try:
-            when = parsedate_to_datetime(text)
-        except (TypeError, ValueError):
-            return None
-        if when is None:
-            return None
-        if when.tzinfo is None:
-            # RFC 9110 fixes HTTP-dates to GMT; a missing offset is not local time.
-            when = when.replace(tzinfo=UTC)
         reference = now if now is not None else datetime.now(UTC)
-        return max(0, int((when - reference).total_seconds()))
+        return http_retries.http_date_delay(text, now=reference)
 
     @classmethod
     def _parse_retry_after(cls, raw: str | None, now: datetime | None = None) -> int:
@@ -281,22 +273,13 @@ class CFBDClient:
         Clamped to MAX_RETRY_AFTER_SECONDS either way, so a distant date or a
         hostile value cannot park the pipeline inside a single sleep.
         """
-        default = 60
-        if raw is None:
-            return default
-        text = str(raw).strip()
-        if not text:
-            return default
-        try:
-            seconds = int(text)
-        except (TypeError, ValueError):
-            seconds = cls._http_date_delay(text, now)
-            if seconds is None:
-                logger.warning("Unparseable Retry-After header %r; using %ds", raw, default)
-                return default
-        if seconds < 0:
-            return default
-        return min(seconds, cls.MAX_RETRY_AFTER_SECONDS)
+        reference = now if now is not None else datetime.now(UTC)
+        return http_retries.parse_retry_after(
+            raw,
+            default_seconds=http_retries.DEFAULT_RETRY_AFTER_SECONDS,
+            max_seconds=cls.MAX_RETRY_AFTER_SECONDS,
+            now=reference,
+        )
 
     def get(
         self,

--- a/src/pipelines/utils/file_fetcher.py
+++ b/src/pipelines/utils/file_fetcher.py
@@ -17,11 +17,18 @@ from pathlib import Path
 
 import httpx
 
+from .http_retries import (
+    DEFAULT_RETRY_AFTER_SECONDS,
+    MAX_RETRY_AFTER_SECONDS,
+    parse_retry_after,
+)
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_TIMEOUT = 60.0
 MAX_RETRIES = 3
 RETRY_DELAY = 1.0
+DEFAULT_MAX_TOTAL_RETRY_WAIT_SECONDS = MAX_RETRIES * MAX_RETRY_AFTER_SECONDS
 USER_AGENT = "cfb-database/0.1 (+https://github.com/rstover-fo/cfb-database)"
 
 
@@ -60,8 +67,17 @@ def _get_with_retries(
                 return response.content
             except httpx.HTTPStatusError as e:
                 if e.response.status_code == 429:
-                    retry_after = int(e.response.headers.get("Retry-After", 60))
-                    logger.warning(f"Rate limited fetching {url}. Waiting {retry_after}s...")
+                    if attempt >= retries:
+                        raise
+                    retry_after = parse_retry_after(
+                        e.response.headers.get("Retry-After"),
+                        default_seconds=DEFAULT_RETRY_AFTER_SECONDS,
+                        max_seconds=MAX_RETRY_AFTER_SECONDS,
+                    )
+                    logger.warning(
+                        f"Rate limited fetching {url}. Waiting {retry_after}s "
+                        f"(retry {attempt + 1}/{retries})..."
+                    )
                     time.sleep(retry_after)
                     continue
                 elif e.response.status_code >= 500 and attempt < retries:

--- a/src/pipelines/utils/http_retries.py
+++ b/src/pipelines/utils/http_retries.py
@@ -1,0 +1,64 @@
+"""Shared HTTP retry helpers that do not define provider retry policy."""
+
+import logging
+from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_RETRY_AFTER_SECONDS = 60
+MAX_RETRY_AFTER_SECONDS = 120
+
+
+def http_date_delay(text: str, *, now: datetime | None = None) -> int | None:
+    """Return whole seconds until an HTTP-date, or ``None`` if it is invalid."""
+    try:
+        when = parsedate_to_datetime(text)
+    except (OverflowError, TypeError, ValueError):
+        return None
+    if when is None:
+        return None
+    if when.tzinfo is None:
+        # RFC 9110 fixes HTTP-dates to GMT; a missing offset is not local time.
+        when = when.replace(tzinfo=UTC)
+    reference = now if now is not None else datetime.now(UTC)
+    if reference.tzinfo is None:
+        reference = reference.replace(tzinfo=UTC)
+    return max(0, int((when - reference).total_seconds()))
+
+
+def parse_retry_after(
+    raw: str | None,
+    *,
+    default_seconds: int = DEFAULT_RETRY_AFTER_SECONDS,
+    max_seconds: int = MAX_RETRY_AFTER_SECONDS,
+    now: datetime | None = None,
+) -> int:
+    """Parse and bound an RFC 9110 ``Retry-After`` header.
+
+    The header may be either non-negative integer seconds or an HTTP-date.
+    Missing, malformed, and negative values use ``default_seconds``. Past
+    HTTP-dates return zero. Every valid or default delay is capped so a remote
+    server cannot create an unbounded sleep.
+    """
+    if default_seconds < 0:
+        raise ValueError("default_seconds must be non-negative")
+    if max_seconds < 0:
+        raise ValueError("max_seconds must be non-negative")
+
+    fallback = min(default_seconds, max_seconds)
+    if raw is None:
+        return fallback
+    text = str(raw).strip()
+    if not text:
+        return fallback
+    try:
+        seconds = int(text)
+    except (TypeError, ValueError):
+        seconds = http_date_delay(text, now=now)
+        if seconds is None:
+            logger.warning("Unparseable Retry-After header %r; using %ds", raw, fallback)
+            return fallback
+    if seconds < 0:
+        return fallback
+    return min(seconds, max_seconds)

--- a/src/pipelines/utils/http_retries.py
+++ b/src/pipelines/utils/http_retries.py
@@ -1,6 +1,7 @@
 """Shared HTTP retry helpers that do not define provider retry policy."""
 
 import logging
+import math
 from datetime import UTC, datetime
 from email.utils import parsedate_to_datetime
 
@@ -24,7 +25,7 @@ def http_date_delay(text: str, *, now: datetime | None = None) -> int | None:
     reference = now if now is not None else datetime.now(UTC)
     if reference.tzinfo is None:
         reference = reference.replace(tzinfo=UTC)
-    return max(0, int((when - reference).total_seconds()))
+    return max(0, math.ceil((when - reference).total_seconds()))
 
 
 def parse_retry_after(

--- a/tests/test_flat_files_framework.py
+++ b/tests/test_flat_files_framework.py
@@ -17,12 +17,27 @@ from src.pipelines.sources.flat_files import (
     resolve_parser,
 )
 from src.pipelines.utils import load_ledger
-from src.pipelines.utils.file_fetcher import fetch_file
+from src.pipelines.utils.file_fetcher import (
+    DEFAULT_MAX_TOTAL_RETRY_WAIT_SECONDS,
+    MAX_RETRIES,
+    RETRY_DELAY,
+    fetch_file,
+)
 from src.pipelines.utils.team_xwalk import XwalkResolver, normalize_name
 
 # ---------------------------------------------------------------------------
 # file_fetcher.fetch_file
 # ---------------------------------------------------------------------------
+
+
+class _FakeClock:
+    def __init__(self):
+        self.elapsed = 0.0
+        self.sleeps = []
+
+    def sleep(self, seconds):
+        self.sleeps.append(seconds)
+        self.elapsed += seconds
 
 
 class TestFetchFileLocalPath:
@@ -91,6 +106,100 @@ class TestFetchFileHttp:
 
         with pytest.raises(httpx.HTTPStatusError):
             fetch_file("https://example.com/missing.csv")
+
+    def test_terminal_429_preserves_http_error_and_never_sleeps_after_it(self, monkeypatch):
+        calls = {"n": 0}
+
+        def handler(request):
+            calls["n"] += 1
+            return httpx.Response(
+                429,
+                headers={"Retry-After": "86400", "X-Attempt": str(calls["n"])},
+                request=request,
+            )
+
+        transport = httpx.MockTransport(handler)
+        real_client_cls = httpx.Client
+        clock = _FakeClock()
+
+        import src.pipelines.utils.file_fetcher as ff_mod
+
+        def fake_client(*, follow_redirects, timeout):
+            return real_client_cls(
+                follow_redirects=follow_redirects, timeout=timeout, transport=transport
+            )
+
+        monkeypatch.setattr(ff_mod.httpx, "Client", fake_client)
+        monkeypatch.setattr(ff_mod.time, "sleep", clock.sleep)
+
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            fetch_file("https://example.com/rate-limited.csv")
+
+        assert calls["n"] == MAX_RETRIES + 1
+        assert exc_info.value.response.headers["X-Attempt"] == str(MAX_RETRIES + 1)
+        assert clock.sleeps == [120, 120, 120]
+        assert clock.elapsed == DEFAULT_MAX_TOTAL_RETRY_WAIT_SECONDS
+
+    def test_malformed_retry_after_uses_bounded_default(self, monkeypatch):
+        calls = {"n": 0}
+
+        def handler(request):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return httpx.Response(429, headers={"Retry-After": "eventually"}, request=request)
+            return httpx.Response(200, content=b"ok", request=request)
+
+        transport = httpx.MockTransport(handler)
+        real_client_cls = httpx.Client
+        clock = _FakeClock()
+
+        import src.pipelines.utils.file_fetcher as ff_mod
+
+        def fake_client(*, follow_redirects, timeout):
+            return real_client_cls(
+                follow_redirects=follow_redirects, timeout=timeout, transport=transport
+            )
+
+        monkeypatch.setattr(ff_mod.httpx, "Client", fake_client)
+        monkeypatch.setattr(ff_mod.time, "sleep", clock.sleep)
+
+        result = fetch_file("https://example.com/eventual.csv")
+
+        assert result.content == b"ok"
+        assert clock.sleeps == [60]
+
+    @pytest.mark.parametrize("failure", ["500", "connection"])
+    def test_transient_failures_keep_existing_attempt_and_backoff_budget(
+        self, monkeypatch, failure
+    ):
+        calls = {"n": 0}
+
+        def handler(request):
+            calls["n"] += 1
+            if failure == "500":
+                return httpx.Response(500, request=request)
+            raise httpx.ConnectError("connection failed", request=request)
+
+        transport = httpx.MockTransport(handler)
+        real_client_cls = httpx.Client
+        clock = _FakeClock()
+
+        import src.pipelines.utils.file_fetcher as ff_mod
+
+        def fake_client(*, follow_redirects, timeout):
+            return real_client_cls(
+                follow_redirects=follow_redirects, timeout=timeout, transport=transport
+            )
+
+        monkeypatch.setattr(ff_mod.httpx, "Client", fake_client)
+        monkeypatch.setattr(ff_mod.time, "sleep", clock.sleep)
+
+        expected_error = httpx.HTTPStatusError if failure == "500" else httpx.ConnectError
+        with pytest.raises(expected_error):
+            fetch_file("https://example.com/transient.csv")
+
+        assert calls["n"] == MAX_RETRIES + 1
+        assert clock.sleeps == [RETRY_DELAY, RETRY_DELAY * 2, RETRY_DELAY * 3]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_http_retries.py
+++ b/tests/test_http_retries.py
@@ -53,3 +53,12 @@ def test_invalid_bounds_are_rejected(default_seconds, max_seconds):
 
 def test_default_is_also_capped():
     assert parse_retry_after(None, default_seconds=600, max_seconds=120) == 120
+
+
+@pytest.mark.parametrize(
+    "second,microsecond,expected",
+    [(0, 900000, 1), (0, 0, 1), (1, 0, 0), (1, 100000, 0)],
+)
+def test_http_date_never_retries_before_future_boundary(second, microsecond, expected):
+    received = NOW.replace(second=second, microsecond=microsecond)
+    assert parse_retry_after("Wed, 21 Oct 2026 07:28:01 GMT", now=received) == expected

--- a/tests/test_http_retries.py
+++ b/tests/test_http_retries.py
@@ -1,0 +1,55 @@
+"""Tests for provider-neutral HTTP retry header parsing."""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from src.pipelines.utils.http_retries import (
+    MAX_RETRY_AFTER_SECONDS,
+    http_date_delay,
+    parse_retry_after,
+)
+
+NOW = datetime(2026, 10, 21, 7, 28, 0, tzinfo=UTC)
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("30", 30),
+        (" 45 ", 45),
+        (None, 60),
+        ("", 60),
+        ("soon", 60),
+        ("-5", 60),
+        ("86400", MAX_RETRY_AFTER_SECONDS),
+        ("Wed, 21 Oct 2026 07:29:30 GMT", 90),
+        ("Wed, 21 Oct 2026 07:00:00 GMT", 0),
+        ("Fri, 25 Dec 2026 00:00:00 GMT", MAX_RETRY_AFTER_SECONDS),
+    ],
+)
+def test_parse_retry_after_is_defensive_and_bounded(raw, expected):
+    assert parse_retry_after(raw, now=NOW) == expected
+
+
+def test_naive_http_date_and_clock_are_interpreted_as_gmt():
+    naive_now = NOW.replace(tzinfo=None)
+    assert http_date_delay("Wed, 21 Oct 2026 07:29:00", now=naive_now) == 60
+
+
+@pytest.mark.parametrize(
+    "default_seconds,max_seconds",
+    [(-1, 120), (60, -1)],
+)
+def test_invalid_bounds_are_rejected(default_seconds, max_seconds):
+    with pytest.raises(ValueError):
+        parse_retry_after(
+            "1",
+            default_seconds=default_seconds,
+            max_seconds=max_seconds,
+            now=NOW,
+        )
+
+
+def test_default_is_also_capped():
+    assert parse_retry_after(None, default_seconds=600, max_seconds=120) == 120


### PR DESCRIPTION
Flat-file downloads could fail while parsing a valid HTTP-date `Retry-After`, sleep without a bound, or sleep after the final 429 and then replace the HTTP error with a generic error. This change shares CFBD's defensive header parser, caps each wait at 120 seconds (360 seconds across the default three retries), and preserves the final `HTTPStatusError` without a final sleep.

![Architecture: shared bounded Retry-After parsing with unchanged provider boundaries](https://github.com/user-attachments/assets/4bceaff8-a9fc-4eb5-a415-101532323f00)

![Sequence: retry budget check, future-date rounding, bounded wait, and terminal HTTP error](https://github.com/user-attachments/assets/ce89c883-8bec-4fa9-b278-f723509fa4f6)

CFBD retry budgets and circuit-breaker behavior remain unchanged, as do flat-file transient retry counts and backoff. The implementation plan is in `docs/plans/2026-09-08-f18-flat-file-retries.md`.

Validation: 194 focused regressions passed; independent review reran 97 focused tests with no findings. Ruff lint/format and diff checks passed. No live provider or database calls were run.

Independent PR in the F10/F11/F28 + F18 + F14/F19 batch; can merge separately from the planner and design work.




<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61688054"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/formentera-operations/-/pull-requests/rstover-fo/cfb-database/135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge.

<details><summary><h3>Summary</h3></summary>

- Hardens HTTP retry handling for flat-file downloads and shares provider-neutral `Retry-After` parsing with the CFBD client.
- Supports numeric and HTTP-date retry values, caps server-directed waits at 120 seconds, and retains the final HTTP error after the retry budget is exhausted.
- Adds focused coverage for retry parsing, bounded waits, terminal errors, and existing retry budgets.
</details>

<!-- /greptile_comment -->