### PR TITLE
Add durable CFBD transport admission and reconciliation allowance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - run: ./scripts/setup_dev.sh
       - name: Managed bootstrap and upgrade integration
-        run: .venv/bin/python -m pytest tests/test_warehouse_migrations_sql.py tests/test_warehouse_bootstrap_sql.py tests/test_adopt_warehouse_catalog_sql.py tests/test_f06_verification_transactions_sql.py tests/test_mart_release_sql.py tests/test_play_partitions.py tests/test_play_indexes_sql.py tests/test_operational_quota_sql.py tests/test_operational_quota_lifecycle_sql.py -q --tb=short
+        run: .venv/bin/python -m pytest tests/test_warehouse_migrations_sql.py tests/test_warehouse_bootstrap_sql.py tests/test_adopt_warehouse_catalog_sql.py tests/test_f06_verification_transactions_sql.py tests/test_mart_release_sql.py tests/test_play_partitions.py tests/test_play_indexes_sql.py tests/test_operational_quota_sql.py tests/test_operational_quota_lifecycle_sql.py tests/test_cfbd_transport_admission_sql.py -q --tb=short
         env:
           F06_TEST_DB_URL: postgresql://postgres:f06-disposable-ci@127.0.0.1:5432/postgres
           F06_REQUIRE_DB: "1"

--- a/docs/SCHEMA_CONTRACT.md
+++ b/docs/SCHEMA_CONTRACT.md
@@ -1199,7 +1199,15 @@ attempts, and record dispatch/results. Existing `meta` schema grants remain
 unchanged; no non-owner can create overloads in the quota RPC namespace. Role
 membership and capacity configuration require a separate rollout.
 
-Existing HTTP callers and `public.get_data_freshness()` are unchanged. See the
+Migration `067_cfbd_transport_admission.sql` adds the `budget_class` dimension
+to periods and attempts, preserving existing rows as `extraction`. The new
+`warehouse_quota.reserve_cfbd_transport_attempt` RPC selects active configured
+windows and admits exact `/info` and `/info/usage` paths through a separate
+`reconciliation` allowance. The legacy reservation RPC remains extraction-only;
+the internal class-selecting helper is not executable by the runtime role.
+Selected HTTP entrypoints can opt into this protocol; workflow activation is
+separate. `public.get_data_freshness()` is unchanged. See the
+[transport implementation and rollout](plans/2026-09-08-f14-transport-admission.md) and the
 [F14 foundation and rollout boundary](plans/2026-09-08-f14-quota-foundation.md).
 
 ### Raw Data Tables

--- a/docs/plans/2026-09-08-f14-transport-admission.md
+++ b/docs/plans/2026-09-08-f14-transport-admission.md
@@ -70,8 +70,11 @@ after extraction exhaustion. Control requests also use a separate 429 circuit
 breaker so extraction refusal cannot prevent reconciliation. Database/accounting
 failure blocks both classes. Existing bounded HTTP retry/backoff rules remain.
 
-Success records a 2xx transport outcome; logical expected-no-data classification
-remains the source adapter's responsibility. HTTP failures preserve their status;
+Success records a 2xx transport outcome. Callers with an explicit empty-list
+contract can pass `expected_empty=True`; scoreboard polling does so, recording
+`expected_no_data` before returning an empty result. Other callers keep ordinary
+transport-success classification, and malformed JSON is surfaced as a decoding
+error rather than no-data. HTTP failures preserve their status;
 network failures have NULL HTTP status. Arbitrary request values, headers,
 credentials, and exception text are not written into the quota ledger. Stored
 request context contains only supported numeric/boolean work-unit identifiers.

--- a/docs/plans/2026-09-08-f14-transport-admission.md
+++ b/docs/plans/2026-09-08-f14-transport-admission.md
@@ -1,0 +1,113 @@
+# F14 CFBD transport admission
+
+## Prepared implementation and rollout boundary
+
+This implements the next slice of the accepted
+[operational-records design](2026-09-08-f14-f19-operational-records.md).
+Migration 067 follows immutable migration 066 in both managed manifests.
+Neither merging this change nor running tests applies production SQL, creates
+budgets or role memberships, or activates workflow admission.
+
+The enrolled command entrypoints are `scripts/load_season.py` (daily),
+`scripts/backfill_refresh.py` (historical), and `scripts/poll_scoreboard.py`
+(live). They create one operation spanning their work when
+`CFBD_QUOTA_MODE=durable`. The deployment default remains `legacy` until the
+separate rollout is authorized. Legacy preserves current behavior; it is not
+an automatic fallback from durable mode. Invalid modes fail explicitly.
+Unenrolled CFBD callers in a process configured for durable mode refuse
+transport instead of silently bypassing admission.
+
+## Configuration and activation
+
+After an authorized managed upgrade through 067, configure:
+
+- `CFBD_QUOTA_MODE=durable` for each enrolled command's environment.
+- `CFBD_QUOTA_DB_URL`, a dedicated database connection whose login can assume
+  `warehouse_ingest`. The adapter explicitly sets this bounded role for every
+  transaction; it does not reuse the dlt load transaction or auto-grant access.
+- `CFBD_QUOTA_ACCOUNT`, the reviewed opaque identifier for the shared provider
+  pool. It is never a token, token hash, or credential fingerprint.
+
+An administrator must configure finite, non-overlapping windows per account
+and budget class in `meta.api_quota_periods`. `extraction` remains the default
+for existing rows and preserves their history. `reconciliation` has independent
+windows and caps and is reserved for exact `/info` and `/info/usage` paths.
+Its cap and window require an explicit small operational allowance; this
+implementation seeds neither. `/scoreboard` uses extraction admission even
+though provider metering may exempt it. Missing/expired/exhausted allowances
+refuse transport. The old explicit-period reservation RPC is extraction-only.
+
+Verify current provider capacity and select an extraction allowance with
+headroom before activation. Provider observations and local reservations are
+separate quantities: this change does not refund attempts, automatically raise
+caps, poll provider information, or persist reconciled provider observations.
+An enrolled administrative caller can use the control endpoints through the
+same client. Automated reconciliation and any cap change remain separate work.
+Configure all intended production callers before claiming account-wide
+coverage; clients outside the enrolled rollout can still consume the shared
+provider pool independently.
+
+## Transaction and failure behavior
+
+The operation parent is committed before clients can see the active operation.
+Each actual HTTP attempt, including each retry, then follows:
+
+1. Resolve the canonical endpoint's budget class and active configured window
+   in PostgreSQL; reserve and commit a new attempt UUID.
+2. Recheck the run/window and commit the single dispatch transition.
+3. Send HTTP once and commit its transport result before returning or retrying.
+
+A failed or uncertain database transaction stops further HTTP in that
+invocation. There is no automatic replay of an uncertain reservation/dispatch
+commit and no refund. A response whose result cannot be committed leaves a
+pending, conservatively charged attempt; a crash can also leave a running
+parent. Recovery must inspect these records under the accepted design before
+closing them; this slice does not implement an automatic recovery worker.
+
+Expected reservation denial marks the run unsuccessful but does not disable
+another budget class. Thus `/info` can still use available control capacity
+after extraction exhaustion. Control requests also use a separate 429 circuit
+breaker so extraction refusal cannot prevent reconciliation. Database/accounting
+failure blocks both classes. Existing bounded HTTP retry/backoff rules remain.
+
+Success records a 2xx transport outcome; logical expected-no-data classification
+remains the source adapter's responsibility. HTTP failures preserve their status;
+network failures have NULL HTTP status. Arbitrary request values, headers,
+credentials, and exception text are not written into the quota ledger. Stored
+request context contains only supported numeric/boolean work-unit identifiers.
+
+A process supports one enrolled invocation at a time. The active operation is
+shared with extraction threads, and transport admission through result recording
+is serialized within that process. Different processes still compete through
+PostgreSQL locks. This prevents another thread from sending after an accounting
+failure; no throughput improvement or benchmark is claimed.
+
+The daily command records returned source/mart errors as run failure. Exhausted
+transient request failures mark the operation partial even if a source records
+a miss and continues; authentication/rate exhaustion marks it failed. Historical
+SQL campaign pacing remains in place and unfinished work records a partial run;
+its JSON admission guard is bypassed when enrolled. The daily drainer JSON gates
+and shared source JSON gate are also bypassed when enrolled. Planning-only daily
+and historical dry runs do not write operation records. Live `--dry-run` still
+sends HTTP, so durable accounting applies even though target snapshots are not
+written. A successful operation is not a source publication/freshness receipt.
+
+## Verification
+
+Executed tests use isolated PostgreSQL 17 with pgvector, actual caller roles,
+and mocked HTTP; no authenticated CFBD or production database is contacted.
+They cover upgrade with existing attempts, rerun safety, separate caps, exact
+endpoint classification, concurrent reservations, expiry, replay, ACLs, real
+adapter commit ordering visible from another connection, reconciliation after
+extraction denial, and capacity shared across fresh Python processes.
+
+Transport tests cover mixed 429/5xx/network retries, terminal 401/403/404,
+reservation/dispatch/result failures, uncertain commit, sanitized errors,
+independent control circuits, concurrent accounting failure, missing enrollment,
+JSON gate bypass, and daily/live lifecycle wiring. Full managed bootstrap and
+prior-baseline upgrade are executed separately from mocked transport checks.
+
+Receipt publication, source freshness compatibility, automatic crash recovery,
+automated provider reconciliation, production caller permissions, and actual
+HTTP commit/send ordering on the deployed host remain future implementation or
+rollout verification. No production enforcement is claimed by the prepared PR.

--- a/docs/warehouse-operations.md
+++ b/docs/warehouse-operations.md
@@ -334,3 +334,11 @@ selections, now validated and dependency-ordered. Failed selected refreshes bloc
 their selected descendants while independent views continue; the command fails
 if any view failed or was blocked. Durable cross-run generation checks and the
 SQL `refresh_all_marts()` RPC are outside this implementation.
+
+## Prepared durable CFBD admission
+
+The daily, historical, and live entrypoints have an opt-in durable quota path.
+See the [F14 transport rollout guide](plans/2026-09-08-f14-transport-admission.md)
+for migration 067, dedicated role/connection configuration, independent control
+allowances, commit-failure behavior, and activation checks. Production defaults
+remain unchanged until that separate rollout is authorized.

