### PR TITLE
Add F10/F11/F28 SQL refresh dependency foundation

### DIFF
--- a/docs/plans/2026-09-04-main-codebase-audit.md
+++ b/docs/plans/2026-09-04-main-codebase-audit.md
@@ -210,6 +210,9 @@ Evidence: [original indexes](https://github.com/rstover-fo/cfb-database/blob/4a7
 Immediate correction plan: [F10 workflow dependencies](2026-09-08-f10-workflow-dependencies.md).
 The missing refreshes and workflow completion ordering are addressed there; the
 broader shared dependency planner remains in the F10/F28 orchestration work.
+The [SQL refresh foundation](2026-09-08-refresh-dependency-foundation.md) adds
+a checked materialized-view registry, descendant selection, and invocation-local
+failure gating; source/job metadata and durable generations remain open.
 
 **P1 · Confirmed · L**
 

--- a/docs/plans/2026-09-08-refresh-dependency-foundation.md
+++ b/docs/plans/2026-09-08-refresh-dependency-foundation.md
@@ -1,0 +1,74 @@
+# SQL refresh dependency foundation — F10/F11/F28
+
+Status: implemented for the Python materialized-view refresher; no production
+execution or schema changes. This is the first shared-planner slice, not closure
+of F10, F11, or F28.
+
+## Behavior
+
+`src/pipelines/config/refresh_assets.py` declares the existing 55 materialized
+views and their 48 external relation inputs. Each view records its canonical SQL
+file, direct relation dependencies, and `whole_relation` refresh coverage. A
+PostgreSQL parser test checks the entire canonical marts/analytics inventory and
+every declared relation edge. Reviewed function-body dependencies include
+`ref.get_era()` → `ref.eras`; source hashes and an explicit catalog-function
+allowlist require dependency review when functions change or are added. `pglast` is a development-only dependency.
+
+`scripts/refresh_marts.py` derives its former separate lists from this registry.
+Full refreshes retain a stable order for independent views. Selected views are
+validated and dependency-ordered, including transitive ordering across omitted
+intermediates. Duplicate selections collapse to one refresh. Unknown or empty
+explicit selections fail before opening a database connection.
+
+The new `--changed` option treats each named relation as already committed and
+selects its SQL materialized-view descendants. Changed roots themselves are not refreshed, including roots that depend on
+another changed root; the caller asserts all named roots are already current. For example:
+
+```sh
+python scripts/refresh_marts.py --changed analytics.adjusted_epa_build --dry-run
+# marts.team_adjusted_epa, then marts.epa_crossvalidation
+python scripts/refresh_marts.py --changed ratings.sdv_ratings_weekly --dry-run
+# marts.epa_crossvalidation
+python scripts/refresh_marts.py --changed ref.coach_tenures --dry-run
+# marts.coach_tenures
+```
+
+`--views` and `--changed` are mutually exclusive; either overrides `--schema`.
+`--views` refreshes exactly the registered selection, assuming omitted parents
+are current. Existing callers may continue using it. Arbitrary unregistered
+names previously accepted by that option are now rejected.
+
+If a selected refresh fails, the existing per-view transaction rolls back.
+Selected descendants are then blocked, even across an unselected intermediate;
+independent views continue. The process returns the count of failed plus blocked
+views, preserving a nonzero workflow result. A no-op changed-input plan succeeds
+without accessing the database.
+
+## Boundaries and follow-up
+
+This graph describes canonical SQL relation lineage. It does not schedule CFBD
+requests, flat-file imports, EPA computations, or model runs, and does not infer
+their dependencies. For example, declaring `core.plays` changed does not rebuild
+`analytics.adjusted_epa_build`. Existing workflows still own those job boundaries.
+API views, dynamically constructed dependencies, live database drift, and
+source coverage are outside this inventory.
+
+Failure gating applies within one Python refresh invocation. It does not prevent
+mixed generations after a prior source/compute failure, coordinate concurrent
+invocations, make the whole refresh atomic, or change `public.refresh_all_marts()`.
+Durable receipt/generation checks, source and compute asset metadata, incremental
+work units, and SQL RPC parity remain required follow-up. The F14/F19 operational
+records proposal develops the durable evidence needed for those gates.
+
+## Verification
+
+- Registry inventory and edges checked using PostgreSQL parse trees, including
+  canonical files rather than only paths listed in the registry.
+- Planner tests cover transitive subset ordering, changed-input selection,
+  duplicate inputs, invalid names, cycles, missing dependencies, and empty plans.
+- Runner tests cover rollback, dependent blocking, independent continuation,
+  database-free dry runs/no-ops, and explicit empty CLI arguments.
+- 186 planner, refresh, season-load, and workflow regression tests passed;
+  Ruff lint/format and diff checks passed. Independent review identified and
+  resolved overlapping changed-root refreshes and function-hidden era inputs.
+- No live SQL refresh or performance claim is made.

--- a/docs/warehouse-operations.md
+++ b/docs/warehouse-operations.md
@@ -321,3 +321,16 @@ hash-skip ledger in `meta.flat_file_loads` to avoid re-processing unchanged file
 repo secret `SUPABASE_DB_URL` only. `.github/workflows/live-scoreboard.yml` separately polls
 CFBD's `/scoreboard` every 5 minutes on Saturdays (games-today guard) to feed
 `live.scoreboard_snapshots` and the house live win-probability model.
+
+### SQL refresh dependency planning (2026-09-08)
+
+The Python refresher now uses the checked SQL registry described in the
+[dependency foundation](plans/2026-09-08-refresh-dependency-foundation.md).
+Use `python scripts/refresh_marts.py --changed <schema.relation> --dry-run` to
+inspect materialized-view descendants of inputs whose writes have committed.
+Remove `--dry-run` only when refresh execution is intended. This command does not
+run source ingestion or computation jobs. Existing `--views` calls remain exact
+selections, now validated and dependency-ordered. Failed selected refreshes block
+their selected descendants while independent views continue; the command fails
+if any view failed or was blocked. Durable cross-run generation checks and the
+SQL `refresh_all_marts()` RPC are outside this implementation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
 dev = [
     "pytest>=8.0.0",
     "ruff>=0.4.0",
+    "pglast>=7,<8",
 ]
 compute = [
     "numpy>=1.26",

--- a/scripts/refresh_marts.py
+++ b/scripts/refresh_marts.py
@@ -8,8 +8,7 @@ Usage:
     python scripts/refresh_marts.py --schema analytics # Only analytics schema
     python scripts/refresh_marts.py --dry-run          # Print SQL without executing
     python scripts/refresh_marts.py --views marts.house_elo,marts.house_elo_game
-                                                         # Refresh exactly these views, in order,
-                                                         # instead of the full layered list.
+    python scripts/refresh_marts.py --changed ratings.sdv_ratings_weekly --dry-run
 """
 
 import argparse
@@ -19,93 +18,15 @@ from datetime import datetime
 
 import dlt
 
+from src.pipelines.utils.refresh_plan import REFRESH_GRAPH
+
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
 
-# Order matters: dependencies must refresh first
-# _game_epa_calc -> team_epa_season
-# team_season_summary -> conference_standings (analytics)
-#
-# NOTE: EPA views (_game_epa_calc, team_epa_season, situational_splits, defensive_havoc)
-# take 10-15 minutes each because they process 2.7M plays. For Supabase, these require
-# statement_timeout=0 which the script sets automatically.
+# Keep the public lists for existing callers, but derive both from the registry.
 
-MARTS_VIEWS = [
-    # Layer 1: No mart dependencies
-    "marts._game_epa_calc",
-    "marts.play_epa",
-    "marts.player_comparison",
-    "marts.conference_head_to_head",
-    "marts.team_wepa_season",
-    "marts.player_wepa_season",
-    "marts.returning_production",
-    "marts.player_usage",
-    "marts.team_ats_records",
-    "marts.core_ratings",
-    "marts.penalty_log",
-    "marts.team_penalty_box",
-    # 2026-08-30 expansion_views unit: passing charting (stats.passing_*) and
-    # coach_tenures (ref.coach_tenures) -- all read base tables only, no
-    # mart dependencies.
-    "marts.passing_charting_player_season",
-    "marts.passing_charting_target_season",
-    "marts.passing_charting_team_season",
-    "marts.coach_tenures",
-    # 2026-09-03 rushing-charting unit (U6): rushing charting
-    # (stats.rushing_player_season, stats.rushing_team_season) -- same shape
-    # as the passing charting marts above, all read base tables only, no
-    # mart dependencies.
-    "marts.rushing_charting_player_season",
-    "marts.rushing_charting_team_season",
-    "marts.rushing_charting_direction_season",
-    # Layer 2: Depends on Layer 1
-    "marts.team_epa_season",
-    "marts.team_season_summary",
-    "marts.player_game_epa",
-    "marts.defensive_havoc",
-    "marts.scoring_opportunities",
-    "marts.team_playcalling_tendencies",
-    "marts.team_situational_success",
-    # Layer 3: Depends on Layer 2
-    "marts.situational_splits",
-    "marts.player_season_epa",
-    "marts.coach_record",
-    "marts.matchup_history",
-    "marts.recruiting_class",
-    "marts.team_talent_composite",
-    "marts.team_tempo_metrics",
-    "marts.transfer_portal_impact",
-    # Layer 4: Depends on Layer 3
-    "marts.team_season_trajectory",
-    "marts.conference_era_summary",
-    "marts.team_style_profile",
-    "marts.coaching_tenure",
-    "marts.recruiting_roi",
-    "marts.conference_comparison",
-    # Layer 5: Depends on Layer 4 + standalone
-    "marts.matchup_edges",
-    "marts.data_freshness",
-    # Layer 6: Tier 2 analytics (read from analytics.* staging + predictions)
-    "marts.house_elo",
-    "marts.house_elo_game",
-    "marts.team_adjusted_epa",
-    "marts.scored_matchup_edges",
-    "marts.prediction_accuracy",
-    # Layer 7: Tier 3 analytics (computed from play/feature builds, depends on Layer 6)
-    "marts.team_week_features",
-    "marts.adjusted_epa_week",
-    # Reads marts.team_adjusted_epa (layer 6) + marts.team_epa_season (layer 2)
-    # against the external ratings tables; cheap (a few thousand rows).
-    "marts.epa_crossvalidation",
-]
-
-ANALYTICS_VIEWS = [
-    "analytics.team_season_summary",
-    "analytics.player_career_stats",
-    "analytics.conference_standings",  # Depends on team_season_summary
-    "analytics.team_recruiting_trend",
-    "analytics.game_results",
-]
+MARTS_VIEWS = list(REFRESH_GRAPH.plan(schema="marts").views)
+ANALYTICS_VIEWS = list(REFRESH_GRAPH.plan(schema="analytics").views)
 
 
 def get_db_url() -> str:
@@ -173,34 +94,24 @@ def refresh_marts(
     concurrently: bool = True,
     dry_run: bool = False,
     views: list[str] | None = None,
+    changed: list[str] | None = None,
 ) -> int:
-    """Refresh materialized views. Returns count of failures.
+    """Refresh selected SQL descendants; return failed plus blocked count.
 
-    If `views` is given, refresh exactly those views, in the given order,
-    instead of the full layered list (schema is ignored in that case). Each
-    name must be schema-qualified as marts.* or analytics.*; a name that
-    doesn't exist yet is not validated here -- Postgres will error on the
-    REFRESH and that failure surfaces per-view like any other.
+    Explicit views are registry-validated and dependency-ordered. Other parents
+    are assumed current, as with the existing targeted refresh contract.
+    Changed relations must already be committed; their SQL descendants are
+    selected automatically. This does not execute ingestion or compute jobs.
     """
-    if views is not None:
-        invalid = [v for v in views if not (v.startswith("marts.") or v.startswith("analytics."))]
-        if invalid:
-            logger.error(
-                f"Invalid --views entries (must be schema-qualified marts.* or "
-                f"analytics.*): {invalid}"
-            )
-            return 1
-    else:
-        # Build view list based on schema filter
-        views = []
-        if schema is None or schema == "marts":
-            views.extend(MARTS_VIEWS)
-        if schema is None or schema == "analytics":
-            views.extend(ANALYTICS_VIEWS)
-
-    if not views:
-        logger.error(f"No views found for schema: {schema}")
+    try:
+        plan = REFRESH_GRAPH.plan(views=views, changed=changed, schema=schema)
+    except ValueError as exc:
+        logger.error("Invalid refresh plan: %s", exc)
         return 1
+    views = list(plan.views)
+    if not views:
+        logger.info("No dependent materialized views require refresh")
+        return 0
 
     logger.info(f"Refreshing {len(views)} materialized view(s)")
     if concurrently:
@@ -232,14 +143,21 @@ def refresh_marts(
             _cur.execute("SET statement_timeout = 0")
         conn.commit()
 
+        unsuccessful: set[str] = set()
         for view in views:
-            if not refresh_view(view, conn, concurrently, dry_run):
+            blocked_by = REFRESH_GRAPH.ancestors(view).intersection(unsuccessful)
+            if blocked_by:
+                logger.error("Blocked %s after upstream failure: %s", view, sorted(blocked_by))
+                unsuccessful.add(view)
+                failures += 1
+            elif not refresh_view(view, conn, concurrently, dry_run):
+                unsuccessful.add(view)
                 failures += 1
     finally:
         conn.close()
 
     if failures:
-        logger.warning(f"{failures} view(s) failed to refresh")
+        logger.warning(f"{failures} view(s) failed or were blocked")
     else:
         logger.info("All views refreshed successfully")
 
@@ -266,19 +184,30 @@ def main() -> None:
     parser.add_argument(
         "--views",
         help=(
-            "Comma-separated fully-qualified matview names to refresh, in order "
+            "Comma-separated registered matview names to refresh in dependency order "
             "(overrides --schema and the full layered list)"
         ),
     )
+    parser.add_argument(
+        "--changed",
+        help="Committed relations; refresh SQL descendants (overrides --schema)",
+    )
     args = parser.parse_args()
+    if args.views is not None and args.changed is not None:
+        parser.error("--views and --changed cannot be combined")
 
-    view_list = [v.strip() for v in args.views.split(",") if v.strip()] if args.views else None
+    view_list = (
+        [v.strip() for v in args.views.split(",") if v.strip()] if args.views is not None else None
+    )
 
     failures = refresh_marts(
         schema=args.schema,
         concurrently=not args.no_concurrent,
         dry_run=args.dry_run,
         views=view_list,
+        changed=[v.strip() for v in args.changed.split(",") if v.strip()]
+        if args.changed is not None
+        else None,
     )
     sys.exit(failures)
 

--- a/src/pipelines/config/refresh_assets.py
+++ b/src/pipelines/config/refresh_assets.py
@@ -1,0 +1,402 @@
+"""Declared SQL refresh assets, checked against their PostgreSQL parse trees.
+
+This registry covers materialized-view refreshes and their relation inputs, not
+provider work units or compute-job generations. Ordering is stable for unrelated
+assets. Existing full-refresh order is retained as the tie-breaker.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RefreshAsset:
+    name: str
+    depends_on: tuple[str, ...]
+    definition: str
+    coverage_grain: str = "whole_relation"
+
+
+# Input relations are updated by separate ingestion/compute jobs. Naming one as
+# changed asserts its writes have already committed; this planner does not run
+# those jobs. Explicit names make typos/missing dependencies fail validation.
+EXTERNAL_RELATIONS = frozenset(
+    (
+        "analytics.adjusted_epa_build",
+        "analytics.adjusted_epa_week_build",
+        "analytics.house_elo_game",
+        "analytics.player_game_epa_build",
+        "betting.lines",
+        "betting.team_ats",
+        "core.drives",
+        "core.game_team_stats",
+        "core.game_team_stats__teams",
+        "core.game_team_stats__teams__stats",
+        "core.games",
+        "core.plays",
+        "core.roster",
+        "draft.draft_picks",
+        "features.team_week",
+        "metrics.ppa_players_season",
+        "metrics.pregame_win_probability",
+        "metrics.wepa_players_kicking",
+        "metrics.wepa_players_passing",
+        "metrics.wepa_players_rushing",
+        "metrics.wepa_team_season",
+        "predictions.game_predictions",
+        "ratings.core_ratings",
+        "ratings.elo_ratings",
+        "ratings.espn_fpi_weekly",
+        "ratings.fpi_ratings",
+        "ratings.sdv_ratings_weekly",
+        "ratings.sp_ratings",
+        "recruiting.recruits",
+        "recruiting.team_recruiting",
+        "recruiting.transfer_portal",
+        "ref.coach_seasons",
+        "ref.coach_tenures",
+        "ref.coaches",
+        "ref.coaches__seasons",
+        "ref.eras",
+        "ref.teams",
+        "stats.game_havoc",
+        "stats.passing_player_season",
+        "stats.passing_plays",
+        "stats.passing_team_season",
+        "stats.play_stats",
+        "stats.player_returning",
+        "stats.player_season_stats",
+        "stats.player_usage",
+        "stats.rushing_player_season",
+        "stats.rushing_plays",
+        "stats.rushing_team_season",
+    )
+)
+
+REFRESH_ASSETS = (
+    RefreshAsset(
+        "marts._game_epa_calc", ("core.plays",), "src/schemas/marts/002_game_epa_calc.sql"
+    ),
+    RefreshAsset("marts.play_epa", ("core.plays",), "src/schemas/marts/010_play_epa.sql"),
+    RefreshAsset(
+        "marts.player_comparison",
+        (
+            "core.roster",
+            "metrics.ppa_players_season",
+            "recruiting.recruits",
+            "stats.player_season_stats",
+        ),
+        "src/schemas/marts/020_player_comparison.sql",
+    ),
+    RefreshAsset(
+        "marts.conference_head_to_head",
+        ("core.games",),
+        "src/schemas/marts/027_conference_head_to_head.sql",
+    ),
+    RefreshAsset(
+        "marts.team_wepa_season",
+        ("metrics.wepa_team_season",),
+        "src/schemas/marts/029_team_wepa_season.sql",
+    ),
+    RefreshAsset(
+        "marts.player_wepa_season",
+        (
+            "metrics.wepa_players_kicking",
+            "metrics.wepa_players_passing",
+            "metrics.wepa_players_rushing",
+        ),
+        "src/schemas/marts/030_player_wepa_season.sql",
+    ),
+    RefreshAsset(
+        "marts.returning_production",
+        ("stats.player_returning",),
+        "src/schemas/marts/031_returning_production.sql",
+    ),
+    RefreshAsset(
+        "marts.player_usage", ("stats.player_usage",), "src/schemas/marts/032_player_usage.sql"
+    ),
+    RefreshAsset(
+        "marts.team_ats_records",
+        ("betting.team_ats",),
+        "src/schemas/marts/033_team_ats_records.sql",
+    ),
+    RefreshAsset(
+        "marts.core_ratings", ("ratings.core_ratings",), "src/schemas/marts/043_core_ratings.sql"
+    ),
+    RefreshAsset(
+        "marts.penalty_log",
+        ("core.games", "core.plays", "ref.teams"),
+        "src/schemas/marts/041_penalty_log.sql",
+    ),
+    RefreshAsset(
+        "marts.team_penalty_box",
+        (
+            "core.game_team_stats",
+            "core.game_team_stats__teams",
+            "core.game_team_stats__teams__stats",
+            "core.games",
+        ),
+        "src/schemas/marts/042_team_penalty_box.sql",
+    ),
+    RefreshAsset(
+        "marts.passing_charting_player_season",
+        ("core.roster", "stats.passing_player_season"),
+        "src/schemas/marts/045_passing_charting_player_season.sql",
+    ),
+    RefreshAsset(
+        "marts.passing_charting_target_season",
+        ("ref.teams", "stats.passing_plays"),
+        "src/schemas/marts/046_passing_charting_target_season.sql",
+    ),
+    RefreshAsset(
+        "marts.passing_charting_team_season",
+        ("stats.passing_plays", "stats.passing_team_season"),
+        "src/schemas/marts/047_passing_charting_team_season.sql",
+    ),
+    RefreshAsset(
+        "marts.coach_tenures",
+        ("ref.coach_tenures", "ref.teams"),
+        "src/schemas/marts/048_coach_tenures.sql",
+    ),
+    RefreshAsset(
+        "marts.rushing_charting_player_season",
+        ("core.roster", "stats.rushing_player_season"),
+        "src/schemas/marts/050_rushing_charting_player_season.sql",
+    ),
+    RefreshAsset(
+        "marts.rushing_charting_team_season",
+        ("stats.rushing_plays", "stats.rushing_team_season"),
+        "src/schemas/marts/051_rushing_charting_team_season.sql",
+    ),
+    RefreshAsset(
+        "marts.rushing_charting_direction_season",
+        ("stats.rushing_player_season", "stats.rushing_plays", "stats.rushing_team_season"),
+        "src/schemas/marts/052_rushing_charting_direction_season.sql",
+    ),
+    RefreshAsset(
+        "marts.team_epa_season",
+        ("core.games", "marts._game_epa_calc"),
+        "src/schemas/marts/003_team_epa_season.sql",
+    ),
+    RefreshAsset(
+        "marts.team_season_summary",
+        (
+            "core.games",
+            "ratings.core_ratings",
+            "ratings.elo_ratings",
+            "ratings.fpi_ratings",
+            "ratings.sp_ratings",
+            "recruiting.team_recruiting",
+        ),
+        "src/schemas/marts/001_team_season_summary.sql",
+    ),
+    RefreshAsset(
+        "marts.player_game_epa",
+        ("analytics.player_game_epa_build", "marts.play_epa", "stats.play_stats"),
+        "src/schemas/marts/011_player_game_epa.sql",
+    ),
+    RefreshAsset(
+        "marts.defensive_havoc",
+        ("core.games", "core.plays", "stats.game_havoc"),
+        "src/schemas/marts/005_defensive_havoc.sql",
+    ),
+    RefreshAsset(
+        "marts.scoring_opportunities",
+        ("core.drives",),
+        "src/schemas/marts/006_scoring_opportunities.sql",
+    ),
+    RefreshAsset(
+        "marts.team_playcalling_tendencies",
+        ("core.plays", "marts.play_epa"),
+        "src/schemas/marts/021_team_playcalling_tendencies.sql",
+    ),
+    RefreshAsset(
+        "marts.team_situational_success",
+        ("core.plays", "marts.play_epa"),
+        "src/schemas/marts/022_team_situational_success.sql",
+    ),
+    RefreshAsset(
+        "marts.situational_splits",
+        ("core.games", "core.plays"),
+        "src/schemas/marts/004_situational_splits.sql",
+    ),
+    RefreshAsset(
+        "marts.player_season_epa",
+        ("marts.player_game_epa",),
+        "src/schemas/marts/012_player_season_epa.sql",
+    ),
+    RefreshAsset(
+        "marts.coach_record",
+        ("recruiting.team_recruiting", "ref.coaches", "ref.coaches__seasons"),
+        "src/schemas/marts/009_coach_record.sql",
+    ),
+    RefreshAsset(
+        "marts.matchup_history", ("core.games",), "src/schemas/marts/007_matchup_history.sql"
+    ),
+    RefreshAsset(
+        "marts.recruiting_class",
+        ("recruiting.recruits", "recruiting.team_recruiting"),
+        "src/schemas/marts/008_recruiting_class.sql",
+    ),
+    RefreshAsset(
+        "marts.team_talent_composite",
+        ("core.roster", "recruiting.recruits", "recruiting.transfer_portal"),
+        "src/schemas/marts/017_team_talent_composite.sql",
+    ),
+    RefreshAsset(
+        "marts.team_tempo_metrics",
+        ("core.games", "core.plays", "marts.team_epa_season"),
+        "src/schemas/marts/019_team_tempo_metrics.sql",
+    ),
+    RefreshAsset(
+        "marts.transfer_portal_impact",
+        ("core.roster", "marts.team_season_summary", "recruiting.transfer_portal"),
+        "src/schemas/marts/025_transfer_portal_impact.sql",
+    ),
+    RefreshAsset(
+        "marts.team_season_trajectory",
+        (
+            "core.games",
+            "marts.defensive_havoc",
+            "marts.team_epa_season",
+            "marts.team_season_summary",
+            "recruiting.team_recruiting",
+            "ref.eras",
+            "ref.teams",
+        ),
+        "src/schemas/marts/013_team_season_trajectory.sql",
+    ),
+    RefreshAsset(
+        "marts.conference_era_summary",
+        ("core.games", "marts.team_epa_season", "ref.eras"),
+        "src/schemas/marts/014_conference_era_summary.sql",
+    ),
+    RefreshAsset(
+        "marts.team_style_profile",
+        ("marts.play_epa",),
+        "src/schemas/marts/015_team_style_profile.sql",
+    ),
+    RefreshAsset(
+        "marts.coaching_tenure",
+        (
+            "core.games",
+            "marts.recruiting_class",
+            "marts.team_season_summary",
+            "ref.coach_seasons",
+            "ref.coaches",
+            "ref.coaches__seasons",
+        ),
+        "src/schemas/marts/023_coaching_tenure.sql",
+    ),
+    RefreshAsset(
+        "marts.recruiting_roi",
+        (
+            "draft.draft_picks",
+            "marts.recruiting_class",
+            "marts.team_epa_season",
+            "marts.team_season_summary",
+        ),
+        "src/schemas/marts/024_recruiting_roi.sql",
+    ),
+    RefreshAsset(
+        "marts.conference_comparison",
+        (
+            "core.games",
+            "marts.recruiting_class",
+            "marts.team_epa_season",
+            "marts.team_season_summary",
+            "ref.teams",
+        ),
+        "src/schemas/marts/026_conference_comparison.sql",
+    ),
+    RefreshAsset(
+        "marts.matchup_edges",
+        ("core.games", "marts.team_style_profile"),
+        "src/schemas/marts/016_matchup_edges.sql",
+    ),
+    RefreshAsset("marts.data_freshness", (), "src/schemas/marts/028_data_freshness.sql"),
+    RefreshAsset(
+        "marts.house_elo",
+        ("analytics.house_elo_game", "ratings.elo_ratings"),
+        "src/schemas/marts/034_house_elo.sql",
+    ),
+    RefreshAsset(
+        "marts.house_elo_game",
+        ("analytics.house_elo_game",),
+        "src/schemas/marts/035_house_elo_game.sql",
+    ),
+    RefreshAsset(
+        "marts.team_adjusted_epa",
+        ("analytics.adjusted_epa_build", "marts.team_wepa_season"),
+        "src/schemas/marts/036_team_adjusted_epa.sql",
+    ),
+    RefreshAsset(
+        "marts.scored_matchup_edges",
+        ("core.games", "predictions.game_predictions"),
+        "src/schemas/marts/037_scored_matchup_edges.sql",
+    ),
+    RefreshAsset(
+        "marts.prediction_accuracy",
+        ("core.games", "metrics.pregame_win_probability", "predictions.game_predictions"),
+        "src/schemas/marts/038_prediction_accuracy.sql",
+    ),
+    RefreshAsset(
+        "marts.team_week_features",
+        ("features.team_week",),
+        "src/schemas/marts/039_team_week_features.sql",
+    ),
+    RefreshAsset(
+        "marts.adjusted_epa_week",
+        ("analytics.adjusted_epa_week_build",),
+        "src/schemas/marts/040_adjusted_epa_week.sql",
+    ),
+    RefreshAsset(
+        "marts.epa_crossvalidation",
+        (
+            "marts.team_adjusted_epa",
+            "marts.team_epa_season",
+            "ratings.espn_fpi_weekly",
+            "ratings.fpi_ratings",
+            "ratings.sdv_ratings_weekly",
+            "ref.teams",
+        ),
+        "src/schemas/marts/044_epa_crossvalidation.sql",
+    ),
+    RefreshAsset(
+        "analytics.team_season_summary", ("core.games",), "src/schemas/013_analytics_views.sql"
+    ),
+    RefreshAsset(
+        "analytics.player_career_stats",
+        ("stats.player_season_stats",),
+        "src/schemas/013_analytics_views.sql",
+    ),
+    RefreshAsset(
+        "analytics.conference_standings",
+        (
+            "analytics.team_season_summary",
+            "ratings.elo_ratings",
+            "ratings.sp_ratings",
+            "recruiting.team_recruiting",
+        ),
+        "src/schemas/013_analytics_views.sql",
+    ),
+    RefreshAsset(
+        "analytics.team_recruiting_trend",
+        ("recruiting.recruits", "recruiting.team_recruiting"),
+        "src/schemas/013_analytics_views.sql",
+    ),
+    RefreshAsset(
+        "analytics.game_results",
+        ("betting.lines", "core.games", "metrics.pregame_win_probability"),
+        "src/schemas/013_analytics_views.sql",
+    ),
+)
+
+# Function bodies hide relation edges from the calling query's RangeVars.
+# Reviewed source hashes force dependency review when these definitions change.
+FUNCTION_RELATIONS = {"ref.get_era": ("ref.eras",)}
+FUNCTION_DEFINITIONS = {
+    "ref.get_era": (
+        "src/schemas/functions/get_era.sql",
+        "504a8d01b3134888852a5c45fbce06717e63609a4dc6f4b5302a6344645ee1a0",
+    ),
+}

--- a/src/pipelines/utils/refresh_plan.py
+++ b/src/pipelines/utils/refresh_plan.py
@@ -1,0 +1,106 @@
+"""Pure, deterministic planning over the declared SQL refresh graph."""
+
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from graphlib import CycleError, TopologicalSorter
+
+from src.pipelines.config.refresh_assets import EXTERNAL_RELATIONS, REFRESH_ASSETS, RefreshAsset
+
+_RELATION = re.compile(r"[a-z_][a-z0-9_]*\.[a-z_][a-z0-9_]*\Z")
+
+
+@dataclass(frozen=True)
+class RefreshPlan:
+    views: tuple[str, ...]
+    changed: tuple[str, ...] = ()
+
+
+class RefreshGraph:
+    """Validate once; retain SQL lineage even through unselected parents."""
+
+    def __init__(self, assets: Iterable[RefreshAsset], external: Iterable[str] = ()):
+        records = tuple(assets)
+        self.assets = {asset.name: asset for asset in records}
+        if len(records) != len(self.assets):
+            raise ValueError("duplicate refresh asset")
+        self.external = frozenset(external)
+        if self.external & self.assets.keys():
+            raise ValueError("refresh assets cannot also be external relations")
+        known = self.external | self.assets.keys()
+        if any(not _RELATION.fullmatch(name) for name in known):
+            raise ValueError("asset names must be unquoted schema-qualified relation names")
+        self.dependencies = {name: frozenset() for name in self.external}
+        for asset in records:
+            unknown = set(asset.depends_on) - known
+            if unknown:
+                raise ValueError(f"{asset.name} has unknown dependencies: {sorted(unknown)}")
+            self.dependencies[asset.name] = frozenset(asset.depends_on)
+        try:
+            tuple(TopologicalSorter(self.dependencies).static_order())
+        except CycleError as exc:
+            raise ValueError(f"refresh dependency cycle: {exc.args[1]}") from exc
+        self.order = {asset.name: index for index, asset in enumerate(records)}
+        self._ancestors: dict[str, frozenset[str]] = {}
+
+    def ancestors(self, name: str) -> frozenset[str]:
+        if name not in self.dependencies:
+            raise ValueError(f"unknown asset: {name}")
+        if name not in self._ancestors:
+            parents = self.dependencies[name]
+            self._ancestors[name] = parents | frozenset(
+                ancestor for parent in parents for ancestor in self.ancestors(parent)
+            )
+        return self._ancestors[name]
+
+    def plan(
+        self,
+        *,
+        views: Iterable[str] | None = None,
+        changed: Iterable[str] | None = None,
+        schema: str | None = None,
+    ) -> RefreshPlan:
+        if views is not None and changed is not None:
+            raise ValueError("--views and --changed cannot be combined")
+        roots = tuple(dict.fromkeys(changed)) if changed is not None else ()
+        if changed is not None:
+            if not roots:
+                raise ValueError("--changed requires at least one relation")
+            unknown = set(roots) - self.dependencies.keys()
+            if unknown:
+                raise ValueError(f"unknown changed relations: {sorted(unknown)}")
+            selected = {
+                name
+                for name in self.assets
+                if name not in roots and self.ancestors(name).intersection(roots)
+            }
+        elif views is not None:
+            selected = set(views)
+            unknown = selected - self.assets.keys()
+            if unknown:
+                raise ValueError(f"unknown refresh views: {sorted(unknown)}")
+            if not selected:
+                raise ValueError("--views requires at least one view")
+        else:
+            if schema not in (None, "marts", "analytics"):
+                raise ValueError(f"unknown refresh schema: {schema}")
+            selected = {
+                name for name in self.assets if schema is None or name.startswith(schema + ".")
+            }
+        # Subset planning considers transitive dependencies, not only direct
+        # edges; an unselected intermediate view must not reverse their order.
+        pending = {name: set(self.ancestors(name)).intersection(selected) for name in selected}
+        ordered = []
+        while pending:
+            ready = min(
+                (name for name, parents in pending.items() if not parents),
+                key=self.order.__getitem__,
+            )
+            ordered.append(ready)
+            del pending[ready]
+            for parents in pending.values():
+                parents.discard(ready)
+        return RefreshPlan(tuple(ordered), roots)
+
+
+REFRESH_GRAPH = RefreshGraph(REFRESH_ASSETS, EXTERNAL_RELATIONS)

--- a/tests/test_refresh_plan.py
+++ b/tests/test_refresh_plan.py
@@ -21,17 +21,58 @@ from src.pipelines.utils.refresh_plan import REFRESH_GRAPH, RefreshGraph
 ROOT = Path(__file__).resolve().parents[1]
 
 
-def relations(node):
+CATALOG_TELEMETRY_RELATIONS = {
+    "pg_class",
+    "pg_stat_user_tables",
+    "pg_catalog.pg_class",
+    "pg_catalog.pg_stat_user_tables",
+}
+
+
+def relations(node, cte_scopes=()):
     if isinstance(node, dict):
+        if "SelectStmt" in node:
+            yield from select_relations(node["SelectStmt"], cte_scopes)
+            return
         if "RangeVar" in node:
             relation = node["RangeVar"]
-            if relation.get("schemaname"):
-                yield relation["schemaname"] + "." + relation["relname"]
+            schema = relation.get("schemaname")
+            name = f"{schema}.{relation['relname']}" if schema else relation["relname"]
+            if name in CATALOG_TELEMETRY_RELATIONS:
+                # These relations provide database-maintenance telemetry rather
+                # than refresh lineage and therefore are intentionally exempt.
+                return
+            if schema:
+                yield name
+                return
+            if any(name in scope for scope in reversed(cte_scopes)):
+                return
+            raise AssertionError(
+                f"unqualified relation {name!r}; qualify source relations or declare a CTE"
+            )
         for value in node.values():
-            yield from relations(value)
+            yield from relations(value, cte_scopes)
     elif isinstance(node, list):
         for value in node:
-            yield from relations(value)
+            yield from relations(value, cte_scopes)
+
+
+def select_relations(select, outer_cte_scopes):
+    with_clause = select.get("withClause")
+    if not with_clause:
+        yield from relations(select, outer_cte_scopes)
+        return
+
+    ctes = [entry["CommonTableExpr"] for entry in with_clause["ctes"]]
+    all_cte_names = frozenset(cte["ctename"] for cte in ctes)
+    visible_cte_names = all_cte_names if with_clause.get("recursive") else frozenset()
+    for cte in ctes:
+        yield from relations(cte["ctequery"], (*outer_cte_scopes, visible_cte_names))
+        if not with_clause.get("recursive"):
+            visible_cte_names = visible_cte_names | {cte["ctename"]}
+
+    query = {key: value for key, value in select.items() if key != "withClause"}
+    yield from relations(query, (*outer_cte_scopes, all_cte_names))
 
 
 # Explicit catalog-function allowlist: a newly introduced function requires
@@ -53,6 +94,77 @@ def functions(node):
     elif isinstance(node, list):
         for value in node:
             yield from functions(value)
+
+
+def parsed_relations(sql):
+    statement = json.loads(parser.parse_sql_json(sql))["stmts"][0]["stmt"]
+    return set(relations(statement))
+
+
+def test_relation_extraction_rejects_unqualified_source():
+    with pytest.raises(AssertionError, match="unqualified relation 'games'"):
+        parsed_relations("SELECT * FROM games")
+
+
+def test_relation_extraction_respects_cte_declaration_order():
+    assert parsed_relations(
+        """
+        WITH games AS (SELECT * FROM core.games),
+             completed AS (SELECT * FROM games)
+        SELECT * FROM completed
+        """
+    ) == {"core.games"}
+
+    with pytest.raises(AssertionError, match="unqualified relation 'completed'"):
+        parsed_relations(
+            """
+            WITH games AS (SELECT * FROM completed),
+                 completed AS (SELECT * FROM core.games)
+            SELECT * FROM games
+            """
+        )
+
+
+def test_relation_extraction_respects_recursive_and_shadowed_ctes():
+    assert parsed_relations(
+        """
+        WITH RECURSIVE games AS (
+            SELECT id FROM core.games
+            UNION ALL
+            SELECT id FROM games
+        )
+        SELECT * FROM games
+        """
+    ) == {"core.games"}
+
+    assert parsed_relations(
+        """
+        WITH source AS (SELECT * FROM core.games)
+        SELECT * FROM source
+        WHERE EXISTS (
+            WITH source AS (SELECT * FROM ratings.elo_ratings)
+            SELECT 1 FROM source
+        )
+        """
+    ) == {"core.games", "ratings.elo_ratings"}
+
+
+def test_relation_extraction_exempts_catalog_telemetry():
+    assert not parsed_relations(
+        """
+        SELECT *
+        FROM pg_stat_user_tables stats
+        JOIN pg_class class ON class.oid = stats.relid
+        JOIN pg_catalog.pg_class qualified ON qualified.oid = class.oid
+        """
+    )
+
+
+def test_relation_extraction_collects_qualified_sources():
+    assert parsed_relations("SELECT * FROM core.games JOIN ratings.elo_ratings ON true") == {
+        "core.games",
+        "ratings.elo_ratings",
+    }
 
 
 def test_reviewed_function_definitions_have_not_changed():

--- a/tests/test_refresh_plan.py
+++ b/tests/test_refresh_plan.py
@@ -1,0 +1,219 @@
+"""Registry drift, planning, and refresh failure propagation regressions."""
+
+import hashlib
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from pglast import parser
+
+from scripts import refresh_marts as runner
+from src.pipelines.config.refresh_assets import (
+    EXTERNAL_RELATIONS,
+    FUNCTION_DEFINITIONS,
+    FUNCTION_RELATIONS,
+    REFRESH_ASSETS,
+    RefreshAsset,
+)
+from src.pipelines.utils.refresh_plan import REFRESH_GRAPH, RefreshGraph
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def relations(node):
+    if isinstance(node, dict):
+        if "RangeVar" in node:
+            relation = node["RangeVar"]
+            if relation.get("schemaname"):
+                yield relation["schemaname"] + "." + relation["relname"]
+        for value in node.values():
+            yield from relations(value)
+    elif isinstance(node, list):
+        for value in node:
+            yield from relations(value)
+
+
+# Explicit catalog-function allowlist: a newly introduced function requires
+# review rather than silently hiding its relation dependencies.
+BUILTIN_FUNCTIONS = set(
+    """abs array_agg avg bool_or btrim corr count
+jsonb_build_array lag length lower max min mode now percent_rank percentile_cont
+pg_catalog.extract pg_catalog.substring pg_partition_root pg_postmaster_start_time
+power rank replace round row_number split_part sqrt stddev stddev_samp sum unnest""".split()
+)
+
+
+def functions(node):
+    if isinstance(node, dict):
+        if "FuncCall" in node:
+            yield ".".join(part["String"]["sval"] for part in node["FuncCall"]["funcname"])
+        for value in node.values():
+            yield from functions(value)
+    elif isinstance(node, list):
+        for value in node:
+            yield from functions(value)
+
+
+def test_reviewed_function_definitions_have_not_changed():
+    assert FUNCTION_DEFINITIONS.keys() == FUNCTION_RELATIONS.keys()
+    for path, digest in FUNCTION_DEFINITIONS.values():
+        assert hashlib.sha256((ROOT / path).read_bytes()).hexdigest() == digest
+
+
+def test_registry_matches_all_canonical_postgres_materialized_views():
+    found = {}
+    paths = [ROOT / "src/schemas/013_analytics_views.sql"]
+    paths.extend(sorted((ROOT / "src/schemas/marts").glob("*.sql")))
+    for path in paths:
+        for statement in json.loads(parser.parse_sql_json(path.read_text()))["stmts"]:
+            create = statement["stmt"].get("CreateTableAsStmt")
+            if not create or create["objtype"] != "OBJECT_MATVIEW":
+                continue
+            relation = create["into"]["rel"]
+            name = relation["schemaname"] + "." + relation["relname"]
+            assert name not in found
+            dependencies = set(relations(create["query"]))
+            for function in functions(create["query"]):
+                assert function in BUILTIN_FUNCTIONS or function in FUNCTION_RELATIONS, function
+                dependencies.update(FUNCTION_RELATIONS.get(function, ()))
+            found[name] = (str(path.relative_to(ROOT)), dependencies)
+    assert set(found) == {asset.name for asset in REFRESH_ASSETS}
+    for asset in REFRESH_ASSETS:
+        assert (asset.definition, set(asset.depends_on)) == found[asset.name]
+        assert asset.coverage_grain == "whole_relation"
+    assert EXTERNAL_RELATIONS == set.union(*(deps for _, deps in found.values())) - set(found)
+
+
+def graph():
+    # Intentionally reverse registration order to exercise actual topology.
+    return RefreshGraph(
+        [
+            RefreshAsset("marts.leaf", ("marts.middle",), "test"),
+            RefreshAsset("marts.middle", ("marts.parent",), "test"),
+            RefreshAsset("marts.parent", ("core.input",), "test"),
+            RefreshAsset("marts.independent", (), "test"),
+        ],
+        ["core.input", "core.unused"],
+    )
+
+
+def test_subset_preserves_transitive_order_and_deduplicates():
+    assert graph().plan(views=["marts.leaf", "marts.parent", "marts.leaf"]).views == (
+        "marts.parent",
+        "marts.leaf",
+    )
+
+
+def test_changed_excludes_committed_root_and_selects_descendants():
+    assert graph().plan(changed=["marts.parent"]).views == ("marts.middle", "marts.leaf")
+    assert graph().plan(changed=["core.unused"]).views == ()
+    assert graph().plan(changed=["core.input", "marts.middle"]).views == (
+        "marts.parent",
+        "marts.leaf",
+    )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"views": []},
+        {"changed": []},
+        {"views": ["marts.missing"]},
+        {"changed": ["core.missing"]},
+        {"schema": "core"},
+        {"views": ["marts.parent"], "changed": ["core.input"]},
+    ],
+)
+def test_invalid_selection(kwargs):
+    with pytest.raises(ValueError):
+        graph().plan(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "assets,external",
+    [
+        ([RefreshAsset("marts.a", (), "test")] * 2, []),
+        ([RefreshAsset("marts.a", ("marts.b",), "test")], []),
+        ([RefreshAsset("marts.a", ("marts.a",), "test")], []),
+        ([RefreshAsset("marts.a", (), "test")], ["marts.a"]),
+        ([RefreshAsset("a; DROP TABLE x", (), "test")], []),
+    ],
+)
+def test_invalid_graph(assets, external):
+    with pytest.raises(ValueError):
+        RefreshGraph(assets, external)
+
+
+def test_actual_committed_input_plans():
+    assert REFRESH_GRAPH.plan(changed=["ratings.sdv_ratings_weekly"]).views == (
+        "marts.epa_crossvalidation",
+    )
+    assert REFRESH_GRAPH.plan(changed=["analytics.adjusted_epa_build"]).views == (
+        "marts.team_adjusted_epa",
+        "marts.epa_crossvalidation",
+    )
+    assert REFRESH_GRAPH.plan(changed=["ref.coach_tenures"]).views == ("marts.coach_tenures",)
+    assert set(REFRESH_GRAPH.plan(changed=["ref.eras"]).views) == {
+        "marts.team_season_trajectory",
+        "marts.conference_era_summary",
+    }
+    ordered = REFRESH_GRAPH.plan().views
+    assert len(ordered) == 55
+    for name in ordered:
+        assert all(
+            ordered.index(parent) < ordered.index(name)
+            for parent in REFRESH_GRAPH.ancestors(name)
+            if parent in ordered
+        )
+
+
+def test_failed_refresh_blocks_transitive_descendants_but_continues_independent(monkeypatch):
+    import psycopg2
+
+    connection = MagicMock()
+    monkeypatch.setattr(runner, "REFRESH_GRAPH", graph())
+    monkeypatch.setattr(runner, "get_db_url", lambda: "test")
+    monkeypatch.setattr(psycopg2, "connect", lambda _: connection)
+    calls = []
+
+    def refresh(name, *args):
+        calls.append(name)
+        return name != "marts.parent"
+
+    monkeypatch.setattr(runner, "refresh_view", refresh)
+    assert runner.refresh_marts() == 3
+    assert calls == ["marts.parent", "marts.independent"]
+    connection.close.assert_called_once()
+
+
+def test_refresh_failure_rolls_back_and_closes_cursor():
+    connection = MagicMock()
+    connection.cursor.return_value.execute.side_effect = RuntimeError("failed refresh")
+    assert not runner.refresh_view("marts.parent", connection, True, False)
+    connection.rollback.assert_called_once()
+    connection.commit.assert_not_called()
+    connection.cursor.return_value.close.assert_called_once()
+
+
+def test_dry_run_invalid_and_noop_never_resolve_database(monkeypatch, capsys):
+    def forbidden():
+        pytest.fail("must not resolve database")
+
+    monkeypatch.setattr(runner, "get_db_url", forbidden)
+    assert runner.refresh_marts(changed=["ratings.sdv_ratings_weekly"], dry_run=True) == 0
+    assert (
+        "REFRESH MATERIALIZED VIEW CONCURRENTLY marts.epa_crossvalidation"
+        in capsys.readouterr().out
+    )
+    assert runner.refresh_marts(views=["marts.missing"]) == 1
+    monkeypatch.setattr(runner, "REFRESH_GRAPH", graph())
+    assert runner.refresh_marts(changed=["core.unused"]) == 0
+
+
+@pytest.mark.parametrize("option", ["--views", "--changed"])
+def test_cli_empty_selection_does_not_refresh_all(monkeypatch, option):
+    monkeypatch.setattr("sys.argv", ["refresh_marts.py", option, "", "--dry-run"])
+    with pytest.raises(SystemExit) as exit_info:
+        runner.main()
+    assert exit_info.value.code == 1


### PR DESCRIPTION
The Python mart refresher duplicated dependency order and continued refreshing downstream views after an upstream refresh failed. This change makes a checked registry authoritative for its 55 materialized views and 48 external relation inputs, orders exact selections by dependencies, and blocks selected descendants after failures while independent refreshes continue.

![Architecture: SQL dependency validation, declared registry, planner, and PostgreSQL refresh runner](https://github.com/user-attachments/assets/b96ff6fb-b9bc-405e-8e88-4cdcb4d951d4)

![Sequence: CTE-aware validation followed by ordered refreshes and descendant failure blocking](https://github.com/user-attachments/assets/570a9ce4-33d3-4b6e-982b-5cf7a9f7cb4a)

`--changed` selects SQL descendants of already committed inputs. For example, `--changed analytics.adjusted_epa_build` refreshes `marts.team_adjusted_epa` followed by `marts.epa_crossvalidation`. Changed roots are excluded from the work plan. Unknown/empty selections fail before database access. PostgreSQL parse-tree tests verify canonical inventory and relation edges, with reviewed function-body dependencies for `ref.get_era()` and drift checks for new/changed functions.

This is a bounded F10/F11/F28 foundation: no source/compute job scheduling, durable generations, incremental refreshes, production DDL, or change to the SQL `refresh_all_marts()` RPC. See `docs/plans/2026-09-08-refresh-dependency-foundation.md` for behavior and remaining scope.

Validation: 186 planner, refresh, season-load, and workflow tests passed; Ruff lint/format and diff checks passed. Independent review found overlapping committed-root refreshes and missing function-hidden era inputs; both were fixed with regression coverage. No live database refresh or performance measurement was run.

Independent of F18 #135; the F14/F19 operational-records proposal describes subsequent durable accounting and publication work.




<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61689361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/formentera-operations/-/pull-requests/rstover-fo/cfb-database/136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge.

<details><summary><h3>Summary</h3></summary>

- No new issues found.
- The refresh dependency registry and planner add deterministic dependency selection, downstream refresh blocking after failures, and registry drift coverage. The prior unqualified-relation feedback is addressed: non-CTE unqualified relations are rejected, while the intended PostgreSQL catalog telemetry relations remain explicitly exempt.
</details>

<!-- /greptile_comment -->