### PR TITLE
Add F14 durable quota reservation foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - run: ./scripts/setup_dev.sh
       - name: Managed bootstrap and upgrade integration
-        run: .venv/bin/python -m pytest tests/test_warehouse_migrations_sql.py tests/test_warehouse_bootstrap_sql.py tests/test_adopt_warehouse_catalog_sql.py tests/test_f06_verification_transactions_sql.py tests/test_mart_release_sql.py tests/test_play_partitions.py tests/test_play_indexes_sql.py tests/test_operational_quota_sql.py -q --tb=short
+        run: .venv/bin/python -m pytest tests/test_warehouse_migrations_sql.py tests/test_warehouse_bootstrap_sql.py tests/test_adopt_warehouse_catalog_sql.py tests/test_f06_verification_transactions_sql.py tests/test_mart_release_sql.py tests/test_play_partitions.py tests/test_play_indexes_sql.py tests/test_operational_quota_sql.py tests/test_operational_quota_lifecycle_sql.py -q --tb=short
         env:
           F06_TEST_DB_URL: postgresql://postgres:f06-disposable-ci@127.0.0.1:5432/postgres
           F06_REQUIRE_DB: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - run: ./scripts/setup_dev.sh
       - name: Managed bootstrap and upgrade integration
-        run: .venv/bin/python -m pytest tests/test_warehouse_migrations_sql.py tests/test_warehouse_bootstrap_sql.py tests/test_adopt_warehouse_catalog_sql.py tests/test_f06_verification_transactions_sql.py tests/test_mart_release_sql.py tests/test_play_partitions.py tests/test_play_indexes_sql.py -q --tb=short
+        run: .venv/bin/python -m pytest tests/test_warehouse_migrations_sql.py tests/test_warehouse_bootstrap_sql.py tests/test_adopt_warehouse_catalog_sql.py tests/test_f06_verification_transactions_sql.py tests/test_mart_release_sql.py tests/test_play_partitions.py tests/test_play_indexes_sql.py tests/test_operational_quota_sql.py -q --tb=short
         env:
           F06_TEST_DB_URL: postgresql://postgres:f06-disposable-ci@127.0.0.1:5432/postgres
           F06_REQUIRE_DB: "1"

--- a/docs/SCHEMA_CONTRACT.md
+++ b/docs/SCHEMA_CONTRACT.md
@@ -1194,7 +1194,9 @@ reserved attempts are conservative capacity units, not provider-billed usage.
 No public view/RPC is added. `anon`, `authenticated`, `analyst_ro`, and other
 non-owner default grantees receive no access to these records. The dedicated
 `warehouse_ingest` role receives only the reviewed function privileges needed
-to create/finish runs, reserve attempts, and record dispatch/results; role
+in the owner-only `warehouse_quota` schema to create/finish runs, reserve
+attempts, and record dispatch/results. Existing `meta` schema grants remain
+unchanged; no non-owner can create overloads in the quota RPC namespace. Role
 membership and capacity configuration require a separate rollout.
 
 Existing HTTP callers and `public.get_data_freshness()` are unchanged. See the

--- a/docs/SCHEMA_CONTRACT.md
+++ b/docs/SCHEMA_CONTRACT.md
@@ -1185,6 +1185,21 @@ schema has no anon/authenticated grants (not PostgREST-reachable) by design.
 
 These objects are implementation details. Do not depend on them from downstream repos.
 
+### Operational quota records (prepared, not deployed)
+
+Migration `066_operational_quota_ledger.sql` adds private `meta.operation_runs`,
+`meta.api_quota_periods`, and `meta.api_request_attempts`. These are internal
+admission/audit records, not source freshness or publication receipts. Local
+reserved attempts are conservative capacity units, not provider-billed usage.
+No public view/RPC is added. `anon`, `authenticated`, `analyst_ro`, and other
+non-owner default grantees receive no access to these records. The dedicated
+`warehouse_ingest` role receives only the reviewed function privileges needed
+to create/finish runs, reserve attempts, and record dispatch/results; role
+membership and capacity configuration require a separate rollout.
+
+Existing HTTP callers and `public.get_data_freshness()` are unchanged. See the
+[F14 foundation and rollout boundary](plans/2026-09-08-f14-quota-foundation.md).
+
 ### Raw Data Tables
 
 | Schema | Tables |