--- a/scripts/backfill_refresh.py
+++ b/scripts/backfill_refresh.py
@@ -896,7 +896,9 @@ def run_campaign(
     from src.pipelines.utils.rate_limiter import get_rate_limiter
 
     local_limiter = get_rate_limiter()
-    if not local_limiter.check_budget(this_run_total):
+    from src.pipelines.utils.quota_admission import active_operation
+
+    if active_operation() is None and not local_limiter.check_budget(this_run_total):
         print(
             f"Local rate limiter shows only {local_limiter.remaining} call(s) remaining "
             "this month (advisory only on ephemeral CI runners); stopping before spending "
@@ -1087,18 +1089,32 @@ def main() -> None:
             print_status(conn, args.campaign, max_calls=args.max_calls)
             sys.exit(0)
 
-        result = run_campaign(
-            conn,
-            campaign=args.campaign,
-            create=args.create,
-            seasons_spec=args.seasons,
-            tasks_spec=args.tasks,
-            max_calls=args.max_calls,
-            monthly_cap=args.monthly_cap,
-            batch_size=args.batch_size,
-            dry_run=args.dry_run,
-            description=args.description,
-        )
+        from src.pipelines.utils.quota_admission import quota_operation
+
+        with quota_operation(
+            "backfill_refresh", {"campaign": args.campaign}, enabled=not args.dry_run
+        ) as operation:
+            result = run_campaign(
+                conn,
+                campaign=args.campaign,
+                create=args.create,
+                seasons_spec=args.seasons,
+                tasks_spec=args.tasks,
+                max_calls=args.max_calls,
+                monthly_cap=args.monthly_cap,
+                batch_size=args.batch_size,
+                dry_run=args.dry_run,
+                description=args.description,
+            )
+            if operation:
+                status = result.get("status")
+                if status == "finalize_failed":
+                    operation.outcome = "failed"
+                elif status == "not_created":
+                    operation.outcome = "blocked"
+                elif status not in {"complete", "already_complete", "finalized"}:
+                    operation.outcome = "partial"
+
     finally:
         conn.close()
 

--- a/scripts/load_season.py
+++ b/scripts/load_season.py
@@ -747,15 +747,22 @@ def main() -> None:
     # which targets a finished season by definition -- so the skip is off.
     allow_skip_final = args.season is None and not args.sources and not args.no_skip_final
 
-    summary = load_season(
-        season=season,
-        sources=sources,
-        dry_run=args.dry_run,
-        skip_refresh=args.skip_refresh,
-        weekly=args.weekly,
-        upcoming_schedule=upcoming,
-        allow_skip_final=allow_skip_final,
-    )
+    from src.pipelines.utils.quota_admission import quota_operation
+
+    with quota_operation(
+        "load_season", {"season": season, "sources": sources}, enabled=not args.dry_run
+    ) as operation:
+        summary = load_season(
+            season=season,
+            sources=sources,
+            dry_run=args.dry_run,
+            skip_refresh=args.skip_refresh,
+            weekly=args.weekly,
+            upcoming_schedule=upcoming,
+            allow_skip_final=allow_skip_final,
+        )
+        if operation and (summary.get("error") or summary.get("errors", 0)):
+            operation.outcome = "failed"
 
     # Validation failures return {"error": str} (singular) before any source
     # runs; per-source failures count up {"errors": int} via _count_failures,

--- a/scripts/poll_scoreboard.py
+++ b/scripts/poll_scoreboard.py
@@ -493,7 +493,9 @@ def main() -> None:
     with quota_operation("poll_scoreboard", {"classification": "fbs", "dry_run": args.dry_run}):
         client = get_client()
         try:
-            raw_games = client.get("/scoreboard", params={"classification": "fbs"})
+            raw_games = client.get(
+                "/scoreboard", params={"classification": "fbs"}, expected_empty=True
+            )
         finally:
             client.close()
 

--- a/scripts/poll_scoreboard.py
+++ b/scripts/poll_scoreboard.py
@@ -483,32 +483,36 @@ def main() -> None:
     parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Fetch + compute + print only; no DB writes (workflow_dispatch smoke test).",
+        help="Fetch and print without snapshot writes; durable quota accounting still applies.",
     )
     args = parser.parse_args()
 
-    client = get_client()
-    try:
-        raw_games = client.get("/scoreboard", params={"classification": "fbs"})
-    finally:
-        client.close()
+    from src.pipelines.utils.quota_admission import quota_operation
 
-    if not raw_games:
-        logger.info("No games returned from /scoreboard (off-season or no games today)")
-        print("SCOREBOARD_POLL games=0 inserted=0 deduped=0 statuses={}")
-        return
+    # Dry-run still sends HTTP, so it must retain durable quota accounting.
+    with quota_operation("poll_scoreboard", {"classification": "fbs", "dry_run": args.dry_run}):
+        client = get_client()
+        try:
+            raw_games = client.get("/scoreboard", params={"classification": "fbs"})
+        finally:
+            client.close()
 
-    import psycopg2
+        if not raw_games:
+            logger.info("No games returned from /scoreboard (off-season or no games today)")
+            print("SCOREBOARD_POLL games=0 inserted=0 deduped=0 statuses={}")
+            return
 
-    conn = psycopg2.connect(get_db_url())
-    try:
-        run(conn, raw_games, dry_run=args.dry_run)
-    except Exception:
-        conn.rollback()
-        logger.exception("Scoreboard poll failed")
-        sys.exit(1)
-    finally:
-        conn.close()
+        import psycopg2
+
+        conn = psycopg2.connect(get_db_url())
+        try:
+            run(conn, raw_games, dry_run=args.dry_run)
+        except Exception:
+            conn.rollback()
+            logger.exception("Scoreboard poll failed")
+            sys.exit(1)
+        finally:
+            conn.close()
 
 
 if __name__ == "__main__":

--- a/src/pipelines/run.py
+++ b/src/pipelines/run.py
@@ -795,7 +795,9 @@ def run_coach_profiles_pipeline(max_coaches: int = MAX_COACH_PROFILES_PER_RUN) -
         }
 
     rate_limiter = get_rate_limiter()