--- a/docs/plans/2026-09-04-main-codebase-audit.md
+++ b/docs/plans/2026-09-04-main-codebase-audit.md
@@ -264,6 +264,10 @@ Evidence: [play-stat fan-out](https://github.com/rstover-fo/cfb-database/blob/4a
 
 ### F14 — API-budget accounting measures successful logical requests, not actual attempts
 
+The [quota foundation](2026-09-08-f14-quota-foundation.md) prepares private
+atomic reservation primitives. Runtime transport integration and production
+rollout remain open; this does not close F14.
+
 **P2 · Confirmed · M**
 
 The request wrapper records a call only after the client returns successfully. Retries and terminal failures consume attempts without equivalent accounting. Budget state is a local JSON file, so fresh workflow runners and separate jobs do not share one durable account-wide total. Source estimates also diverge from actual fan-out cost and cannot safely govern execution.

--- a/docs/plans/2026-09-08-f14-quota-foundation.md
+++ b/docs/plans/2026-09-08-f14-quota-foundation.md
@@ -44,11 +44,11 @@ membership; no existing application role is automatically enrolled.
 
 | Function | Contract |
 |---|---|
-| `meta.start_operation_run` | Creates an invocation UUID, or returns it for an exact-context replay. |
-| `meta.finish_operation_run` | Closes a run; a successful finish cannot leave pending attempts. |
-| `meta.reserve_cfbd_attempt` | Locks the explicit account period, reserves one local unit, and rejects UUID/context conflicts. |
-| `meta.mark_cfbd_attempt_dispatched` | Allows only one reserved-to-dispatched transition, while the period and run remain active. |
-| `meta.record_cfbd_attempt_result` | Records a terminal transport result; an exact replay is harmless and a conflicting result is rejected. |
+| `warehouse_quota.start_operation_run` | Creates an invocation UUID, or returns it for an exact-context replay. |
+| `warehouse_quota.finish_operation_run` | Closes a run; a successful finish cannot leave pending attempts. |
+| `warehouse_quota.reserve_cfbd_attempt` | Locks the explicit account period, reserves one local unit, and rejects UUID/context conflicts. |
+| `warehouse_quota.mark_cfbd_attempt_dispatched` | Allows only one reserved-to-dispatched transition, while the period and run remain active. |
+| `warehouse_quota.record_cfbd_attempt_result` | Records a terminal transport result; an exact replay is harmless and a conflicting result is rejected. |
 
 `btree_gist` enforces non-overlapping `[start,end)` periods for each shared
 account. The migration discovers the extension's installed schema for its
@@ -58,13 +58,19 @@ an explicit schema so both an empty and normal session search path work.
 Successful and expected-empty transport results require 2xx status. A 404 is
 recorded as an HTTP error at this layer, even if a future source adapter treats
 it as expected missing data. That source outcome and publication coverage are
-separate from transport status.
+separate from transport status. `transport_error` requires NULL HTTP status.
+`unknown` also requires NULL HTTP status, with `dispatch_unconfirmed` before
+dispatch or `response_unobserved` after dispatch.
 
 The migration removes non-owner ACLs on only the new tables/functions, including
 implicit PUBLIC function execution and arbitrary host-default grantees, then
-grants the five entry points to the runtime role. Schema usage for existing
-ledgers and named writers' schema privileges are preserved. PUBLIC/runtime
-schema creation is denied. No existing public data surface is recreated.
+grants the five entry points to the runtime role. The routines live in the owner-only
+`warehouse_quota` schema; all existing `meta` schema grants are preserved.
+Pre-existing quota namespaces with a foreign owner, non-owner CREATE grants,
+types, or unexpected/untrusted routines are rejected without adoption. This prevents
+hostile overloads or same-named domain casts from capturing calls with string
+arguments. No existing
+public data surface is recreated.
 
 ## Provider evidence and initial allowance
 
@@ -107,7 +113,7 @@ by the schema-only PR.
 
 ## Executed verification
 
-- 11 quota SQL cases passed on an isolated local PostgreSQL 17 cluster. Tests
+- 26 quota SQL cases passed on an isolated local PostgreSQL 17 cluster. Tests
   use actual `warehouse_ingest` and public/bystander roles, ordinary and broad
   default grants, exact/conflicting concurrent UUID reuse, separate operation
   runs competing for one cap, committed-crash versus rollback accounting,
@@ -117,8 +123,12 @@ by the schema-only PR.
 - Both full managed bootstrap and prior-baseline upgrade passed, including
   catalog shape, unchanged representative data, public caller access, private
   quota access denial, restored session settings, and an idempotent second run.
-  The combined executed SQL suite passed all 13 cases.
-- 77 migration-runner/CLI unit tests passed. Ruff lint/format, actionlint for
+  The combined executed SQL suite passed all 28 cases.
+- Review regressions cover hostile overloads and domain casts, rejection of
+  pre-existing unsafe namespaces without adoption, phase-specific unknown
+  results, exact run replay, pending-attempt finish rejection, immutable
+  reservation context, and DELETE/TRUNCATE denial.
+- 77 migration-runner/CLI unit tests passed in the initial implementation. Ruff lint/format, actionlint for
   the changed CI workflow, and diff checks passed.
 - Independent review found and resolved implicit PUBLIC function execution,
   arbitrary host-default grants, and NULL/non-2xx success classification. The

--- a/docs/plans/2026-09-08-f14-quota-foundation.md
+++ b/docs/plans/2026-09-08-f14-quota-foundation.md
@@ -1,0 +1,131 @@
+# F14 durable quota foundation
+
+Status: implemented and verified on disposable PostgreSQL 17; not deployed. This is the first schema
+slice of the [accepted operational-records design](https://github.com/rstover-fo/cfb-database/pull/137).
+It does not enable admission enforcement in existing HTTP callers.
+
+## Accepted direction
+
+Production callers will fail closed if the shared admission database is
+unavailable. A local development bypass, if added later, must be explicit.
+Freshness consumers retain their existing interface while publication receipts
+are developed separately. Quota records land first; a controlled load and a
+derived mart will prove atomic receipt publication in a subsequent PR.
+
+## Scope
+
+Migration `066_operational_quota_ledger.sql` adds a private operation-run parent,
+configured quota periods, per-attempt reservations, and restricted SQL entry
+points. An account key names an opaque shared CFBD/CBBD pool, never an API key.
+The database serializes reservations against a configured period and refuses
+requests when capacity is exhausted or the period is unavailable. Every
+committed reservation remains charged locally, including ambiguous transport
+outcomes and a process crash. Recording a failed result never refunds it.
+
+The reservation UUID identifies one admission attempt. Repeating the database
+reservation with the same UUID and exact context is safe after an uncertain
+SQL response; it is not permission to issue another HTTP request. Each actual
+HTTP retry must use a new attempt UUID. A dispatch transition will prevent
+reusing a completed reservation for a new transport attempt. Callers must
+commit admission/dispatch transactions before sending HTTP bytes; this schema
+alone cannot prove client ordering or exactly-once external effects.
+
+No period, cap, role membership, credential, or runtime invocation is seeded.
+An administrator explicitly configures the period bounds and local allowance.
+The restricted caller cannot create its own budget or update counters directly.
+There is no automatic calendar rollover and no fallback to JSON admission.
+Existing JSON admission behavior remains in place until the transport PR.
+
+## Database interface
+
+The dedicated `warehouse_ingest` role is NOLOGIN and receives schema usage
+plus execution on five private functions. An operator later chooses the login
+membership; no existing application role is automatically enrolled.
+
+| Function | Contract |
+|---|---|
+| `meta.start_operation_run` | Creates an invocation UUID, or returns it for an exact-context replay. |
+| `meta.finish_operation_run` | Closes a run; a successful finish cannot leave pending attempts. |
+| `meta.reserve_cfbd_attempt` | Locks the explicit account period, reserves one local unit, and rejects UUID/context conflicts. |
+| `meta.mark_cfbd_attempt_dispatched` | Allows only one reserved-to-dispatched transition, while the period and run remain active. |
+| `meta.record_cfbd_attempt_result` | Records a terminal transport result; an exact replay is harmless and a conflicting result is rejected. |
+
+`btree_gist` enforces non-overlapping `[start,end)` periods for each shared
+account. The migration discovers the extension's installed schema for its
+operator class; pre-existing installations are retained. New installation uses
+an explicit schema so both an empty and normal session search path work.
+
+Successful and expected-empty transport results require 2xx status. A 404 is
+recorded as an HTTP error at this layer, even if a future source adapter treats
+it as expected missing data. That source outcome and publication coverage are
+separate from transport status.
+
+The migration removes non-owner ACLs on only the new tables/functions, including
+implicit PUBLIC function execution and arbitrary host-default grantees, then
+grants the five entry points to the runtime role. Schema usage for existing
+ledgers and named writers' schema privileges are preserved. PUBLIC/runtime
+schema creation is denied. No existing public data surface is recreated.
+
+## Provider evidence and initial allowance
+
+The official CFBD source at revision
+[`0d5559e337966cba08005feceac4f483209329f9`](https://github.com/CFBD/cfb-api-v2/tree/0d5559e337966cba08005feceac4f483209329f9)
+reports the next reset as the first of the next month at 00:00 UTC.
+[`/info`](https://github.com/CFBD/cfb-api-v2/blob/0d5559e337966cba08005feceac4f483209329f9/src/app/info/service.ts)
+returns remaining capacity and the shared CFB/CBB-pool flag.
+[`/info/usage`](https://github.com/CFBD/cfb-api-v2/blob/0d5559e337966cba08005feceac4f483209329f9/src/app/info/controller.ts)
+is a trailing request-metrics window, not the billing counter.
+
+The [quota middleware](https://github.com/CFBD/cfb-api-v2/blob/0d5559e337966cba08005feceac4f483209329f9/src/config/middleware/quotas.ts)
+refunds non-2xx responses and exempts some endpoints. Our reserved-attempt count
+is intentionally conservative; it must never be labeled provider-billed usage.
+Before adoption, verify live account capacity and configure at most its
+remaining allowance minus headroom for other callers. Starting midmonth with
+a full monthly cap would permit overspending. All callers sharing the pool
+must participate for strict local coordination. External callers can consume
+provider capacity independently, so reconciliation remains necessary.
+
+No authenticated provider request was made for this work. The pinned source
+is evidence of implementation intent, not measured deployment parity or the
+current account's remaining quota.
+
+## Rollout boundary
+
+The migration is appended to both the disposable bootstrap manifest and the
+separately adopted production manifest. Historical entries and baseline bytes
+are preserved. Intended application is the managed upgrade path; merging this
+branch is not production application. Review the pending migration plan before
+an explicitly authorized rollout. Existing public freshness RPCs, API views,
+raw data, prediction provenance, and private scouting contracts are unchanged.
+
+After schema rollout, a separate transport integration PR must create runs,
+commit a reservation for each attempted send, persist dispatch state, and
+record terminal outcomes. It must test database-unavailable denial, fresh
+processes sharing capacity, HTTP retries, and crashes at each boundary before
+retiring JSON admission for a caller. No account-wide enforcement claim is made
+by the schema-only PR.
+
+## Executed verification
+
+- 11 quota SQL cases passed on an isolated local PostgreSQL 17 cluster. Tests
+  use actual `warehouse_ingest` and public/bystander roles, ordinary and broad
+  default grants, exact/conflicting concurrent UUID reuse, separate operation
+  runs competing for one cap, committed-crash versus rollback accounting,
+  expiry after an observed lock wait, result validation, and reapplication
+  with populated records. Eight independent runs competing for a cap of three
+  produced exactly three reservations and five quota refusals.
+- Both full managed bootstrap and prior-baseline upgrade passed, including
+  catalog shape, unchanged representative data, public caller access, private
+  quota access denial, restored session settings, and an idempotent second run.
+  The combined executed SQL suite passed all 13 cases.
+- 77 migration-runner/CLI unit tests passed. Ruff lint/format, actionlint for
+  the changed CI workflow, and diff checks passed.
+- Independent review found and resolved implicit PUBLIC function execution,
+  arbitrary host-default grants, and NULL/non-2xx success classification. The
+  full bootstrap test also caught and resolved extension creation under an
+  empty search path. Final review reported no material findings.
+
+No production SQL, runtime provider admission, authenticated CFBD request, or
+performance benchmark was run. These tests do not prove deployed Supabase
+permissions or HTTP commit/send ordering; those remain rollout and transport
+integration checks.

--- a/src/schemas/migrations/066_operational_quota_ledger.sql
+++ b/src/schemas/migrations/066_operational_quota_ledger.sql
@@ -13,6 +13,59 @@
 
 CREATE SCHEMA IF NOT EXISTS meta;
 
+-- This namespace is dedicated to trusted quota routines. Existing meta writers
+-- may keep CREATE there; placing RPCs alongside them would permit hostile
+-- overloads to capture unknown/string arguments even with qualified calls.
+DO $namespace$
+DECLARE
+    schema_row record;
+BEGIN
+    SELECT oid, nspowner, nspacl INTO schema_row
+    FROM pg_catalog.pg_namespace WHERE nspname = 'warehouse_quota';
+    IF NOT FOUND THEN
+        CREATE SCHEMA warehouse_quota;
+    ELSE
+        IF schema_row.nspowner <> (SELECT oid FROM pg_catalog.pg_roles
+                WHERE rolname = current_user) THEN
+            RAISE EXCEPTION 'warehouse_quota must be owned by the migration role';
+        END IF;
+        IF EXISTS (
+            SELECT 1 FROM pg_catalog.aclexplode(schema_row.nspacl) acl
+            WHERE acl.grantee <> schema_row.nspowner AND acl.privilege_type = 'CREATE'
+        ) THEN
+            RAISE EXCEPTION 'existing warehouse_quota has untrusted CREATE grants';
+        END IF;
+        -- A same-named domain can turn a one-argument RPC call into a cast.
+        -- This dedicated routines-only namespace has no legitimate types.
+        IF EXISTS (
+            SELECT 1 FROM pg_catalog.pg_type WHERE typnamespace = schema_row.oid
+        ) THEN
+            RAISE EXCEPTION 'warehouse_quota contains an unexpected type';
+        END IF;
+        -- Do not adopt an already-compromised namespace by merely removing ACLs:
+        -- an attacker-owned routine can restore its own EXECUTE grants later.
+        IF EXISTS (
+            SELECT 1 FROM pg_catalog.pg_proc p
+            WHERE p.pronamespace = schema_row.oid AND (
+                p.proowner <> schema_row.nspowner OR p.prokind <> 'f'
+                OR p.provariadic <> 0 OR p.pronargdefaults <> 0
+                OR NOT COALESCE(p.oid = ANY(ARRAY[
+                    pg_catalog.to_regprocedure('warehouse_quota.guard_api_request_attempt_update()'),
+                    pg_catalog.to_regprocedure('warehouse_quota.reject_api_request_attempt_removal()'),
+                    pg_catalog.to_regprocedure('warehouse_quota.start_operation_run(uuid,text,text,jsonb,text,text)'),
+                    pg_catalog.to_regprocedure('warehouse_quota.finish_operation_run(uuid,text,text)'),
+                    pg_catalog.to_regprocedure('warehouse_quota.reserve_cfbd_attempt(uuid,uuid,text,timestamptz,text,integer,jsonb)'),
+                    pg_catalog.to_regprocedure('warehouse_quota.mark_cfbd_attempt_dispatched(uuid)'),
+                    pg_catalog.to_regprocedure('warehouse_quota.record_cfbd_attempt_result(uuid,text,integer,text)')
+                ]::oid[]), false)
+            )
+        ) THEN
+            RAISE EXCEPTION 'warehouse_quota contains an unexpected or untrusted routine';
+        END IF;
+    END IF;
+END
+$namespace$;
+
 -- Text equality in the account-scoped exclusion constraint comes from
 -- btree_gist. The DO block below discovers its actual installation schema, so
 -- this works both on plain PostgreSQL (normally public) and hosts that install
@@ -182,10 +235,15 @@ CREATE TABLE IF NOT EXISTS meta.api_request_attempts (
         OR
         (state = 'transport_error'
             AND dispatched_at IS NOT NULL AND result_recorded_at IS NOT NULL
-            AND error_category IS NOT NULL)
+            AND http_status IS NULL AND error_category IS NOT NULL)
         OR
         (state = 'unknown'
-            AND result_recorded_at IS NOT NULL)
+            AND result_recorded_at IS NOT NULL AND http_status IS NULL
+            AND error_category IS NOT NULL
+            AND (
+                (dispatched_at IS NULL AND error_category = 'dispatch_unconfirmed')
+                OR (dispatched_at IS NOT NULL AND error_category = 'response_unobserved')
+            ))
     )
 );
 
@@ -199,7 +257,7 @@ COMMENT ON COLUMN meta.api_request_attempts.request_context IS
 COMMENT ON COLUMN meta.api_request_attempts.state IS
     'Transport lifecycle, separate from source-level publication/freshness. reserved/dispatched can remain pending after a crash and remain locally charged.';
 
-CREATE OR REPLACE FUNCTION meta.guard_api_request_attempt_update()
+CREATE OR REPLACE FUNCTION warehouse_quota.guard_api_request_attempt_update()
 RETURNS trigger
 LANGUAGE plpgsql
 SET search_path = ''
@@ -233,9 +291,9 @@ $function$;
 DROP TRIGGER IF EXISTS guard_api_request_attempt_update ON meta.api_request_attempts;
 CREATE TRIGGER guard_api_request_attempt_update
     BEFORE UPDATE ON meta.api_request_attempts
-    FOR EACH ROW EXECUTE FUNCTION meta.guard_api_request_attempt_update();
+    FOR EACH ROW EXECUTE FUNCTION warehouse_quota.guard_api_request_attempt_update();
 
-CREATE OR REPLACE FUNCTION meta.reject_api_request_attempt_removal()
+CREATE OR REPLACE FUNCTION warehouse_quota.reject_api_request_attempt_removal()
 RETURNS trigger
 LANGUAGE plpgsql
 SET search_path = ''
@@ -248,9 +306,9 @@ $function$;
 DROP TRIGGER IF EXISTS reject_api_request_attempt_delete ON meta.api_request_attempts;
 CREATE TRIGGER reject_api_request_attempt_delete
     BEFORE DELETE OR TRUNCATE ON meta.api_request_attempts
-    FOR EACH STATEMENT EXECUTE FUNCTION meta.reject_api_request_attempt_removal();
+    FOR EACH STATEMENT EXECUTE FUNCTION warehouse_quota.reject_api_request_attempt_removal();
 
-CREATE OR REPLACE FUNCTION meta.start_operation_run(
+CREATE OR REPLACE FUNCTION warehouse_quota.start_operation_run(
     p_operation_run_id uuid,
     p_operation_kind text,
     p_initiator text,
@@ -300,7 +358,7 @@ BEGIN
 END
 $function$;
 
-CREATE OR REPLACE FUNCTION meta.finish_operation_run(
+CREATE OR REPLACE FUNCTION warehouse_quota.finish_operation_run(
     p_operation_run_id uuid,
     p_outcome text,
     p_error_summary text
@@ -360,7 +418,7 @@ BEGIN
 END
 $function$;
 
-CREATE OR REPLACE FUNCTION meta.reserve_cfbd_attempt(
+CREATE OR REPLACE FUNCTION warehouse_quota.reserve_cfbd_attempt(
     p_attempt_id uuid,
     p_operation_run_id uuid,
     p_account_key text,
@@ -477,7 +535,7 @@ BEGIN
 END
 $function$;
 
-CREATE OR REPLACE FUNCTION meta.mark_cfbd_attempt_dispatched(p_attempt_id uuid)
+CREATE OR REPLACE FUNCTION warehouse_quota.mark_cfbd_attempt_dispatched(p_attempt_id uuid)
 RETURNS timestamptz
 LANGUAGE plpgsql
 SECURITY DEFINER
@@ -533,7 +591,7 @@ BEGIN
 END
 $function$;
 
-CREATE OR REPLACE FUNCTION meta.record_cfbd_attempt_result(
+CREATE OR REPLACE FUNCTION warehouse_quota.record_cfbd_attempt_result(
     p_attempt_id uuid,
     p_state text,
     p_http_status integer,
@@ -571,9 +629,9 @@ BEGIN
             USING ERRCODE = '22023';
     END IF;
     IF p_state = 'transport_error' AND (
-        p_error_category IS NULL OR length(pg_catalog.btrim(p_error_category)) = 0
+        p_http_status IS NOT NULL OR p_error_category IS NULL OR length(pg_catalog.btrim(p_error_category)) = 0
     ) THEN
-        RAISE EXCEPTION 'transport error result requires an error category'
+        RAISE EXCEPTION 'transport error requires no HTTP status and an error category'
             USING ERRCODE = '22023';
     END IF;
 
@@ -583,6 +641,15 @@ BEGIN
     FOR UPDATE;
     IF NOT FOUND THEN
         RAISE EXCEPTION 'attempt is not reserved' USING ERRCODE = '22023';
+    END IF;
+
+    IF p_state = 'unknown' AND (
+        p_http_status IS NOT NULL OR p_error_category IS DISTINCT FROM
+            CASE WHEN attempt_row.dispatched_at IS NULL THEN 'dispatch_unconfirmed'
+                 ELSE 'response_unobserved' END
+    ) THEN
+        RAISE EXCEPTION 'unknown result requires no HTTP status and the matching dispatch phase category'
+            USING ERRCODE = '22023';
     END IF;
 
     IF attempt_row.state IN (
@@ -623,9 +690,15 @@ DECLARE
     recipient text;
 BEGIN
     FOR entry IN
-        SELECT DISTINCT 'TABLE' AS object_kind,
-            pg_catalog.format('%I.%I', n.nspname, c.relname) AS object_name,
+        SELECT DISTINCT 'SCHEMA' AS object_kind,
+            pg_catalog.format('%I', n.nspname) AS object_name,
             acl.grantee, 'ALL' AS privileges
+        FROM pg_catalog.pg_namespace n
+        CROSS JOIN LATERAL pg_catalog.aclexplode(n.nspacl) acl
+        WHERE n.nspname = 'warehouse_quota' AND acl.grantee <> n.nspowner
+        UNION
+        SELECT DISTINCT 'TABLE',
+            pg_catalog.format('%I.%I', n.nspname, c.relname), acl.grantee, 'ALL'
         FROM pg_catalog.pg_class AS c
         JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace
         CROSS JOIN LATERAL pg_catalog.aclexplode(c.relacl) AS acl
@@ -642,7 +715,7 @@ BEGIN
         CROSS JOIN LATERAL pg_catalog.aclexplode(
             COALESCE(p.proacl, pg_catalog.acldefault('f', p.proowner))
         ) AS acl
-        WHERE n.nspname = 'meta'
+        WHERE n.nspname = 'warehouse_quota'
           AND p.proname IN (
               'guard_api_request_attempt_update', 'reject_api_request_attempt_removal',
               'start_operation_run', 'finish_operation_run', 'reserve_cfbd_attempt',
@@ -658,13 +731,11 @@ BEGIN
 END
 $quota_acl$;
 
-REVOKE CREATE ON SCHEMA meta FROM PUBLIC;
-REVOKE CREATE ON SCHEMA meta FROM warehouse_ingest;
-GRANT USAGE ON SCHEMA meta TO warehouse_ingest;
+GRANT USAGE ON SCHEMA warehouse_quota TO warehouse_ingest;
 
-GRANT EXECUTE ON FUNCTION meta.start_operation_run(uuid, text, text, jsonb, text, text),
-    meta.finish_operation_run(uuid, text, text),
-    meta.reserve_cfbd_attempt(uuid, uuid, text, timestamptz, text, integer, jsonb),
-    meta.mark_cfbd_attempt_dispatched(uuid),
-    meta.record_cfbd_attempt_result(uuid, text, integer, text)
+GRANT EXECUTE ON FUNCTION warehouse_quota.start_operation_run(uuid, text, text, jsonb, text, text),
+    warehouse_quota.finish_operation_run(uuid, text, text),
+    warehouse_quota.reserve_cfbd_attempt(uuid, uuid, text, timestamptz, text, integer, jsonb),
+    warehouse_quota.mark_cfbd_attempt_dispatched(uuid),
+    warehouse_quota.record_cfbd_attempt_result(uuid, text, integer, text)
     TO warehouse_ingest;

--- a/src/schemas/migrations/066_operational_quota_ledger.sql
+++ b/src/schemas/migrations/066_operational_quota_ledger.sql
@@ -1,0 +1,670 @@
+-- Migration: 066_operational_quota_ledger
+--
+-- F14 quota foundation. This creates private operational audit and conservative
+-- local admission records only; no pipeline caller is changed by this migration.
+-- Apply through the reviewed forward-migration manifest. Preparing this file
+-- does not authorize a production rollout.
+--
+-- The caller must commit reserve_cfbd_attempt(), then commit
+-- mark_cfbd_attempt_dispatched(), before sending HTTP bytes. PostgreSQL cannot
+-- make that cross-system ordering automatic. A committed reservation is always
+-- charged locally, including a crash/unknown outcome. Provider reconciliation
+-- is separate because provider billing may treat a response differently.
+
+CREATE SCHEMA IF NOT EXISTS meta;
+
+-- Text equality in the account-scoped exclusion constraint comes from
+-- btree_gist. The DO block below discovers its actual installation schema, so
+-- this works both on plain PostgreSQL (normally public) and hosts that install
+-- extensions into a dedicated schema.
+CREATE EXTENSION IF NOT EXISTS btree_gist WITH SCHEMA public;
+
+DO $role$
+DECLARE
+    existing_role_is_unsafe boolean;
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'warehouse_ingest') THEN
+        CREATE ROLE warehouse_ingest NOLOGIN NOINHERIT NOSUPERUSER NOCREATEDB
+            NOCREATEROLE NOREPLICATION NOBYPASSRLS;
+    ELSE
+        SELECT r.rolcanlogin OR r.rolsuper OR r.rolcreatedb OR r.rolcreaterole
+            OR r.rolreplication OR r.rolbypassrls OR r.rolinherit
+            OR EXISTS (
+                SELECT 1 FROM pg_catalog.pg_auth_members m WHERE m.member = r.oid
+            )
+        INTO existing_role_is_unsafe
+        FROM pg_catalog.pg_roles AS r
+        WHERE r.rolname = 'warehouse_ingest';
+        IF existing_role_is_unsafe THEN
+            RAISE EXCEPTION 'existing warehouse_ingest role is not the required bounded NOLOGIN role';
+        END IF;
+    END IF;
+END
+$role$;
+
+CREATE TABLE IF NOT EXISTS meta.operation_runs (
+    operation_run_id uuid PRIMARY KEY,
+    operation_kind text NOT NULL CHECK (
+        operation_kind IN ('extract', 'load', 'compute', 'refresh', 'verify')
+    ),
+    initiator text NOT NULL CHECK (length(btrim(initiator)) > 0),
+    requested_scope jsonb NOT NULL CHECK (jsonb_typeof(requested_scope) = 'object'),
+    plan_digest text CHECK (plan_digest IS NULL OR length(btrim(plan_digest)) > 0),
+    code_revision text CHECK (code_revision IS NULL OR length(btrim(code_revision)) > 0),
+    started_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+    finished_at timestamptz,
+    outcome text NOT NULL DEFAULT 'running' CHECK (
+        outcome IN ('running', 'succeeded', 'failed', 'partial', 'blocked', 'cancelled')
+    ),
+    error_summary text,
+    recorded_by text NOT NULL DEFAULT session_user,
+    CONSTRAINT operation_runs_lifecycle_check CHECK (
+        (outcome = 'running' AND finished_at IS NULL AND error_summary IS NULL)
+        OR
+        (outcome <> 'running' AND finished_at IS NOT NULL
+            AND (outcome <> 'succeeded' OR error_summary IS NULL))
+    )
+);
+
+COMMENT ON TABLE meta.operation_runs IS
+    'Private audit parent for one warehouse operation invocation. A successful run is not by itself a source-freshness or publication claim.';
+COMMENT ON COLUMN meta.operation_runs.requested_scope IS
+    'Caller-supplied non-secret JSON scope such as selected sources, assets, years, or work units.';
+COMMENT ON COLUMN meta.operation_runs.recorded_by IS
+    'Database session identity that invoked start_operation_run; initiator is the scheduler/CLI identity.';
+
+CREATE TABLE IF NOT EXISTS meta.api_quota_periods (
+    account_key text NOT NULL CHECK (length(btrim(account_key)) > 0),
+    period_start_at timestamptz NOT NULL,
+    period_end_at timestamptz NOT NULL,
+    attempt_limit integer NOT NULL CHECK (attempt_limit > 0),
+    reserved_attempts integer NOT NULL DEFAULT 0 CHECK (
+        reserved_attempts >= 0 AND reserved_attempts <= attempt_limit
+    ),
+    provider_observed_used integer CHECK (provider_observed_used >= 0),
+    provider_observed_at timestamptz,
+    reconciliation_note text,
+    created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+    updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+    PRIMARY KEY (account_key, period_start_at),
+    CONSTRAINT api_quota_periods_bounds_check CHECK (
+        pg_catalog.isfinite(period_start_at)
+        AND pg_catalog.isfinite(period_end_at)
+        AND period_start_at < period_end_at
+    ),
+    CONSTRAINT api_quota_periods_observation_check CHECK (
+        (provider_observed_used IS NULL) = (provider_observed_at IS NULL)
+    )
+);
+
+DO $constraint$
+DECLARE
+    extension_schema text;
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_constraint
+        WHERE conrelid = 'meta.api_quota_periods'::pg_catalog.regclass
+          AND conname = 'api_quota_periods_no_overlap'
+    ) THEN
+        SELECT n.nspname
+        INTO STRICT extension_schema
+        FROM pg_catalog.pg_extension e
+        JOIN pg_catalog.pg_namespace n ON n.oid = e.extnamespace
+        WHERE e.extname = 'btree_gist';
+
+        EXECUTE pg_catalog.format(
+            'ALTER TABLE meta.api_quota_periods '
+            'ADD CONSTRAINT api_quota_periods_no_overlap '
+            'EXCLUDE USING gist '
+            '(account_key %I.gist_text_ops WITH =, '
+            'tstzrange(period_start_at, period_end_at, ''[)'') WITH &&)',
+            extension_schema
+        );
+    END IF;
+END
+$constraint$;
+
+COMMENT ON TABLE meta.api_quota_periods IS
+    'Owner-configured local admission periods. account_key is an opaque non-secret identifier for one shared provider pool, including shared CFBD/CBBD products; it is never a token or token fingerprint.';
+COMMENT ON COLUMN meta.api_quota_periods.attempt_limit IS
+    'Conservative local reservation cap for this explicit period. At mid-period it must be configured from verified remaining capacity minus headroom, not copied from the full provider monthly limit.';
+COMMENT ON COLUMN meta.api_quota_periods.reserved_attempts IS
+    'Monotone local count maintained by reserve_cfbd_attempt. Every committed transport reservation stays charged regardless of HTTP/result status.';
+COMMENT ON COLUMN meta.api_quota_periods.provider_observed_used IS
+    'Optional owner-recorded provider observation for reconciliation; it never rewrites local immutable attempt history.';
+
+CREATE TABLE IF NOT EXISTS meta.api_request_attempts (
+    attempt_id uuid PRIMARY KEY,
+    operation_run_id uuid NOT NULL REFERENCES meta.operation_runs (operation_run_id),
+    account_key text NOT NULL,
+    period_start_at timestamptz NOT NULL,
+    period_attempt_number integer NOT NULL CHECK (period_attempt_number > 0),
+    endpoint_class text NOT NULL CHECK (length(btrim(endpoint_class)) > 0),
+    retry_ordinal integer NOT NULL CHECK (retry_ordinal >= 0),
+    request_context jsonb NOT NULL CHECK (jsonb_typeof(request_context) = 'object'),
+    reserved_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+    state text NOT NULL DEFAULT 'reserved' CHECK (
+        state IN (
+            'reserved', 'dispatched', 'succeeded', 'expected_no_data',
+            'http_error', 'transport_error', 'unknown'
+        )
+    ),
+    dispatched_at timestamptz,
+    result_recorded_at timestamptz,
+    http_status integer CHECK (http_status BETWEEN 100 AND 599),
+    error_category text CHECK (
+        error_category IS NULL OR length(btrim(error_category)) > 0
+    ),
+    CONSTRAINT api_request_attempts_period_fk FOREIGN KEY (account_key, period_start_at)
+        REFERENCES meta.api_quota_periods (account_key, period_start_at),
+    CONSTRAINT api_request_attempts_period_number_key UNIQUE (
+        account_key, period_start_at, period_attempt_number
+    ),
+    CONSTRAINT api_request_attempts_lifecycle_check CHECK (
+        (state = 'reserved'
+            AND dispatched_at IS NULL AND result_recorded_at IS NULL
+            AND http_status IS NULL AND error_category IS NULL)
+        OR
+        (state = 'dispatched'
+            AND dispatched_at IS NOT NULL AND result_recorded_at IS NULL
+            AND http_status IS NULL AND error_category IS NULL)
+        OR
+        (state IN ('succeeded', 'expected_no_data')
+            AND dispatched_at IS NOT NULL AND result_recorded_at IS NOT NULL
+            AND http_status IS NOT NULL AND http_status BETWEEN 200 AND 299
+            AND error_category IS NULL)
+        OR
+        (state = 'http_error'
+            AND dispatched_at IS NOT NULL AND result_recorded_at IS NOT NULL
+            AND http_status IS NOT NULL AND (http_status < 200 OR http_status >= 300)
+            AND error_category IS NOT NULL)
+        OR
+        (state = 'transport_error'
+            AND dispatched_at IS NOT NULL AND result_recorded_at IS NOT NULL
+            AND error_category IS NOT NULL)
+        OR
+        (state = 'unknown'
+            AND result_recorded_at IS NOT NULL)
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_api_request_attempts_operation_state
+    ON meta.api_request_attempts (operation_run_id, state);
+
+COMMENT ON TABLE meta.api_request_attempts IS
+    'One private row per locally admitted HTTP transport attempt. Reservation identity and charge are immutable; terminal failure and unknown states never refund quota.';
+COMMENT ON COLUMN meta.api_request_attempts.request_context IS
+    'Non-secret immutable logical context used to reject an attempt UUID replayed for a different request. Callers must never include credentials or authorization material.';
+COMMENT ON COLUMN meta.api_request_attempts.state IS
+    'Transport lifecycle, separate from source-level publication/freshness. reserved/dispatched can remain pending after a crash and remain locally charged.';
+
+CREATE OR REPLACE FUNCTION meta.guard_api_request_attempt_update()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $function$
+BEGIN
+    IF ROW(
+        NEW.attempt_id, NEW.operation_run_id, NEW.account_key, NEW.period_start_at,
+        NEW.period_attempt_number, NEW.endpoint_class, NEW.retry_ordinal,
+        NEW.request_context, NEW.reserved_at
+    ) IS DISTINCT FROM ROW(
+        OLD.attempt_id, OLD.operation_run_id, OLD.account_key, OLD.period_start_at,
+        OLD.period_attempt_number, OLD.endpoint_class, OLD.retry_ordinal,
+        OLD.request_context, OLD.reserved_at
+    ) THEN
+        RAISE EXCEPTION 'API attempt reservation identity is immutable';
+    END IF;
+
+    IF NOT (
+        (OLD.state = 'reserved' AND NEW.state IN ('dispatched', 'unknown'))
+        OR (OLD.state = 'dispatched' AND NEW.state IN (
+            'succeeded', 'expected_no_data', 'http_error', 'transport_error', 'unknown'
+        ))
+    ) THEN
+        RAISE EXCEPTION 'Invalid API attempt state transition from % to %',
+            OLD.state, NEW.state;
+    END IF;
+    RETURN NEW;
+END
+$function$;
+
+DROP TRIGGER IF EXISTS guard_api_request_attempt_update ON meta.api_request_attempts;
+CREATE TRIGGER guard_api_request_attempt_update
+    BEFORE UPDATE ON meta.api_request_attempts
+    FOR EACH ROW EXECUTE FUNCTION meta.guard_api_request_attempt_update();
+
+CREATE OR REPLACE FUNCTION meta.reject_api_request_attempt_removal()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $function$
+BEGIN
+    RAISE EXCEPTION 'API attempt history is append-only and cannot be removed';
+END
+$function$;
+
+DROP TRIGGER IF EXISTS reject_api_request_attempt_delete ON meta.api_request_attempts;
+CREATE TRIGGER reject_api_request_attempt_delete
+    BEFORE DELETE OR TRUNCATE ON meta.api_request_attempts
+    FOR EACH STATEMENT EXECUTE FUNCTION meta.reject_api_request_attempt_removal();
+
+CREATE OR REPLACE FUNCTION meta.start_operation_run(
+    p_operation_run_id uuid,
+    p_operation_kind text,
+    p_initiator text,
+    p_requested_scope jsonb,
+    p_plan_digest text,
+    p_code_revision text
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $function$
+DECLARE
+    existing_run meta.operation_runs%ROWTYPE;
+BEGIN
+    IF p_operation_run_id IS NULL THEN
+        RAISE EXCEPTION 'operation_run_id is required' USING ERRCODE = '22023';
+    END IF;
+
+    PERFORM pg_catalog.pg_advisory_xact_lock(
+        pg_catalog.hashtextextended(p_operation_run_id::text, 0)
+    );
+    SELECT r.* INTO existing_run
+    FROM meta.operation_runs AS r
+    WHERE r.operation_run_id = p_operation_run_id;
+
+    IF FOUND THEN
+        IF existing_run.operation_kind IS DISTINCT FROM p_operation_kind
+            OR existing_run.initiator IS DISTINCT FROM p_initiator
+            OR existing_run.requested_scope IS DISTINCT FROM p_requested_scope
+            OR existing_run.plan_digest IS DISTINCT FROM p_plan_digest
+            OR existing_run.code_revision IS DISTINCT FROM p_code_revision THEN
+            RAISE EXCEPTION 'operation_run_id already exists with different context'
+                USING ERRCODE = '22023';
+        END IF;
+        RETURN p_operation_run_id;
+    END IF;
+
+    INSERT INTO meta.operation_runs (
+        operation_run_id, operation_kind, initiator, requested_scope,
+        plan_digest, code_revision
+    ) VALUES (
+        p_operation_run_id, p_operation_kind, p_initiator, p_requested_scope,
+        p_plan_digest, p_code_revision
+    );
+    RETURN p_operation_run_id;
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION meta.finish_operation_run(
+    p_operation_run_id uuid,
+    p_outcome text,
+    p_error_summary text
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $function$
+DECLARE
+    run_row meta.operation_runs%ROWTYPE;
+    pending_attempts integer;
+BEGIN
+    IF p_outcome IS NULL OR p_outcome NOT IN (
+        'succeeded', 'failed', 'partial', 'blocked', 'cancelled'
+    ) THEN
+        RAISE EXCEPTION 'terminal operation outcome is invalid' USING ERRCODE = '22023';
+    END IF;
+    IF p_outcome = 'succeeded' AND p_error_summary IS NOT NULL THEN
+        RAISE EXCEPTION 'a succeeded operation cannot have an error summary'
+            USING ERRCODE = '22023';
+    END IF;
+
+    SELECT r.* INTO run_row
+    FROM meta.operation_runs AS r
+    WHERE r.operation_run_id = p_operation_run_id
+    FOR UPDATE;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'operation run is not configured' USING ERRCODE = '22023';
+    END IF;
+
+    SELECT count(*)::integer INTO pending_attempts
+    FROM meta.api_request_attempts AS a
+    WHERE a.operation_run_id = p_operation_run_id
+      AND a.state IN ('reserved', 'dispatched');
+
+    IF run_row.outcome <> 'running' THEN
+        IF run_row.outcome IS DISTINCT FROM p_outcome
+            OR run_row.error_summary IS DISTINCT FROM p_error_summary THEN
+            RAISE EXCEPTION 'operation run already finished with a different result'
+                USING ERRCODE = '22023';
+        END IF;
+        RETURN pending_attempts;
+    END IF;
+
+    IF p_outcome = 'succeeded' AND pending_attempts > 0 THEN
+        RAISE EXCEPTION 'cannot succeed operation with % pending API attempt(s)',
+            pending_attempts USING ERRCODE = '22023';
+    END IF;
+
+    UPDATE meta.operation_runs
+    SET outcome = p_outcome,
+        error_summary = p_error_summary,
+        finished_at = pg_catalog.clock_timestamp()
+    WHERE operation_run_id = p_operation_run_id;
+    RETURN pending_attempts;
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION meta.reserve_cfbd_attempt(
+    p_attempt_id uuid,
+    p_operation_run_id uuid,
+    p_account_key text,
+    p_period_start_at timestamptz,
+    p_endpoint_class text,
+    p_retry_ordinal integer,
+    p_request_context jsonb
+)
+RETURNS TABLE (
+    attempt_id uuid,
+    reserved_at timestamptz,
+    period_attempt_number integer,
+    attempt_limit integer,
+    reused boolean
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $function$
+DECLARE
+    existing_attempt meta.api_request_attempts%ROWTYPE;
+    run_outcome text;
+    period_row meta.api_quota_periods%ROWTYPE;
+    reservation_time timestamptz;
+    new_period_count integer;
+BEGIN
+    IF p_attempt_id IS NULL OR p_operation_run_id IS NULL
+        OR p_account_key IS NULL OR length(pg_catalog.btrim(p_account_key)) = 0
+        OR p_period_start_at IS NULL
+        OR p_endpoint_class IS NULL OR length(pg_catalog.btrim(p_endpoint_class)) = 0
+        OR p_retry_ordinal IS NULL OR p_retry_ordinal < 0
+        OR p_request_context IS NULL OR pg_catalog.jsonb_typeof(p_request_context) <> 'object' THEN
+        RAISE EXCEPTION 'attempt reservation context is invalid' USING ERRCODE = '22023';
+    END IF;
+
+    -- Serialize on the logical attempt before any period counter is touched.
+    -- Hash collisions only add harmless serialization.
+    PERFORM pg_catalog.pg_advisory_xact_lock(
+        pg_catalog.hashtextextended(p_attempt_id::text, 1)
+    );
+    SELECT a.* INTO existing_attempt
+    FROM meta.api_request_attempts AS a
+    WHERE a.attempt_id = p_attempt_id;
+
+    IF FOUND THEN
+        IF existing_attempt.operation_run_id IS DISTINCT FROM p_operation_run_id
+            OR existing_attempt.account_key IS DISTINCT FROM p_account_key
+            OR existing_attempt.period_start_at IS DISTINCT FROM p_period_start_at
+            OR existing_attempt.endpoint_class IS DISTINCT FROM p_endpoint_class
+            OR existing_attempt.retry_ordinal IS DISTINCT FROM p_retry_ordinal
+            OR existing_attempt.request_context IS DISTINCT FROM p_request_context THEN
+            RAISE EXCEPTION 'attempt_id already reserved with different context'
+                USING ERRCODE = '22023';
+        END IF;
+
+        RETURN QUERY
+        SELECT existing_attempt.attempt_id, existing_attempt.reserved_at,
+            existing_attempt.period_attempt_number, p.attempt_limit, true
+        FROM meta.api_quota_periods AS p
+        WHERE p.account_key = existing_attempt.account_key
+          AND p.period_start_at = existing_attempt.period_start_at;
+        RETURN;
+    END IF;
+
+    SELECT r.outcome INTO run_outcome
+    FROM meta.operation_runs AS r
+    WHERE r.operation_run_id = p_operation_run_id
+    FOR UPDATE;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'operation run is not configured' USING ERRCODE = '22023';
+    END IF;
+    IF run_outcome <> 'running' THEN
+        RAISE EXCEPTION 'operation run is already terminal' USING ERRCODE = '22023';
+    END IF;
+
+    SELECT p.* INTO period_row
+    FROM meta.api_quota_periods AS p
+    WHERE p.account_key = p_account_key
+      AND p.period_start_at = p_period_start_at
+    FOR UPDATE;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'quota period is not configured' USING ERRCODE = '22023';
+    END IF;
+
+    -- Use a fresh wall clock only after the potentially blocking period lock.
+    reservation_time := pg_catalog.clock_timestamp();
+    IF reservation_time < period_row.period_start_at
+        OR reservation_time >= period_row.period_end_at THEN
+        RAISE EXCEPTION 'quota period is not active' USING ERRCODE = '22023';
+    END IF;
+    IF period_row.reserved_attempts >= period_row.attempt_limit THEN
+        RAISE EXCEPTION 'quota period is exhausted' USING ERRCODE = 'P0001';
+    END IF;
+
+    UPDATE meta.api_quota_periods AS p
+    SET reserved_attempts = p.reserved_attempts + 1,
+        updated_at = reservation_time
+    WHERE p.account_key = p_account_key
+      AND p.period_start_at = p_period_start_at
+    RETURNING p.reserved_attempts INTO new_period_count;
+
+    INSERT INTO meta.api_request_attempts (
+        attempt_id, operation_run_id, account_key, period_start_at,
+        period_attempt_number, endpoint_class, retry_ordinal, request_context,
+        reserved_at
+    ) VALUES (
+        p_attempt_id, p_operation_run_id, p_account_key, p_period_start_at,
+        new_period_count, p_endpoint_class, p_retry_ordinal, p_request_context,
+        reservation_time
+    );
+
+    RETURN QUERY SELECT p_attempt_id, reservation_time, new_period_count,
+        period_row.attempt_limit, false;
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION meta.mark_cfbd_attempt_dispatched(p_attempt_id uuid)
+RETURNS timestamptz
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $function$
+DECLARE
+    attempt_row meta.api_request_attempts%ROWTYPE;
+    run_outcome text;
+    period_row meta.api_quota_periods%ROWTYPE;
+    dispatch_time timestamptz;
+BEGIN
+    -- Read identity, then lock in the same run -> attempt -> period order used
+    -- by operation finish/reservation to avoid lock-order inversions.
+    SELECT a.* INTO attempt_row
+    FROM meta.api_request_attempts AS a
+    WHERE a.attempt_id = p_attempt_id;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'attempt is not reserved' USING ERRCODE = '22023';
+    END IF;
+
+    SELECT r.outcome INTO run_outcome
+    FROM meta.operation_runs AS r
+    WHERE r.operation_run_id = attempt_row.operation_run_id
+    FOR UPDATE;
+
+    SELECT a.* INTO attempt_row
+    FROM meta.api_request_attempts AS a
+    WHERE a.attempt_id = p_attempt_id
+    FOR UPDATE;
+    IF attempt_row.state <> 'reserved' THEN
+        RAISE EXCEPTION 'attempt is already dispatched or terminal; do not send it again'
+            USING ERRCODE = '22023';
+    END IF;
+    IF run_outcome <> 'running' THEN
+        RAISE EXCEPTION 'operation run is already terminal' USING ERRCODE = '22023';
+    END IF;
+
+    SELECT p.* INTO period_row
+    FROM meta.api_quota_periods AS p
+    WHERE p.account_key = attempt_row.account_key
+      AND p.period_start_at = attempt_row.period_start_at
+    FOR UPDATE;
+    dispatch_time := pg_catalog.clock_timestamp();
+    IF dispatch_time < period_row.period_start_at
+        OR dispatch_time >= period_row.period_end_at THEN
+        RAISE EXCEPTION 'quota period is not active at dispatch' USING ERRCODE = '22023';
+    END IF;
+
+    UPDATE meta.api_request_attempts
+    SET state = 'dispatched', dispatched_at = dispatch_time
+    WHERE attempt_id = p_attempt_id;
+    RETURN dispatch_time;
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION meta.record_cfbd_attempt_result(
+    p_attempt_id uuid,
+    p_state text,
+    p_http_status integer,
+    p_error_category text
+)
+RETURNS timestamptz
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $function$
+DECLARE
+    attempt_row meta.api_request_attempts%ROWTYPE;
+    result_time timestamptz;
+BEGIN
+    IF p_state IS NULL OR p_state NOT IN (
+        'succeeded', 'expected_no_data', 'http_error', 'transport_error', 'unknown'
+    ) THEN
+        RAISE EXCEPTION 'terminal attempt state is invalid' USING ERRCODE = '22023';
+    END IF;
+    IF p_http_status IS NOT NULL AND (p_http_status < 100 OR p_http_status > 599) THEN
+        RAISE EXCEPTION 'HTTP status is invalid' USING ERRCODE = '22023';
+    END IF;
+    IF p_state IN ('succeeded', 'expected_no_data') AND (
+        p_http_status IS NULL OR p_http_status < 200 OR p_http_status >= 300
+        OR p_error_category IS NOT NULL
+    ) THEN
+        RAISE EXCEPTION 'successful/logical no-data transport result requires 2xx status and no error category'
+            USING ERRCODE = '22023';
+    END IF;
+    IF p_state = 'http_error' AND (
+        p_http_status IS NULL OR (p_http_status >= 200 AND p_http_status < 300)
+        OR p_error_category IS NULL OR length(pg_catalog.btrim(p_error_category)) = 0
+    ) THEN
+        RAISE EXCEPTION 'HTTP error result requires non-2xx status and error category'
+            USING ERRCODE = '22023';
+    END IF;
+    IF p_state = 'transport_error' AND (
+        p_error_category IS NULL OR length(pg_catalog.btrim(p_error_category)) = 0
+    ) THEN
+        RAISE EXCEPTION 'transport error result requires an error category'
+            USING ERRCODE = '22023';
+    END IF;
+
+    SELECT a.* INTO attempt_row
+    FROM meta.api_request_attempts AS a
+    WHERE a.attempt_id = p_attempt_id
+    FOR UPDATE;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'attempt is not reserved' USING ERRCODE = '22023';
+    END IF;
+
+    IF attempt_row.state IN (
+        'succeeded', 'expected_no_data', 'http_error', 'transport_error', 'unknown'
+    ) THEN
+        IF attempt_row.state IS DISTINCT FROM p_state
+            OR attempt_row.http_status IS DISTINCT FROM p_http_status
+            OR attempt_row.error_category IS DISTINCT FROM p_error_category THEN
+            RAISE EXCEPTION 'attempt already has a different terminal result'
+                USING ERRCODE = '22023';
+        END IF;
+        RETURN attempt_row.result_recorded_at;
+    END IF;
+
+    IF attempt_row.state = 'reserved' AND p_state <> 'unknown' THEN
+        RAISE EXCEPTION 'attempt must be marked dispatched before recording this result'
+            USING ERRCODE = '22023';
+    END IF;
+
+    result_time := pg_catalog.clock_timestamp();
+    UPDATE meta.api_request_attempts
+    SET state = p_state,
+        result_recorded_at = result_time,
+        http_status = p_http_status,
+        error_category = p_error_category
+    WHERE attempt_id = p_attempt_id;
+    RETURN result_time;
+END
+$function$;
+
+-- Host defaults can be deliberately broad and can name arbitrary roles.
+-- Remove their ACL entries from only the new private objects/functions. Do not
+-- rewrite named roles' pre-existing meta schema privileges: older ledgers and
+-- loaders already use that schema.
+DO $quota_acl$
+DECLARE
+    entry record;
+    recipient text;
+BEGIN
+    FOR entry IN
+        SELECT DISTINCT 'TABLE' AS object_kind,
+            pg_catalog.format('%I.%I', n.nspname, c.relname) AS object_name,
+            acl.grantee, 'ALL' AS privileges
+        FROM pg_catalog.pg_class AS c
+        JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace
+        CROSS JOIN LATERAL pg_catalog.aclexplode(c.relacl) AS acl
+        WHERE n.nspname = 'meta'
+          AND c.relname IN ('operation_runs', 'api_quota_periods', 'api_request_attempts')
+          AND c.relkind IN ('r', 'p') AND acl.grantee <> c.relowner
+        UNION
+        SELECT DISTINCT 'FUNCTION',
+            pg_catalog.format('%I.%I(%s)', n.nspname, p.proname,
+                pg_catalog.pg_get_function_identity_arguments(p.oid)),
+            acl.grantee, 'ALL'
+        FROM pg_catalog.pg_proc AS p
+        JOIN pg_catalog.pg_namespace AS n ON n.oid = p.pronamespace
+        CROSS JOIN LATERAL pg_catalog.aclexplode(
+            COALESCE(p.proacl, pg_catalog.acldefault('f', p.proowner))
+        ) AS acl
+        WHERE n.nspname = 'meta'
+          AND p.proname IN (
+              'guard_api_request_attempt_update', 'reject_api_request_attempt_removal',
+              'start_operation_run', 'finish_operation_run', 'reserve_cfbd_attempt',
+              'mark_cfbd_attempt_dispatched', 'record_cfbd_attempt_result'
+          )
+          AND acl.grantee <> p.proowner
+    LOOP
+        recipient := CASE WHEN entry.grantee = 0 THEN 'PUBLIC'
+            ELSE pg_catalog.format('%I', pg_catalog.pg_get_userbyid(entry.grantee)) END;
+        EXECUTE pg_catalog.format('REVOKE %s ON %s %s FROM %s',
+            entry.privileges, entry.object_kind, entry.object_name, recipient);
+    END LOOP;
+END
+$quota_acl$;
+
+REVOKE CREATE ON SCHEMA meta FROM PUBLIC;
+REVOKE CREATE ON SCHEMA meta FROM warehouse_ingest;
+GRANT USAGE ON SCHEMA meta TO warehouse_ingest;
+
+GRANT EXECUTE ON FUNCTION meta.start_operation_run(uuid, text, text, jsonb, text, text),
+    meta.finish_operation_run(uuid, text, text),
+    meta.reserve_cfbd_attempt(uuid, uuid, text, timestamptz, text, integer, jsonb),
+    meta.mark_cfbd_attempt_dispatched(uuid),
+    meta.record_cfbd_attempt_result(uuid, text, integer, text)
+    TO warehouse_ingest;

--- a/src/schemas/production-manifest.json
+++ b/src/schemas/production-manifest.json
@@ -4,6 +4,11 @@
       "id": "warehouse.production.catalog-adopted.20260907.288b4eaf817b",
       "kind": "immutable",
       "path": "src/schemas/adoptions/20260907_production_catalog_receipt.sql"
+    },
+    {
+      "id": "warehouse.f14.066",
+      "path": "src/schemas/migrations/066_operational_quota_ledger.sql",
+      "kind": "immutable"
     }
   ],
   "version": 1

--- a/src/schemas/warehouse-manifest.json
+++ b/src/schemas/warehouse-manifest.json
@@ -30,6 +30,11 @@
       "id": "warehouse.f06.065",
       "path": "src/schemas/migrations/065_trajectory_wrapper_access.sql",
       "kind": "immutable"
+    },
+    {
+      "id": "warehouse.f14.066",
+      "path": "src/schemas/migrations/066_operational_quota_ledger.sql",
+      "kind": "immutable"
     }
   ]
 }

--- a/tests/test_operational_quota_lifecycle_sql.py
+++ b/tests/test_operational_quota_lifecycle_sql.py
@@ -1,0 +1,273 @@
+"""Executed lifecycle invariants for the private F14 quota ledger."""
+
+from __future__ import annotations
+
+import uuid
+
+import psycopg2
+import pytest
+
+from tests.test_operational_quota_sql import add_period, reserve, runtime_query, start_run
+from tests.test_operational_quota_sql import quota_db as _quota_db_fixture  # noqa: F401
+from tests.test_warehouse_migrations_sql import query
+from tests.test_warehouse_migrations_sql import warehouse_db as _warehouse_db  # noqa: F401
+
+
+@pytest.fixture(name="quota_db")
+def _lifecycle_quota_db(request):
+    return request.getfixturevalue("_quota_db_fixture")
+
+
+def test_operation_run_uuid_replay_requires_exact_context(quota_db):
+    conn, _ = quota_db
+    run_id = start_run(conn)
+
+    replayed = runtime_query(
+        conn,
+        """
+        SELECT warehouse_quota.start_operation_run(
+            %s, 'extract', 'pytest', '{"sources":["games"]}'::jsonb,
+            'fixture-plan', 'fixture-revision'
+        )
+        """,
+        (str(run_id),),
+    )
+    assert str(replayed[0][0]) == str(run_id)
+    assert query(
+        conn,
+        "SELECT count(*) FROM meta.operation_runs WHERE operation_run_id=%s",
+        (str(run_id),),
+    ) == [(1,)]
+
+    with pytest.raises(psycopg2.Error, match="different context"):
+        runtime_query(
+            conn,
+            """
+            SELECT warehouse_quota.start_operation_run(
+                %s, 'extract', 'pytest', '{"sources":["plays"]}'::jsonb,
+                'fixture-plan', 'fixture-revision'
+            )
+            """,
+            (str(run_id),),
+        )
+    conn.rollback()
+    assert query(
+        conn,
+        "SELECT requested_scope FROM meta.operation_runs WHERE operation_run_id=%s",
+        (str(run_id),),
+    ) == [({"sources": ["games"]},)]
+
+
+def test_success_finish_waits_for_reserved_and_dispatched_attempts(quota_db):
+    conn, _ = quota_db
+    run_id = start_run(conn)
+    period_start, _ = add_period(conn, limit=2)
+    reserved_id = uuid.uuid4()
+    dispatched_id = uuid.uuid4()
+    reserve(conn, reserved_id, run_id, period_start)
+    reserve(conn, dispatched_id, run_id, period_start)
+    runtime_query(
+        conn,
+        "SELECT warehouse_quota.mark_cfbd_attempt_dispatched(%s)",
+        (str(dispatched_id),),
+    )
+
+    with pytest.raises(psycopg2.Error, match="cannot succeed operation with 2 pending API attempt"):
+        runtime_query(
+            conn,
+            "SELECT warehouse_quota.finish_operation_run(%s, 'succeeded', NULL)",
+            (str(run_id),),
+        )
+    conn.rollback()
+
+    runtime_query(
+        conn,
+        """
+        SELECT warehouse_quota.record_cfbd_attempt_result(
+            %s, 'unknown', NULL, 'dispatch_unconfirmed'
+        )
+        """,
+        (str(reserved_id),),
+    )
+    runtime_query(
+        conn,
+        """
+        SELECT warehouse_quota.record_cfbd_attempt_result(
+            %s, 'succeeded', 200, NULL
+        )
+        """,
+        (str(dispatched_id),),
+    )
+    assert runtime_query(
+        conn,
+        "SELECT warehouse_quota.finish_operation_run(%s, 'succeeded', NULL)",
+        (str(run_id),),
+    ) == [(0,)]
+    assert query(
+        conn,
+        """
+        SELECT outcome,
+            ARRAY(
+                SELECT state FROM meta.api_request_attempts
+                WHERE operation_run_id=%s ORDER BY state
+            )
+        FROM meta.operation_runs WHERE operation_run_id=%s
+        """,
+        (str(run_id), str(run_id)),
+    ) == [("succeeded", ["succeeded", "unknown"])]
+
+
+def test_terminal_operation_context_and_result_cannot_change(quota_db):
+    conn, _ = quota_db
+    run_id = start_run(conn)
+    assert runtime_query(
+        conn,
+        "SELECT warehouse_quota.finish_operation_run(%s, 'failed', 'fixture failure')",
+        (str(run_id),),
+    ) == [(0,)]
+    original = query(
+        conn,
+        """
+        SELECT outcome, error_summary, finished_at
+        FROM meta.operation_runs WHERE operation_run_id=%s
+        """,
+        (str(run_id),),
+    )
+
+    assert runtime_query(
+        conn,
+        "SELECT warehouse_quota.finish_operation_run(%s, 'failed', 'fixture failure')",
+        (str(run_id),),
+    ) == [(0,)]
+    with pytest.raises(psycopg2.Error, match="different result"):
+        runtime_query(
+            conn,
+            "SELECT warehouse_quota.finish_operation_run(%s, 'blocked', 'fixture failure')",
+            (str(run_id),),
+        )
+    conn.rollback()
+    with pytest.raises(psycopg2.Error, match="different context"):
+        runtime_query(
+            conn,
+            """
+            SELECT warehouse_quota.start_operation_run(
+                %s, 'extract', 'changed-initiator',
+                '{"sources":["games"]}'::jsonb, 'fixture-plan', 'fixture-revision'
+            )
+            """,
+            (str(run_id),),
+        )
+    conn.rollback()
+    assert (
+        query(
+            conn,
+            """
+        SELECT outcome, error_summary, finished_at
+        FROM meta.operation_runs WHERE operation_run_id=%s
+        """,
+            (str(run_id),),
+        )
+        == original
+    )
+
+
+def test_owner_update_cannot_change_reservation_identity(quota_db):
+    conn, _ = quota_db
+    run_id = start_run(conn)
+    period_start, _ = add_period(conn)
+    attempt_id = uuid.uuid4()
+    reserve(conn, attempt_id, run_id, period_start)
+    assert query(
+        conn,
+        """
+        SELECT current_user = pg_catalog.pg_get_userbyid(c.relowner)
+        FROM pg_catalog.pg_class AS c
+        WHERE c.oid='meta.api_request_attempts'::regclass
+        """,
+    ) == [(True,)]
+    original = query(
+        conn,
+        """
+        SELECT endpoint_class, retry_ordinal, request_context, reserved_at
+        FROM meta.api_request_attempts WHERE attempt_id=%s
+        """,
+        (str(attempt_id),),
+    )
+
+    with pytest.raises(psycopg2.Error, match="reservation identity is immutable"):
+        query(
+            conn,
+            "UPDATE meta.api_request_attempts SET endpoint_class='plays' WHERE attempt_id=%s",
+            (str(attempt_id),),
+        )
+    conn.rollback()
+    assert (
+        query(
+            conn,
+            """
+        SELECT endpoint_class, retry_ordinal, request_context, reserved_at
+        FROM meta.api_request_attempts WHERE attempt_id=%s
+        """,
+            (str(attempt_id),),
+        )
+        == original
+    )
+
+
+def test_owner_cannot_delete_or_truncate_attempt_history(quota_db):
+    conn, _ = quota_db
+    run_id = start_run(conn)
+    period_start, _ = add_period(conn)
+    attempt_id = uuid.uuid4()
+    reserve(conn, attempt_id, run_id, period_start)
+
+    statements = (
+        ("DELETE FROM meta.api_request_attempts WHERE attempt_id=%s", (str(attempt_id),)),
+        ("DELETE FROM meta.api_request_attempts WHERE false", None),
+        ("TRUNCATE meta.api_request_attempts", None),
+    )
+    for statement, args in statements:
+        with pytest.raises(psycopg2.Error, match="append-only and cannot be removed"):
+            query(conn, statement, args)
+        conn.rollback()
+        assert query(conn, "SELECT count(*) FROM meta.api_request_attempts") == [(1,)]
+
+
+def test_invalid_attempt_states_are_rejected_without_mutation(quota_db):
+    conn, _ = quota_db
+    run_id = start_run(conn)
+    period_start, _ = add_period(conn)
+    attempt_id = uuid.uuid4()
+    reserve(conn, attempt_id, run_id, period_start)
+
+    with pytest.raises(psycopg2.Error, match="Invalid API attempt state transition"):
+        query(
+            conn,
+            """
+            UPDATE meta.api_request_attempts
+            SET state='succeeded', dispatched_at=clock_timestamp(),
+                result_recorded_at=clock_timestamp(), http_status=200
+            WHERE attempt_id=%s
+            """,
+            (str(attempt_id),),
+        )
+    conn.rollback()
+    with pytest.raises(psycopg2.Error, match="terminal attempt state is invalid"):
+        runtime_query(
+            conn,
+            """
+            SELECT warehouse_quota.record_cfbd_attempt_result(
+                %s, 'invalid-state', NULL, NULL
+            )
+            """,
+            (str(attempt_id),),
+        )
+    conn.rollback()
+    assert query(
+        conn,
+        """
+        SELECT state, dispatched_at, result_recorded_at, http_status, error_category
+        FROM meta.api_request_attempts WHERE attempt_id=%s
+        """,
+        (str(attempt_id),),
+    ) == [("reserved", None, None, None, None)]

--- a/tests/test_operational_quota_sql.py
+++ b/tests/test_operational_quota_sql.py
@@ -67,7 +67,7 @@ def start_run(conn, run_id=None):
     runtime_query(
         conn,
         """
-        SELECT meta.start_operation_run(%s, 'extract', 'pytest', %s::jsonb, %s, %s)
+        SELECT warehouse_quota.start_operation_run(%s, 'extract', 'pytest', %s::jsonb, %s, %s)
         """,
         (str(run_id), '{"sources":["games"]}', "fixture-plan", "fixture-revision"),
     )
@@ -95,7 +95,7 @@ def reserve(conn, attempt_id, run_id, period_start, *, endpoint="games", context
     return runtime_query(
         conn,
         """
-        SELECT * FROM meta.reserve_cfbd_attempt(
+        SELECT * FROM warehouse_quota.reserve_cfbd_attempt(
             %s, %s, %s, %s, %s, 0, %s::jsonb
         )
         """,
@@ -123,7 +123,7 @@ def test_schema_is_idempotent_private_and_runtime_is_bounded(quota_db):
                 has_table_privilege(%s, 'meta.api_quota_periods', 'SELECT,INSERT,UPDATE,DELETE'),
                 has_table_privilege(%s, 'meta.api_request_attempts', 'SELECT,INSERT,UPDATE,DELETE'),
                 has_function_privilege(%s,
-                    'meta.reserve_cfbd_attempt(uuid,uuid,text,timestamptz,text,integer,jsonb)',
+                    'warehouse_quota.reserve_cfbd_attempt(uuid,uuid,text,timestamptz,text,integer,jsonb)',
                     'EXECUTE'),
                 has_schema_privilege(%s, 'meta', 'CREATE')
             """,
@@ -138,11 +138,11 @@ def test_schema_is_idempotent_private_and_runtime_is_bounded(quota_db):
     assert query(
         conn,
         """
-        SELECT has_schema_privilege('warehouse_ingest','meta','USAGE'),
-            has_schema_privilege('warehouse_ingest','meta','CREATE'),
+        SELECT has_schema_privilege('warehouse_ingest','warehouse_quota','USAGE'),
+            has_schema_privilege('warehouse_ingest','warehouse_quota','CREATE'),
             has_table_privilege('warehouse_ingest','meta.api_quota_periods','SELECT'),
             has_function_privilege('warehouse_ingest',
-                'meta.reserve_cfbd_attempt(uuid,uuid,text,timestamptz,text,integer,jsonb)',
+                'warehouse_quota.reserve_cfbd_attempt(uuid,uuid,text,timestamptz,text,integer,jsonb)',
                 'EXECUTE')
         """,
     ) == [(True, False, False, True)]
@@ -154,7 +154,7 @@ def test_schema_is_idempotent_private_and_runtime_is_bounded(quota_db):
         CROSS JOIN LATERAL aclexplode(
             COALESCE(p.proacl, acldefault('f',p.proowner))
         ) acl
-        WHERE n.nspname='meta'
+        WHERE n.nspname='warehouse_quota'
           AND p.proname IN (
               'start_operation_run','finish_operation_run','reserve_cfbd_attempt',
               'mark_cfbd_attempt_dispatched','record_cfbd_attempt_result'
@@ -240,7 +240,7 @@ def test_rollback_is_free_but_committed_crash_reservation_stays_charged(quota_db
     with conn.cursor() as cur:
         cur.execute("SET LOCAL ROLE warehouse_ingest")
         cur.execute(
-            "SELECT * FROM meta.reserve_cfbd_attempt(%s,%s,%s,%s,'games',0,'{}')",
+            "SELECT * FROM warehouse_quota.reserve_cfbd_attempt(%s,%s,%s,%s,'games',0,'{}')",
             (str(rolled_back_id), str(run_id), ACCOUNT, period_start),
         )
     conn.rollback()
@@ -261,7 +261,7 @@ def test_rollback_is_free_but_committed_crash_reservation_stays_charged(quota_db
 
     assert runtime_query(
         conn,
-        "SELECT meta.finish_operation_run(%s, 'failed', 'fixture crash')",
+        "SELECT warehouse_quota.finish_operation_run(%s, 'failed', 'fixture crash')",
         (str(run_id),),
     ) == [(1,)]
     with pytest.raises(psycopg2.Error, match="already terminal"):
@@ -277,36 +277,38 @@ def test_dispatch_rechecks_period_and_terminal_results_do_not_refund(quota_db):
     reserve(conn, attempt_id, run_id, period_start)
     runtime_query(
         conn,
-        "SELECT meta.mark_cfbd_attempt_dispatched(%s)",
+        "SELECT warehouse_quota.mark_cfbd_attempt_dispatched(%s)",
         (str(attempt_id),),
     )
     with pytest.raises(psycopg2.Error, match="do not send it again"):
         runtime_query(
             conn,
-            "SELECT meta.mark_cfbd_attempt_dispatched(%s)",
+            "SELECT warehouse_quota.mark_cfbd_attempt_dispatched(%s)",
             (str(attempt_id),),
         )
     conn.rollback()
     completed_at = runtime_query(
         conn,
-        "SELECT meta.record_cfbd_attempt_result(%s,'http_error',429,'rate_limited')",
+        "SELECT warehouse_quota.record_cfbd_attempt_result(%s,'http_error',429,'rate_limited')",
         (str(attempt_id),),
     )[0][0]
     assert runtime_query(
         conn,
-        "SELECT meta.record_cfbd_attempt_result(%s,'http_error',429,'rate_limited')",
+        "SELECT warehouse_quota.record_cfbd_attempt_result(%s,'http_error',429,'rate_limited')",
         (str(attempt_id),),
     ) == [(completed_at,)]
     with pytest.raises(psycopg2.Error, match="different terminal result"):
         runtime_query(
             conn,
-            "SELECT meta.record_cfbd_attempt_result(%s,'succeeded',200,NULL)",
+            "SELECT warehouse_quota.record_cfbd_attempt_result(%s,'succeeded',200,NULL)",
             (str(attempt_id),),
         )
     conn.rollback()
     success_id = uuid.uuid4()
     reserve(conn, success_id, run_id, period_start)
-    runtime_query(conn, "SELECT meta.mark_cfbd_attempt_dispatched(%s)", (str(success_id),))
+    runtime_query(
+        conn, "SELECT warehouse_quota.mark_cfbd_attempt_dispatched(%s)", (str(success_id),)
+    )
     # The persisted invariant also rejects NULL (CHECK otherwise accepts UNKNOWN).
     for invalid_status in (None, 500):
         with pytest.raises(psycopg2.errors.CheckViolation):
@@ -321,21 +323,23 @@ def test_dispatch_rechecks_period_and_terminal_results_do_not_refund(quota_db):
         with pytest.raises(psycopg2.Error, match="requires 2xx"):
             runtime_query(
                 conn,
-                "SELECT meta.record_cfbd_attempt_result(%s,'succeeded',%s,NULL)",
+                "SELECT warehouse_quota.record_cfbd_attempt_result(%s,'succeeded',%s,NULL)",
                 (str(success_id), invalid_status),
             )
         conn.rollback()
     runtime_query(
         conn,
-        "SELECT meta.record_cfbd_attempt_result(%s,'succeeded',200,NULL)",
+        "SELECT warehouse_quota.record_cfbd_attempt_result(%s,'succeeded',200,NULL)",
         (str(success_id),),
     )
     no_data_id = uuid.uuid4()
     reserve(conn, no_data_id, run_id, period_start)
-    runtime_query(conn, "SELECT meta.mark_cfbd_attempt_dispatched(%s)", (str(no_data_id),))
+    runtime_query(
+        conn, "SELECT warehouse_quota.mark_cfbd_attempt_dispatched(%s)", (str(no_data_id),)
+    )
     runtime_query(
         conn,
-        "SELECT meta.record_cfbd_attempt_result(%s,'expected_no_data',204,NULL)",
+        "SELECT warehouse_quota.record_cfbd_attempt_result(%s,'expected_no_data',204,NULL)",
         (str(no_data_id),),
     )
     # Re-applying populated schema preserves the charged counter and terminal rows.
@@ -368,13 +372,14 @@ def test_expired_period_blocks_dispatch_but_not_unknown_result(quota_db):
     with pytest.raises(psycopg2.Error, match="not active at dispatch"):
         runtime_query(
             conn,
-            "SELECT meta.mark_cfbd_attempt_dispatched(%s)",
+            "SELECT warehouse_quota.mark_cfbd_attempt_dispatched(%s)",
             (str(attempt_id),),
         )
     conn.rollback()
     runtime_query(
         conn,
-        "SELECT meta.record_cfbd_attempt_result(%s,'unknown',NULL,'expired_before_dispatch')",
+        "SELECT warehouse_quota.record_cfbd_attempt_result("
+        "%s,'unknown',NULL,'dispatch_unconfirmed')",
         (str(attempt_id),),
     )
     assert query(
@@ -520,18 +525,18 @@ def test_ordinary_default_public_function_execution_is_revoked(request):
         "WHERE oid='public.quota_public_control()'::regprocedure",
     ) == [(True,)]
     query(conn, MIGRATION.read_text())
-    query(conn, "GRANT USAGE ON SCHEMA meta TO quota_bystander")
+    query(conn, "GRANT USAGE ON SCHEMA warehouse_quota TO quota_bystander")
     assert query(
         conn,
         "SELECT count(*), bool_and(NOT has_function_privilege('quota_bystander', "
         "p.oid, 'EXECUTE')) FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace "
-        "WHERE n.nspname='meta'",
+        "WHERE n.nspname='warehouse_quota'",
     ) == [(7, True)]
     with conn.cursor() as cur:
         cur.execute("SET LOCAL ROLE quota_bystander")
         with pytest.raises(psycopg2.errors.InsufficientPrivilege):
             cur.execute(
-                "SELECT meta.start_operation_run(%s,'extract','fixture','{}',NULL,NULL)",
+                "SELECT warehouse_quota.start_operation_run(%s,'extract','fixture','{}',NULL,NULL)",
                 (str(uuid.uuid4()),),
             )
     conn.rollback()
@@ -540,3 +545,140 @@ def test_ordinary_default_public_function_execution_is_revoked(request):
         "SELECT has_function_privilege('quota_bystander', "
         "'public.quota_public_control()', 'EXECUTE')",
     ) == [(True,)]
+
+
+def test_meta_overload_cannot_capture_private_quota_rpc(quota_db):
+    conn, _ = quota_db
+    with conn.cursor() as cur:
+        cur.execute("SET LOCAL ROLE quota_bystander")
+        cur.execute("""
+            CREATE FUNCTION meta.reserve_cfbd_attempt(text,uuid,text,timestamptz,text,integer,jsonb)
+            RETURNS integer LANGUAGE sql AS 'SELECT -1'
+        """)
+    conn.commit()
+    with conn.cursor() as cur:
+        cur.execute("SET LOCAL ROLE quota_bystander")
+        with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+            cur.execute("""
+                CREATE FUNCTION warehouse_quota.reserve_cfbd_attempt(
+                    text,uuid,text,timestamptz,text,integer,jsonb
+                ) RETURNS integer LANGUAGE sql AS 'SELECT -1'
+            """)
+    conn.rollback()
+    run_id = start_run(conn)
+    period_start, _ = add_period(conn)
+    result = reserve(conn, uuid.uuid4(), run_id, period_start)
+    assert result[2] == 1
+    assert query(conn, "SELECT reserved_attempts FROM meta.api_quota_periods") == [(1,)]
+
+
+def test_transport_and_unknown_results_cannot_claim_http_responses(quota_db):
+    conn, _ = quota_db
+    run_id = start_run(conn)
+    period_start, _ = add_period(conn, limit=3)
+    for dispatched in (False, True):
+        attempt_id = uuid.uuid4()
+        reserve(conn, attempt_id, run_id, period_start)
+        if dispatched:
+            runtime_query(
+                conn, "SELECT warehouse_quota.mark_cfbd_attempt_dispatched(%s)", (str(attempt_id),)
+            )
+        correct = "response_unobserved" if dispatched else "dispatch_unconfirmed"
+        wrong = "dispatch_unconfirmed" if dispatched else "response_unobserved"
+        for state, status, category in (
+            ("unknown", 500, correct),
+            ("unknown", None, wrong),
+            ("unknown", None, None),
+            ("transport_error", 429, "timeout"),
+        ):
+            with pytest.raises(psycopg2.Error):
+                runtime_query(
+                    conn,
+                    "SELECT warehouse_quota.record_cfbd_attempt_result(%s,%s,%s,%s)",
+                    (str(attempt_id), state, status, category),
+                )
+            conn.rollback()
+            with pytest.raises(psycopg2.Error):
+                query(
+                    conn,
+                    "UPDATE meta.api_request_attempts SET state=%s, http_status=%s, "
+                    "error_category=%s, result_recorded_at=clock_timestamp() WHERE attempt_id=%s",
+                    (state, status, category, str(attempt_id)),
+                )
+            conn.rollback()
+        runtime_query(
+            conn,
+            "SELECT warehouse_quota.record_cfbd_attempt_result(%s,'unknown',NULL,%s)",
+            (str(attempt_id), correct),
+        )
+    attempt_id = uuid.uuid4()
+    reserve(conn, attempt_id, run_id, period_start)
+    runtime_query(
+        conn, "SELECT warehouse_quota.mark_cfbd_attempt_dispatched(%s)", (str(attempt_id),)
+    )
+    runtime_query(
+        conn,
+        "SELECT warehouse_quota.record_cfbd_attempt_result(%s,'transport_error',NULL,'timeout')",
+        (str(attempt_id),),
+    )
+    assert query(
+        conn,
+        "SELECT state,http_status FROM meta.api_request_attempts ORDER BY period_attempt_number",
+    ) == [("unknown", None), ("unknown", None), ("transport_error", None)]
+
+
+@pytest.mark.parametrize(
+    "setup, message",
+    [
+        ("ALTER SCHEMA warehouse_quota OWNER TO quota_bystander", "owned by the migration role"),
+        ("GRANT CREATE ON SCHEMA warehouse_quota TO quota_bystander", "untrusted CREATE"),
+        (
+            "CREATE DOMAIN warehouse_quota.mark_cfbd_attempt_dispatched AS uuid; "
+            "ALTER DOMAIN warehouse_quota.mark_cfbd_attempt_dispatched OWNER TO quota_bystander",
+            "unexpected type",
+        ),
+        (
+            "CREATE FUNCTION warehouse_quota.mark_cfbd_attempt_dispatched(uuid) "
+            "RETURNS boolean LANGUAGE sql AS 'SELECT true'; "
+            "ALTER FUNCTION warehouse_quota.mark_cfbd_attempt_dispatched(uuid) "
+            "OWNER TO quota_bystander",
+            "unexpected or untrusted routine",
+        ),
+        (
+            "CREATE FUNCTION warehouse_quota.mark_cfbd_attempt_dispatched(text) "
+            "RETURNS boolean LANGUAGE sql AS 'SELECT true'",
+            "unexpected or untrusted routine",
+        ),
+        (
+            "CREATE FUNCTION warehouse_quota.mark_cfbd_attempt_dispatched(uuid, text DEFAULT '') "
+            "RETURNS boolean LANGUAGE sql AS 'SELECT true'",
+            "unexpected or untrusted routine",
+        ),
+        (
+            "CREATE FUNCTION warehouse_quota.mark_cfbd_attempt_dispatched(VARIADIC text[]) "
+            "RETURNS boolean LANGUAGE sql AS 'SELECT true'",
+            "unexpected or untrusted routine",
+        ),
+    ],
+)
+def test_untrusted_existing_namespace_is_rejected_without_adoption(request, setup, message):
+    conn, _ = request.getfixturevalue("_warehouse_db")
+    query(
+        conn,
+        "DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname='quota_bystander') "
+        "THEN CREATE ROLE quota_bystander NOLOGIN; END IF; END $$; "
+        "CREATE SCHEMA warehouse_quota; " + setup,
+    )
+    snapshot_sql = """
+        SELECT n.nspowner, n.nspacl::text, p.oid, p.proowner, p.proacl::text,
+            t.oid, t.typowner
+        FROM pg_namespace n LEFT JOIN pg_proc p ON p.pronamespace=n.oid
+        LEFT JOIN pg_type t ON t.typnamespace=n.oid
+        WHERE n.nspname='warehouse_quota' ORDER BY p.oid, t.oid
+    """
+    before = query(conn, snapshot_sql)
+    with pytest.raises(psycopg2.Error, match=message):
+        query(conn, MIGRATION.read_text())
+    conn.rollback()
+    assert query(conn, snapshot_sql) == before
+    assert query(conn, "SELECT to_regclass('meta.api_request_attempts')") == [(None,)]

--- a/tests/test_operational_quota_sql.py
+++ b/tests/test_operational_quota_sql.py
@@ -1,0 +1,542 @@
+"""Executed F14 quota-ledger behavior on an isolated loopback PostgreSQL database."""
+
+from __future__ import annotations
+
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from time import monotonic, sleep
+
+import psycopg2
+import pytest
+
+from tests.test_warehouse_migrations_sql import query
+from tests.test_warehouse_migrations_sql import warehouse_db as _warehouse_db  # noqa: F401
+
+MIGRATION = (
+    Path(__file__).resolve().parents[1] / "src/schemas/migrations/066_operational_quota_ledger.sql"
+)
+ACCOUNT = "fixture-shared-cfbd-cbbd-pool"
+
+
+@pytest.fixture
+def quota_db(request):
+    conn, target = request.getfixturevalue("_warehouse_db")
+    query(
+        conn,
+        """
+        DO $roles$ BEGIN
+            IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname='anon') THEN
+                CREATE ROLE anon NOLOGIN;
+            END IF;
+            IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname='authenticated') THEN
+                CREATE ROLE authenticated NOLOGIN;
+            END IF;
+            IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname='analyst_ro') THEN
+                CREATE ROLE analyst_ro NOLOGIN;
+            END IF;
+            IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname='quota_bystander') THEN
+                CREATE ROLE quota_bystander NOLOGIN;
+            END IF;
+        END $roles$;
+        ALTER DEFAULT PRIVILEGES GRANT ALL ON SCHEMAS
+            TO anon, authenticated, analyst_ro, quota_bystander;
+        ALTER DEFAULT PRIVILEGES GRANT ALL ON TABLES
+            TO anon, authenticated, analyst_ro, quota_bystander;
+        ALTER DEFAULT PRIVILEGES GRANT ALL ON FUNCTIONS
+            TO anon, authenticated, analyst_ro, quota_bystander;
+        """,
+    )
+    query(conn, MIGRATION.read_text())
+    query(conn, MIGRATION.read_text())
+    return conn, target
+
+
+def runtime_query(conn, statement, args=None):
+    with conn.cursor() as cur:
+        cur.execute("SET LOCAL ROLE warehouse_ingest")
+        cur.execute(statement, args)
+        result = cur.fetchall() if cur.description else None
+    conn.commit()
+    return result
+
+
+def start_run(conn, run_id=None):
+    run_id = run_id or uuid.uuid4()
+    runtime_query(
+        conn,
+        """
+        SELECT meta.start_operation_run(%s, 'extract', 'pytest', %s::jsonb, %s, %s)
+        """,
+        (str(run_id), '{"sources":["games"]}', "fixture-plan", "fixture-revision"),
+    )
+    return run_id
+
+
+def add_period(conn, *, limit=2, start=None, end=None, account=ACCOUNT):
+    now = datetime.now(UTC)
+    start = start or now - timedelta(hours=1)
+    end = end or now + timedelta(hours=1)
+    query(
+        conn,
+        """
+        INSERT INTO meta.api_quota_periods
+            (account_key, period_start_at, period_end_at, attempt_limit)
+        VALUES (%s, %s, %s, %s)
+        """,
+        (account, start, end, limit),
+    )
+    return start, end
+
+
+def reserve(conn, attempt_id, run_id, period_start, *, endpoint="games", context=None):
+    context = context or '{"season":2026,"week":1}'
+    return runtime_query(
+        conn,
+        """
+        SELECT * FROM meta.reserve_cfbd_attempt(
+            %s, %s, %s, %s, %s, 0, %s::jsonb
+        )
+        """,
+        (str(attempt_id), str(run_id), ACCOUNT, period_start, endpoint, context),
+    )[0]
+
+
+def test_schema_is_idempotent_private_and_runtime_is_bounded(quota_db):
+    conn, _ = quota_db
+    role_flags = query(
+        conn,
+        """
+        SELECT rolcanlogin, rolinherit, rolsuper, rolcreatedb, rolcreaterole,
+            rolreplication, rolbypassrls
+        FROM pg_roles WHERE rolname='warehouse_ingest'
+        """,
+    )
+    assert role_flags == [(False, False, False, False, False, False, False)]
+
+    for role in ("anon", "authenticated", "analyst_ro", "quota_bystander"):
+        assert query(
+            conn,
+            """
+            SELECT has_table_privilege(%s, 'meta.operation_runs', 'SELECT,INSERT,UPDATE,DELETE'),
+                has_table_privilege(%s, 'meta.api_quota_periods', 'SELECT,INSERT,UPDATE,DELETE'),
+                has_table_privilege(%s, 'meta.api_request_attempts', 'SELECT,INSERT,UPDATE,DELETE'),
+                has_function_privilege(%s,
+                    'meta.reserve_cfbd_attempt(uuid,uuid,text,timestamptz,text,integer,jsonb)',
+                    'EXECUTE'),
+                has_schema_privilege(%s, 'meta', 'CREATE')
+            """,
+            (role, role, role, role, role),
+        ) == [(False, False, False, False, True)]
+        with conn.cursor() as cur:
+            cur.execute(f"SET LOCAL ROLE {role}")
+            with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+                cur.execute("SELECT * FROM meta.api_quota_periods")
+        conn.rollback()
+
+    assert query(
+        conn,
+        """
+        SELECT has_schema_privilege('warehouse_ingest','meta','USAGE'),
+            has_schema_privilege('warehouse_ingest','meta','CREATE'),
+            has_table_privilege('warehouse_ingest','meta.api_quota_periods','SELECT'),
+            has_function_privilege('warehouse_ingest',
+                'meta.reserve_cfbd_attempt(uuid,uuid,text,timestamptz,text,integer,jsonb)',
+                'EXECUTE')
+        """,
+    ) == [(True, False, False, True)]
+    assert query(
+        conn,
+        """
+        SELECT count(*) FROM pg_proc p
+        JOIN pg_namespace n ON n.oid=p.pronamespace
+        CROSS JOIN LATERAL aclexplode(
+            COALESCE(p.proacl, acldefault('f',p.proowner))
+        ) acl
+        WHERE n.nspname='meta'
+          AND p.proname IN (
+              'start_operation_run','finish_operation_run','reserve_cfbd_attempt',
+              'mark_cfbd_attempt_dispatched','record_cfbd_attempt_result'
+          )
+          AND acl.grantee=0
+        """,
+    ) == [(0,)]
+    run_id = start_run(conn)
+    period_start, _ = add_period(conn)
+    reserve(conn, uuid.uuid4(), run_id, period_start)
+    with conn.cursor() as cur:
+        cur.execute("SET LOCAL ROLE warehouse_ingest")
+        with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+            cur.execute("UPDATE meta.api_quota_periods SET attempt_limit=999")
+    conn.rollback()
+
+
+def test_periods_require_finite_nonoverlapping_explicit_bounds(quota_db):
+    conn, _ = quota_db
+    now = datetime.now(UTC)
+    first_start, first_end = add_period(
+        conn, start=now - timedelta(hours=2), end=now - timedelta(hours=1)
+    )
+    # Adjacent half-open periods are valid.
+    add_period(conn, start=first_end, end=now + timedelta(hours=1))
+    with pytest.raises(psycopg2.errors.ExclusionViolation):
+        query(
+            conn,
+            """
+            INSERT INTO meta.api_quota_periods
+                (account_key, period_start_at, period_end_at, attempt_limit)
+            VALUES (%s, %s, %s, 10)
+            """,
+            (ACCOUNT, first_start + timedelta(minutes=1), first_end + timedelta(minutes=1)),
+        )
+    conn.rollback()
+    with pytest.raises(psycopg2.errors.CheckViolation):
+        query(
+            conn,
+            """
+            INSERT INTO meta.api_quota_periods
+                (account_key, period_start_at, period_end_at, attempt_limit)
+            VALUES ('infinite-fixture', '-infinity', 'infinity', 10)
+            """,
+        )
+    conn.rollback()
+
+    run_id = start_run(conn)
+    with pytest.raises(psycopg2.Error, match="not configured"):
+        reserve(conn, uuid.uuid4(), run_id, now, endpoint="unconfigured")
+    conn.rollback()
+    with pytest.raises(psycopg2.Error, match="not active"):
+        reserve(conn, uuid.uuid4(), run_id, first_start, endpoint="expired")
+    conn.rollback()
+
+
+def test_reservation_retry_is_exact_and_does_not_double_charge(quota_db):
+    conn, _ = quota_db
+    run_id = start_run(conn)
+    period_start, _ = add_period(conn)
+    attempt_id = uuid.uuid4()
+    first = reserve(conn, attempt_id, run_id, period_start)
+    retried = reserve(conn, attempt_id, run_id, period_start)
+    assert first[2:] == (1, 2, False)
+    assert retried[0:4] == first[0:4]
+    assert retried[4] is True
+    assert query(
+        conn,
+        "SELECT reserved_attempts FROM meta.api_quota_periods WHERE account_key=%s",
+        (ACCOUNT,),
+    ) == [(1,)]
+    with pytest.raises(psycopg2.Error, match="different context"):
+        reserve(conn, attempt_id, run_id, period_start, endpoint="plays")
+    conn.rollback()
+    assert query(conn, "SELECT count(*) FROM meta.api_request_attempts") == [(1,)]
+
+
+def test_rollback_is_free_but_committed_crash_reservation_stays_charged(quota_db):
+    conn, target = quota_db
+    run_id = start_run(conn)
+    period_start, _ = add_period(conn)
+    rolled_back_id = uuid.uuid4()
+    with conn.cursor() as cur:
+        cur.execute("SET LOCAL ROLE warehouse_ingest")
+        cur.execute(
+            "SELECT * FROM meta.reserve_cfbd_attempt(%s,%s,%s,%s,'games',0,'{}')",
+            (str(rolled_back_id), str(run_id), ACCOUNT, period_start),
+        )
+    conn.rollback()
+    assert query(conn, "SELECT reserved_attempts FROM meta.api_quota_periods") == [(0,)]
+
+    committed_id = uuid.uuid4()
+    reserve(conn, committed_id, run_id, period_start)
+    observer = psycopg2.connect(target)
+    try:
+        assert query(
+            observer,
+            "SELECT state FROM meta.api_request_attempts WHERE attempt_id=%s",
+            (str(committed_id),),
+        ) == [("reserved",)]
+        assert query(observer, "SELECT reserved_attempts FROM meta.api_quota_periods") == [(1,)]
+    finally:
+        observer.close()
+
+    assert runtime_query(
+        conn,
+        "SELECT meta.finish_operation_run(%s, 'failed', 'fixture crash')",
+        (str(run_id),),
+    ) == [(1,)]
+    with pytest.raises(psycopg2.Error, match="already terminal"):
+        reserve(conn, uuid.uuid4(), run_id, period_start)
+    conn.rollback()
+
+
+def test_dispatch_rechecks_period_and_terminal_results_do_not_refund(quota_db):
+    conn, _ = quota_db
+    run_id = start_run(conn)
+    period_start, _ = add_period(conn, limit=3)
+    attempt_id = uuid.uuid4()
+    reserve(conn, attempt_id, run_id, period_start)
+    runtime_query(
+        conn,
+        "SELECT meta.mark_cfbd_attempt_dispatched(%s)",
+        (str(attempt_id),),
+    )
+    with pytest.raises(psycopg2.Error, match="do not send it again"):
+        runtime_query(
+            conn,
+            "SELECT meta.mark_cfbd_attempt_dispatched(%s)",
+            (str(attempt_id),),
+        )
+    conn.rollback()
+    completed_at = runtime_query(
+        conn,
+        "SELECT meta.record_cfbd_attempt_result(%s,'http_error',429,'rate_limited')",
+        (str(attempt_id),),
+    )[0][0]
+    assert runtime_query(
+        conn,
+        "SELECT meta.record_cfbd_attempt_result(%s,'http_error',429,'rate_limited')",
+        (str(attempt_id),),
+    ) == [(completed_at,)]
+    with pytest.raises(psycopg2.Error, match="different terminal result"):
+        runtime_query(
+            conn,
+            "SELECT meta.record_cfbd_attempt_result(%s,'succeeded',200,NULL)",
+            (str(attempt_id),),
+        )
+    conn.rollback()
+    success_id = uuid.uuid4()
+    reserve(conn, success_id, run_id, period_start)
+    runtime_query(conn, "SELECT meta.mark_cfbd_attempt_dispatched(%s)", (str(success_id),))
+    # The persisted invariant also rejects NULL (CHECK otherwise accepts UNKNOWN).
+    for invalid_status in (None, 500):
+        with pytest.raises(psycopg2.errors.CheckViolation):
+            query(
+                conn,
+                "UPDATE meta.api_request_attempts SET state='succeeded', "
+                "result_recorded_at=clock_timestamp(), http_status=%s WHERE attempt_id=%s",
+                (invalid_status, str(success_id)),
+            )
+        conn.rollback()
+    for invalid_status in (None, 500):
+        with pytest.raises(psycopg2.Error, match="requires 2xx"):
+            runtime_query(
+                conn,
+                "SELECT meta.record_cfbd_attempt_result(%s,'succeeded',%s,NULL)",
+                (str(success_id), invalid_status),
+            )
+        conn.rollback()
+    runtime_query(
+        conn,
+        "SELECT meta.record_cfbd_attempt_result(%s,'succeeded',200,NULL)",
+        (str(success_id),),
+    )
+    no_data_id = uuid.uuid4()
+    reserve(conn, no_data_id, run_id, period_start)
+    runtime_query(conn, "SELECT meta.mark_cfbd_attempt_dispatched(%s)", (str(no_data_id),))
+    runtime_query(
+        conn,
+        "SELECT meta.record_cfbd_attempt_result(%s,'expected_no_data',204,NULL)",
+        (str(no_data_id),),
+    )
+    # Re-applying populated schema preserves the charged counter and terminal rows.
+    query(conn, MIGRATION.read_text())
+    query(conn, MIGRATION.read_text())
+    with pytest.raises(psycopg2.Error, match="exhausted"):
+        reserve(conn, uuid.uuid4(), run_id, period_start)
+    conn.rollback()
+    assert query(conn, "SELECT reserved_attempts FROM meta.api_quota_periods") == [(3,)]
+    assert query(
+        conn, "SELECT state FROM meta.api_request_attempts ORDER BY period_attempt_number"
+    ) == [("http_error",), ("succeeded",), ("expected_no_data",)]
+
+
+def test_expired_period_blocks_dispatch_but_not_unknown_result(quota_db):
+    conn, _ = quota_db
+    run_id = start_run(conn)
+    period_start, _ = add_period(conn)
+    attempt_id = uuid.uuid4()
+    reserve(conn, attempt_id, run_id, period_start)
+    query(
+        conn,
+        """
+        UPDATE meta.api_quota_periods
+        SET period_end_at=clock_timestamp() - interval '1 second'
+        WHERE account_key=%s AND period_start_at=%s
+        """,
+        (ACCOUNT, period_start),
+    )
+    with pytest.raises(psycopg2.Error, match="not active at dispatch"):
+        runtime_query(
+            conn,
+            "SELECT meta.mark_cfbd_attempt_dispatched(%s)",
+            (str(attempt_id),),
+        )
+    conn.rollback()
+    runtime_query(
+        conn,
+        "SELECT meta.record_cfbd_attempt_result(%s,'unknown',NULL,'expired_before_dispatch')",
+        (str(attempt_id),),
+    )
+    assert query(
+        conn,
+        "SELECT state, reserved_attempts "
+        "FROM meta.api_request_attempts CROSS JOIN meta.api_quota_periods",
+    ) == [("unknown", 1)]
+
+
+def test_concurrent_workers_cannot_reserve_above_cap(quota_db):
+    conn, target = quota_db
+    run_ids = [start_run(conn) for _ in range(8)]
+    period_start, _ = add_period(conn, limit=3)
+
+    def contender(number):
+        worker = psycopg2.connect(target)
+        try:
+            try:
+                reserve(
+                    worker,
+                    uuid.uuid5(uuid.NAMESPACE_URL, f"quota-worker-{number}"),
+                    run_ids[number],
+                    period_start,
+                )
+                return "reserved"
+            except psycopg2.Error as exc:
+                worker.rollback()
+                assert "exhausted" in str(exc)
+                return "exhausted"
+        finally:
+            worker.close()
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        outcomes = list(pool.map(contender, range(8)))
+    assert outcomes.count("reserved") == 3
+    assert outcomes.count("exhausted") == 5
+    assert query(conn, "SELECT reserved_attempts FROM meta.api_quota_periods") == [(3,)]
+    assert query(conn, "SELECT count(*) FROM meta.api_request_attempts") == [(3,)]
+
+
+@pytest.mark.parametrize("same_context", [False, True])
+def test_concurrent_same_uuid_serializes_before_charging_period(quota_db, same_context):
+    conn, target = quota_db
+    run_id = start_run(conn)
+    period_start, _ = add_period(conn, limit=2)
+    attempt_id = uuid.uuid4()
+
+    def same_attempt(number):
+        worker = psycopg2.connect(target)
+        try:
+            try:
+                result = reserve(
+                    worker,
+                    attempt_id,
+                    run_id,
+                    period_start,
+                    endpoint=("games" if same_context or number == 0 else "plays"),
+                )
+                return "reused" if result[4] else "reserved"
+            except psycopg2.Error as exc:
+                worker.rollback()
+                assert "different context" in str(exc)
+                return "conflict"
+        finally:
+            worker.close()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        outcomes = list(pool.map(same_attempt, range(2)))
+    expected = ["reserved", "reused"] if same_context else ["conflict", "reserved"]
+    assert sorted(outcomes) == expected
+    assert query(conn, "SELECT reserved_attempts FROM meta.api_quota_periods") == [(1,)]
+    assert query(conn, "SELECT count(*) FROM meta.api_request_attempts") == [(1,)]
+
+
+def test_reservation_uses_clock_after_waiting_for_period_lock(quota_db):
+    conn, target = quota_db
+    run_id = start_run(conn)
+    now = datetime.now(UTC)
+    period_start, _ = add_period(
+        conn,
+        start=now - timedelta(seconds=1),
+        end=now + timedelta(seconds=3),
+    )
+    locker = psycopg2.connect(target)
+    waiter = psycopg2.connect(target)
+    try:
+        with locker.cursor() as cur:
+            cur.execute(
+                """
+                SELECT 1 FROM meta.api_quota_periods
+                WHERE account_key=%s AND period_start_at=%s FOR UPDATE
+                """,
+                (ACCOUNT, period_start),
+            )
+
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            pending = pool.submit(reserve, waiter, uuid.uuid4(), run_id, period_start)
+            deadline = monotonic() + 2
+            while monotonic() < deadline:
+                waiting = query(
+                    conn,
+                    "SELECT wait_event_type FROM pg_stat_activity WHERE pid=%s",
+                    (waiter.get_backend_pid(),),
+                )
+                if waiting == [("Lock",)]:
+                    break
+                sleep(0.01)
+            else:
+                locker.rollback()
+                pytest.fail("reservation did not block on the held period lock")
+            remaining = (now + timedelta(seconds=3) - datetime.now(UTC)).total_seconds()
+            if remaining <= 0:
+                locker.rollback()
+                pytest.fail("waiter must start before expiry to test a fresh wall clock")
+            sleep(remaining + 0.05)
+            locker.commit()
+            with pytest.raises(psycopg2.Error, match="not active"):
+                pending.result(timeout=5)
+        waiter.rollback()
+    finally:
+        locker.close()
+        waiter.close()
+    assert query(conn, "SELECT reserved_attempts FROM meta.api_quota_periods") == [(0,)]
+
+
+def test_ordinary_default_public_function_execution_is_revoked(request):
+    conn, _ = request.getfixturevalue("_warehouse_db")
+    query(
+        conn,
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname='quota_bystander') THEN
+                CREATE ROLE quota_bystander NOLOGIN;
+            END IF;
+        END $$;
+        CREATE FUNCTION public.quota_public_control() RETURNS integer
+            LANGUAGE sql AS 'SELECT 1';
+        """,
+    )
+    assert query(
+        conn,
+        "SELECT proacl IS NULL FROM pg_proc "
+        "WHERE oid='public.quota_public_control()'::regprocedure",
+    ) == [(True,)]
+    query(conn, MIGRATION.read_text())
+    query(conn, "GRANT USAGE ON SCHEMA meta TO quota_bystander")
+    assert query(
+        conn,
+        "SELECT count(*), bool_and(NOT has_function_privilege('quota_bystander', "
+        "p.oid, 'EXECUTE')) FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace "
+        "WHERE n.nspname='meta'",
+    ) == [(7, True)]
+    with conn.cursor() as cur:
+        cur.execute("SET LOCAL ROLE quota_bystander")
+        with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+            cur.execute(
+                "SELECT meta.start_operation_run(%s,'extract','fixture','{}',NULL,NULL)",
+                (str(uuid.uuid4()),),
+            )
+    conn.rollback()
+    assert query(
+        conn,
+        "SELECT has_function_privilege('quota_bystander', "
+        "'public.quota_public_control()', 'EXECUTE')",
+    ) == [(True,)]

--- a/tests/test_warehouse_bootstrap_sql.py
+++ b/tests/test_warehouse_bootstrap_sql.py
@@ -123,6 +123,10 @@ def _fixture_snapshot(conn):
 
 def _assert_catalog_shape(conn):
     catalog = json.loads(CATALOG_PATH.read_text())
+    expected_counts = {tuple(row[:2]): row[2] for row in catalog["object_counts"]}
+    # F14 adds three private tables and six indexes; keep baseline evidence immutable.
+    expected_counts[("meta", "r")] += 3
+    expected_counts[("meta", "i")] += 6
     assert query(
         conn,
         """
@@ -134,7 +138,7 @@ def _assert_catalog_shape(conn):
         ORDER BY 1, 2
         """,
         (catalog["schemas"],),
-    ) == [tuple(row) for row in catalog["object_counts"]]
+    ) == [(*key, count) for key, count in sorted(expected_counts.items())]
 
     assert query(
         conn,
@@ -145,7 +149,7 @@ def _assert_catalog_shape(conn):
         conn,
         "SELECT extname FROM pg_extension e JOIN pg_namespace n ON n.oid=e.extnamespace "
         "WHERE n.nspname='public' ORDER BY extname",
-    ) == [("fuzzystrmatch",), ("pg_trgm",), ("vector",)]
+    ) == [("btree_gist",), ("fuzzystrmatch",), ("pg_trgm",), ("vector",)]
     assert query(
         conn,
         """
@@ -311,6 +315,9 @@ def _assert_fixture_and_access(conn):
     for role in CALLER_ROLES:
         _assert_denied(conn, role, "SELECT * FROM warehouse_control.schema_migrations")
         _assert_denied(conn, role, "SELECT * FROM scouting.players")
+    for role in (*CALLER_ROLES, "warehouse_ingest"):
+        for table in ("operation_runs", "api_quota_periods", "api_request_attempts"):
+            _assert_denied(conn, role, f"SELECT * FROM meta.{table}")
     for role in ("anon", "authenticated"):
         assert _query_as(conn, role, "SELECT count(*) FROM features.training_fits") == [(0,)]
         assert _query_as(conn, role, "SELECT count(*) FROM marts.team_season_trajectory") == [(0,)]
@@ -375,7 +382,7 @@ def test_managed_warehouse_catalog_data_and_access(
         _insert_representative_rows(conn)
         before_upgrade = _fixture_snapshot(conn)
         upgrade = apply_manifest(conn, manifest, mode="upgrade")
-        assert len(upgrade.pending) == 2
+        assert len(upgrade.pending) == 3
         assert [step.id for step in upgrade.pending] == [
             migration.id for migration in manifest.migrations[4:]
         ]


### PR DESCRIPTION
Separate warehouse jobs cannot coordinate CFBD capacity through the current process-local counter. This first F14 schema slice adds private operation runs, explicit quota periods, and atomic per-attempt reservations. Committed reservations remain charged locally after errors or crashes, and retries of the same database reservation cannot double-charge or change its context.

The restricted NOLOGIN runtime role can create/finish runs, reserve attempts, mark one dispatch, and record a terminal result through five private functions in the owner-only warehouse_quota schema. Pre-existing unsafe namespaces, hostile overloads, and same-named domain casts are rejected; existing meta grants are preserved. It cannot configure caps or modify the tables directly. Periods cannot overlap; admission and dispatch recheck wall-clock expiry after locking. Successful transport results require 2xx status. Transport failures and unknown outcomes require NULL HTTP status; unknown categories identify the dispatch phase. New object ACLs remove implicit PUBLIC execution and arbitrary host-default grants.

This implements the accepted quota-first direction in #137. Official CFBD source reports shared CFB/CBB capacity and UTC monthly reset dates, but refunds non-2xx responses; our local count is deliberately conservative and is not provider-billed usage. Live account capacity must be verified before any budget is configured.

No callers, budget rows, credentials, or role memberships are enabled. Migration 066 is appended to the managed bootstrap and production manifests for a separately authorized rollout. Merging this PR does not apply production SQL or enable runtime enforcement. Public freshness interfaces are unchanged. See `docs/plans/2026-09-08-f14-quota-foundation.md` for the interface and rollout boundary.

Validation: 28 executed PostgreSQL 17 cases passed (26 quota cases plus fresh-bootstrap and prior-baseline upgrade), along with 77 migration/CLI unit tests. Tests cover separate concurrent runs, exact/conflicting UUID replay, crash accounting, populated reapplication, ordinary/broad default grants, actual caller roles, namespace adoption rejection, pending-attempt finish guards, immutable reservation identity, and DELETE/TRUNCATE denial. Ruff, actionlint, and diff checks passed. Independent review findings were resolved; final review is clear. No production SQL, authenticated provider requests, or performance benchmark was run.




<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61741160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/formentera-operations/-/pull-requests/rstover-fo/cfb-database/138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; the previous lifecycle findings are fixed and no actionable new failure remains.

<details><summary><h3>Summary</h3></summary>

- Adds operation-run, quota-period, and immutable request-attempt records.
- Exposes five restricted lifecycle functions through the owner-controlled `warehouse_quota` schema.
- Enforces atomic reservation limits, dispatch/result transitions, terminal-state consistency, and conservative crash accounting.
- Adds the migration to managed bootstrap and production manifests with expanded PostgreSQL lifecycle, privilege, concurrency, and upgrade coverage.
- The changes since the previous review resolve the ambiguous terminal-state constraints and add direct tests for the previously missing lifecycle guarantees.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller as Warehouse caller
    participant Run as Operation run
    participant Quota as Quota period
    participant Attempt as Request attempt
    participant CFBD as CFBD API

    Caller->>Run: start_operation_run
    Caller->>Quota: reserve_cfbd_attempt
    Quota->>Attempt: Create charged reservation
    Caller->>Attempt: mark_cfbd_attempt_dispatched
    Caller->>CFBD: Send HTTP request
    CFBD-->>Caller: Response or transport uncertainty
    Caller->>Attempt: record_cfbd_attempt_result
    Caller->>Run: finish_operation_run
```
</details>

<!-- /greptile_comment -->