-    if not rate_limiter.check_budget(len(missing)):
+    from src.pipelines.utils.quota_admission import active_operation
+
+    if active_operation() is None and not rate_limiter.check_budget(len(missing)):
         msg = (
             f"API budget insufficient for {len(missing)} coach-profile calls "
             f"({rate_limiter.remaining} calls remaining this month)"
@@ -1053,7 +1055,9 @@ def run_metrics_wp_pipeline(
         }
 
     rate_limiter = get_rate_limiter()
-    if not rate_limiter.check_budget(len(game_ids)):
+    from src.pipelines.utils.quota_admission import active_operation
+
+    if active_operation() is None and not rate_limiter.check_budget(len(game_ids)):
         msg = (
             f"API budget insufficient for {len(game_ids)} win-probability calls "
             f"({rate_limiter.remaining} calls remaining this month)"
@@ -1415,7 +1419,9 @@ def run_player_overview_pipeline(
         }
 
     rate_limiter = get_rate_limiter()
-    if not rate_limiter.check_budget(len(missing)):
+    from src.pipelines.utils.quota_admission import active_operation
+
+    if active_operation() is None and not rate_limiter.check_budget(len(missing)):
         msg = (
             f"API budget insufficient for {len(missing)} player-overview calls "
             f"({rate_limiter.remaining} calls remaining this month)"

--- a/src/pipelines/sources/base.py
+++ b/src/pipelines/sources/base.py
@@ -4,6 +4,7 @@ import dlt
 from dlt.sources import DltResource
 
 from ..utils.api_client import CFBDClient, get_client
+from ..utils.quota_admission import transport_operation
 from ..utils.rate_limiter import get_rate_limiter
 
 
@@ -26,6 +27,9 @@ def make_request(
     Returns:
         API response data
     """
+    if transport_operation() is not None:
+        return client.get(endpoint, params=params)
+
     rate_limiter = get_rate_limiter()
 
     if not rate_limiter.check_budget():

--- a/src/pipelines/utils/api_client.py
+++ b/src/pipelines/utils/api_client.py
@@ -248,9 +248,11 @@ class CFBDClient:
         """Clear this client's breaker so it can issue requests again.
 
         Resets the run-wide breaker unless a private one was injected, since
-        that is the one blocking every client in the run.
+        that is the one blocking every client in the run. Also clears the shared
+        control breaker used by durable reconciliation requests.
         """
         self._breaker.reset()
+        _CONTROL_BREAKER.reset()
 
     @staticmethod
     def _http_date_delay(text: str, now: datetime | None = None) -> int | None:
@@ -285,7 +287,9 @@ class CFBDClient:
             now=reference,
         )
 
-    def _send_attempt(self, endpoint: str, params: dict | None, retry: int):
+    def _send_attempt(
+        self, endpoint: str, params: dict | None, retry: int, expected_empty: bool = False
+    ):
         from .quota_admission import transport_operation
 
         operation = transport_operation()
@@ -305,9 +309,19 @@ class CFBDClient:
                 operation.result(attempt_id, "unknown", None, "response_unobserved")
                 raise
             status = response.status_code
+            state = "succeeded" if 200 <= status < 300 else "http_error"
+            if state == "succeeded" and expected_empty:
+                # Only a caller with an explicit empty-response contract may
+                # classify no-data. Invalid JSON is still a received 2xx;
+                # get() will surface its decoding error after recording it.
+                try:
+                    if response.json() == []:
+                        state = "expected_no_data"
+                except ValueError:
+                    pass
             operation.result(
                 attempt_id,
-                "succeeded" if 200 <= status < 300 else "http_error",
+                state,
                 status,
                 None if 200 <= status < 300 else "http_error",
             )
@@ -318,6 +332,8 @@ class CFBDClient:
         endpoint: str,
         params: dict[str, Any] | None = None,
         retries: int = MAX_RETRIES,
+        *,
+        expected_empty: bool = False,
     ) -> list[dict]:
         """Make a GET request to the API.
 
@@ -341,6 +357,9 @@ class CFBDClient:
             retries: Number of retries on 429 rate-limited responses.
                 Transient faults use the separate TRANSIENT_MAX_RETRIES
                 budget regardless of this value.
+            expected_empty: Caller confirms an empty JSON list is expected no-data.
+                Durable admission records that terminal classification before
+                returning the response. Other payloads remain transport successes.
 
         Returns:
             JSON response as a list of dicts
@@ -385,7 +404,9 @@ class CFBDClient:
         transient_failures = 0  # 5xx / network failures retried so far
         while True:
             try:
-                response = self._send_attempt(endpoint, params, attempt + transient_failures)
+                response = self._send_attempt(
+                    endpoint, params, attempt + transient_failures, expected_empty
+                )
                 response.raise_for_status()
                 # Any success clears the breaker: a transient burst block that
                 # resolves must not accumulate toward the quota threshold.

--- a/src/pipelines/utils/api_client.py
+++ b/src/pipelines/utils/api_client.py
@@ -163,6 +163,10 @@ def reset_rate_limit_circuit() -> None:
     waited out a quota reset, or a test isolating itself from a prior run.
     """
     _SHARED_BREAKER.reset()
+    _CONTROL_BREAKER.reset()
+
+
+_CONTROL_BREAKER = RateLimitBreaker()
 
 
 class CFBDClient:
@@ -281,6 +285,34 @@ class CFBDClient:
             now=reference,
         )
 
+    def _send_attempt(self, endpoint: str, params: dict | None, retry: int):
+        from .quota_admission import transport_operation
+
+        operation = transport_operation()
+        if operation is None:
+            return self._client.get(endpoint, params=params)
+        # Serialize admission through result recording within one invocation.
+        # Another extraction thread cannot send after a failed accounting write.
+        with operation.transport_lock:
+            attempt_id = operation.reserve(endpoint, retry, params)
+            operation.dispatch(attempt_id)
+            try:
+                response = self._client.get(endpoint, params=params)
+            except httpx.RequestError:
+                operation.result(attempt_id, "transport_error", None, "request_error")
+                raise
+            except BaseException:
+                operation.result(attempt_id, "unknown", None, "response_unobserved")
+                raise
+            status = response.status_code
+            operation.result(
+                attempt_id,
+                "succeeded" if 200 <= status < 300 else "http_error",
+                status,
+                None if 200 <= status < 300 else "http_error",
+            )
+            return response
+
     def get(
         self,
         endpoint: str,
@@ -325,9 +357,19 @@ class CFBDClient:
             httpx.RequestError: a network fault (connect/read timeout, etc.)
                 that outlasted the transient budget.
         """
-        if self._breaker.is_open():
+        from .quota_admission import transport_operation
+
+        operation = transport_operation()
+        breaker = (
+            _CONTROL_BREAKER
+            if operation is not None and endpoint in {"/info", "/info/usage"}
+            else self._breaker
+        )
+        if breaker.is_open():
+            if operation is not None:
+                operation.note_transport_failure("failed")
             raise RateLimitCircuitOpen(
-                f"{self._breaker.consecutive} consecutive HTTP 429 response(s) "
+                f"{breaker.consecutive} consecutive HTTP 429 response(s) "
                 f"before {endpoint}. The API is refusing everything -- "
                 "most likely the monthly quota is spent. Stopping instead of retrying; "
                 "further requests cannot succeed until the quota resets."
@@ -343,34 +385,38 @@ class CFBDClient:
         transient_failures = 0  # 5xx / network failures retried so far
         while True:
             try:
-                response = self._client.get(endpoint, params=params)
+                response = self._send_attempt(endpoint, params, attempt + transient_failures)
                 response.raise_for_status()
                 # Any success clears the breaker: a transient burst block that
                 # resolves must not accumulate toward the quota threshold.
-                self._breaker.record_success()
+                breaker.record_success()
                 return response.json()
             except httpx.HTTPStatusError as e:
                 if e.response.status_code == 429:  # Rate limited
                     retry_after = self._parse_retry_after(e.response.headers.get("Retry-After"))
                     # Every 429 counts, including the ones we are about to
                     # retry. See RateLimitBreaker.record_rate_limited.
-                    consecutive = self._breaker.record_rate_limited()
+                    consecutive = breaker.record_rate_limited()
                     if attempt >= retries:
                         # Out of attempts. Fail loudly -- falling through to an
                         # empty list here would tell the caller this endpoint
                         # has no data.
+                        if operation is not None:
+                            operation.note_transport_failure("failed")
                         raise RateLimitExhausted(
                             f"Rate limited on all {retries + 1} attempt(s) for {endpoint} "
                             f"(params={params}). Consecutive rate-limited responses: "
                             f"{consecutive}."
                         ) from e
-                    if self._breaker.is_open():
+                    if breaker.is_open():
                         # Checked BEFORE sleeping, not just at the top of get().
                         # Sleeping out a retry budget we already know is doomed
                         # is the exact waste the breaker exists to prevent, and
                         # the top-of-method guard alone cannot stop it because
                         # a single request can burn its whole budget without
                         # ever re-entering get().
+                        if operation is not None:
+                            operation.note_transport_failure("failed")
                         raise RateLimitCircuitOpen(
                             f"{consecutive} consecutive HTTP 429 response(s), most recently "
                             f"{endpoint}. The API is refusing everything -- most likely the "
@@ -396,6 +442,13 @@ class CFBDClient:
                     )
                     time.sleep(delay)
                     continue
+                if operation is not None:
+                    if e.response.status_code in {401, 403}:
+                        operation.note_transport_failure("failed")
+                    elif e.response.status_code >= 500 and operation.outcome != "failed":
+                        # Some source adapters deliberately retain a miss and
+                        # continue after exhausted transient failures.
+                        operation.note_transport_failure("partial")
                 # Non-retryable (4xx) or a 5xx past the transient budget: the
                 # final attempt fails HERE, inside the guarded loop.
                 raise
@@ -409,6 +462,8 @@ class CFBDClient:
                     )
                     time.sleep(delay)
                     continue
+                if operation is not None and operation.outcome != "failed":
+                    operation.note_transport_failure("partial")
                 raise
 
     def close(self):

--- a/src/pipelines/utils/quota_admission.py
+++ b/src/pipelines/utils/quota_admission.py
@@ -1,0 +1,184 @@
+"""Opt-in durable CFBD admission for enrolled command invocations.
+
+The active invocation is process-wide so dlt extraction threads cannot lose it.
+One invocation per process is supported; overlapping/nested invocations fail.
+Every SQL call uses its own committed transaction under warehouse_ingest.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import threading
+import uuid
+from contextlib import contextmanager
+from typing import Any
+
+import psycopg2
+from psycopg2.extras import Json
+
+
+class QuotaAdmissionError(RuntimeError):
+    """Durable accounting could not safely authorize continued transport."""
+
+
+class QuotaDeniedError(QuotaAdmissionError):
+    """A committed database decision denied this attempt, not other budget classes."""
+
+
+_ACTIVE: QuotaOperation | None = None
+_OPERATION_LOCK = threading.Lock()
+_PATH = re.compile(r"/[A-Za-z0-9_-]+(?:/[A-Za-z0-9_-]+)*\Z")
+
+
+def durable_quota_enabled() -> bool:
+    mode = os.environ.get("CFBD_QUOTA_MODE", "legacy")
+    if mode not in {"legacy", "durable"}:
+        raise QuotaAdmissionError("CFBD_QUOTA_MODE must be legacy or durable")
+    return mode == "durable"
+
+
+def active_operation() -> QuotaOperation | None:
+    return _ACTIVE
+
+
+def transport_operation() -> QuotaOperation | None:
+    operation = active_operation()
+    if operation is None and durable_quota_enabled():
+        raise QuotaAdmissionError("Durable CFBD transport requires an enrolled operation")
+    return operation
+
+
+class QuotaOperation:
+    def __init__(self, dsn: str, account: str, initiator: str, scope: dict[str, Any]):
+        self._dsn = dsn
+        self.account = account
+        self.run_id = str(uuid.uuid4())
+        self.initiator = initiator
+        self.scope = scope
+        self.outcome = "succeeded"
+        self._unavailable = threading.Event()
+        self.transport_lock = threading.RLock()
+
+    def _call(self, statement: str, args: tuple = (), *, allow_denial: bool = False):
+        conn = None
+        try:
+            conn = psycopg2.connect(self._dsn, connect_timeout=10)
+            with conn.cursor() as cur:
+                cur.execute("SET LOCAL ROLE warehouse_ingest")
+                cur.execute("SET LOCAL statement_timeout = '15s'")
+                cur.execute(statement, args)
+                rows = cur.fetchall() if cur.description else None
+            conn.commit()
+            return rows
+        except Exception as error:
+            if (
+                allow_denial
+                and isinstance(error, psycopg2.Error)
+                and error.pgcode in {"22023", "P0001"}
+            ):
+                self.outcome = "failed"
+                raise QuotaDeniedError("Durable quota denied this attempt") from None
+            # SQL messages/connection exceptions can contain credentials, request
+            # context, or internal server details. Do not chain them to CLI logs.
+            self._unavailable.set()
+            self.outcome = "failed"
+            if conn is not None:
+                try:
+                    conn.rollback()
+                except Exception:
+                    pass
+            raise QuotaAdmissionError(
+                "Durable quota transaction failed; no further HTTP allowed"
+            ) from None
+        finally:
+            if conn is not None:
+                conn.close()
+
+    def start(self) -> None:
+        self._call(
+            "SELECT warehouse_quota.start_operation_run(%s,'extract',%s,%s,NULL,NULL)",
+            (self.run_id, self.initiator, Json(self.scope)),
+        )
+
+    def reserve(self, endpoint: str, retry: int, params: dict | None) -> str:
+        if self._unavailable.is_set():
+            raise QuotaAdmissionError("Durable quota accounting is unavailable; HTTP denied")
+        if not _PATH.fullmatch(endpoint):
+            self.outcome = "failed"
+            raise QuotaAdmissionError("CFBD endpoint must be a canonical API path")
+        attempt_id = str(uuid.uuid4())
+        # Store only numeric/boolean work-unit identifiers. Tokens, free text,
+        # URLs, headers and other arbitrary request values never enter the ledger.
+        context = {
+            key: value
+            for key, value in (params or {}).items()
+            if key in {"year", "week", "gameId", "teamId", "playerId"}
+            and isinstance(value, (int, bool))
+        }
+        self._call(
+            "SELECT * FROM warehouse_quota.reserve_cfbd_transport_attempt(%s,%s,%s,%s,%s,%s)",
+            (attempt_id, self.run_id, self.account, endpoint, retry, Json(context)),
+            allow_denial=True,
+        )
+        return attempt_id
+
+    def dispatch(self, attempt_id: str) -> None:
+        if self._unavailable.is_set():
+            raise QuotaAdmissionError("Durable quota accounting is unavailable; HTTP denied")
+        self._call("SELECT warehouse_quota.mark_cfbd_attempt_dispatched(%s)", (attempt_id,))
+
+    def result(self, attempt_id: str, state: str, status: int | None, category: str | None) -> None:
+        self._call(
+            "SELECT warehouse_quota.record_cfbd_attempt_result(%s,%s,%s,%s)",
+            (attempt_id, state, status, category),
+        )
+
+    def note_transport_failure(self, outcome: str) -> None:
+        with self.transport_lock:
+            if self.outcome != "failed":
+                self.outcome = outcome
+
+    def finish(self, failed: bool = False) -> None:
+        outcome = "failed" if failed or self._unavailable.is_set() else self.outcome
+        self._call(
+            "SELECT warehouse_quota.finish_operation_run(%s,%s,%s)",
+            (self.run_id, outcome, "invocation_failed" if outcome == "failed" else None),
+        )
+
+
+@contextmanager
+def quota_operation(initiator: str, scope: dict[str, Any], *, enabled: bool = True):
+    """Enroll only selected jobs; opt-in is separate from migration rollout.
+
+    Legacy is the unchanged deployment default until a separately authorized
+    rollout sets CFBD_QUOTA_MODE=durable. Once selected there is no fallback.
+    Planning-only paths pass enabled=False and perform no quota writes.
+    """
+    global _ACTIVE
+    if not enabled or not durable_quota_enabled():
+        yield None
+        return
+    dsn = os.environ.get("CFBD_QUOTA_DB_URL")
+    account = os.environ.get("CFBD_QUOTA_ACCOUNT")
+    if not dsn or not account or not account.strip():
+        raise QuotaAdmissionError("Durable quota requires CFBD_QUOTA_DB_URL and CFBD_QUOTA_ACCOUNT")
+    if not _OPERATION_LOCK.acquire(blocking=False):
+        raise QuotaAdmissionError("Only one durable CFBD invocation per process is supported")
+    operation = QuotaOperation(dsn, account, initiator, scope)
+    try:
+        operation.start()  # Committed before it can become visible to clients.
+        _ACTIVE = operation
+        try:
+            yield operation
+        except BaseException:
+            try:
+                operation.finish(failed=True)
+            except QuotaAdmissionError:
+                pass  # Preserve original failure; unclosed parent is never success.
+            raise
+        else:
+            operation.finish()
+    finally:
+        _ACTIVE = None
+        _OPERATION_LOCK.release()

--- a/src/schemas/migrations/067_cfbd_transport_admission.sql
+++ b/src/schemas/migrations/067_cfbd_transport_admission.sql
@@ -1,0 +1,390 @@
+-- F14 transport admission. Follow-up to immutable migration 066.
+-- Apply only through the managed manifests after separate rollout approval.
+-- No budgets or runtime memberships are configured here.
+DO $namespace$
+DECLARE
+    schema_row record;
+BEGIN
+    SELECT oid, nspowner, nspacl INTO schema_row
+    FROM pg_catalog.pg_namespace WHERE nspname = 'warehouse_quota';
+    IF NOT FOUND THEN
+        CREATE SCHEMA warehouse_quota;
+    ELSE
+        IF schema_row.nspowner <> (SELECT oid FROM pg_catalog.pg_roles
+                WHERE rolname = current_user) THEN
+            RAISE EXCEPTION 'warehouse_quota must be owned by the migration role';
+        END IF;
+        IF EXISTS (
+            SELECT 1 FROM pg_catalog.aclexplode(schema_row.nspacl) acl
+            WHERE acl.grantee <> schema_row.nspowner AND acl.privilege_type = 'CREATE'
+        ) THEN
+            RAISE EXCEPTION 'existing warehouse_quota has untrusted CREATE grants';
+        END IF;
+        -- A same-named domain can turn a one-argument RPC call into a cast.
+        -- This dedicated routines-only namespace has no legitimate types.
+        IF EXISTS (
+            SELECT 1 FROM pg_catalog.pg_type WHERE typnamespace = schema_row.oid
+        ) THEN
+            RAISE EXCEPTION 'warehouse_quota contains an unexpected type';
+        END IF;
+        -- Do not adopt an already-compromised namespace by merely removing ACLs:
+        -- an attacker-owned routine can restore its own EXECUTE grants later.
+        IF EXISTS (
+            SELECT 1 FROM pg_catalog.pg_proc p
+            WHERE p.pronamespace = schema_row.oid AND (
+                p.proowner <> schema_row.nspowner OR p.prokind <> 'f'
+                OR p.provariadic <> 0 OR p.pronargdefaults <> 0
+                OR NOT COALESCE(p.oid = ANY(ARRAY[
+                    pg_catalog.to_regprocedure('warehouse_quota.guard_api_request_attempt_update()'),
+                    pg_catalog.to_regprocedure('warehouse_quota.reject_api_request_attempt_removal()'),
+                    pg_catalog.to_regprocedure('warehouse_quota.start_operation_run(uuid,text,text,jsonb,text,text)'),
+                    pg_catalog.to_regprocedure('warehouse_quota.finish_operation_run(uuid,text,text)'),
+                    pg_catalog.to_regprocedure('warehouse_quota.reserve_cfbd_attempt(uuid,uuid,text,timestamptz,text,integer,jsonb)'),
+                    pg_catalog.to_regprocedure('warehouse_quota.mark_cfbd_attempt_dispatched(uuid)'),
+                    pg_catalog.to_regprocedure('warehouse_quota.record_cfbd_attempt_result(uuid,text,integer,text)'),
+                    pg_catalog.to_regprocedure('warehouse_quota.reserve_cfbd_budget_attempt(uuid,uuid,text,timestamptz,text,integer,jsonb,text)'),
+                    pg_catalog.to_regprocedure('warehouse_quota.reserve_cfbd_transport_attempt(uuid,uuid,text,text,integer,jsonb)')
+                ]::oid[]), false)
+            )
+        ) THEN
+            RAISE EXCEPTION 'warehouse_quota contains an unexpected or untrusted routine';
+        END IF;
+    END IF;
+END
+$namespace$;
+
+ALTER TABLE meta.api_quota_periods ADD COLUMN IF NOT EXISTS budget_class text
+    NOT NULL DEFAULT 'extraction' CHECK (budget_class IN ('extraction', 'reconciliation'));
+ALTER TABLE meta.api_request_attempts ADD COLUMN IF NOT EXISTS budget_class text
+    NOT NULL DEFAULT 'extraction' CHECK (budget_class IN ('extraction', 'reconciliation'));
+ALTER TABLE meta.api_request_attempts DROP CONSTRAINT IF EXISTS api_request_attempts_period_fk;
+ALTER TABLE meta.api_request_attempts DROP CONSTRAINT IF EXISTS api_request_attempts_period_number_key;
+ALTER TABLE meta.api_quota_periods DROP CONSTRAINT IF EXISTS api_quota_periods_pkey;
+ALTER TABLE meta.api_quota_periods DROP CONSTRAINT IF EXISTS api_quota_periods_no_overlap;
+ALTER TABLE meta.api_quota_periods ADD PRIMARY KEY (account_key, budget_class, period_start_at);
+ALTER TABLE meta.api_request_attempts ADD CONSTRAINT api_request_attempts_period_fk
+    FOREIGN KEY (account_key, budget_class, period_start_at)
+    REFERENCES meta.api_quota_periods(account_key, budget_class, period_start_at);
+ALTER TABLE meta.api_request_attempts ADD CONSTRAINT api_request_attempts_period_number_key
+    UNIQUE (account_key, budget_class, period_start_at, period_attempt_number);
+COMMENT ON COLUMN meta.api_quota_periods.budget_class IS
+    'Independent owner-configured finite allowances. Reconciliation is only for exact /info and /info/usage paths.';
+
+
+DO $constraint$
+DECLARE
+    extension_schema text;
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_constraint
+        WHERE conrelid = 'meta.api_quota_periods'::pg_catalog.regclass
+          AND conname = 'api_quota_periods_no_overlap'
+    ) THEN
+        SELECT n.nspname
+        INTO STRICT extension_schema
+        FROM pg_catalog.pg_extension e
+        JOIN pg_catalog.pg_namespace n ON n.oid = e.extnamespace
+        WHERE e.extname = 'btree_gist';
+
+        EXECUTE pg_catalog.format(
+            'ALTER TABLE meta.api_quota_periods '
+            'ADD CONSTRAINT api_quota_periods_no_overlap '
+            'EXCLUDE USING gist '
+            '(account_key %I.gist_text_ops WITH =, '
+            'budget_class %I.gist_text_ops WITH =, '
+            'tstzrange(period_start_at, period_end_at, ''[)'') WITH &&)',
+            extension_schema, extension_schema
+        );
+    END IF;
+END
+$constraint$;
+
+
+
+CREATE OR REPLACE FUNCTION warehouse_quota.guard_api_request_attempt_update()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $function$
+BEGIN
+    IF ROW(
+        NEW.attempt_id, NEW.operation_run_id, NEW.account_key, NEW.period_start_at,
+        NEW.period_attempt_number, NEW.endpoint_class, NEW.retry_ordinal,
+        NEW.request_context, NEW.reserved_at, NEW.budget_class
+    ) IS DISTINCT FROM ROW(
+        OLD.attempt_id, OLD.operation_run_id, OLD.account_key, OLD.period_start_at,
+        OLD.period_attempt_number, OLD.endpoint_class, OLD.retry_ordinal,
+        OLD.request_context, OLD.reserved_at, OLD.budget_class
+    ) THEN
+        RAISE EXCEPTION 'API attempt reservation identity is immutable';
+    END IF;
+
+    IF NOT (
+        (OLD.state = 'reserved' AND NEW.state IN ('dispatched', 'unknown'))
+        OR (OLD.state = 'dispatched' AND NEW.state IN (
+            'succeeded', 'expected_no_data', 'http_error', 'transport_error', 'unknown'
+        ))
+    ) THEN
+        RAISE EXCEPTION 'Invalid API attempt state transition from % to %',
+            OLD.state, NEW.state;
+    END IF;
+    RETURN NEW;
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION warehouse_quota.reserve_cfbd_budget_attempt(
+    p_attempt_id uuid,
+    p_operation_run_id uuid,
+    p_account_key text,
+    p_period_start_at timestamptz,
+    p_endpoint_class text,
+    p_retry_ordinal integer,
+    p_request_context jsonb,
+    p_budget_class text
+)
+RETURNS TABLE (
+    attempt_id uuid,
+    reserved_at timestamptz,
+    period_attempt_number integer,
+    attempt_limit integer,
+    reused boolean
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $function$
+DECLARE
+    existing_attempt meta.api_request_attempts%ROWTYPE;
+    run_outcome text;
+    period_row meta.api_quota_periods%ROWTYPE;
+    reservation_time timestamptz;
+    new_period_count integer;
+BEGIN
+    IF p_budget_class IS NULL OR p_budget_class NOT IN ('extraction', 'reconciliation')
+        OR p_attempt_id IS NULL OR p_operation_run_id IS NULL
+        OR p_account_key IS NULL OR length(pg_catalog.btrim(p_account_key)) = 0
+        OR p_period_start_at IS NULL
+        OR p_endpoint_class IS NULL OR length(pg_catalog.btrim(p_endpoint_class)) = 0
+        OR p_retry_ordinal IS NULL OR p_retry_ordinal < 0
+        OR p_request_context IS NULL OR pg_catalog.jsonb_typeof(p_request_context) <> 'object' THEN
+        RAISE EXCEPTION 'attempt reservation context is invalid' USING ERRCODE = '22023';
+    END IF;
+
+    -- Serialize on the logical attempt before any period counter is touched.
+    -- Hash collisions only add harmless serialization.
+    PERFORM pg_catalog.pg_advisory_xact_lock(
+        pg_catalog.hashtextextended(p_attempt_id::text, 1)
+    );
+    SELECT a.* INTO existing_attempt
+    FROM meta.api_request_attempts AS a
+    WHERE a.attempt_id = p_attempt_id;
+
+    IF FOUND THEN
+        IF existing_attempt.operation_run_id IS DISTINCT FROM p_operation_run_id
+            OR existing_attempt.budget_class IS DISTINCT FROM p_budget_class
+            OR existing_attempt.account_key IS DISTINCT FROM p_account_key
+            OR existing_attempt.period_start_at IS DISTINCT FROM p_period_start_at
+            OR existing_attempt.endpoint_class IS DISTINCT FROM p_endpoint_class
+            OR existing_attempt.retry_ordinal IS DISTINCT FROM p_retry_ordinal
+            OR existing_attempt.request_context IS DISTINCT FROM p_request_context THEN
+            RAISE EXCEPTION 'attempt_id already reserved with different context'
+                USING ERRCODE = '22023';
+        END IF;
+
+        RETURN QUERY
+        SELECT existing_attempt.attempt_id, existing_attempt.reserved_at,
+            existing_attempt.period_attempt_number, p.attempt_limit, true
+        FROM meta.api_quota_periods AS p
+        WHERE p.budget_class = existing_attempt.budget_class
+          AND p.account_key = existing_attempt.account_key
+          AND p.period_start_at = existing_attempt.period_start_at;
+        RETURN;
+    END IF;
+
+    SELECT r.outcome INTO run_outcome
+    FROM meta.operation_runs AS r
+    WHERE r.operation_run_id = p_operation_run_id
+    FOR UPDATE;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'operation run is not configured' USING ERRCODE = '22023';
+    END IF;
+    IF run_outcome <> 'running' THEN
+        RAISE EXCEPTION 'operation run is already terminal' USING ERRCODE = '22023';
+    END IF;
+
+    SELECT p.* INTO period_row
+    FROM meta.api_quota_periods AS p
+    WHERE p.budget_class = p_budget_class
+      AND p.account_key = p_account_key
+      AND p.period_start_at = p_period_start_at
+    FOR UPDATE;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'quota period is not configured' USING ERRCODE = '22023';
+    END IF;
+
+    -- Use a fresh wall clock only after the potentially blocking period lock.
+    reservation_time := pg_catalog.clock_timestamp();
+    IF reservation_time < period_row.period_start_at
+        OR reservation_time >= period_row.period_end_at THEN
+        RAISE EXCEPTION 'quota period is not active' USING ERRCODE = '22023';
+    END IF;
+    IF period_row.reserved_attempts >= period_row.attempt_limit THEN
+        RAISE EXCEPTION 'quota period is exhausted' USING ERRCODE = 'P0001';
+    END IF;
+
+    UPDATE meta.api_quota_periods AS p
+    SET reserved_attempts = p.reserved_attempts + 1,
+        updated_at = reservation_time
+    WHERE p.budget_class = p_budget_class
+      AND p.account_key = p_account_key
+      AND p.period_start_at = p_period_start_at
+    RETURNING p.reserved_attempts INTO new_period_count;
+
+    INSERT INTO meta.api_request_attempts (
+        attempt_id, operation_run_id, account_key, period_start_at,
+        period_attempt_number, endpoint_class, retry_ordinal, request_context,
+        reserved_at, budget_class
+    ) VALUES (
+        p_attempt_id, p_operation_run_id, p_account_key, p_period_start_at,
+        new_period_count, p_endpoint_class, p_retry_ordinal, p_request_context,
+        reservation_time, p_budget_class
+    );
+
+    RETURN QUERY SELECT p_attempt_id, reservation_time, new_period_count,
+        period_row.attempt_limit, false;
+END
+$function$;
+
+-- Retain the original explicit-period RPC as extraction-only.
+CREATE OR REPLACE FUNCTION warehouse_quota.reserve_cfbd_attempt(
+    p_attempt_id uuid, p_operation_run_id uuid, p_account_key text,
+    p_period_start_at timestamptz, p_endpoint_class text, p_retry_ordinal integer,
+    p_request_context jsonb
+)
+RETURNS TABLE (attempt_id uuid, reserved_at timestamptz, period_attempt_number integer,
+    attempt_limit integer, reused boolean)
+LANGUAGE sql SECURITY DEFINER SET search_path = '' AS $function$
+    SELECT * FROM warehouse_quota.reserve_cfbd_budget_attempt(
+        p_attempt_id, p_operation_run_id, p_account_key, p_period_start_at,
+        p_endpoint_class, p_retry_ordinal, p_request_context, 'extraction');
+$function$;
+
+CREATE OR REPLACE FUNCTION warehouse_quota.reserve_cfbd_transport_attempt(
+    p_attempt_id uuid, p_operation_run_id uuid, p_account_key text,
+    p_endpoint text, p_retry_ordinal integer, p_request_context jsonb
+)
+RETURNS TABLE (attempt_id uuid, reserved_at timestamptz, period_attempt_number integer,
+    attempt_limit integer, reused boolean)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $function$
+DECLARE
+    selected_class text;
+    selected_start timestamptz;
+BEGIN
+    -- Absolute URLs, query strings, dot segments, escapes and fragments cannot
+    -- masquerade as trusted control endpoints or escape the configured API host.
+    IF p_endpoint IS NULL OR p_endpoint !~ '^/[A-Za-z0-9_-]+(/[A-Za-z0-9_-]+)*$' THEN
+        RAISE EXCEPTION 'endpoint must be a canonical API path' USING ERRCODE = '22023';
+    END IF;
+    selected_class := CASE WHEN p_endpoint IN ('/info', '/info/usage')
+        THEN 'reconciliation' ELSE 'extraction' END;
+    PERFORM pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended(p_attempt_id::text, 1));
+    -- Replays use their original period, including after its expiry. The helper
+    -- verifies every context field and class before returning the old charge.
+    SELECT a.period_start_at INTO selected_start FROM meta.api_request_attempts a
+        WHERE a.attempt_id = p_attempt_id;
+    IF NOT FOUND THEN
+        SELECT p.period_start_at INTO selected_start FROM meta.api_quota_periods p
+        WHERE p.account_key = p_account_key AND p.budget_class = selected_class
+          AND p.period_start_at <= pg_catalog.clock_timestamp()
+          AND p.period_end_at > pg_catalog.clock_timestamp();
+        IF NOT FOUND THEN
+            RAISE EXCEPTION 'active quota allowance is not configured' USING ERRCODE = '22023';
+        END IF;
+    END IF;
+    RETURN QUERY SELECT * FROM warehouse_quota.reserve_cfbd_budget_attempt(
+        p_attempt_id, p_operation_run_id, p_account_key, selected_start,
+        p_endpoint, p_retry_ordinal, p_request_context, selected_class);
+END
+$function$;
+
+
+CREATE OR REPLACE FUNCTION warehouse_quota.mark_cfbd_attempt_dispatched(p_attempt_id uuid)
+RETURNS timestamptz
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $function$
+DECLARE
+    attempt_row meta.api_request_attempts%ROWTYPE;
+    run_outcome text;
+    period_row meta.api_quota_periods%ROWTYPE;
+    dispatch_time timestamptz;
+BEGIN
+    -- Read identity, then lock in the same run -> attempt -> period order used
+    -- by operation finish/reservation to avoid lock-order inversions.
+    SELECT a.* INTO attempt_row
+    FROM meta.api_request_attempts AS a
+    WHERE a.attempt_id = p_attempt_id;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'attempt is not reserved' USING ERRCODE = '22023';
+    END IF;
+
+    SELECT r.outcome INTO run_outcome
+    FROM meta.operation_runs AS r
+    WHERE r.operation_run_id = attempt_row.operation_run_id
+    FOR UPDATE;
+
+    SELECT a.* INTO attempt_row
+    FROM meta.api_request_attempts AS a
+    WHERE a.attempt_id = p_attempt_id
+    FOR UPDATE;
+    IF attempt_row.state <> 'reserved' THEN
+        RAISE EXCEPTION 'attempt is already dispatched or terminal; do not send it again'
+            USING ERRCODE = '22023';
+    END IF;
+    IF run_outcome <> 'running' THEN
+        RAISE EXCEPTION 'operation run is already terminal' USING ERRCODE = '22023';
+    END IF;
+
+    SELECT p.* INTO period_row
+    FROM meta.api_quota_periods AS p
+    WHERE p.budget_class = attempt_row.budget_class
+      AND p.account_key = attempt_row.account_key
+      AND p.period_start_at = attempt_row.period_start_at
+    FOR UPDATE;
+    dispatch_time := pg_catalog.clock_timestamp();
+    IF dispatch_time < period_row.period_start_at
+        OR dispatch_time >= period_row.period_end_at THEN
+        RAISE EXCEPTION 'quota period is not active at dispatch' USING ERRCODE = '22023';
+    END IF;
+
+    UPDATE meta.api_request_attempts
+    SET state = 'dispatched', dispatched_at = dispatch_time
+    WHERE attempt_id = p_attempt_id;
+    RETURN dispatch_time;
+END
+$function$;
+
+-- New routines may inherit broad host defaults: scrub every non-owner grantee,
+-- including implicit PUBLIC, before granting only the transport entry point.
+DO $acl$
+DECLARE r record; recipient text;
+BEGIN
+    FOR r IN
+        SELECT p.oid::pg_catalog.regprocedure AS signature, a.grantee
+        FROM pg_catalog.pg_proc p JOIN pg_catalog.pg_namespace n ON n.oid=p.pronamespace
+        CROSS JOIN LATERAL pg_catalog.aclexplode(
+            COALESCE(p.proacl, pg_catalog.acldefault('f',p.proowner))) a
+        WHERE n.nspname='warehouse_quota'
+          AND p.proname IN ('reserve_cfbd_budget_attempt','reserve_cfbd_transport_attempt')
+          AND a.grantee <> p.proowner
+    LOOP
+        recipient := CASE WHEN r.grantee=0 THEN 'PUBLIC'
+            ELSE pg_catalog.quote_ident(pg_catalog.pg_get_userbyid(r.grantee)) END;
+        EXECUTE pg_catalog.format('REVOKE ALL ON FUNCTION %s FROM %s',r.signature,recipient);
+    END LOOP;
+END
+$acl$;
+GRANT EXECUTE ON FUNCTION warehouse_quota.reserve_cfbd_transport_attempt(uuid,uuid,text,text,integer,jsonb)
+    TO warehouse_ingest;

--- a/src/schemas/production-manifest.json
+++ b/src/schemas/production-manifest.json
@@ -9,6 +9,11 @@
       "id": "warehouse.f14.066",
       "path": "src/schemas/migrations/066_operational_quota_ledger.sql",
       "kind": "immutable"
+    },
+    {
+      "id": "warehouse.f14.067",
+      "path": "src/schemas/migrations/067_cfbd_transport_admission.sql",
+      "kind": "immutable"
     }
   ],
   "version": 1

--- a/src/schemas/warehouse-manifest.json
+++ b/src/schemas/warehouse-manifest.json
@@ -35,6 +35,11 @@
       "id": "warehouse.f14.066",
       "path": "src/schemas/migrations/066_operational_quota_ledger.sql",
       "kind": "immutable"
+    },
+    {
+      "id": "warehouse.f14.067",
+      "path": "src/schemas/migrations/067_cfbd_transport_admission.sql",
+      "kind": "immutable"
     }
   ]
 }

--- a/tests/test_cfbd_transport_admission_sql.py
+++ b/tests/test_cfbd_transport_admission_sql.py
@@ -1,0 +1,307 @@
+"""Executed class-separated quota admission and transport transactions."""
+
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import psycopg2
+import pytest
+
+from tests.test_operational_quota_sql import ACCOUNT, add_period, reserve, runtime_query, start_run
+from tests.test_operational_quota_sql import quota_db as _quota_db  # noqa: F401
+from tests.test_warehouse_migrations_sql import query
+from tests.test_warehouse_migrations_sql import warehouse_db as _warehouse_db  # noqa: F401
+
+MIGRATION = (
+    Path(__file__).resolve().parents[1] / "src/schemas/migrations/067_cfbd_transport_admission.sql"
+)
+
+
+@pytest.fixture
+def transport_db(request):
+    conn, target = request.getfixturevalue("_quota_db")
+    query(conn, MIGRATION.read_text())
+    query(conn, MIGRATION.read_text())
+    return conn, target
+
+
+def control_period(conn, limit=2):
+    now = datetime.now(UTC)
+    query(
+        conn,
+        "INSERT INTO meta.api_quota_periods "
+        "(account_key,budget_class,period_start_at,period_end_at,attempt_limit) "
+        "VALUES (%s,'reconciliation',%s,%s,%s)",
+        (ACCOUNT, now - timedelta(minutes=1), now + timedelta(minutes=10), limit),
+    )
+
+
+def transport_reserve(conn, run, endpoint, attempt=None):
+    return runtime_query(
+        conn,
+        "SELECT * FROM warehouse_quota.reserve_cfbd_transport_attempt(%s,%s,%s,%s,0,'{}')",
+        (str(attempt or uuid.uuid4()), str(run), ACCOUNT, endpoint),
+    )[0]
+
+
+def test_exhausted_extraction_still_allows_bounded_control(transport_db):
+    conn, _ = transport_db
+    run = start_run(conn)
+    add_period(conn, limit=1)
+    control_period(conn, limit=2)
+    transport_reserve(conn, run, "/games")
+    with pytest.raises(psycopg2.Error, match="exhausted"):
+        transport_reserve(conn, run, "/scoreboard")
+    conn.rollback()
+    for endpoint in ("/info", "/info/usage"):
+        attempt = transport_reserve(conn, run, endpoint)[0]
+        runtime_query(conn, "SELECT warehouse_quota.mark_cfbd_attempt_dispatched(%s)", (attempt,))
+        runtime_query(
+            conn,
+            "SELECT warehouse_quota.record_cfbd_attempt_result(%s,'succeeded',200,NULL)",
+            (attempt,),
+        )
+    with pytest.raises(psycopg2.Error, match="exhausted"):
+        transport_reserve(conn, run, "/info")
+    conn.rollback()
+    assert query(
+        conn, "SELECT budget_class,reserved_attempts FROM meta.api_quota_periods ORDER BY 1"
+    ) == [("extraction", 1), ("reconciliation", 2)]
+
+
+def test_control_is_exact_and_cannot_be_selected_via_legacy_rpc(transport_db):
+    conn, _ = transport_db
+    run = start_run(conn)
+    control_period(conn)
+    for endpoint in (
+        "/info/other",
+        "/scoreboard",
+        "/INFO",
+        "/info?x=1",
+        "https://evil/info",
+        "/info/",
+    ):
+        with pytest.raises(psycopg2.Error):
+            transport_reserve(conn, run, endpoint)
+        conn.rollback()
+    start = query(conn, "SELECT period_start_at FROM meta.api_quota_periods")[0][0]
+    with pytest.raises(psycopg2.Error, match="not configured"):
+        reserve(conn, uuid.uuid4(), run, start, endpoint="/info")
+    conn.rollback()
+    with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+        runtime_query(
+            conn,
+            "SELECT * FROM warehouse_quota.reserve_cfbd_budget_attempt("
+            "%s,%s,%s,%s,'/info',0,'{}','reconciliation')",
+            (str(uuid.uuid4()), str(run), ACCOUNT, start),
+        )
+    conn.rollback()
+    assert query(conn, "SELECT reserved_attempts FROM meta.api_quota_periods") == [(0,)]
+
+
+def test_existing_extraction_history_survives_upgrade(request):
+    conn, _ = request.getfixturevalue("_quota_db")
+    run = start_run(conn)
+    start, _ = add_period(conn)
+    attempt = uuid.uuid4()
+    original = reserve(conn, attempt, run, start)
+    query(conn, MIGRATION.read_text())
+    query(conn, MIGRATION.read_text())
+    assert reserve(conn, attempt, run, start)[:4] == original[:4]
+    runtime_query(conn, "SELECT warehouse_quota.mark_cfbd_attempt_dispatched(%s)", (str(attempt),))
+    assert query(conn, "SELECT budget_class,state FROM meta.api_request_attempts") == [
+        ("extraction", "dispatched")
+    ]
+    with pytest.raises(psycopg2.Error, match="immutable"):
+        query(conn, "UPDATE meta.api_request_attempts SET budget_class='reconciliation'")
+    conn.rollback()
+
+
+def test_control_concurrency_cannot_exceed_cap(transport_db):
+    conn, target = transport_db
+    runs = [start_run(conn) for _ in range(6)]
+    control_period(conn, limit=2)
+
+    def worker(run):
+        with psycopg2.connect(target) as other:
+            try:
+                transport_reserve(other, run, "/info")
+                return True
+            except psycopg2.Error as e:
+                assert "exhausted" in str(e)
+                return False
+
+    with ThreadPoolExecutor(max_workers=6) as pool:
+        assert sum(pool.map(worker, runs)) == 2
+    assert query(conn, "SELECT reserved_attempts FROM meta.api_quota_periods") == [(2,)]
+
+
+def test_control_replay_context_and_expiry(transport_db):
+    conn, _ = transport_db
+    run = start_run(conn)
+    control_period(conn)
+    attempt = uuid.uuid4()
+    first = transport_reserve(conn, run, "/info", attempt)
+    assert transport_reserve(conn, run, "/info", attempt)[4] is True
+    with pytest.raises(psycopg2.Error, match="different context"):
+        transport_reserve(conn, run, "/info/usage", attempt)
+    conn.rollback()
+    query(
+        conn,
+        "UPDATE meta.api_quota_periods SET period_end_at=clock_timestamp()-interval '1 second'",
+    )
+    assert transport_reserve(conn, run, "/info", attempt)[:4] == first[:4]
+    with pytest.raises(psycopg2.Error, match="not active at dispatch"):
+        runtime_query(
+            conn, "SELECT warehouse_quota.mark_cfbd_attempt_dispatched(%s)", (str(attempt),)
+        )
+    conn.rollback()
+
+
+def test_real_adapter_commits_parent_attempt_and_response(transport_db, monkeypatch):
+    import httpx
+
+    from src.pipelines.utils.api_client import CFBDClient
+    from src.pipelines.utils.quota_admission import quota_operation
+
+    conn, target = transport_db
+    add_period(conn, limit=2)
+    monkeypatch.setenv("CFBD_QUOTA_MODE", "durable")
+    monkeypatch.setenv("CFBD_QUOTA_DB_URL", target)
+    monkeypatch.setenv("CFBD_QUOTA_ACCOUNT", ACCOUNT)
+    observed = []
+
+    def http_send(endpoint, params):
+        observed.append(
+            query(conn, "SELECT state FROM meta.api_request_attempts ORDER BY reserved_at")
+        )
+        assert query(conn, "SELECT outcome FROM meta.operation_runs") == [("running",)]
+        return httpx.Response(
+            200, json=[], request=httpx.Request("GET", "https://api.collegefootballdata.com/games")
+        )
+
+    with quota_operation("sql-test", {}) as operation:
+        client = CFBDClient(api_key="fixture")
+        monkeypatch.setattr(client._client, "get", http_send)
+        try:
+            assert client.get("/games", {"year": 2026}) == []
+        finally:
+            client.close()
+    assert observed == [[("dispatched",)]]
+    assert query(
+        conn,
+        "SELECT outcome FROM meta.operation_runs WHERE operation_run_id=%s",
+        (operation.run_id,),
+    ) == [("succeeded",)]
+    assert query(conn, "SELECT state,http_status FROM meta.api_request_attempts") == [
+        ("succeeded", 200)
+    ]
+
+
+def test_same_operation_can_reconcile_after_extraction_denial(transport_db, monkeypatch):
+    import httpx
+
+    from src.pipelines.utils.api_client import CFBDClient
+    from src.pipelines.utils.quota_admission import QuotaDeniedError, quota_operation
+
+    conn, target = transport_db
+    add_period(conn, limit=1)
+    control_period(conn, limit=1)
+    monkeypatch.setenv("CFBD_QUOTA_MODE", "durable")
+    monkeypatch.setenv("CFBD_QUOTA_DB_URL", target)
+    monkeypatch.setenv("CFBD_QUOTA_ACCOUNT", ACCOUNT)
+    sends = []
+    with quota_operation("test", {}):
+        with CFBDClient(api_key="fixture") as client:
+
+            def send(endpoint, params):
+                sends.append(endpoint)
+                return httpx.Response(200, json=[], request=httpx.Request("GET", "https://fixture"))
+
+            monkeypatch.setattr(client._client, "get", send)
+            client.get("/games")
+            with pytest.raises(QuotaDeniedError):
+                client.get("/games")
+            client.get("/info")
+    assert sends == ["/games", "/info"]
+    assert query(
+        conn, "SELECT budget_class,reserved_attempts FROM meta.api_quota_periods ORDER BY 1"
+    ) == [("extraction", 1), ("reconciliation", 1)]
+
+
+def test_fresh_process_observes_prior_usage(transport_db):
+    import subprocess
+    import sys
+
+    conn, target = transport_db
+    add_period(conn, limit=1)
+    code = """
+import httpx
+from src.pipelines.utils.api_client import CFBDClient
+from src.pipelines.utils.quota_admission import quota_operation, QuotaAdmissionError
+try:
+    with quota_operation("fresh-process", {}):
+        with CFBDClient(api_key="fixture") as client:
+            def send(*args, **kwargs):
+                print("SENT")
+                return httpx.Response(200,json=[],request=httpx.Request("GET","https://fixture"))
+            client._client.get = send
+            client.get("/games")
+except QuotaAdmissionError:
+    print("DENIED")
+"""
+    import os
+
+    env = dict(
+        os.environ, CFBD_QUOTA_MODE="durable", CFBD_QUOTA_DB_URL=target, CFBD_QUOTA_ACCOUNT=ACCOUNT
+    )
+    first = subprocess.run(
+        [sys.executable, "-c", code], env=env, capture_output=True, text=True, check=True
+    )
+    second = subprocess.run(
+        [sys.executable, "-c", code], env=env, capture_output=True, text=True, check=True
+    )
+    assert first.stdout.strip() == "SENT"
+    assert second.stdout.strip() == "DENIED"
+    assert query(conn, "SELECT reserved_attempts FROM meta.api_quota_periods") == [(1,)]
+
+
+def test_new_rpc_default_grants_are_private(transport_db):
+    conn, _ = transport_db
+    for role in ("anon", "authenticated", "analyst_ro", "quota_bystander"):
+        assert query(
+            conn,
+            "SELECT bool_and(NOT has_function_privilege(%s,p.oid,'EXECUTE')) "
+            "FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace "
+            "WHERE n.nspname='warehouse_quota'",
+            (role,),
+        ) == [(True,)]
+    with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+        runtime_query(conn, "UPDATE meta.api_quota_periods SET attempt_limit=100")
+    conn.rollback()
+
+
+def test_new_attempt_uses_next_window_while_old_charge_remains(transport_db):
+    conn, _ = transport_db
+    run = start_run(conn)
+    control_period(conn, limit=1)
+    first = transport_reserve(conn, run, "/info")
+    query(
+        conn,
+        "UPDATE meta.api_quota_periods SET period_end_at=clock_timestamp()-interval '1 second'",
+    )
+    next_start = query(conn, "SELECT period_end_at FROM meta.api_quota_periods")[0][0]
+    query(
+        conn,
+        "INSERT INTO meta.api_quota_periods "
+        "(account_key,budget_class,period_start_at,period_end_at,attempt_limit) "
+        "VALUES (%s,'reconciliation',%s,clock_timestamp()+interval '10 minutes',1)",
+        (ACCOUNT, next_start),
+    )
+    second = transport_reserve(conn, run, "/info")
+    assert second[0] != first[0]
+    assert second[2] == first[2] == 1
+    assert query(
+        conn, "SELECT reserved_attempts FROM meta.api_quota_periods ORDER BY period_start_at"
+    ) == [(1,), (1,)]

--- a/tests/test_cfbd_transport_admission_sql.py
+++ b/tests/test_cfbd_transport_admission_sql.py
@@ -159,7 +159,10 @@ def test_control_replay_context_and_expiry(transport_db):
     conn.rollback()
 
 
-def test_real_adapter_commits_parent_attempt_and_response(transport_db, monkeypatch):
+@pytest.mark.parametrize("expected_empty", [False, True])
+def test_real_adapter_commits_parent_attempt_and_response(
+    transport_db, monkeypatch, expected_empty
+):
     import httpx
 
     from src.pipelines.utils.api_client import CFBDClient
@@ -185,7 +188,7 @@ def test_real_adapter_commits_parent_attempt_and_response(transport_db, monkeypa
         client = CFBDClient(api_key="fixture")
         monkeypatch.setattr(client._client, "get", http_send)
         try:
-            assert client.get("/games", {"year": 2026}) == []
+            assert client.get("/scoreboard", expected_empty=expected_empty) == []
         finally:
             client.close()
     assert observed == [[("dispatched",)]]
@@ -195,7 +198,7 @@ def test_real_adapter_commits_parent_attempt_and_response(transport_db, monkeypa
         (operation.run_id,),
     ) == [("succeeded",)]
     assert query(conn, "SELECT state,http_status FROM meta.api_request_attempts") == [
-        ("succeeded", 200)
+        ("expected_no_data" if expected_empty else "succeeded", 200)
     ]
 
 

--- a/tests/test_quota_admission.py
+++ b/tests/test_quota_admission.py
@@ -1,0 +1,280 @@
+"""Transport ordering, fail-closed boundaries and enrolled CLI lifecycles."""
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+from unittest.mock import Mock
+
+import httpx
+import pytest
+
+from src.pipelines.utils import api_client
+from src.pipelines.utils import quota_admission as quota
+
+
+class RecordingOperation(quota.QuotaOperation):
+    def __init__(self):
+        super().__init__("unused", "fixture", "test", {})
+        self.calls = []
+
+    def _call(self, statement, args=(), **kwargs):
+        self.calls.append((statement, args))
+        return []
+
+
+@pytest.fixture
+def admitted(monkeypatch):
+    operation = RecordingOperation()
+    monkeypatch.setattr(quota, "_ACTIVE", operation)
+    monkeypatch.setattr(api_client, "_CONTROL_BREAKER", api_client.RateLimitBreaker())
+    monkeypatch.setattr(api_client.time, "sleep", lambda _: None)
+    with api_client.CFBDClient(api_key="fixture") as client:
+        yield operation, client
+
+
+def response(status):
+    return httpx.Response(status, json=[], request=httpx.Request("GET", "https://fixture/games"))
+
+
+def test_each_retry_is_reserved_dispatched_and_recorded(admitted, monkeypatch):
+    operation, client = admitted
+    sends = []
+    responses = iter([response(429), response(503), httpx.ConnectError("fixture"), response(200)])
+
+    def send(*args, **kwargs):
+        assert "mark_cfbd_attempt_dispatched" in operation.calls[-1][0]
+        sends.append(operation.calls[-1][1][0])
+        item = next(responses)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    monkeypatch.setattr(client._client, "get", send)
+    assert client.get("/games") == []
+    assert len(set(sends)) == 4
+    reservations = [a for s, a in operation.calls if "reserve_cfbd_transport" in s]
+    results = [a for s, a in operation.calls if "record_cfbd_attempt_result" in s]
+    assert [a[4] for a in reservations] == [0, 1, 2, 3]
+    assert [(a[1], a[2]) for a in results] == [
+        ("http_error", 429),
+        ("http_error", 503),
+        ("transport_error", None),
+        ("succeeded", 200),
+    ]
+
+
+@pytest.mark.parametrize("status", [401, 403, 404])
+def test_nonretryable_response_has_one_terminal_record(admitted, monkeypatch, status):
+    operation, client = admitted
+    send = Mock(return_value=response(status))
+    monkeypatch.setattr(client._client, "get", send)
+    with pytest.raises(httpx.HTTPStatusError):
+        client.get("/games")
+    assert send.call_count == 1
+    assert operation.calls[-1][1][1:3] == ("http_error", status)
+
+
+@pytest.mark.parametrize("boundary", ["reserve", "dispatch", "result"])
+def test_accounting_failure_stops_send_and_retry(admitted, monkeypatch, boundary):
+    operation, client = admitted
+
+    def failed(*args):
+        operation._unavailable.set()
+        raise quota.QuotaAdmissionError("failed")
+
+    monkeypatch.setattr(operation, boundary, failed)
+    send = Mock(return_value=response(503))
+    monkeypatch.setattr(client._client, "get", send)
+    with pytest.raises(quota.QuotaAdmissionError):
+        client.get("/games")
+    assert send.call_count == (1 if boundary == "result" else 0)
+    with pytest.raises(quota.QuotaAdmissionError):
+        client.get("/info")
+    assert send.call_count == (1 if boundary == "result" else 0)
+
+
+def test_control_does_not_share_extraction_circuit(admitted, monkeypatch):
+    operation, client = admitted
+    for _ in range(client._breaker.threshold):
+        client._breaker.record_rate_limited()
+    monkeypatch.setattr(client._client, "get", Mock(return_value=response(200)))
+    with pytest.raises(api_client.RateLimitCircuitOpen):
+        client.get("/games")
+    assert not operation.calls
+    assert client.get("/info") == []
+    assert client._breaker.is_open()
+
+
+def test_concurrent_thread_cannot_send_after_result_failure(admitted, monkeypatch):
+    operation, client = admitted
+    entered = threading.Event()
+    release = threading.Event()
+    second_started = threading.Event()
+    send = Mock(return_value=response(200))
+    monkeypatch.setattr(client._client, "get", send)
+
+    def result(*args):
+        entered.set()
+        assert release.wait(5)
+        operation._unavailable.set()
+        raise quota.QuotaAdmissionError("write failed")
+
+    monkeypatch.setattr(operation, "result", result)
+
+    def second():
+        second_started.set()
+        return client.get("/games")
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(client.get, "/games")
+        assert entered.wait(5)
+        other = pool.submit(second)
+        assert second_started.wait(5)
+        release.set()
+        for future in (first, other):
+            with pytest.raises(quota.QuotaAdmissionError):
+                future.result(timeout=5)
+    assert send.call_count == 1
+
+
+def test_database_failure_is_sanitized_and_latched(monkeypatch):
+    monkeypatch.setattr(quota.psycopg2, "connect", Mock(side_effect=RuntimeError("SECRET DSN")))
+    operation = quota.QuotaOperation("SECRET DSN", "fixture", "test", {})
+    with pytest.raises(quota.QuotaAdmissionError) as error:
+        operation.start()
+    assert "SECRET" not in str(error.value)
+    assert operation._unavailable.is_set()
+    assert operation.outcome == "failed"
+
+
+def test_uncertain_commit_never_allows_http(monkeypatch):
+    connection = Mock()
+    connection.cursor.return_value.__enter__ = Mock(return_value=Mock())
+    connection.cursor.return_value.__exit__ = Mock(return_value=False)
+    connection.commit.side_effect = RuntimeError("commit response lost")
+    monkeypatch.setattr(quota.psycopg2, "connect", Mock(return_value=connection))
+    operation = quota.QuotaOperation("fixture", "fixture", "test", {})
+    with pytest.raises(quota.QuotaAdmissionError):
+        operation.reserve("/games", 0, {})
+    assert operation._unavailable.is_set()
+    assert connection.close.called
+
+
+def test_enrollment_requires_configuration_and_parent_commit(monkeypatch):
+    monkeypatch.setenv("CFBD_QUOTA_MODE", "durable")
+    monkeypatch.delenv("CFBD_QUOTA_DB_URL", raising=False)
+    with pytest.raises(quota.QuotaAdmissionError):
+        with quota.quota_operation("test", {}):
+            pytest.fail("must not enter")
+    monkeypatch.setenv("CFBD_QUOTA_DB_URL", "fixture")
+    monkeypatch.setenv("CFBD_QUOTA_ACCOUNT", "fixture")
+    calls = []
+
+    def call(self, statement, args=(), **kwargs):
+        if "start_operation" in statement:
+            assert quota.active_operation() is None
+        calls.append((statement, args))
+
+    monkeypatch.setattr(quota.QuotaOperation, "_call", call)
+    with quota.quota_operation("test", {}) as operation:
+        assert quota.active_operation() is operation
+        assert "start_operation" in calls[0][0]
+    assert quota.active_operation() is None
+    assert calls[-1][1][1] == "succeeded"
+
+
+def test_durable_client_without_enrollment_denies_http(monkeypatch):
+    monkeypatch.setenv("CFBD_QUOTA_MODE", "durable")
+    with api_client.CFBDClient(api_key="fixture") as client:
+        send = Mock()
+        monkeypatch.setattr(client._client, "get", send)
+        with pytest.raises(quota.QuotaAdmissionError):
+            client.get("/games")
+        send.assert_not_called()
+
+
+def test_enrolled_make_request_ignores_json_gate(admitted, monkeypatch):
+    from src.pipelines.sources import base
+
+    _, client = admitted
+    monkeypatch.setattr(base, "get_rate_limiter", Mock(side_effect=AssertionError("JSON gate")))
+    monkeypatch.setattr(client._client, "get", Mock(return_value=response(200)))
+    assert base.make_request(client, "/games") == []
+
+
+def test_load_main_records_returned_errors(monkeypatch):
+    from scripts import load_season
+
+    operation = RecordingOperation()
+
+    @contextmanager
+    def context(*args, **kwargs):
+        yield operation
+
+    monkeypatch.setattr(quota, "quota_operation", context)
+    monkeypatch.setattr(load_season, "load_season", Mock(return_value={"errors": 1}))
+    monkeypatch.setattr("sys.argv", ["load_season", "--season", "2026"])
+    with pytest.raises(SystemExit) as error:
+        load_season.main()
+    assert error.value.code == 1
+    assert operation.outcome == "failed"
+
+
+def test_live_dry_run_still_enrolls_transport(monkeypatch):
+    from scripts import poll_scoreboard
+
+    seen = []
+
+    @contextmanager
+    def context(*args, **kwargs):
+        seen.append((args, kwargs))
+        yield RecordingOperation()
+
+    monkeypatch.setattr(quota, "quota_operation", context)
+    client = Mock()
+    client.get.return_value = []
+    monkeypatch.setattr(poll_scoreboard, "get_client", Mock(return_value=client))
+    monkeypatch.setattr("sys.argv", ["poll_scoreboard", "--dry-run"])
+    poll_scoreboard.main()
+    assert seen[0][0][0] == "poll_scoreboard"
+    assert seen[0][1].get("enabled", True)
+    client.close.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "status,outcome,exit_code",
+    [("ok", "partial", 0), ("complete", "succeeded", 0), ("finalize_failed", "failed", 1)],
+)
+def test_historical_summary_preserves_run_outcome(monkeypatch, status, outcome, exit_code):
+    from scripts import backfill_refresh
+
+    operation = RecordingOperation()
+
+    @contextmanager
+    def context(*args, **kwargs):
+        yield operation
+
+    monkeypatch.setattr(quota, "quota_operation", context)
+    monkeypatch.setattr(backfill_refresh, "get_db_url", lambda: "fixture")
+    monkeypatch.setattr(quota.psycopg2, "connect", Mock(return_value=Mock()))
+    monkeypatch.setattr(backfill_refresh, "run_campaign", Mock(return_value={"status": status}))
+    monkeypatch.setattr("sys.argv", ["backfill_refresh", "--campaign", "fixture"])
+    with pytest.raises(SystemExit) as error:
+        backfill_refresh.main()
+    assert error.value.code == exit_code
+    assert operation.outcome == outcome
+
+
+@pytest.mark.parametrize("network", [False, True])
+def test_exhausted_transient_failure_cannot_leave_successful_run(admitted, monkeypatch, network):
+    operation, client = admitted
+    monkeypatch.setattr(client, "TRANSIENT_MAX_RETRIES", 0)
+    send = (
+        Mock(side_effect=httpx.ConnectError("fixture"))
+        if network
+        else Mock(return_value=response(503))
+    )
+    monkeypatch.setattr(client._client, "get", send)
+    with pytest.raises((httpx.HTTPStatusError, httpx.RequestError)):
+        client.get("/games")
+    assert operation.outcome == "partial"

--- a/tests/test_quota_admission.py
+++ b/tests/test_quota_admission.py
@@ -238,6 +238,9 @@ def test_live_dry_run_still_enrolls_transport(monkeypatch):
     poll_scoreboard.main()
     assert seen[0][0][0] == "poll_scoreboard"
     assert seen[0][1].get("enabled", True)
+    client.get.assert_called_once_with(
+        "/scoreboard", params={"classification": "fbs"}, expected_empty=True
+    )
     client.close.assert_called_once()
 
 
@@ -278,3 +281,48 @@ def test_exhausted_transient_failure_cannot_leave_successful_run(admitted, monke
     with pytest.raises((httpx.HTTPStatusError, httpx.RequestError)):
         client.get("/games")
     assert operation.outcome == "partial"
+
+
+@pytest.mark.parametrize(
+    "payload,expected_empty,state",
+    [
+        ([], True, "expected_no_data"),
+        ([], False, "succeeded"),
+        ([{"id": 1}], True, "succeeded"),
+        ({}, True, "succeeded"),
+    ],
+)
+def test_explicit_empty_contract_records_terminal_classification(
+    admitted, monkeypatch, payload, expected_empty, state
+):
+    operation, client = admitted
+    reply = httpx.Response(200, json=payload, request=httpx.Request("GET", "https://fixture"))
+    monkeypatch.setattr(client._client, "get", Mock(return_value=reply))
+    assert client.get("/scoreboard", expected_empty=expected_empty) == payload
+    assert operation.calls[-1][1][1:3] == (state, 200)
+    assert sum("record_cfbd_attempt_result" in sql for sql, _ in operation.calls) == 1
+
+
+def test_invalid_json_is_not_recorded_as_expected_no_data(admitted, monkeypatch):
+    operation, client = admitted
+    reply = httpx.Response(
+        200, content=b"bad json", request=httpx.Request("GET", "https://fixture")
+    )
+    monkeypatch.setattr(client._client, "get", Mock(return_value=reply))
+    with pytest.raises(ValueError):
+        client.get("/scoreboard", expected_empty=True)
+    assert operation.calls[-1][1][1:3] == ("succeeded", 200)
+
+
+def test_client_reset_reopens_control_without_restarting(admitted, monkeypatch):
+    _, client = admitted
+    for _ in range(api_client._CONTROL_BREAKER.threshold):
+        api_client._CONTROL_BREAKER.record_rate_limited()
+    send = Mock(return_value=response(200))
+    monkeypatch.setattr(client._client, "get", send)
+    with pytest.raises(api_client.RateLimitCircuitOpen):
+        client.get("/info")
+    send.assert_not_called()
+    client.reset_rate_limit_circuit()
+    assert client.get("/info") == []
+    send.assert_called_once()

--- a/tests/test_warehouse_bootstrap_sql.py
+++ b/tests/test_warehouse_bootstrap_sql.py
@@ -382,7 +382,7 @@ def test_managed_warehouse_catalog_data_and_access(
         _insert_representative_rows(conn)
         before_upgrade = _fixture_snapshot(conn)
         upgrade = apply_manifest(conn, manifest, mode="upgrade")
-        assert len(upgrade.pending) == 3
+        assert len(upgrade.pending) == 4
         assert [step.id for step in upgrade.pending] == [
             migration.id for migration in manifest.migrations[4:]
         ]


### PR DESCRIPTION
CFBD retries currently share only a process-local JSON counter, so separate runners can exceed one account's allowance.

Review fixes in `69e1152`:

![PR Lens: scoreboard empty lists are recorded as expected no-data, and client reset clears both extraction and control circuits](https://github.com/user-attachments/assets/81227208-d4b7-48c4-afc7-8a7052a6aa40)

This adds opt-in durable transport admission for the daily loader, historical refresh, and live scoreboard commands. Each invocation commits its operation parent before requesting quota, and each actual HTTP attempt commits its reservation and dispatch before sending and records its result before retrying.

Migration 067 preserves existing extraction history and adds independent reconciliation windows/caps. Only exact `/info` and `/info/usage` paths can use that allowance; the old reservation RPC remains extraction-only. Reconciliation remains usable after extraction exhaustion or its 429 circuit opens. Database or uncertain-commit failures stop further transport, including competing threads in the same operation. Source/mart failures and exhausted transient requests cannot leave a successful operation record.

The change follows the merged design in #137 and foundation in #138. Deployment still defaults to legacy behavior until a separately authorized rollout applies the managed migration, configures finite allowances and a dedicated bounded-role connection, and enables `CFBD_QUOTA_MODE=durable` for enrolled commands. No workflow activation, production SQL, budgets, memberships, authenticated provider calls, or automatic reconciliation/cap changes are included. Publication receipts and freshness interfaces remain later work. See `docs/plans/2026-09-08-f14-transport-admission.md` for the rollout contract.

Validation:
- 38 executed PostgreSQL 17 cases across quota foundation, transport allowance, fresh bootstrap, and prior-baseline upgrade; actual caller roles, concurrency, populated upgrade/replay, fresh-process capacity, separate control allowance, and commit ordering visible from a separate connection.
- 76 transport/client tests; focused loader, historical, drainer, migration-runner and CLI regressions also passed.
- Ruff lint/format, actionlint, and diff checks passed. Independent review findings were resolved.
- SQL ran only against disposable local PostgreSQL with mocked HTTP. Production permissions, deployed HTTP ordering, automated crash recovery, and throughput remain unverified.




<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61847439"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/formentera-operations/-/pull-requests/rstover-fo/cfb-database/139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge.

<details><summary><h3>Summary</h3></summary>

- This update adds opt-in, PostgreSQL-backed CFBD transport admission for daily ingestion, historical refresh, and live scoreboard polling. It keeps legacy behavior until durable mode is enabled, records reservation and request outcomes, resets reconciliation protection through the existing client reset path, classifies empty scoreboard responses explicitly, and adds focused coverage for concurrency, migrations, access control, and error handling.
</details>

<!-- /greptile_comment -->