### PR TITLE
Publish full house Elo rebuilds with atomic receipts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - run: ./scripts/setup_dev.sh
       - name: Managed bootstrap and upgrade integration
-        run: .venv/bin/python -m pytest tests/test_warehouse_migrations_sql.py tests/test_warehouse_bootstrap_sql.py tests/test_adopt_warehouse_catalog_sql.py tests/test_f06_verification_transactions_sql.py tests/test_mart_release_sql.py tests/test_play_partitions.py tests/test_play_indexes_sql.py tests/test_operational_quota_sql.py tests/test_operational_quota_lifecycle_sql.py tests/test_cfbd_transport_admission_sql.py -q --tb=short
+        run: .venv/bin/python -m pytest tests/test_warehouse_migrations_sql.py tests/test_warehouse_bootstrap_sql.py tests/test_adopt_warehouse_catalog_sql.py tests/test_f06_verification_transactions_sql.py tests/test_mart_release_sql.py tests/test_play_partitions.py tests/test_play_indexes_sql.py tests/test_operational_quota_sql.py tests/test_operational_quota_lifecycle_sql.py tests/test_cfbd_transport_admission_sql.py tests/test_asset_publication_sql.py -q --tb=short
         env:
           F06_TEST_DB_URL: postgresql://postgres:f06-disposable-ci@127.0.0.1:5432/postgres
           F06_REQUIRE_DB: "1"

--- a/docs/SCHEMA_CONTRACT.md
+++ b/docs/SCHEMA_CONTRACT.md
@@ -1210,6 +1210,24 @@ separate. `public.get_data_freshness()` is unchanged. See the
 [transport implementation and rollout](plans/2026-09-08-f14-transport-admission.md) and the
 [F14 foundation and rollout boundary](plans/2026-09-08-f14-quota-foundation.md).
 
+### Controlled publication receipts (prepared, not deployed)
+
+Migration `068_asset_publication_receipts.sql` adds private
+`meta.asset_publication_locks`, `meta.asset_receipts`,
+`meta.asset_current_generations`, and `meta.asset_receipt_inputs`. The first
+producer is opt-in full house Elo computation: game output, the current team
+snapshot, the game mart and both game-asset receipts commit together. The mart
+receipt names its exact source generation; upstream `core.games` is recorded
+as an unversioned input observation. Current pointers require complete success
+or evaluated expected-no-data coverage. Legacy target writes and relevant DDL
+invalidate current evidence. These records do not change
+`public.get_data_freshness()` or prove provider completeness.
+
+The owner-controlled `warehouse_publication` namespace grants only bounded RPCs
+to `warehouse_publisher`; no runtime membership is granted. Published timestamps
+are transaction-local clock observations, not exact commit times. See the
+[publication protocol and rollout](plans/2026-09-09-f14-publication-receipts.md).
+
 ### Raw Data Tables
 
 | Schema | Tables |

--- a/docs/SCHEMA_CONTRACT.md
+++ b/docs/SCHEMA_CONTRACT.md
@@ -1225,7 +1225,10 @@ invalidate current evidence. These records do not change
 
 The owner-controlled `warehouse_publication` namespace grants only bounded RPCs
 to `warehouse_publisher`; no runtime membership is granted. Published timestamps
-are transaction-local clock observations, not exact commit times. See the
+are transaction-local clock observations, not exact commit times. Elo-scoped
+operation wrappers enforce fixed scope and session ownership; the publisher has
+no generic quota operation access. Superseded originals require a present,
+matching reviewed replacement before complete coverage is published. See the
 [publication protocol and rollout](plans/2026-09-09-f14-publication-receipts.md).
 
 ### Raw Data Tables

--- a/docs/plans/2026-09-09-f14-publication-receipts.md
+++ b/docs/plans/2026-09-09-f14-publication-receipts.md
@@ -1,0 +1,130 @@
+# F14/F19: controlled house Elo publication
+
+Status: prepared implementation; production migration and workflow activation require a
+separate rollout. This is the first publication slice after the operational quota ledger.
+
+## Scope and meaning
+
+`compute_house_elo.py --full --publish-receipts` publishes the complete
+`analytics.house_elo_game` output and refreshes its sole-input mart,
+`marts.house_elo_game`. It also replaces `analytics.house_elo_current` in that
+transaction to preserve the full-run snapshot side effect. The current snapshot
+has no separate receipt in this slice. Elo parameters, game selection, ordering,
+season carryover and schedule-based pooling remain unchanged.
+
+A generation identifies one publication, not a mutable table version. The private
+`meta.asset_receipts` ledger is append-only. `meta.asset_current_generations`
+selects at most one successful, complete generation for each asset and
+`source-wide` coverage. `meta.asset_receipt_inputs` records the mart's exact source
+generation. Stable asset keys match the F28 refresh registry.
+
+The source receipt records an observation of all `core.games` rows, including
+unfinished games that affect pooling, and the reviewed exclusions. This input
+has no generation receipt yet: the digest is unversioned provenance, not proof
+that the upstream warehouse is fresh or that the provider's history is complete.
+Coverage means the complete eligible input currently present in this warehouse.
+An empty eligible completed-game set can publish `expected_no_data`; a transport
+failure or partially computed result cannot stand in for an empty result.
+Unlike the legacy writer's silent filtering, this mode rejects eligible games
+marked completed without final scores or team names: those rows require input
+repair before complete publication can be claimed.
+
+`published_at` is a clock observation inside the publishing transaction, visible
+only when that transaction commits. It is not the exact commit time.
+`committed_at` remains NULL. Data and current-generation evidence must be read in
+one statement or a shared transaction snapshot.
+
+## Transaction protocol
+
+1. Start and commit a `compute` operation run; log the run and both generation IDs.
+2. Read the max season, current generations, input digest, completed games and
+   full schedule counts in one repeatable-read snapshot. End that transaction.
+3. Compute the existing Elo engine output in memory.
+4. In a fresh READ COMMITTED transaction, call the bounded publication RPC. It
+   locks and revalidates inputs and expected current generations, checks full
+   coverage and payload grain, replaces the game and current tables, refreshes
+   the mart, and inserts receipts, dependency evidence and current pointers.
+   Finish the operation successfully in this same transaction, then commit.
+5. A known failure rolls back publication before attempting to record failure
+   evidence and finish the operation as failed. Failure, deferred, partial and
+   blocked receipts never become current. Failure evidence is best effort when
+   the database itself is unavailable.
+
+A competing publisher or a source correction during preparation causes validation
+to fail; it cannot publish against the stale prepared observation. Matching RPC
+replay returns the original immutable receipt without making it current again.
+A conflicting replay is rejected. The CLI does not retry automatically after an
+uncertain commit: inspect the logged receipt IDs and operation before retrying.
+No contradictory failure receipt is written after a lost commit acknowledgement.
+
+For commit recovery, use an authorized owner connection to look up the three
+IDs from the CLI log. A receipt's presence proves the publishing transaction
+committed; an old receipt need not still be current. An absent current pointer
+means no current evidence, not an empty asset. Check receipt absence only after
+the original database session has ended, so an in-flight commit cannot be
+mistaken for a rollback.
+
+```sql
+SELECT generation_id, operation_run_id, asset_key, outcome, published_at
+FROM meta.asset_receipts
+WHERE generation_id IN ('<source-generation-uuid>', '<mart-generation-uuid>');
+
+SELECT operation_run_id, outcome, finished_at
+FROM meta.operation_runs
+WHERE operation_run_id = '<run-uuid>';
+```
+
+Existing full/incremental calls and direct source writes remain possible. Game
+or current-snapshot DML invalidates both pointers; relevant DDL also invalidates
+evidence, and later mart refreshes invalidate the mart pointer. The publisher
+verifies its guards before publishing. Thus a legacy mutation cannot preserve
+an old pointer as evidence for new contents. Historical receipts and their
+dependency edges remain available after invalidation.
+
+The guards protect ordinary SQL operations while installed and enabled. A
+trusted administrator can bypass the protocol: PostgreSQL does not fire event
+triggers for changes to event triggers themselves (see the
+[event-trigger semantics](https://www.postgresql.org/docs/17/event-trigger-definition.html)).
+Before disabling or dropping
+these guards, an administrator must explicitly clear the current pointers;
+restore and verify the guards before publishing again. The publisher refuses
+to create a new generation when required guards are absent or disabled. This
+does not make historical pointers trustworthy after an administrative bypass.
+
+## Access and rollout
+
+Migration `068_asset_publication_receipts.sql` follows 066/067 in the warehouse
+and production manifests. It adds private ledger tables and the owner-controlled
+`warehouse_publication` namespace. The bounded `warehouse_publisher` role has RPC
+execution and no direct ledger/target DML privileges. The migration does not
+grant login membership or change any public API, freshness response, RLS policy,
+mart definition or workflow activation.
+
+Before a production rollout, verify event-trigger privileges on the actual
+platform, review the migration and role ownership, then separately authorize
+application and runtime membership. The compute connection still requires read
+access to `core.games`, plus permission to assume `warehouse_publisher`. Use a
+controlled full run to establish the first receipts. Full-history publication
+holds locks and refreshes the mart in one transaction; production lock duration,
+memory use and latency have not been benchmarked.
+
+Supabase documents event-trigger creation by its `postgres` user through
+Supautils; this implementation has been designed around that capability but
+still requires a target-specific rollout check. See the
+[Supabase event-trigger guide](https://supabase.com/docs/guides/database/postgres/event-triggers).
+
+After publication, inspect both receipts, their pointer IDs and the mart input
+edge in a shared snapshot, plus operation outcome and representative data. Check
+legacy invalidation and failure behavior under actual caller roles before any
+workflow activation. Existing daily incremental computation and general mart
+refreshes will invalidate receipt pointers, so scheduling this mode requires a
+separate operational decision.
+
+## Verification
+
+`tests/test_house_elo_publication.py` covers engine/snapshot parity, transaction
+ordering, empty input, partial-mode rejection and commit uncertainty.
+`tests/test_asset_publication_sql.py` executes the migration and publication
+protocol against explicitly selected disposable loopback PostgreSQL. The normal
+bootstrap suite checks both fresh and upgrade manifest paths. These tests do not
+constitute a production deployment or a provider-coverage audit.

--- a/docs/plans/2026-09-09-f14-publication-receipts.md
+++ b/docs/plans/2026-09-09-f14-publication-receipts.md
@@ -28,6 +28,10 @@ failure or partially computed result cannot stand in for an empty result.
 Unlike the legacy writer's silent filtering, this mode rejects eligible games
 marked completed without final scores or team names: those rows require input
 repair before complete publication can be claimed.
+If a superseded original is present, its reviewed replacement must also be
+present with matching, non-NULL season and team identities. The publisher
+validates these pairs under the input lock before excluding originals and
+claiming complete coverage.
 
 `published_at` is a clock observation inside the publishing transaction, visible
 only when that transaction commits. It is not the exact commit time.
@@ -99,6 +103,12 @@ and production manifests. It adds private ledger tables and the owner-controlled
 execution and no direct ledger/target DML privileges. The migration does not
 grant login membership or change any public API, freshness response, RLS policy,
 mart definition or workflow activation.
+
+Operation lifecycle access goes through `start_house_elo_run(uuid)` and
+`finish_house_elo_run(uuid, outcome)` in `warehouse_publication`. The start
+wrapper fixes the compute kind, initiator and full-history asset scope; both
+wrappers enforce the calling session's ownership of the run. The runtime role
+cannot call the generic quota operation helpers or finish unrelated runs.
 
 Before a production rollout, verify event-trigger privileges on the actual
 platform, review the migration and role ownership, then separately authorize

--- a/docs/warehouse-operations.md
+++ b/docs/warehouse-operations.md
@@ -342,3 +342,13 @@ See the [F14 transport rollout guide](plans/2026-09-08-f14-transport-admission.m
 for migration 067, dedicated role/connection configuration, independent control
 allowances, commit-failure behavior, and activation checks. Production defaults
 remain unchanged until that separate rollout is authorized.
+
+## Prepared house Elo publication receipts
+
+The opt-in `compute_house_elo.py --full --publish-receipts` path publishes full
+game output, the current team snapshot, the game mart and private receipts in
+one transaction after validating its prepared input snapshot. Migration 068 and
+runtime role membership must be deployed separately before using it. Existing
+incremental computation and later mart refreshes invalidate current evidence.
+See the [publication rollout guide](plans/2026-09-09-f14-publication-receipts.md)
+for receipt semantics, lost-commit recovery, locking and activation boundaries.

--- a/scripts/compute_house_elo.py
+++ b/scripts/compute_house_elo.py
@@ -641,11 +641,6 @@ def run_full_published(conn) -> list[dict]:
     from psycopg2.extras import Json
 
     run_id, source_id, mart_id = (str(uuid.uuid4()) for _ in range(3))
-    scope = {
-        "assets": ["analytics.house_elo_game", "marts.house_elo_game"],
-        "mode": "full",
-        "start_season": DEFAULT_START_SEASON,
-    }
     logger.info(
         "Publication run=%s source_generation=%s mart_generation=%s", run_id, source_id, mart_id
     )
@@ -655,8 +650,8 @@ def run_full_published(conn) -> list[dict]:
         with conn.cursor() as cur:
             cur.execute("SET LOCAL ROLE warehouse_publisher")
             cur.execute(
-                "SELECT warehouse_quota.start_operation_run(%s,'compute',%s,%s,NULL,NULL)",
-                (run_id, "compute_house_elo", Json(scope)),
+                "SELECT warehouse_publication.start_house_elo_run(%s)",
+                (run_id,),
             )
         conn.commit()
         started = True
@@ -713,7 +708,7 @@ def run_full_published(conn) -> list[dict]:
             )
             cur.fetchone()
             cur.execute(
-                "SELECT warehouse_quota.finish_operation_run(%s,'succeeded',NULL)", (run_id,)
+                "SELECT warehouse_publication.finish_house_elo_run(%s,'succeeded')", (run_id,)
             )
         commit_pending = True
         conn.commit()
@@ -732,8 +727,7 @@ def run_full_published(conn) -> list[dict]:
                         (run_id, source_id, mart_id),
                     )
                     cur.execute(
-                        "SELECT warehouse_quota.finish_operation_run("
-                        "%s,'failed','publication_failed')",
+                        "SELECT warehouse_publication.finish_house_elo_run(%s,'failed')",
                         (run_id,),
                     )
                 conn.commit()

--- a/scripts/compute_house_elo.py
+++ b/scripts/compute_house_elo.py
@@ -15,6 +15,10 @@ Retuned 2026-07-22 (user-approved tune_params walk-forward advisory): K
 200 -> 100. Blend margin MAE 13.60 -> 13.20 over 2015-2025, ATS flat.
 
 Usage:
+    python scripts/compute_house_elo.py --full --publish-receipts
+        Opt-in atomic game output, current snapshot, mart and private receipts.
+        Requires migration 068 and warehouse_publisher role membership.
+
     python scripts/compute_house_elo.py --full
         Recompute all of history: seasons 1869..max(core.games.season),
         rewriting analytics.house_elo_game season by season and the
@@ -37,14 +41,20 @@ season >= 2015 rows where CFBD's value is present (expect r >~ 0.9).
 """
 
 import argparse
+import json
 import logging
 import math
 import sys
+import uuid
 from collections import Counter, defaultdict
 
 import dlt
 
-from src.pipelines.game_identity import eligible_game_sql
+from src.pipelines.game_identity import (
+    CANCELLED_GAME_IDS,
+    SUPERSEDED_GAME_REPLACEMENTS,
+    eligible_game_sql,
+)
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
@@ -608,6 +618,137 @@ def run_full(conn, start_season: int, end_season: int) -> list[dict]:
     return all_rows
 
 
+class PublicationError(RuntimeError):
+    """Publication failed or commit acknowledgement was lost; no automatic retry."""
+
+
+def _publication_json(value):
+    from datetime import date, datetime
+
+    if isinstance(value, (date, datetime)):
+        return value.isoformat()
+    raise TypeError(f"Unsupported publication value: {type(value).__name__}")
+
+
+def run_full_published(conn) -> list[dict]:
+    """Opt-in full replacement: data, mart, receipts and pointers commit together.
+
+    Preparation reads a repeatable snapshot. It ends BEFORE publication, which
+    rechecks the input digest and expected generations under locks in a fresh
+    READ COMMITTED transaction. A lost commit acknowledgement is left unresolved
+    for receipt-ID inspection; it must never produce a contradictory failure.
+    """
+    from psycopg2.extras import Json
+
+    run_id, source_id, mart_id = (str(uuid.uuid4()) for _ in range(3))
+    scope = {
+        "assets": ["analytics.house_elo_game", "marts.house_elo_game"],
+        "mode": "full",
+        "start_season": DEFAULT_START_SEASON,
+    }
+    logger.info(
+        "Publication run=%s source_generation=%s mart_generation=%s", run_id, source_id, mart_id
+    )
+    started = False
+    commit_pending = False
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SET LOCAL ROLE warehouse_publisher")
+            cur.execute(
+                "SELECT warehouse_quota.start_operation_run(%s,'compute',%s,%s,NULL,NULL)",
+                (run_id, "compute_house_elo", Json(scope)),
+            )
+        conn.commit()
+        started = True
+
+        with conn.cursor() as cur:
+            cur.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ")
+            cur.execute("SET LOCAL TIME ZONE 'UTC'")
+        end_season = fetch_max_season(conn) or DEFAULT_START_SEASON
+        with conn.cursor() as cur:
+            cur.execute("SET LOCAL ROLE warehouse_publisher")
+            cur.execute(
+                "SELECT * FROM warehouse_publication.get_house_elo_state(%s,%s)",
+                (DEFAULT_START_SEASON, end_season),
+            )
+            expected_source, expected_mart, input_digest = cur.fetchone()
+            cur.execute("RESET ROLE")
+        buckets = load_games_by_season(conn, DEFAULT_START_SEASON, end_season)
+        counts = fetch_scheduled_counts(conn, DEFAULT_START_SEASON, end_season)
+        conn.commit()
+
+        engine = EloEngine()
+        rows = []
+        for season in sorted(buckets):
+            season_games = buckets[season]
+            engine.start_season(
+                season, counts.get(season) or compute_team_game_counts(season_games)
+            )
+            rows.extend(engine.process_game(to_engine_game(game)) for game in season_games)
+        snapshot = engine.current_snapshot(max(buckets)) if buckets else []
+        excluded = sorted(set(SUPERSEDED_GAME_REPLACEMENTS) | set(CANCELLED_GAME_IDS))
+
+        def dumps(value):
+            return json.dumps(value, default=_publication_json, allow_nan=False)
+
+        with conn.cursor() as cur:
+            cur.execute("SET TRANSACTION ISOLATION LEVEL READ COMMITTED")
+            cur.execute("SET LOCAL ROLE warehouse_publisher")
+            cur.execute(
+                "SELECT * FROM warehouse_publication.publish_house_elo("
+                "%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s::bigint[])",
+                (
+                    run_id,
+                    source_id,
+                    mart_id,
+                    expected_source,
+                    expected_mart,
+                    input_digest,
+                    Json(rows, dumps=dumps),
+                    Json(snapshot, dumps=dumps),
+                    DEFAULT_START_SEASON,
+                    end_season,
+                    excluded,
+                ),
+            )
+            cur.fetchone()
+            cur.execute(
+                "SELECT warehouse_quota.finish_operation_run(%s,'succeeded',NULL)", (run_id,)
+            )
+        commit_pending = True
+        conn.commit()
+        commit_pending = False
+        logger.info("Publication committed: %s games, %s snapshot teams", len(rows), len(snapshot))
+        return rows
+    except Exception:
+        try:
+            conn.rollback()
+            if started and not commit_pending:
+                with conn.cursor() as cur:
+                    cur.execute("SET LOCAL ROLE warehouse_publisher")
+                    cur.execute(
+                        "SELECT * FROM warehouse_publication.record_house_elo_failure("
+                        "%s,%s,%s,'failed','publication_failed')",
+                        (run_id, source_id, mart_id),
+                    )
+                    cur.execute(
+                        "SELECT warehouse_quota.finish_operation_run("
+                        "%s,'failed','publication_failed')",
+                        (run_id,),
+                    )
+                conn.commit()
+        except Exception:
+            logger.error("Could not persist failure evidence for publication run=%s", run_id)
+        detail = (
+            "commit acknowledgement unavailable; inspect receipt IDs"
+            if commit_pending
+            else "failed"
+        )
+        raise PublicationError(
+            f"House Elo publication {detail}; run={run_id} source={source_id} mart={mart_id}"
+        ) from None
+
+
 def run_season(conn, season: int) -> list[dict]:
     engine = EloEngine()
     logger.info(f"Seeding engine state from analytics.house_elo_game (season < {season})")
@@ -660,13 +801,23 @@ def main() -> None:
         action="store_true",
         help="Recompute the current season (max season in core.games with completed games)",
     )
+    parser.add_argument(
+        "--publish-receipts",
+        action="store_true",
+        help="With --full only: atomically publish output, snapshot, mart and receipts "
+        "(migration 068 required)",
+    )
     args = parser.parse_args()
+    if args.publish_receipts and not args.full:
+        parser.error("--publish-receipts requires --full")
 
     import psycopg2
 
     conn = psycopg2.connect(get_db_url())
     try:
-        if args.full:
+        if args.publish_receipts:
+            rows = run_full_published(conn)
+        elif args.full:
             max_season = fetch_max_season(conn)
             if max_season is None:
                 logger.error("core.games is empty -- nothing to compute")

--- a/src/schemas/migrations/068_asset_publication_receipts.sql
+++ b/src/schemas/migrations/068_asset_publication_receipts.sql
@@ -1,0 +1,1101 @@
+-- Migration: 068_asset_publication_receipts
+--
+-- F14/F19 controlled publication foundation. Prepared, not a production
+-- rollout. This bounded publisher owns only the full-history house Elo game
+-- table, its current-team snapshot, and marts.house_elo_game.
+--
+-- The producer computes from one REPEATABLE READ snapshot, commits that read
+-- transaction, then calls publish_house_elo() in a fresh READ COMMITTED
+-- transaction. The RPC locks and re-digests all of core.games before replacing
+-- either target. Data, ordinary mart refresh, receipts and current pointers
+-- become visible together. published_at is an in-transaction clock reading;
+-- PostgreSQL does not expose an exact commit timestamp here.
+
+CREATE SCHEMA IF NOT EXISTS meta;
+
+-- A routines-only namespace prevents hostile overloads in broader schemas.
+DO $namespace$
+DECLARE schema_row record;
+BEGIN
+    SELECT oid, nspowner, nspacl INTO schema_row
+    FROM pg_catalog.pg_namespace WHERE nspname = 'warehouse_publication';
+    IF NOT FOUND THEN
+        CREATE SCHEMA warehouse_publication;
+    ELSE
+        IF schema_row.nspowner <> (SELECT oid FROM pg_catalog.pg_roles
+                WHERE rolname = current_user) THEN
+            RAISE EXCEPTION 'warehouse_publication must be owned by the migration role';
+        END IF;
+        IF EXISTS (
+            SELECT 1 FROM pg_catalog.aclexplode(schema_row.nspacl) acl
+            WHERE acl.grantee <> schema_row.nspowner AND acl.privilege_type = 'CREATE'
+        ) THEN
+            RAISE EXCEPTION 'warehouse_publication has untrusted CREATE grants';
+        END IF;
+        IF EXISTS (SELECT 1 FROM pg_catalog.pg_type WHERE typnamespace = schema_row.oid) THEN
+            RAISE EXCEPTION 'warehouse_publication contains an unexpected type';
+        END IF;
+        IF EXISTS (
+            SELECT 1 FROM pg_catalog.pg_proc p
+            WHERE p.pronamespace = schema_row.oid AND (
+                p.proowner <> schema_row.nspowner OR p.prokind <> 'f'
+                OR p.provariadic <> 0 OR p.pronargdefaults <> 0
+                OR NOT COALESCE(p.oid = ANY(ARRAY[
+                    pg_catalog.to_regprocedure('warehouse_publication.reject_append_only_mutation()'),
+                    pg_catalog.to_regprocedure('warehouse_publication.guard_current_generation()'),
+                    pg_catalog.to_regprocedure('warehouse_publication.guard_receipt_input()'),
+                    pg_catalog.to_regprocedure('warehouse_publication.invalidate_house_elo_pointers()'),
+                    pg_catalog.to_regprocedure('warehouse_publication.invalidate_asset_pointer_ddl()'),
+                    pg_catalog.to_regprocedure('warehouse_publication.invalidate_asset_pointer_drop()'),
+                    pg_catalog.to_regprocedure('warehouse_publication.get_house_elo_state(bigint,bigint)'),
+                    pg_catalog.to_regprocedure('warehouse_publication.publish_house_elo(uuid,uuid,uuid,uuid,uuid,text,jsonb,jsonb,bigint,bigint,bigint[])'),
+                    pg_catalog.to_regprocedure('warehouse_publication.record_house_elo_failure(uuid,uuid,uuid,text,text)')
+                ]::oid[]), false)
+            )
+        ) THEN
+            RAISE EXCEPTION 'warehouse_publication contains an unexpected or untrusted routine';
+        END IF;
+    END IF;
+END
+$namespace$;
+
+DO $role$
+DECLARE unsafe boolean;
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'warehouse_publisher') THEN
+        CREATE ROLE warehouse_publisher NOLOGIN NOINHERIT NOSUPERUSER NOCREATEDB
+            NOCREATEROLE NOREPLICATION NOBYPASSRLS;
+    ELSE
+        SELECT r.rolcanlogin OR r.rolsuper OR r.rolcreatedb OR r.rolcreaterole
+            OR r.rolreplication OR r.rolbypassrls OR r.rolinherit
+            OR EXISTS (SELECT 1 FROM pg_catalog.pg_auth_members m WHERE m.member = r.oid)
+        INTO unsafe FROM pg_catalog.pg_roles r WHERE r.rolname = 'warehouse_publisher';
+        IF unsafe THEN
+            RAISE EXCEPTION 'existing warehouse_publisher is not the required bounded NOLOGIN role';
+        END IF;
+    END IF;
+END
+$role$;
+
+CREATE TABLE IF NOT EXISTS meta.asset_publication_locks (
+    asset_key text PRIMARY KEY CHECK (asset_key IN (
+        'analytics.house_elo_game', 'marts.house_elo_game'
+    )),
+    relation_schema text NOT NULL,
+    relation_name text NOT NULL,
+    relation_oid oid NOT NULL UNIQUE,
+    relation_kind "char" NOT NULL CHECK (relation_kind IN ('r', 'm')),
+    CHECK (asset_key = relation_schema || '.' || relation_name)
+);
+
+CREATE TABLE IF NOT EXISTS meta.asset_receipts (
+    generation_id uuid PRIMARY KEY,
+    operation_run_id uuid NOT NULL REFERENCES meta.operation_runs(operation_run_id),
+    asset_key text NOT NULL REFERENCES meta.asset_publication_locks(asset_key),
+    coverage_key text NOT NULL DEFAULT 'source-wide' CHECK (coverage_key = 'source-wide'),
+    outcome text NOT NULL CHECK (outcome IN (
+        'succeeded', 'expected_no_data', 'failed', 'deferred', 'partial', 'blocked'
+    )),
+    coverage jsonb NOT NULL CHECK (
+        pg_catalog.jsonb_typeof(coverage) = 'object'
+        AND coverage ? 'complete'
+        AND coverage->'complete' IN ('true'::jsonb, 'false'::jsonb)
+    ),
+    source_watermark text,
+    input_observations jsonb NOT NULL DEFAULT '{}' CHECK (
+        pg_catalog.jsonb_typeof(input_observations) = 'object'
+    ),
+    row_delta jsonb NOT NULL DEFAULT '{}' CHECK (pg_catalog.jsonb_typeof(row_delta) = 'object'),
+    request_digest text NOT NULL CHECK (request_digest ~ '^[0-9a-f]{32}$'),
+    recorded_at timestamptz NOT NULL DEFAULT pg_catalog.clock_timestamp(),
+    published_at timestamptz,
+    committed_at timestamptz CHECK (committed_at IS NULL),
+    error_summary text,
+    UNIQUE (asset_key, coverage_key, generation_id),
+    CHECK (
+        (outcome IN ('succeeded', 'expected_no_data')
+            AND published_at IS NOT NULL AND coverage->'complete' = 'true'::jsonb
+            AND error_summary IS NULL)
+        OR (outcome NOT IN ('succeeded', 'expected_no_data')
+            AND published_at IS NULL AND coverage->'complete' = 'false'::jsonb
+            AND error_summary IS NOT NULL)
+    )
+);
+
+CREATE INDEX IF NOT EXISTS asset_receipts_operation_run_idx
+    ON meta.asset_receipts(operation_run_id);
+CREATE INDEX IF NOT EXISTS asset_receipts_asset_published_idx
+    ON meta.asset_receipts(asset_key, published_at DESC) WHERE published_at IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS meta.asset_current_generations (
+    asset_key text NOT NULL,
+    coverage_key text NOT NULL DEFAULT 'source-wide' CHECK (coverage_key = 'source-wide'),
+    generation_id uuid NOT NULL,
+    PRIMARY KEY (asset_key, coverage_key),
+    FOREIGN KEY (asset_key, coverage_key, generation_id)
+        REFERENCES meta.asset_receipts(asset_key, coverage_key, generation_id)
+);
+
+CREATE TABLE IF NOT EXISTS meta.asset_receipt_inputs (
+    generation_id uuid NOT NULL REFERENCES meta.asset_receipts(generation_id),
+    input_asset_key text NOT NULL,
+    input_coverage_key text NOT NULL DEFAULT 'source-wide' CHECK (
+        input_coverage_key = 'source-wide'
+    ),
+    input_generation_id uuid NOT NULL,
+    PRIMARY KEY (generation_id, input_asset_key, input_coverage_key),
+    FOREIGN KEY (input_asset_key, input_coverage_key, input_generation_id)
+        REFERENCES meta.asset_receipts(asset_key, coverage_key, generation_id),
+    CHECK (generation_id <> input_generation_id)
+);
+
+CREATE INDEX IF NOT EXISTS asset_receipt_inputs_input_idx
+    ON meta.asset_receipt_inputs(input_generation_id);
+
+DO $private_objects$
+DECLARE object_name text; object_row record;
+BEGIN
+    FOREACH object_name IN ARRAY ARRAY[
+        'asset_publication_locks', 'asset_receipts',
+        'asset_current_generations', 'asset_receipt_inputs'
+    ] LOOP
+        SELECT c.relowner, c.relkind INTO object_row
+        FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'meta' AND c.relname = object_name;
+        IF NOT FOUND OR object_row.relkind <> 'r'
+            OR object_row.relowner <> (SELECT oid FROM pg_catalog.pg_roles
+                WHERE rolname = current_user) THEN
+            RAISE EXCEPTION 'meta.% must be a migration-owned ordinary table', object_name;
+        END IF;
+    END LOOP;
+END
+$private_objects$;
+
+-- Register exact OIDs. Re-adoption after drop/recreate is allowed only after
+-- its current pointer was invalidated.
+DO $assets$
+DECLARE
+    item record;
+    existing meta.asset_publication_locks%ROWTYPE;
+    current_oid oid;
+    current_kind "char";
+BEGIN
+    FOR item IN SELECT * FROM (VALUES
+        ('analytics.house_elo_game', 'analytics', 'house_elo_game', 'r'::"char"),
+        ('marts.house_elo_game', 'marts', 'house_elo_game', 'm'::"char")
+    ) AS v(asset_key, relation_schema, relation_name, relation_kind) LOOP
+        current_oid := pg_catalog.to_regclass(
+            pg_catalog.format('%I.%I', item.relation_schema, item.relation_name));
+        IF current_oid IS NULL THEN
+            RAISE EXCEPTION 'required publication relation % is missing', item.asset_key;
+        END IF;
+        SELECT c.relkind INTO current_kind FROM pg_catalog.pg_class c WHERE c.oid = current_oid;
+        IF current_kind <> item.relation_kind THEN
+            RAISE EXCEPTION 'publication relation % has unexpected kind', item.asset_key;
+        END IF;
+        SELECT * INTO existing FROM meta.asset_publication_locks l
+        WHERE l.asset_key = item.asset_key;
+        IF NOT FOUND THEN
+            INSERT INTO meta.asset_publication_locks(
+                asset_key, relation_schema, relation_name, relation_oid, relation_kind
+            ) VALUES (item.asset_key, item.relation_schema, item.relation_name,
+                current_oid, item.relation_kind);
+        ELSIF existing.relation_oid IS DISTINCT FROM current_oid
+            OR existing.relation_schema IS DISTINCT FROM item.relation_schema
+            OR existing.relation_name IS DISTINCT FROM item.relation_name
+            OR existing.relation_kind IS DISTINCT FROM item.relation_kind THEN
+            IF EXISTS (SELECT 1 FROM meta.asset_current_generations p
+                WHERE p.asset_key = item.asset_key) THEN
+                RAISE EXCEPTION 'cannot adopt replacement relation % while a current pointer exists',
+                    item.asset_key;
+            END IF;
+            UPDATE meta.asset_publication_locks
+            SET relation_schema = item.relation_schema, relation_name = item.relation_name,
+                relation_oid = current_oid, relation_kind = item.relation_kind
+            WHERE asset_key = item.asset_key;
+        END IF;
+    END LOOP;
+    IF pg_catalog.to_regclass('analytics.house_elo_current') IS NULL
+        OR (SELECT relkind FROM pg_catalog.pg_class
+            WHERE oid = pg_catalog.to_regclass('analytics.house_elo_current')) <> 'r' THEN
+        RAISE EXCEPTION 'required publication relation analytics.house_elo_current is missing or invalid';
+    END IF;
+END
+$assets$;
+
+COMMENT ON TABLE meta.asset_receipts IS
+    'Append-only private publication evidence. Unversioned input_observations are observations, not dependency-generation proof.';
+COMMENT ON COLUMN meta.asset_receipts.published_at IS
+    'Wall-clock observation inside the publishing transaction; not an exact commit timestamp.';
+COMMENT ON COLUMN meta.asset_receipts.committed_at IS
+    'Reserved for a future verified commit-time source; migration 068 always leaves it NULL.';
+COMMENT ON TABLE meta.asset_current_generations IS
+    'One current complete receipt per asset and source-wide scope. Read data and pointer in one snapshot.';
+
+CREATE OR REPLACE FUNCTION warehouse_publication.reject_append_only_mutation()
+RETURNS trigger LANGUAGE plpgsql SET search_path = '' AS $function$
+BEGIN
+    RAISE EXCEPTION 'publication receipt evidence is append-only';
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION warehouse_publication.record_house_elo_failure(
+    p_operation_run_id uuid,
+    p_source_generation_id uuid,
+    p_mart_generation_id uuid,
+    p_outcome text,
+    p_error_category text
+)
+RETURNS TABLE (source_generation uuid, mart_generation uuid, replayed boolean)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $function$
+DECLARE
+    run_row meta.operation_runs%ROWTYPE;
+    source_receipt meta.asset_receipts%ROWTYPE;
+    mart_receipt meta.asset_receipts%ROWTYPE;
+    digest text;
+    failure_coverage jsonb := '{"complete":false,"mode":"full","scope":"source-wide"}'::jsonb;
+    observations jsonb := '{"publisher":"compute_house_elo","mode":"full"}'::jsonb;
+BEGIN
+    IF p_operation_run_id IS NULL OR p_source_generation_id IS NULL
+        OR p_mart_generation_id IS NULL OR p_source_generation_id = p_mart_generation_id
+        OR p_outcome NOT IN ('failed', 'deferred', 'partial', 'blocked')
+        OR p_error_category IS DISTINCT FROM 'publication_failed' THEN
+        RAISE EXCEPTION 'house Elo failure context is invalid' USING ERRCODE = '22023';
+    END IF;
+    digest := pg_catalog.md5(pg_catalog.jsonb_build_object(
+        'operation_run_id', p_operation_run_id,
+        'source_generation_id', p_source_generation_id,
+        'mart_generation_id', p_mart_generation_id,
+        'outcome', p_outcome,
+        'error_category', p_error_category
+    )::text);
+
+    SELECT r.* INTO run_row FROM meta.operation_runs r
+    WHERE r.operation_run_id = p_operation_run_id FOR UPDATE;
+    IF NOT FOUND OR run_row.operation_kind <> 'compute'
+        OR run_row.recorded_by <> session_user
+        OR run_row.initiator <> 'compute_house_elo'
+        OR run_row.requested_scope->>'mode' IS DISTINCT FROM 'full'
+        OR run_row.requested_scope->>'start_season' IS DISTINCT FROM '1869'
+        OR run_row.requested_scope->'assets' IS DISTINCT FROM
+            '["analytics.house_elo_game", "marts.house_elo_game"]'::jsonb THEN
+        RAISE EXCEPTION 'operation run does not belong to this house Elo publisher'
+            USING ERRCODE = '22023';
+    END IF;
+
+    SELECT r.* INTO source_receipt FROM meta.asset_receipts r
+    WHERE r.generation_id = p_source_generation_id;
+    SELECT r.* INTO mart_receipt FROM meta.asset_receipts r
+    WHERE r.generation_id = p_mart_generation_id;
+    IF source_receipt.generation_id IS NOT NULL OR mart_receipt.generation_id IS NOT NULL THEN
+        IF source_receipt.generation_id IS NULL OR mart_receipt.generation_id IS NULL
+            OR source_receipt.operation_run_id <> p_operation_run_id
+            OR mart_receipt.operation_run_id <> p_operation_run_id
+            OR source_receipt.asset_key <> 'analytics.house_elo_game'
+            OR mart_receipt.asset_key <> 'marts.house_elo_game'
+            OR source_receipt.outcome <> p_outcome OR mart_receipt.outcome <> p_outcome
+            OR source_receipt.error_summary <> p_error_category
+            OR mart_receipt.error_summary <> p_error_category
+            OR source_receipt.request_digest <> digest OR mart_receipt.request_digest <> digest THEN
+            RAISE EXCEPTION 'generation ID already has different failure context'
+                USING ERRCODE = '22023';
+        END IF;
+        RETURN QUERY SELECT p_source_generation_id, p_mart_generation_id, true;
+        RETURN;
+    END IF;
+    IF run_row.outcome <> 'running' THEN
+        RAISE EXCEPTION 'operation run is already terminal' USING ERRCODE = '22023';
+    END IF;
+
+    INSERT INTO meta.asset_receipts(
+        generation_id, operation_run_id, asset_key, outcome, coverage,
+        input_observations, row_delta, request_digest, error_summary
+    ) VALUES
+        (p_source_generation_id, p_operation_run_id, 'analytics.house_elo_game',
+         p_outcome, failure_coverage, observations, '{}'::jsonb, digest, p_error_category),
+        (p_mart_generation_id, p_operation_run_id, 'marts.house_elo_game',
+         p_outcome, failure_coverage, observations, '{}'::jsonb, digest, p_error_category);
+
+    RETURN QUERY SELECT p_source_generation_id, p_mart_generation_id, false;
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION warehouse_publication.publish_house_elo(
+    p_operation_run_id uuid,
+    p_source_generation_id uuid,
+    p_mart_generation_id uuid,
+    p_expected_source_generation_id uuid,
+    p_expected_mart_generation_id uuid,
+    p_input_digest text,
+    p_rows jsonb,
+    p_snapshot jsonb,
+    p_start_season bigint,
+    p_end_season bigint,
+    p_excluded_game_ids bigint[]
+)
+RETURNS TABLE (
+    source_generation uuid,
+    mart_generation uuid,
+    replayed boolean,
+    source_rows bigint,
+    mart_rows bigint
+)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $function$
+DECLARE
+    reviewed_exclusions constant bigint[] := ARRAY[
+        401540999,401545766,401545768,401545773,401545780,401545781,
+        401549719,401550299,401552878,401552884,401640992,401833535,
+        401866625
+    ]::bigint[];
+    run_row meta.operation_runs%ROWTYPE;
+    source_receipt meta.asset_receipts%ROWTYPE;
+    mart_receipt meta.asset_receipts%ROWTYPE;
+    request_digest_value text;
+    fresh_input_digest text;
+    actual_source_generation uuid;
+    actual_mart_generation uuid;
+    old_source_rows bigint;
+    old_mart_rows bigint;
+    eligible_scheduled_rows bigint;
+    eligible_completed_rows bigint;
+    parsed_source_rows bigint;
+    parsed_snapshot_rows bigint;
+    refreshed_mart_rows bigint;
+    mismatch_rows bigint;
+    max_season bigint;
+    publication_time timestamptz;
+    publication_outcome text;
+    source_coverage jsonb;
+    mart_coverage jsonb;
+    observations jsonb;
+BEGIN
+    IF p_operation_run_id IS NULL OR p_source_generation_id IS NULL
+        OR p_mart_generation_id IS NULL OR p_source_generation_id = p_mart_generation_id
+        OR p_input_digest IS NULL OR p_input_digest !~ '^[0-9a-f]{32}$'
+        OR p_rows IS NULL OR pg_catalog.jsonb_typeof(p_rows) <> 'array'
+        OR p_snapshot IS NULL OR pg_catalog.jsonb_typeof(p_snapshot) <> 'array'
+        OR p_start_season IS DISTINCT FROM 1869 OR p_end_season IS NULL
+        OR p_end_season < p_start_season
+        OR p_excluded_game_ids IS DISTINCT FROM reviewed_exclusions THEN
+        RAISE EXCEPTION 'house Elo publication context is invalid' USING ERRCODE = '22023';
+    END IF;
+
+    request_digest_value := pg_catalog.md5(pg_catalog.jsonb_build_object(
+        'protocol', 'house-elo-full-v1',
+        'operation_run_id', p_operation_run_id,
+        'source_generation_id', p_source_generation_id,
+        'mart_generation_id', p_mart_generation_id,
+        'expected_source_generation_id', p_expected_source_generation_id,
+        'expected_mart_generation_id', p_expected_mart_generation_id,
+        'input_digest', p_input_digest, 'rows', p_rows, 'snapshot', p_snapshot,
+        'start_season', p_start_season, 'end_season', p_end_season,
+        'excluded_game_ids', pg_catalog.to_jsonb(p_excluded_game_ids)
+    )::text);
+
+    SELECT r.* INTO run_row FROM meta.operation_runs r
+    WHERE r.operation_run_id = p_operation_run_id FOR UPDATE;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'operation run is not configured' USING ERRCODE = '22023';
+    END IF;
+    IF run_row.operation_kind <> 'compute' OR run_row.recorded_by <> session_user
+        OR run_row.initiator <> 'compute_house_elo'
+        OR run_row.requested_scope->>'mode' IS DISTINCT FROM 'full'
+        OR run_row.requested_scope->>'start_season' IS DISTINCT FROM '1869'
+        OR run_row.requested_scope->'assets' IS DISTINCT FROM
+            '["analytics.house_elo_game", "marts.house_elo_game"]'::jsonb THEN
+        RAISE EXCEPTION 'operation run does not belong to this house Elo publisher'
+            USING ERRCODE = '22023';
+    END IF;
+
+    -- A matching immutable pair is a pure lookup. It never repoints after a
+    -- later correction and is allowed after the operation run became terminal.
+    SELECT r.* INTO source_receipt FROM meta.asset_receipts r
+    WHERE r.generation_id = p_source_generation_id;
+    SELECT r.* INTO mart_receipt FROM meta.asset_receipts r
+    WHERE r.generation_id = p_mart_generation_id;
+    IF source_receipt.generation_id IS NOT NULL OR mart_receipt.generation_id IS NOT NULL THEN
+        IF source_receipt.generation_id IS NULL OR mart_receipt.generation_id IS NULL
+            OR source_receipt.operation_run_id <> p_operation_run_id
+            OR mart_receipt.operation_run_id <> p_operation_run_id
+            OR source_receipt.asset_key <> 'analytics.house_elo_game'
+            OR mart_receipt.asset_key <> 'marts.house_elo_game'
+            OR source_receipt.outcome NOT IN ('succeeded', 'expected_no_data')
+            OR mart_receipt.outcome <> source_receipt.outcome
+            OR source_receipt.request_digest <> request_digest_value
+            OR mart_receipt.request_digest <> request_digest_value
+            OR NOT EXISTS (
+                SELECT 1 FROM meta.asset_receipt_inputs i
+                WHERE i.generation_id = p_mart_generation_id
+                  AND i.input_asset_key = 'analytics.house_elo_game'
+                  AND i.input_coverage_key = 'source-wide'
+                  AND i.input_generation_id = p_source_generation_id
+            ) THEN
+            RAISE EXCEPTION 'generation ID already has different publication context'
+                USING ERRCODE = '22023';
+        END IF;
+        RETURN QUERY SELECT p_source_generation_id, p_mart_generation_id, true,
+            (source_receipt.row_delta->>'published_rows')::bigint,
+            (mart_receipt.row_delta->>'published_rows')::bigint;
+        RETURN;
+    END IF;
+    IF run_row.outcome <> 'running' THEN
+        RAISE EXCEPTION 'operation run is already terminal' USING ERRCODE = '22023';
+    END IF;
+    IF current_setting('transaction_isolation') <> 'read committed'
+        OR current_setting('session_replication_role') <> 'origin'
+        OR COALESCE(current_setting('event_triggers', true), 'on') <> 'on' THEN
+        RAISE EXCEPTION 'house Elo publication requires a fresh READ COMMITTED transaction'
+            USING ERRCODE = '25001';
+    END IF;
+
+    -- Lock order: operation run -> unversioned input -> targets -> asset rows.
+    LOCK TABLE core.games IN SHARE MODE;
+    LOCK TABLE analytics.house_elo_game, analytics.house_elo_current IN EXCLUSIVE MODE;
+    -- PostgreSQL LOCK TABLE excludes materialized views. The ordinary REFRESH
+    -- below takes its AccessExclusiveLock; source/asset serialization makes it
+    -- the final target lock in the protocol.
+    PERFORM 1 FROM meta.asset_publication_locks l
+    WHERE l.asset_key IN ('analytics.house_elo_game', 'marts.house_elo_game')
+    ORDER BY l.asset_key FOR UPDATE;
+
+    -- Refuse to install future proof if any invalidation guard was altered.
+    IF EXISTS (
+        SELECT 1 FROM meta.asset_publication_locks l
+        WHERE l.relation_oid <> pg_catalog.to_regclass(
+            pg_catalog.format('%I.%I', l.relation_schema, l.relation_name))
+    ) OR NOT EXISTS (
+        SELECT 1 FROM pg_catalog.pg_trigger t
+        WHERE t.tgrelid = pg_catalog.to_regclass('analytics.house_elo_game')
+          AND t.tgname = 'invalidate_house_elo_game_pointer'
+          AND t.tgfoid = pg_catalog.to_regprocedure(
+              'warehouse_publication.invalidate_house_elo_pointers()')
+          AND t.tgtype = 62 AND t.tgenabled IN ('O', 'A') AND NOT t.tgisinternal
+    ) OR NOT EXISTS (
+        SELECT 1 FROM pg_catalog.pg_trigger t
+        WHERE t.tgrelid = pg_catalog.to_regclass('analytics.house_elo_current')
+          AND t.tgname = 'invalidate_house_elo_current_pointer'
+          AND t.tgfoid = pg_catalog.to_regprocedure(
+              'warehouse_publication.invalidate_house_elo_pointers()')
+          AND t.tgtype = 62 AND t.tgenabled IN ('O', 'A') AND NOT t.tgisinternal
+    ) OR NOT EXISTS (
+        SELECT 1 FROM pg_catalog.pg_event_trigger e
+        WHERE e.evtname = 'warehouse_publication_invalidate_ddl'
+          AND e.evtevent = 'ddl_command_end' AND e.evtenabled IN ('O', 'A')
+          AND e.evtfoid = pg_catalog.to_regprocedure(
+              'warehouse_publication.invalidate_asset_pointer_ddl()')
+    ) OR NOT EXISTS (
+        SELECT 1 FROM pg_catalog.pg_event_trigger e
+        WHERE e.evtname = 'warehouse_publication_invalidate_drop'
+          AND e.evtevent = 'sql_drop' AND e.evtenabled IN ('O', 'A')
+          AND e.evtfoid = pg_catalog.to_regprocedure(
+              'warehouse_publication.invalidate_asset_pointer_drop()')
+    ) THEN
+        RAISE EXCEPTION 'house Elo publication invalidation guards are missing or stale';
+    END IF;
+
+    SELECT p.generation_id INTO actual_source_generation
+    FROM meta.asset_current_generations p
+    WHERE p.asset_key = 'analytics.house_elo_game' AND p.coverage_key = 'source-wide';
+    SELECT p.generation_id INTO actual_mart_generation
+    FROM meta.asset_current_generations p
+    WHERE p.asset_key = 'marts.house_elo_game' AND p.coverage_key = 'source-wide';
+    IF actual_source_generation IS DISTINCT FROM p_expected_source_generation_id
+        OR actual_mart_generation IS DISTINCT FROM p_expected_mart_generation_id THEN
+        RAISE EXCEPTION 'house Elo current generation changed during preparation'
+            USING ERRCODE = '40001';
+    END IF;
+
+    PERFORM pg_catalog.set_config('TimeZone', 'UTC', true);
+    SELECT pg_catalog.md5(COALESCE(pg_catalog.string_agg(
+        pg_catalog.md5(pg_catalog.to_jsonb(g)::text), '' ORDER BY g.id), ''))
+    INTO fresh_input_digest FROM core.games g;
+    IF fresh_input_digest IS DISTINCT FROM p_input_digest THEN
+        RAISE EXCEPTION 'core.games changed during house Elo preparation'
+            USING ERRCODE = '40001';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM core.games g WHERE g.id <> ALL(reviewed_exclusions)
+          AND (g.season IS NULL OR g.season < p_start_season OR g.season > p_end_season)
+    ) THEN
+        RAISE EXCEPTION 'house Elo publication scope does not cover every eligible game'
+            USING ERRCODE = '22023';
+    END IF;
+    SELECT max(g.season), count(*) INTO max_season, eligible_scheduled_rows
+    FROM core.games g WHERE g.id <> ALL(reviewed_exclusions);
+    IF max_season IS NOT NULL AND p_end_season < max_season THEN
+        RAISE EXCEPTION 'house Elo publication end season does not cover current schedule'
+            USING ERRCODE = '22023';
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM core.games g
+        WHERE g.id <> ALL(reviewed_exclusions) AND g.completed = true
+          AND (g.home_points IS NULL OR g.away_points IS NULL
+               OR g.home_team IS NULL OR g.away_team IS NULL)
+    ) THEN
+        RAISE EXCEPTION 'completed eligible games require teams and final scores'
+            USING ERRCODE = '22023';
+    END IF;
+    SELECT count(*) INTO eligible_completed_rows FROM core.games g
+    WHERE g.id <> ALL(reviewed_exclusions) AND g.completed = true
+      AND g.home_points IS NOT NULL AND g.away_points IS NOT NULL;
+
+    IF EXISTS (
+        SELECT 1 FROM pg_catalog.jsonb_array_elements(p_rows) e(value)
+        WHERE pg_catalog.jsonb_typeof(value) <> 'object'
+           OR NOT value ?& ARRAY[
+                'game_id','season','week','season_type','start_date','neutral_site',
+                'home_team','away_team','home_pregame_elo','away_pregame_elo',
+                'home_postgame_elo','away_postgame_elo','home_win_prob',
+                'expected_home_margin','actual_home_margin','mov_multiplier',
+                'cfbd_home_pregame_elo','cfbd_away_pregame_elo'
+              ]
+           OR value - ARRAY[
+                'game_id','season','week','season_type','start_date','neutral_site',
+                'home_team','away_team','home_pregame_elo','away_pregame_elo',
+                'home_postgame_elo','away_postgame_elo','home_win_prob',
+                'expected_home_margin','actual_home_margin','mov_multiplier',
+                'cfbd_home_pregame_elo','cfbd_away_pregame_elo'
+              ] <> '{}'::jsonb
+    ) THEN
+        RAISE EXCEPTION 'house Elo row payload has an invalid object shape'
+            USING ERRCODE = '22023';
+    END IF;
+
+    SELECT count(*), count(*) - count(DISTINCT r.game_id)
+    INTO parsed_source_rows, mismatch_rows
+    FROM pg_catalog.jsonb_populate_recordset(NULL::analytics.house_elo_game, p_rows) r;
+    IF mismatch_rows <> 0 OR parsed_source_rows <> eligible_completed_rows THEN
+        RAISE EXCEPTION 'house Elo row payload has duplicate or missing game IDs'
+            USING ERRCODE = '22023';
+    END IF;
+    IF EXISTS (
+        SELECT 1
+        FROM pg_catalog.jsonb_populate_recordset(NULL::analytics.house_elo_game, p_rows) r
+        WHERE r.game_id IS NULL OR r.season IS NULL OR r.neutral_site IS NULL
+           OR r.home_team IS NULL OR length(pg_catalog.btrim(r.home_team)) = 0
+           OR r.away_team IS NULL OR length(pg_catalog.btrim(r.away_team)) = 0
+           OR r.home_pregame_elo IS NULL OR r.away_pregame_elo IS NULL
+           OR r.home_postgame_elo IS NULL OR r.away_postgame_elo IS NULL
+           OR r.home_win_prob IS NULL OR r.home_win_prob < 0 OR r.home_win_prob > 1
+           OR r.expected_home_margin IS NULL OR r.actual_home_margin IS NULL
+           OR r.mov_multiplier IS NULL OR r.mov_multiplier < 0
+           OR r.home_pregame_elo::text IN ('NaN','Infinity','-Infinity')
+           OR r.away_pregame_elo::text IN ('NaN','Infinity','-Infinity')
+           OR r.home_postgame_elo::text IN ('NaN','Infinity','-Infinity')
+           OR r.away_postgame_elo::text IN ('NaN','Infinity','-Infinity')
+           OR r.home_win_prob::text IN ('NaN','Infinity','-Infinity')
+           OR r.expected_home_margin::text IN ('NaN','Infinity','-Infinity')
+           OR r.mov_multiplier::text IN ('NaN','Infinity','-Infinity')
+    ) THEN
+        RAISE EXCEPTION 'house Elo row payload contains invalid values'
+            USING ERRCODE = '22023';
+    END IF;
+
+    SELECT count(*) INTO mismatch_rows
+    FROM pg_catalog.jsonb_populate_recordset(NULL::analytics.house_elo_game, p_rows) r
+    FULL JOIN (
+        SELECT * FROM core.games source_game
+        WHERE source_game.id <> ALL(reviewed_exclusions)
+          AND source_game.completed = true
+          AND source_game.home_points IS NOT NULL
+          AND source_game.away_points IS NOT NULL
+    ) g ON g.id = r.game_id
+    WHERE r.game_id IS NULL OR g.id IS NULL
+       OR r.season IS DISTINCT FROM g.season OR r.week IS DISTINCT FROM g.week
+       OR r.season_type IS DISTINCT FROM g.season_type
+       OR r.start_date IS DISTINCT FROM g.start_date
+       OR r.neutral_site IS DISTINCT FROM COALESCE(g.neutral_site, false)
+       OR r.home_team IS DISTINCT FROM g.home_team OR r.away_team IS DISTINCT FROM g.away_team
+       OR r.actual_home_margin IS DISTINCT FROM (g.home_points - g.away_points)
+       OR r.cfbd_home_pregame_elo IS DISTINCT FROM g.home_pregame_elo
+       OR r.cfbd_away_pregame_elo IS DISTINCT FROM g.away_pregame_elo;
+    IF mismatch_rows <> 0 THEN
+        RAISE EXCEPTION 'house Elo row payload does not match the locked source rows'
+            USING ERRCODE = '22023';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM pg_catalog.jsonb_array_elements(p_snapshot) e(value)
+        WHERE pg_catalog.jsonb_typeof(value) <> 'object'
+           OR NOT value ?& ARRAY[
+                'team','season','rating','games_played','last_game_id',
+                'last_game_date','low_confidence'
+              ]
+           OR value - ARRAY[
+                'team','season','rating','games_played','last_game_id',
+                'last_game_date','low_confidence'
+              ] <> '{}'::jsonb
+    ) THEN
+        RAISE EXCEPTION 'house Elo snapshot payload has an invalid object shape'
+            USING ERRCODE = '22023';
+    END IF;
+    SELECT count(*), count(*) - count(DISTINCT s.team)
+    INTO parsed_snapshot_rows, mismatch_rows
+    FROM pg_catalog.jsonb_to_recordset(p_snapshot) AS s(
+        team text, season bigint, rating numeric, games_played bigint,
+        last_game_id bigint, last_game_date timestamptz, low_confidence boolean
+    );
+    IF mismatch_rows <> 0 THEN
+        RAISE EXCEPTION 'house Elo snapshot payload has duplicate teams'
+            USING ERRCODE = '22023';
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM pg_catalog.jsonb_to_recordset(p_snapshot) AS s(
+            team text, season bigint, rating numeric, games_played bigint,
+            last_game_id bigint, last_game_date timestamptz, low_confidence boolean
+        )
+        WHERE s.team IS NULL OR length(pg_catalog.btrim(s.team)) = 0
+           OR s.season IS NULL OR s.rating IS NULL
+           OR s.rating::text IN ('NaN','Infinity','-Infinity')
+           OR s.games_played IS NULL OR s.games_played < 0
+           OR s.last_game_id IS NULL OR s.low_confidence IS NULL
+    ) THEN
+        RAISE EXCEPTION 'house Elo snapshot payload contains invalid values'
+            USING ERRCODE = '22023';
+    END IF;
+
+    WITH payload_teams AS (
+        SELECT s.team, s.season
+        FROM pg_catalog.jsonb_to_recordset(p_snapshot) AS s(
+            team text, season bigint, rating numeric, games_played bigint,
+            last_game_id bigint, last_game_date timestamptz, low_confidence boolean
+        )
+    ), source_teams AS (
+        SELECT team, max(season) AS season FROM (
+            SELECT r.home_team AS team, r.season
+            FROM pg_catalog.jsonb_populate_recordset(NULL::analytics.house_elo_game, p_rows) r
+            UNION ALL
+            SELECT r.away_team AS team, r.season
+            FROM pg_catalog.jsonb_populate_recordset(NULL::analytics.house_elo_game, p_rows) r
+        ) sides GROUP BY team
+    )
+    SELECT count(*) INTO mismatch_rows
+    FROM payload_teams p FULL JOIN source_teams s USING (team)
+    WHERE p.team IS NULL OR s.team IS NULL OR p.season IS DISTINCT FROM s.season;
+    IF mismatch_rows <> 0 THEN
+        RAISE EXCEPTION 'house Elo snapshot does not cover the computed team set'
+            USING ERRCODE = '22023';
+    END IF;
+
+    SELECT count(*) INTO old_source_rows FROM analytics.house_elo_game;
+    SELECT count(*) INTO old_mart_rows FROM marts.house_elo_game;
+
+    DELETE FROM analytics.house_elo_game;
+    INSERT INTO analytics.house_elo_game(
+        game_id, season, week, season_type, start_date, neutral_site,
+        home_team, away_team, home_pregame_elo, away_pregame_elo,
+        home_postgame_elo, away_postgame_elo, home_win_prob,
+        expected_home_margin, actual_home_margin, mov_multiplier,
+        cfbd_home_pregame_elo, cfbd_away_pregame_elo
+    )
+    SELECT game_id, season, week, season_type, start_date, neutral_site,
+        home_team, away_team, home_pregame_elo, away_pregame_elo,
+        home_postgame_elo, away_postgame_elo, home_win_prob,
+        expected_home_margin, actual_home_margin, mov_multiplier,
+        cfbd_home_pregame_elo, cfbd_away_pregame_elo
+    FROM pg_catalog.jsonb_populate_recordset(NULL::analytics.house_elo_game, p_rows);
+
+    DELETE FROM analytics.house_elo_current;
+    INSERT INTO analytics.house_elo_current(
+        team, season, rating, games_played, last_game_id,
+        last_game_date, low_confidence, updated_at
+    )
+    SELECT s.team, s.season, s.rating, s.games_played, s.last_game_id,
+        s.last_game_date, s.low_confidence, pg_catalog.clock_timestamp()
+    FROM pg_catalog.jsonb_to_recordset(p_snapshot) AS s(
+        team text, season bigint, rating numeric, games_played bigint,
+        last_game_id bigint, last_game_date timestamptz, low_confidence boolean
+    );
+
+    REFRESH MATERIALIZED VIEW marts.house_elo_game;
+    -- REFRESH now retains AccessExclusiveLock through commit. Recheck the
+    -- registered identity to close the pre-refresh DROP/rename/recreate race.
+    IF (SELECT l.relation_oid FROM meta.asset_publication_locks l
+            WHERE l.asset_key = 'marts.house_elo_game')
+        IS DISTINCT FROM pg_catalog.to_regclass('marts.house_elo_game') THEN
+        RAISE EXCEPTION 'house Elo mart relation changed during publication'
+            USING ERRCODE = '40001';
+    END IF;
+    SELECT count(*) INTO refreshed_mart_rows FROM marts.house_elo_game;
+    IF refreshed_mart_rows <> parsed_source_rows THEN
+        RAISE EXCEPTION 'house Elo mart row count differs from its source';
+    END IF;
+
+    publication_time := pg_catalog.clock_timestamp();
+    publication_outcome := CASE WHEN eligible_completed_rows = 0
+        THEN 'expected_no_data' ELSE 'succeeded' END;
+    source_coverage := pg_catalog.jsonb_build_object(
+        'complete', true, 'mode', 'full', 'scope', 'source-wide',
+        'start_season', p_start_season, 'end_season', p_end_season,
+        'eligible_scheduled_games', eligible_scheduled_rows,
+        'eligible_completed_games', eligible_completed_rows,
+        'excluded_game_ids', pg_catalog.to_jsonb(p_excluded_game_ids));
+    mart_coverage := source_coverage || pg_catalog.jsonb_build_object(
+        'input_generation_id', p_source_generation_id);
+    observations := pg_catalog.jsonb_build_object(
+        'publisher', 'compute_house_elo', 'mode', 'full',
+        'input_asset', 'core.games', 'input_digest', p_input_digest,
+        'expected_source_generation_id', p_expected_source_generation_id,
+        'expected_mart_generation_id', p_expected_mart_generation_id,
+        'excluded_game_ids', pg_catalog.to_jsonb(p_excluded_game_ids));
+
+    INSERT INTO meta.asset_receipts(
+        generation_id, operation_run_id, asset_key, outcome, coverage,
+        source_watermark, input_observations, row_delta, request_digest, published_at
+    ) VALUES (
+        p_source_generation_id, p_operation_run_id, 'analytics.house_elo_game',
+        publication_outcome, source_coverage, p_input_digest, observations,
+        pg_catalog.jsonb_build_object('previous_rows', old_source_rows,
+            'published_rows', parsed_source_rows, 'snapshot_rows', parsed_snapshot_rows),
+        request_digest_value, publication_time
+    ), (
+        p_mart_generation_id, p_operation_run_id, 'marts.house_elo_game',
+        publication_outcome, mart_coverage, p_input_digest, observations,
+        pg_catalog.jsonb_build_object('observed_previous_rows', old_mart_rows,
+            'published_rows', refreshed_mart_rows), request_digest_value, publication_time
+    );
+
+    INSERT INTO meta.asset_receipt_inputs(
+        generation_id, input_asset_key, input_coverage_key, input_generation_id
+    ) VALUES (p_mart_generation_id, 'analytics.house_elo_game', 'source-wide',
+        p_source_generation_id);
+
+    INSERT INTO meta.asset_current_generations(asset_key, coverage_key, generation_id)
+    VALUES
+        ('analytics.house_elo_game', 'source-wide', p_source_generation_id),
+        ('marts.house_elo_game', 'source-wide', p_mart_generation_id)
+    ON CONFLICT (asset_key, coverage_key) DO UPDATE
+    SET generation_id = EXCLUDED.generation_id;
+
+    RETURN QUERY SELECT p_source_generation_id, p_mart_generation_id, false,
+        parsed_source_rows, refreshed_mart_rows;
+END
+$function$;
+
+DROP TRIGGER IF EXISTS reject_asset_receipt_mutation ON meta.asset_receipts;
+CREATE TRIGGER reject_asset_receipt_mutation
+    BEFORE UPDATE OR DELETE OR TRUNCATE ON meta.asset_receipts
+    FOR EACH STATEMENT EXECUTE FUNCTION warehouse_publication.reject_append_only_mutation();
+DROP TRIGGER IF EXISTS reject_asset_receipt_input_mutation ON meta.asset_receipt_inputs;
+CREATE TRIGGER reject_asset_receipt_input_mutation
+    BEFORE UPDATE OR DELETE OR TRUNCATE ON meta.asset_receipt_inputs
+    FOR EACH STATEMENT EXECUTE FUNCTION warehouse_publication.reject_append_only_mutation();
+
+CREATE OR REPLACE FUNCTION warehouse_publication.guard_current_generation()
+RETURNS trigger LANGUAGE plpgsql SET search_path = '' AS $function$
+DECLARE receipt meta.asset_receipts%ROWTYPE;
+BEGIN
+    SELECT r.* INTO receipt FROM meta.asset_receipts r
+    WHERE r.asset_key = NEW.asset_key AND r.coverage_key = NEW.coverage_key
+      AND r.generation_id = NEW.generation_id;
+    IF NOT FOUND OR receipt.outcome NOT IN ('succeeded', 'expected_no_data')
+        OR receipt.coverage->'complete' <> 'true'::jsonb OR receipt.published_at IS NULL THEN
+        RAISE EXCEPTION 'current publication pointer requires a complete successful receipt';
+    END IF;
+    RETURN NEW;
+END
+$function$;
+
+DROP TRIGGER IF EXISTS guard_asset_current_generation ON meta.asset_current_generations;
+CREATE TRIGGER guard_asset_current_generation BEFORE INSERT OR UPDATE
+    ON meta.asset_current_generations FOR EACH ROW
+    EXECUTE FUNCTION warehouse_publication.guard_current_generation();
+
+CREATE OR REPLACE FUNCTION warehouse_publication.guard_receipt_input()
+RETURNS trigger LANGUAGE plpgsql SET search_path = '' AS $function$
+DECLARE output_ok boolean; input_ok boolean;
+BEGIN
+    SELECT r.outcome IN ('succeeded', 'expected_no_data')
+        AND r.coverage->'complete' = 'true'::jsonb INTO output_ok
+    FROM meta.asset_receipts r WHERE r.generation_id = NEW.generation_id;
+    SELECT r.outcome IN ('succeeded', 'expected_no_data')
+        AND r.coverage->'complete' = 'true'::jsonb INTO input_ok
+    FROM meta.asset_receipts r WHERE r.asset_key = NEW.input_asset_key
+      AND r.coverage_key = NEW.input_coverage_key
+      AND r.generation_id = NEW.input_generation_id;
+    IF NOT COALESCE(output_ok, false) OR NOT COALESCE(input_ok, false) THEN
+        RAISE EXCEPTION 'receipt dependency edges require complete successful receipts';
+    END IF;
+    RETURN NEW;
+END
+$function$;
+
+DROP TRIGGER IF EXISTS guard_asset_receipt_input ON meta.asset_receipt_inputs;
+CREATE TRIGGER guard_asset_receipt_input BEFORE INSERT ON meta.asset_receipt_inputs
+    FOR EACH ROW EXECUTE FUNCTION warehouse_publication.guard_receipt_input();
+
+-- Legacy writes invalidate both proofs before any target changes.
+CREATE OR REPLACE FUNCTION warehouse_publication.invalidate_house_elo_pointers()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $function$
+BEGIN
+    DELETE FROM meta.asset_current_generations p
+    WHERE p.asset_key IN ('analytics.house_elo_game', 'marts.house_elo_game');
+    RETURN NULL;
+END
+$function$;
+
+DROP TRIGGER IF EXISTS invalidate_house_elo_game_pointer ON analytics.house_elo_game;
+CREATE TRIGGER invalidate_house_elo_game_pointer
+    BEFORE INSERT OR UPDATE OR DELETE OR TRUNCATE ON analytics.house_elo_game
+    FOR EACH STATEMENT EXECUTE FUNCTION warehouse_publication.invalidate_house_elo_pointers();
+DROP TRIGGER IF EXISTS invalidate_house_elo_current_pointer ON analytics.house_elo_current;
+CREATE TRIGGER invalidate_house_elo_current_pointer
+    BEFORE INSERT OR UPDATE OR DELETE OR TRUNCATE ON analytics.house_elo_current
+    FOR EACH STATEMENT EXECUTE FUNCTION warehouse_publication.invalidate_house_elo_pointers();
+
+-- DDL invalidation matches stored OIDs and canonical names. It covers relation
+-- rename/schema move/drop/recreate, direct mart refresh, and relation-trigger
+-- changes. PostgreSQL does not fire event triggers for DDL targeting event
+-- triggers themselves; those are trusted-administrator operations. The RPC
+-- refuses to publish while either event trigger is missing or disabled.
+CREATE OR REPLACE FUNCTION warehouse_publication.invalidate_asset_pointer_ddl()
+RETURNS event_trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $function$
+DECLARE
+    command record;
+    source_changed boolean := false;
+    mart_changed boolean := false;
+    protocol_changed boolean := false;
+BEGIN
+    FOR command IN SELECT * FROM pg_catalog.pg_event_trigger_ddl_commands() LOOP
+        IF command.object_identity IN (
+            'warehouse_publication_invalidate_ddl',
+            'warehouse_publication_invalidate_drop'
+        ) OR command.object_identity LIKE '%invalidate_house_elo_%pointer%'
+          OR command.object_identity LIKE 'warehouse_publication.invalidate_%' THEN
+            protocol_changed := true;
+        END IF;
+        IF EXISTS (
+            SELECT 1 FROM meta.asset_publication_locks l
+            WHERE l.asset_key = 'analytics.house_elo_game'
+              AND (command.objid = l.relation_oid OR command.objid =
+                    pg_catalog.to_regclass(pg_catalog.format('%I.%I',
+                        l.relation_schema, l.relation_name)))
+        ) OR command.objid = pg_catalog.to_regclass('analytics.house_elo_current')
+          OR EXISTS (
+              SELECT 1 FROM pg_catalog.pg_trigger t
+              WHERE t.tgrelid = command.objid
+                AND t.tgname = 'invalidate_house_elo_current_pointer'
+                AND t.tgfoid = pg_catalog.to_regprocedure(
+                    'warehouse_publication.invalidate_house_elo_pointers()')
+          ) THEN
+            source_changed := true;
+        END IF;
+        IF EXISTS (
+            SELECT 1 FROM meta.asset_publication_locks l
+            WHERE l.asset_key = 'marts.house_elo_game'
+              AND (command.objid = l.relation_oid OR command.objid =
+                    pg_catalog.to_regclass(pg_catalog.format('%I.%I',
+                        l.relation_schema, l.relation_name)))
+        ) THEN
+            mart_changed := true;
+        END IF;
+    END LOOP;
+    -- ALTER SCHEMA ... RENAME identifies only the namespace. Resolve the
+    -- canonical bindings after the command to cover whole-schema changes.
+    IF EXISTS (
+        SELECT 1 FROM meta.asset_publication_locks l
+        WHERE l.asset_key = 'analytics.house_elo_game'
+          AND l.relation_oid IS DISTINCT FROM pg_catalog.to_regclass(
+              pg_catalog.format('%I.%I', l.relation_schema, l.relation_name))
+    ) OR pg_catalog.to_regclass('analytics.house_elo_current') IS NULL THEN
+        source_changed := true;
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM meta.asset_publication_locks l
+        WHERE l.asset_key = 'marts.house_elo_game'
+          AND l.relation_oid IS DISTINCT FROM pg_catalog.to_regclass(
+              pg_catalog.format('%I.%I', l.relation_schema, l.relation_name))
+    ) THEN
+        mart_changed := true;
+    END IF;
+    IF source_changed OR protocol_changed THEN
+        DELETE FROM meta.asset_current_generations p
+        WHERE p.asset_key IN ('analytics.house_elo_game', 'marts.house_elo_game');
+    ELSIF mart_changed THEN
+        DELETE FROM meta.asset_current_generations p WHERE p.asset_key = 'marts.house_elo_game';
+    END IF;
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION warehouse_publication.invalidate_asset_pointer_drop()
+RETURNS event_trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $function$
+DECLARE
+    dropped record;
+    source_changed boolean := false;
+    mart_changed boolean := false;
+    protocol_changed boolean := false;
+BEGIN
+    FOR dropped IN SELECT * FROM pg_catalog.pg_event_trigger_dropped_objects() LOOP
+        IF dropped.object_identity IN (
+            'warehouse_publication_invalidate_ddl',
+            'warehouse_publication_invalidate_drop'
+        ) OR 'invalidate_house_elo_game_pointer' = ANY(dropped.address_names)
+          OR 'invalidate_house_elo_current_pointer' = ANY(dropped.address_names)
+          OR dropped.object_identity LIKE 'warehouse_publication.invalidate_%' THEN
+            protocol_changed := true;
+        END IF;
+        IF EXISTS (
+            SELECT 1 FROM meta.asset_publication_locks l
+            WHERE l.asset_key = 'analytics.house_elo_game'
+              AND (dropped.objid = l.relation_oid OR
+                   (dropped.address_names[1] = l.relation_schema
+                    AND dropped.address_names[2] = l.relation_name))
+        ) OR (dropped.address_names[1] = 'analytics'
+              AND dropped.address_names[2] = 'house_elo_current') THEN
+            source_changed := true;
+        END IF;
+        IF EXISTS (
+            SELECT 1 FROM meta.asset_publication_locks l
+            WHERE l.asset_key = 'marts.house_elo_game'
+              AND (dropped.objid = l.relation_oid OR
+                   (dropped.address_names[1] = l.relation_schema
+                    AND dropped.address_names[2] = l.relation_name))
+        ) THEN
+            mart_changed := true;
+        END IF;
+    END LOOP;
+    IF EXISTS (
+        SELECT 1 FROM meta.asset_publication_locks l
+        WHERE l.asset_key = 'analytics.house_elo_game'
+          AND l.relation_oid IS DISTINCT FROM pg_catalog.to_regclass(
+              pg_catalog.format('%I.%I', l.relation_schema, l.relation_name))
+    ) OR pg_catalog.to_regclass('analytics.house_elo_current') IS NULL THEN
+        source_changed := true;
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM meta.asset_publication_locks l
+        WHERE l.asset_key = 'marts.house_elo_game'
+          AND l.relation_oid IS DISTINCT FROM pg_catalog.to_regclass(
+              pg_catalog.format('%I.%I', l.relation_schema, l.relation_name))
+    ) THEN
+        mart_changed := true;
+    END IF;
+    IF source_changed OR protocol_changed THEN
+        DELETE FROM meta.asset_current_generations p
+        WHERE p.asset_key IN ('analytics.house_elo_game', 'marts.house_elo_game');
+    ELSIF mart_changed THEN
+        DELETE FROM meta.asset_current_generations p WHERE p.asset_key = 'marts.house_elo_game';
+    END IF;
+END
+$function$;
+
+DROP EVENT TRIGGER IF EXISTS warehouse_publication_invalidate_ddl;
+CREATE EVENT TRIGGER warehouse_publication_invalidate_ddl ON ddl_command_end
+    EXECUTE FUNCTION warehouse_publication.invalidate_asset_pointer_ddl();
+DROP EVENT TRIGGER IF EXISTS warehouse_publication_invalidate_drop;
+CREATE EVENT TRIGGER warehouse_publication_invalidate_drop ON sql_drop
+    EXECUTE FUNCTION warehouse_publication.invalidate_asset_pointer_drop();
+
+CREATE OR REPLACE FUNCTION warehouse_publication.get_house_elo_state(
+    p_start_season bigint,
+    p_end_season bigint
+)
+RETURNS TABLE (source_generation uuid, mart_generation uuid, input_digest text)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $function$
+DECLARE max_season bigint;
+BEGIN
+    IF p_start_season IS DISTINCT FROM 1869 OR p_end_season IS NULL
+        OR p_end_season < p_start_season THEN
+        RAISE EXCEPTION 'house Elo publication requires full history beginning in 1869'
+            USING ERRCODE = '22023';
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM core.games g
+        WHERE g.id <> ALL(ARRAY[
+            401540999,401545766,401545768,401545773,401545780,401545781,
+            401549719,401550299,401552878,401552884,401640992,401833535,
+            401866625
+        ]::bigint[]) AND g.season IS NULL
+    ) THEN
+        RAISE EXCEPTION 'eligible core.games rows require a season' USING ERRCODE = '22023';
+    END IF;
+    SELECT max(g.season) INTO max_season FROM core.games g
+    WHERE g.id <> ALL(ARRAY[
+        401540999,401545766,401545768,401545773,401545780,401545781,
+        401549719,401550299,401552878,401552884,401640992,401833535,
+        401866625
+    ]::bigint[]);
+    IF max_season IS NOT NULL AND p_end_season < max_season THEN
+        RAISE EXCEPTION 'house Elo publication end season does not cover current schedule'
+            USING ERRCODE = '22023';
+    END IF;
+    PERFORM pg_catalog.set_config('TimeZone', 'UTC', true);
+    RETURN QUERY SELECT
+        (SELECT p.generation_id FROM meta.asset_current_generations p
+         WHERE p.asset_key = 'analytics.house_elo_game' AND p.coverage_key = 'source-wide'),
+        (SELECT p.generation_id FROM meta.asset_current_generations p
+         WHERE p.asset_key = 'marts.house_elo_game' AND p.coverage_key = 'source-wide'),
+        (SELECT pg_catalog.md5(COALESCE(pg_catalog.string_agg(
+                    pg_catalog.md5(pg_catalog.to_jsonb(g)::text), '' ORDER BY g.id), ''))
+         FROM core.games g);
+END
+$function$;
+
+-- Scrub broad host defaults from the new private objects and every routine.
+DO $acl$
+DECLARE entry record; recipient text;
+BEGIN
+    FOR entry IN
+        SELECT DISTINCT 'SCHEMA' AS object_kind,
+            pg_catalog.format('%I', n.nspname) AS object_name, acl.grantee
+        FROM pg_catalog.pg_namespace n
+        CROSS JOIN LATERAL pg_catalog.aclexplode(n.nspacl) acl
+        WHERE n.nspname = 'warehouse_publication' AND acl.grantee <> n.nspowner
+        UNION
+        SELECT DISTINCT 'TABLE', pg_catalog.format('%I.%I', n.nspname, c.relname), acl.grantee
+        FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        CROSS JOIN LATERAL pg_catalog.aclexplode(c.relacl) acl
+        WHERE n.nspname = 'meta'
+          AND c.relname IN ('asset_publication_locks', 'asset_receipts',
+              'asset_current_generations', 'asset_receipt_inputs')
+          AND c.relkind = 'r' AND acl.grantee <> c.relowner
+        UNION
+        SELECT DISTINCT 'FUNCTION', p.oid::pg_catalog.regprocedure::text, acl.grantee
+        FROM pg_catalog.pg_proc p JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+        CROSS JOIN LATERAL pg_catalog.aclexplode(
+            COALESCE(p.proacl, pg_catalog.acldefault('f', p.proowner))) acl
+        WHERE n.nspname = 'warehouse_publication' AND acl.grantee <> p.proowner
+    LOOP
+        recipient := CASE WHEN entry.grantee = 0 THEN 'PUBLIC'
+            ELSE pg_catalog.quote_ident(pg_catalog.pg_get_userbyid(entry.grantee)) END;
+        EXECUTE pg_catalog.format('REVOKE ALL ON %s %s FROM %s',
+            entry.object_kind, entry.object_name, recipient);
+    END LOOP;
+END
+$acl$;
+
+-- No direct target mutation is part of the runtime role contract.
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE
+    ON analytics.house_elo_game, analytics.house_elo_current
+    FROM warehouse_publisher;
+
+DO $publisher_boundary$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_catalog.pg_class c
+        WHERE c.oid IN (
+            pg_catalog.to_regclass('analytics.house_elo_game'),
+            pg_catalog.to_regclass('analytics.house_elo_current'),
+            pg_catalog.to_regclass('marts.house_elo_game')
+        ) AND c.relowner = (SELECT oid FROM pg_catalog.pg_roles
+            WHERE rolname = 'warehouse_publisher')
+    ) OR pg_catalog.has_table_privilege(
+            'warehouse_publisher', 'analytics.house_elo_game', 'INSERT,UPDATE,DELETE,TRUNCATE')
+       OR pg_catalog.has_table_privilege(
+            'warehouse_publisher', 'analytics.house_elo_current', 'INSERT,UPDATE,DELETE,TRUNCATE') THEN
+        RAISE EXCEPTION 'warehouse_publisher has unsafe direct target privileges';
+    END IF;
+END
+$publisher_boundary$;
+
+GRANT USAGE ON SCHEMA warehouse_publication, warehouse_quota TO warehouse_publisher;
+GRANT EXECUTE ON FUNCTION
+    warehouse_publication.get_house_elo_state(bigint, bigint),
+    warehouse_publication.publish_house_elo(
+        uuid, uuid, uuid, uuid, uuid, text, jsonb, jsonb, bigint, bigint, bigint[]
+    ),
+    warehouse_publication.record_house_elo_failure(uuid, uuid, uuid, text, text),
+    warehouse_quota.start_operation_run(uuid, text, text, jsonb, text, text),
+    warehouse_quota.finish_operation_run(uuid, text, text)
+TO warehouse_publisher;

--- a/src/schemas/migrations/068_asset_publication_receipts.sql
+++ b/src/schemas/migrations/068_asset_publication_receipts.sql
@@ -47,6 +47,8 @@ BEGIN
                     pg_catalog.to_regprocedure('warehouse_publication.invalidate_house_elo_pointers()'),
                     pg_catalog.to_regprocedure('warehouse_publication.invalidate_asset_pointer_ddl()'),
                     pg_catalog.to_regprocedure('warehouse_publication.invalidate_asset_pointer_drop()'),
+                    pg_catalog.to_regprocedure('warehouse_publication.start_house_elo_run(uuid)'),
+                    pg_catalog.to_regprocedure('warehouse_publication.finish_house_elo_run(uuid,text)'),
                     pg_catalog.to_regprocedure('warehouse_publication.get_house_elo_state(bigint,bigint)'),
                     pg_catalog.to_regprocedure('warehouse_publication.publish_house_elo(uuid,uuid,uuid,uuid,uuid,text,jsonb,jsonb,bigint,bigint,bigint[])'),
                     pg_catalog.to_regprocedure('warehouse_publication.record_house_elo_failure(uuid,uuid,uuid,text,text)')
@@ -320,6 +322,73 @@ BEGIN
 END
 $function$;
 
+-- Bounded lifecycle wrappers keep the runtime role away from generic quota
+-- helpers that can create arbitrary operation kinds/scopes.
+CREATE OR REPLACE FUNCTION warehouse_publication.start_house_elo_run(
+    p_operation_run_id uuid
+)
+RETURNS uuid
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $function$
+DECLARE run_row meta.operation_runs%ROWTYPE;
+BEGIN
+    IF p_operation_run_id IS NULL THEN
+        RAISE EXCEPTION 'operation_run_id is required' USING ERRCODE = '22023';
+    END IF;
+    PERFORM warehouse_quota.start_operation_run(
+        p_operation_run_id,
+        'compute',
+        'compute_house_elo',
+        '{"assets":["analytics.house_elo_game","marts.house_elo_game"],"mode":"full","start_season":1869}'::jsonb,
+        NULL,
+        NULL
+    );
+    -- start_operation_run retains its advisory transaction lock. Validate the
+    -- actor after an insert or replay so another login cannot adopt the UUID.
+    SELECT r.* INTO STRICT run_row FROM meta.operation_runs r
+    WHERE r.operation_run_id = p_operation_run_id;
+    IF run_row.recorded_by <> session_user
+        OR run_row.operation_kind <> 'compute'
+        OR run_row.initiator <> 'compute_house_elo'
+        OR run_row.requested_scope IS DISTINCT FROM
+            '{"assets":["analytics.house_elo_game","marts.house_elo_game"],"mode":"full","start_season":1869}'::jsonb
+        OR run_row.plan_digest IS NOT NULL OR run_row.code_revision IS NOT NULL THEN
+        RAISE EXCEPTION 'operation run does not belong to this house Elo publisher'
+            USING ERRCODE = '22023';
+    END IF;
+    RETURN p_operation_run_id;
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION warehouse_publication.finish_house_elo_run(
+    p_operation_run_id uuid,
+    p_outcome text
+)
+RETURNS integer
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $function$
+DECLARE run_row meta.operation_runs%ROWTYPE;
+BEGIN
+    IF p_operation_run_id IS NULL OR p_outcome NOT IN ('succeeded', 'failed') THEN
+        RAISE EXCEPTION 'house Elo operation outcome is invalid' USING ERRCODE = '22023';
+    END IF;
+    SELECT r.* INTO run_row FROM meta.operation_runs r
+    WHERE r.operation_run_id = p_operation_run_id FOR UPDATE;
+    IF NOT FOUND OR run_row.recorded_by <> session_user
+        OR run_row.operation_kind <> 'compute'
+        OR run_row.initiator <> 'compute_house_elo'
+        OR run_row.requested_scope IS DISTINCT FROM
+            '{"assets":["analytics.house_elo_game","marts.house_elo_game"],"mode":"full","start_season":1869}'::jsonb
+        OR run_row.plan_digest IS NOT NULL OR run_row.code_revision IS NOT NULL THEN
+        RAISE EXCEPTION 'operation run does not belong to this house Elo publisher'
+            USING ERRCODE = '22023';
+    END IF;
+    RETURN warehouse_quota.finish_operation_run(
+        p_operation_run_id,
+        p_outcome,
+        CASE WHEN p_outcome = 'failed' THEN 'publication_failed' ELSE NULL END
+    );
+END
+$function$;
+
 CREATE OR REPLACE FUNCTION warehouse_publication.publish_house_elo(
     p_operation_run_id uuid,
     p_source_generation_id uuid,
@@ -512,6 +581,32 @@ BEGIN
     IF fresh_input_digest IS DISTINCT FROM p_input_digest THEN
         RAISE EXCEPTION 'core.games changed during house Elo preparation'
             USING ERRCODE = '40001';
+    END IF;
+
+    -- Excluding a reviewed postponed original is safe only while its reviewed
+    -- replacement is present and carries the same non-NULL game identity.
+    -- This mirrors select_canonical_game_rows() without changing raw rows.
+    IF EXISTS (
+        SELECT 1
+        FROM (VALUES
+            (401866625::bigint, 401917058::bigint),
+            (401549719::bigint, 401611307::bigint),
+            (401550299::bigint, 401611308::bigint),
+            (401552878::bigint, 401611306::bigint),
+            (401552884::bigint, 401612659::bigint)
+        ) mapping(original_id, replacement_id)
+        JOIN core.games original_game ON original_game.id = mapping.original_id
+        LEFT JOIN core.games replacement_game ON replacement_game.id = mapping.replacement_id
+        WHERE replacement_game.id IS NULL
+           OR original_game.season IS NULL
+           OR original_game.home_team IS NULL
+           OR original_game.away_team IS NULL
+           OR original_game.season IS DISTINCT FROM replacement_game.season
+           OR original_game.home_team IS DISTINCT FROM replacement_game.home_team
+           OR original_game.away_team IS DISTINCT FROM replacement_game.away_team
+    ) THEN
+        RAISE EXCEPTION 'reviewed superseded game is missing a matching replacement'
+            USING ERRCODE = '22023';
     END IF;
 
     IF EXISTS (
@@ -1069,6 +1164,11 @@ $acl$;
 REVOKE INSERT, UPDATE, DELETE, TRUNCATE
     ON analytics.house_elo_game, analytics.house_elo_current
     FROM warehouse_publisher;
+REVOKE EXECUTE ON FUNCTION
+    warehouse_quota.start_operation_run(uuid, text, text, jsonb, text, text),
+    warehouse_quota.finish_operation_run(uuid, text, text)
+FROM warehouse_publisher;
+REVOKE USAGE ON SCHEMA warehouse_quota FROM warehouse_publisher;
 
 DO $publisher_boundary$
 BEGIN
@@ -1083,19 +1183,27 @@ BEGIN
     ) OR pg_catalog.has_table_privilege(
             'warehouse_publisher', 'analytics.house_elo_game', 'INSERT,UPDATE,DELETE,TRUNCATE')
        OR pg_catalog.has_table_privilege(
-            'warehouse_publisher', 'analytics.house_elo_current', 'INSERT,UPDATE,DELETE,TRUNCATE') THEN
+            'warehouse_publisher', 'analytics.house_elo_current', 'INSERT,UPDATE,DELETE,TRUNCATE')
+       OR pg_catalog.has_function_privilege(
+            'warehouse_publisher',
+            'warehouse_quota.start_operation_run(uuid,text,text,jsonb,text,text)',
+            'EXECUTE')
+       OR pg_catalog.has_function_privilege(
+            'warehouse_publisher',
+            'warehouse_quota.finish_operation_run(uuid,text,text)',
+            'EXECUTE') THEN
         RAISE EXCEPTION 'warehouse_publisher has unsafe direct target privileges';
     END IF;
 END
 $publisher_boundary$;
 
-GRANT USAGE ON SCHEMA warehouse_publication, warehouse_quota TO warehouse_publisher;
+GRANT USAGE ON SCHEMA warehouse_publication TO warehouse_publisher;
 GRANT EXECUTE ON FUNCTION
+    warehouse_publication.start_house_elo_run(uuid),
+    warehouse_publication.finish_house_elo_run(uuid, text),
     warehouse_publication.get_house_elo_state(bigint, bigint),
     warehouse_publication.publish_house_elo(
         uuid, uuid, uuid, uuid, uuid, text, jsonb, jsonb, bigint, bigint, bigint[]
     ),
-    warehouse_publication.record_house_elo_failure(uuid, uuid, uuid, text, text),
-    warehouse_quota.start_operation_run(uuid, text, text, jsonb, text, text),
-    warehouse_quota.finish_operation_run(uuid, text, text)
+    warehouse_publication.record_house_elo_failure(uuid, uuid, uuid, text, text)
 TO warehouse_publisher;

--- a/src/schemas/production-manifest.json
+++ b/src/schemas/production-manifest.json
@@ -14,6 +14,11 @@
       "id": "warehouse.f14.067",
       "path": "src/schemas/migrations/067_cfbd_transport_admission.sql",
       "kind": "immutable"
+    },
+    {
+      "id": "warehouse.f14.068",
+      "path": "src/schemas/migrations/068_asset_publication_receipts.sql",
+      "kind": "immutable"
     }
   ],
   "version": 1

--- a/src/schemas/warehouse-manifest.json
+++ b/src/schemas/warehouse-manifest.json
@@ -40,6 +40,11 @@
       "id": "warehouse.f14.067",
       "path": "src/schemas/migrations/067_cfbd_transport_admission.sql",
       "kind": "immutable"
+    },
+    {
+      "id": "warehouse.f14.068",
+      "path": "src/schemas/migrations/068_asset_publication_receipts.sql",
+      "kind": "immutable"
     }
   ]
 }

--- a/tests/test_asset_publication_sql.py
+++ b/tests/test_asset_publication_sql.py
@@ -184,14 +184,7 @@ def start_run(conn, run_id=None):
     run_id = run_id or uuid.uuid4()
     publisher_query(
         conn,
-        """
-        SELECT warehouse_quota.start_operation_run(
-            %s, 'compute', 'compute_house_elo',
-            '{"assets":["analytics.house_elo_game","marts.house_elo_game"],
-              "mode":"full","start_season":1869}'::jsonb,
-            NULL, NULL
-        )
-        """,
+        "SELECT warehouse_publication.start_house_elo_run(%s)",
         (str(run_id),),
     )
     return run_id
@@ -817,3 +810,125 @@ def test_administrator_clears_pointers_before_disabling_event_guard(publication_
     conn.rollback()
     assert query(conn, "SELECT count(*) FROM meta.asset_receipts") == [(2,)]
     assert query(conn, "SELECT count(*) FROM meta.asset_current_generations") == [(0,)]
+
+
+def add_reviewed_game(conn, game_id, *, completed=False, season=2025, home="Alpha", away="Beta"):
+    query(
+        conn,
+        """
+        INSERT INTO core.games(id,season,week,season_type,start_date,completed,
+            neutral_site,home_team,away_team,home_points,away_points,
+            _dlt_load_id,_dlt_id)
+        VALUES (%s,%s,1,'regular','2025-08-31 17:00+00',%s,false,%s,%s,28,14,'fixture',%s)
+        """,
+        (game_id, season, completed, home, away, str(game_id)),
+    )
+
+
+@pytest.mark.parametrize(
+    "defect",
+    ["missing", "season", "home", "away", "original_season", "original_home", "original_away"],
+)
+def test_superseded_pair_defects_cannot_advance_complete_receipts(publication_db, defect):
+    conn, _ = publication_db
+    publish(conn, publication_args(conn))
+    before = current_snapshot(conn)
+    args = list(publication_args(conn, expected=state(conn)))
+    original, replacement = next(iter(SUPERSEDED_GAME_REPLACEMENTS.items()))
+    original_values = {}
+    if defect.startswith("original_"):
+        original_values[defect.removeprefix("original_")] = None
+    add_reviewed_game(conn, original, **original_values)
+    if defect != "missing":
+        replacement_values = {}
+        if defect in {"season", "home", "away"}:
+            replacement_values[defect] = 2024 if defect == "season" else "Different"
+        add_reviewed_game(conn, replacement, **replacement_values)
+    # Supply the current digest directly to exercise locked publication validation,
+    # even when the optional preparation lookup rejects the broken pair first.
+    args[5] = query(
+        conn,
+        "SELECT md5(coalesce(string_agg(md5(to_jsonb(g)::text),'' ORDER BY id),'')) "
+        "FROM core.games g",
+    )[0][0]
+    with pytest.raises(psycopg2.Error, match="replacement|superseded"):
+        publish(conn, tuple(args))
+    conn.rollback()
+    assert current_snapshot(conn) == before
+
+
+@pytest.mark.parametrize("original,replacement", list(SUPERSEDED_GAME_REPLACEMENTS.items()))
+def test_every_reviewed_replacement_pair_can_publish(publication_db, original, replacement):
+    from scripts.compute_house_elo import run_full_published
+
+    conn, _ = publication_db
+    add_reviewed_game(conn, original, completed=True)
+    add_reviewed_game(conn, replacement, completed=True)
+    rows = run_full_published(conn)
+    assert {row["game_id"] for row in rows} == {101, replacement}
+    assert query(conn, "SELECT count(*) FROM meta.asset_current_generations") == [(2,)]
+
+
+def test_publisher_cannot_use_generic_operation_rpcs_even_after_migration_reapply(publication_db):
+    conn, _ = publication_db
+    # Simulate grants from the original PR version before reapplying the fix.
+    query(
+        conn,
+        """
+        GRANT USAGE ON SCHEMA warehouse_quota TO warehouse_publisher;
+        GRANT EXECUTE ON FUNCTION
+            warehouse_quota.start_operation_run(uuid,text,text,jsonb,text,text),
+            warehouse_quota.finish_operation_run(uuid,text,text) TO warehouse_publisher;
+        """,
+    )
+    query(conn, MIGRATIONS[-1].read_text())
+    for statement in (
+        "SELECT warehouse_quota.start_operation_run(%s,'extract','forged','{}',NULL,NULL)",
+        "SELECT warehouse_quota.finish_operation_run(%s,'failed','forged')",
+    ):
+        with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+            publisher_query(conn, statement, (str(uuid.uuid4()),))
+        conn.rollback()
+    assert query(conn, "SELECT count(*) FROM meta.operation_runs") == [(0,)]
+
+
+def test_elo_wrappers_reject_other_principal_and_unrelated_operation(publication_db):
+    conn, target = publication_db
+    unrelated = str(uuid.uuid4())
+    query(
+        conn,
+        "SELECT warehouse_quota.start_operation_run(%s,'extract','fixture','{}',NULL,NULL)",
+        (unrelated,),
+    )
+    for statement in (
+        "SELECT warehouse_publication.start_house_elo_run(%s)",
+        "SELECT warehouse_publication.finish_house_elo_run(%s,'failed')",
+    ):
+        with pytest.raises(psycopg2.Error):
+            publisher_query(conn, statement, (unrelated,))
+        conn.rollback()
+    other_role = "publication_caller_" + uuid.uuid4().hex
+    query(conn, f"CREATE ROLE {other_role} NOLOGIN")
+    query(conn, f"GRANT warehouse_publisher TO {other_role}")
+    other = psycopg2.connect(target)
+    try:
+        query(other, f"SET SESSION AUTHORIZATION {other_role}")
+        other_run = str(start_run(other))
+        for statement in (
+            "SELECT warehouse_publication.start_house_elo_run(%s)",
+            "SELECT warehouse_publication.finish_house_elo_run(%s,'failed')",
+        ):
+            with pytest.raises(psycopg2.Error):
+                publisher_query(conn, statement, (other_run,))
+            conn.rollback()
+        assert query(
+            conn,
+            "SELECT recorded_by,outcome FROM meta.operation_runs WHERE operation_run_id=%s",
+            (other_run,),
+        ) == [(other_role, "running")]
+        assert query(
+            conn, "SELECT outcome FROM meta.operation_runs WHERE operation_run_id=%s", (unrelated,)
+        ) == [("running",)]
+    finally:
+        other.close()
+        query(conn, f"DROP ROLE {other_role}")

--- a/tests/test_asset_publication_sql.py
+++ b/tests/test_asset_publication_sql.py
@@ -1,0 +1,819 @@
+"""Executed F14 house-Elo publication receipts on isolated PostgreSQL 17."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from threading import Event
+from time import monotonic, sleep
+
+import psycopg2
+import pytest
+
+from src.pipelines.game_identity import CANCELLED_GAME_IDS, SUPERSEDED_GAME_REPLACEMENTS
+from tests.test_warehouse_migrations_sql import query
+from tests.test_warehouse_migrations_sql import warehouse_db as _warehouse_db  # noqa: F401
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATIONS = [
+    ROOT / "src/schemas/migrations/066_operational_quota_ledger.sql",
+    ROOT / "src/schemas/migrations/067_cfbd_transport_admission.sql",
+    ROOT / "src/schemas/migrations/068_asset_publication_receipts.sql",
+]
+EXCLUDED_GAME_IDS = sorted(set(CANCELLED_GAME_IDS) | set(SUPERSEDED_GAME_REPLACEMENTS))
+
+SETUP = """
+DO $roles$ BEGIN
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname='anon') THEN
+        CREATE ROLE anon NOLOGIN;
+    END IF;
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname='authenticated') THEN
+        CREATE ROLE authenticated NOLOGIN;
+    END IF;
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname='analyst_ro') THEN
+        CREATE ROLE analyst_ro NOLOGIN;
+    END IF;
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname='publication_bystander') THEN
+        CREATE ROLE publication_bystander NOLOGIN;
+    END IF;
+END $roles$;
+ALTER DEFAULT PRIVILEGES GRANT ALL ON SCHEMAS
+    TO anon, authenticated, analyst_ro, publication_bystander;
+ALTER DEFAULT PRIVILEGES GRANT ALL ON TABLES
+    TO anon, authenticated, analyst_ro, publication_bystander;
+ALTER DEFAULT PRIVILEGES GRANT ALL ON SEQUENCES
+    TO anon, authenticated, analyst_ro, publication_bystander;
+ALTER DEFAULT PRIVILEGES GRANT ALL ON FUNCTIONS
+    TO anon, authenticated, analyst_ro, publication_bystander;
+"""
+
+HOUSE_ELO_OBJECTS = """
+CREATE SCHEMA core;
+CREATE SCHEMA analytics;
+CREATE SCHEMA marts;
+
+CREATE TABLE core.games (
+    id bigint PRIMARY KEY,
+    season bigint,
+    week bigint,
+    season_type varchar,
+    start_date timestamptz,
+    start_time_tbd boolean,
+    completed boolean,
+    neutral_site boolean,
+    conference_game boolean,
+    home_id bigint,
+    home_team varchar,
+    home_classification varchar,
+    home_conference varchar,
+    home_points bigint,
+    away_id bigint,
+    away_team varchar,
+    away_points bigint,
+    highlights varchar,
+    _dlt_load_id varchar NOT NULL,
+    _dlt_id varchar NOT NULL,
+    attendance bigint,
+    venue_id bigint,
+    venue varchar,
+    home_postgame_win_probability double precision,
+    home_pregame_elo bigint,
+    home_postgame_elo bigint,
+    away_classification varchar,
+    away_conference varchar,
+    away_postgame_win_probability double precision,
+    away_pregame_elo bigint,
+    away_postgame_elo bigint,
+    excitement_index double precision,
+    notes varchar,
+    playoff__competition varchar,
+    playoff__format varchar,
+    playoff__round varchar,
+    playoff__round_name varchar,
+    playoff__bracket_slot varchar,
+    playoff__home_seed bigint,
+    playoff__away_seed bigint,
+    playoff__bowl_name varchar
+);
+
+INSERT INTO core.games (
+    id, season, week, season_type, start_date, start_time_tbd, completed,
+    neutral_site, conference_game, home_id, home_team, home_classification,
+    home_conference, home_points, away_id, away_team, away_points,
+    _dlt_load_id, _dlt_id, away_classification, away_conference,
+    home_pregame_elo, away_pregame_elo
+) VALUES
+    (101, 2025, 1, 'regular', '2025-08-30 17:00:00+00', false, true,
+     false, true, 1, 'Alpha', 'fbs', 'Test', 28, 2, 'Beta', 14,
+     'load-1', 'game-101', 'fbs', 'Test', 1510, 1490),
+    (102, 2025, 2, 'regular', '2025-09-06 17:00:00+00', false, false,
+     false, true, 1, 'Alpha', 'fbs', 'Test', NULL, 3, 'Gamma', NULL,
+     'load-1', 'game-102', 'fbs', 'Test', NULL, NULL);
+
+CREATE TABLE analytics.house_elo_game (
+    game_id bigint NOT NULL,
+    season bigint NOT NULL,
+    week bigint,
+    season_type varchar,
+    start_date timestamptz,
+    neutral_site boolean,
+    home_team varchar NOT NULL,
+    away_team varchar NOT NULL,
+    home_pregame_elo numeric(8,2),
+    away_pregame_elo numeric(8,2),
+    home_postgame_elo numeric(8,2),
+    away_postgame_elo numeric(8,2),
+    home_win_prob numeric(5,4),
+    expected_home_margin numeric(6,2),
+    actual_home_margin bigint,
+    mov_multiplier numeric(6,3),
+    cfbd_home_pregame_elo numeric(8,2),
+    cfbd_away_pregame_elo numeric(8,2)
+);
+CREATE UNIQUE INDEX house_elo_game_key ON analytics.house_elo_game(game_id);
+
+CREATE TABLE analytics.house_elo_current (
+    team varchar NOT NULL,
+    season bigint,
+    rating numeric(8,2) NOT NULL,
+    games_played bigint,
+    last_game_id bigint,
+    last_game_date timestamptz,
+    low_confidence boolean,
+    updated_at timestamptz
+);
+CREATE UNIQUE INDEX house_elo_current_key ON analytics.house_elo_current(team);
+
+CREATE MATERIALIZED VIEW marts.house_elo_game AS
+SELECT game_id, season, week, season_type, start_date, neutral_site,
+    home_team, away_team, home_pregame_elo, away_pregame_elo,
+    home_postgame_elo, away_postgame_elo, home_win_prob,
+    expected_home_margin, actual_home_margin, mov_multiplier,
+    cfbd_home_pregame_elo, cfbd_away_pregame_elo,
+    expected_home_margin - actual_home_margin AS margin_error,
+    abs(expected_home_margin - actual_home_margin) AS abs_margin_error
+FROM analytics.house_elo_game;
+CREATE UNIQUE INDEX house_elo_game_mart_key ON marts.house_elo_game(game_id);
+"""
+
+
+@pytest.fixture
+def publication_db(request):
+    conn, target = request.getfixturevalue("_warehouse_db")
+    query(conn, SETUP)
+    query(conn, MIGRATIONS[0].read_text())
+    query(conn, MIGRATIONS[1].read_text())
+    query(conn, HOUSE_ELO_OBJECTS)
+    query(conn, MIGRATIONS[2].read_text())
+    query(conn, MIGRATIONS[2].read_text())
+    return conn, target
+
+
+def publisher_query(conn, statement, values=None):
+    with conn.cursor() as cur:
+        cur.execute("SET LOCAL ROLE warehouse_publisher")
+        cur.execute(statement, values)
+        result = cur.fetchall() if cur.description else None
+    conn.commit()
+    return result
+
+
+def start_run(conn, run_id=None):
+    run_id = run_id or uuid.uuid4()
+    publisher_query(
+        conn,
+        """
+        SELECT warehouse_quota.start_operation_run(
+            %s, 'compute', 'compute_house_elo',
+            '{"assets":["analytics.house_elo_game","marts.house_elo_game"],
+              "mode":"full","start_season":1869}'::jsonb,
+            NULL, NULL
+        )
+        """,
+        (str(run_id),),
+    )
+    return run_id
+
+
+def state(conn):
+    return publisher_query(
+        conn,
+        "SELECT * FROM warehouse_publication.get_house_elo_state(1869, 2025)",
+    )[0]
+
+
+def game_rows(*, postgame=1518.25):
+    return [
+        {
+            "game_id": 101,
+            "season": 2025,
+            "week": 1,
+            "season_type": "regular",
+            "start_date": "2025-08-30T17:00:00+00:00",
+            "neutral_site": False,
+            "home_team": "Alpha",
+            "away_team": "Beta",
+            "home_pregame_elo": 1500,
+            "away_pregame_elo": 1500,
+            "home_postgame_elo": postgame,
+            "away_postgame_elo": 3000 - postgame,
+            "home_win_prob": 0.5925,
+            "expected_home_margin": 2.95,
+            "actual_home_margin": 14,
+            "mov_multiplier": 1.322,
+            "cfbd_home_pregame_elo": 1510,
+            "cfbd_away_pregame_elo": 1490,
+        }
+    ]
+
+
+def snapshot(*, alpha_rating=1518.25):
+    return [
+        {
+            "team": "Alpha",
+            "season": 2025,
+            "rating": alpha_rating,
+            "games_played": 1,
+            "last_game_id": 101,
+            "last_game_date": "2025-08-30T17:00:00+00:00",
+            "low_confidence": True,
+        },
+        {
+            "team": "Beta",
+            "season": 2025,
+            "rating": 3000 - alpha_rating,
+            "games_played": 1,
+            "last_game_id": 101,
+            "last_game_date": "2025-08-30T17:00:00+00:00",
+            "low_confidence": True,
+        },
+    ]
+
+
+def publication_args(
+    conn,
+    *,
+    run_id=None,
+    source_generation=None,
+    mart_generation=None,
+    expected=None,
+    digest=None,
+    postgame=1518.25,
+):
+    expected = expected or state(conn)
+    return (
+        str(run_id or start_run(conn)),
+        str(source_generation or uuid.uuid4()),
+        str(mart_generation or uuid.uuid4()),
+        str(expected[0]) if expected[0] else None,
+        str(expected[1]) if expected[1] else None,
+        digest or expected[2],
+        json.dumps(game_rows(postgame=postgame)),
+        json.dumps(snapshot(alpha_rating=postgame)),
+        1869,
+        2025,
+        EXCLUDED_GAME_IDS,
+    )
+
+
+PUBLISH_SQL = """
+SELECT * FROM warehouse_publication.publish_house_elo(
+    %s, %s, %s, %s, %s, %s, %s::jsonb, %s::jsonb, %s, %s, %s::bigint[]
+)
+"""
+
+
+def publish(conn, args):
+    return publisher_query(conn, PUBLISH_SQL, args)[0]
+
+
+def current_snapshot(conn):
+    return query(
+        conn,
+        """
+        SELECT
+            (SELECT array_agg((game_id, home_postgame_elo)::text ORDER BY game_id)
+             FROM analytics.house_elo_game),
+            (SELECT array_agg((game_id, home_postgame_elo)::text ORDER BY game_id)
+             FROM marts.house_elo_game),
+            (SELECT array_agg((team, rating)::text ORDER BY team)
+             FROM analytics.house_elo_current),
+            (SELECT array_agg((asset_key, generation_id)::text ORDER BY asset_key)
+             FROM meta.asset_current_generations),
+            (SELECT count(*) FROM meta.asset_receipts),
+            (SELECT count(*) FROM meta.asset_receipt_inputs)
+        """,
+    )[0]
+
+
+def visible_state_without_mart(conn):
+    return query(
+        conn,
+        """
+        SELECT
+            (SELECT array_agg((game_id, home_postgame_elo)::text ORDER BY game_id)
+             FROM analytics.house_elo_game),
+            (SELECT array_agg((team, rating)::text ORDER BY team)
+             FROM analytics.house_elo_current),
+            (SELECT array_agg((asset_key, generation_id)::text ORDER BY asset_key)
+             FROM meta.asset_current_generations),
+            (SELECT count(*) FROM meta.asset_receipts),
+            (SELECT count(*) FROM meta.asset_receipt_inputs)
+        """,
+    )[0]
+
+
+def test_migration_is_idempotent_private_and_publisher_role_is_bounded(publication_db):
+    conn, _ = publication_db
+    assert query(
+        conn,
+        """
+        SELECT rolcanlogin, rolinherit, rolsuper, rolcreatedb, rolcreaterole,
+            rolreplication, rolbypassrls
+        FROM pg_roles WHERE rolname='warehouse_publisher'
+        """,
+    ) == [(False, False, False, False, False, False, False)]
+
+    for role in ("anon", "authenticated", "analyst_ro", "publication_bystander"):
+        assert query(
+            conn,
+            """
+            SELECT has_schema_privilege(%s, 'warehouse_publication', 'USAGE,CREATE'),
+                has_table_privilege(%s, 'meta.asset_receipts',
+                    'SELECT,INSERT,UPDATE,DELETE,TRUNCATE'),
+                has_table_privilege(%s, 'meta.asset_current_generations',
+                    'SELECT,INSERT,UPDATE,DELETE,TRUNCATE'),
+                has_function_privilege(%s,
+                    'warehouse_publication.get_house_elo_state(bigint,bigint)', 'EXECUTE')
+            """,
+            (role, role, role, role),
+        ) == [(False, False, False, False)]
+
+    assert query(
+        conn,
+        """
+        SELECT has_schema_privilege('warehouse_publisher','warehouse_publication','USAGE'),
+            has_schema_privilege('warehouse_publisher','warehouse_publication','CREATE'),
+            has_table_privilege('warehouse_publisher','meta.asset_receipts','SELECT,INSERT'),
+            has_function_privilege('warehouse_publisher',
+                'warehouse_publication.publish_house_elo(uuid,uuid,uuid,uuid,uuid,text,jsonb,jsonb,bigint,bigint,bigint[])',
+                'EXECUTE')
+        """,
+    ) == [(True, False, False, True)]
+    for role, statement in (
+        ("anon", "SELECT * FROM warehouse_publication.get_house_elo_state(1869,2025)"),
+        ("warehouse_publisher", "INSERT INTO meta.asset_receipts DEFAULT VALUES"),
+        ("warehouse_publisher", "DELETE FROM meta.asset_current_generations"),
+    ):
+        with conn.cursor() as cur:
+            cur.execute(f"SET LOCAL ROLE {role}")
+            with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+                cur.execute(statement)
+        conn.rollback()
+
+
+def test_publication_data_receipts_dependencies_and_pointers_commit_atomically(publication_db):
+    conn, target = publication_db
+    first = publication_args(conn)
+    result = publish(conn, first)
+    assert result[0:3] == (first[1], first[2], False)
+    assert result[3:] == (1, 1)
+    committed = current_snapshot(conn)
+    assert committed[4:] == (2, 1)
+    assert query(
+        conn,
+        """
+        SELECT child.asset_key,parent.asset_key
+        FROM meta.asset_receipt_inputs edge
+        JOIN meta.asset_receipts child ON child.generation_id=edge.generation_id
+        JOIN meta.asset_receipts parent ON parent.generation_id=edge.input_generation_id
+        """,
+    ) == [("marts.house_elo_game", "analytics.house_elo_game")]
+    assert query(
+        conn,
+        """
+        SELECT count(*)
+        FROM meta.asset_current_generations pointer
+        JOIN meta.asset_receipts receipt USING (asset_key,coverage_key,generation_id)
+        WHERE receipt.outcome='succeeded'
+          AND receipt.coverage->'complete'='true'::jsonb
+        """,
+    ) == [(2,)]
+    committed_visible = visible_state_without_mart(conn)
+
+    observer = psycopg2.connect(target)
+    second = publication_args(conn, expected=state(conn), postgame=1524.0)
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SET LOCAL ROLE warehouse_publisher")
+            cur.execute(PUBLISH_SQL, second)
+            assert cur.fetchone()[2] is False
+        # REFRESH holds AccessExclusive on the mart until transaction end, so
+        # inspect the independently readable source, snapshot and metadata.
+        assert visible_state_without_mart(observer) == committed_visible
+        conn.rollback()
+        assert current_snapshot(observer) == committed
+
+        with conn.cursor() as cur:
+            cur.execute("SET LOCAL ROLE warehouse_publisher")
+            cur.execute(PUBLISH_SQL, second)
+            cur.fetchone()
+            with pytest.raises(psycopg2.errors.DivisionByZero):
+                cur.execute("SELECT 1/0")
+        conn.rollback()
+        assert current_snapshot(observer) == committed
+    finally:
+        observer.close()
+
+
+def test_python_full_publication_serializes_and_finishes_one_operation(publication_db):
+    from scripts.compute_house_elo import run_full_published
+
+    conn, _ = publication_db
+    rows = run_full_published(conn)
+    assert len(rows) == 1
+    assert rows[0]["game_id"] == 101
+    assert query(
+        conn,
+        "SELECT game_id FROM analytics.house_elo_game ORDER BY game_id",
+    ) == [(101,)]
+    assert query(
+        conn,
+        "SELECT game_id FROM marts.house_elo_game ORDER BY game_id",
+    ) == [(101,)]
+    assert query(
+        conn,
+        """
+        SELECT operation_kind,outcome,error_summary
+        FROM meta.operation_runs ORDER BY started_at
+        """,
+    ) == [("compute", "succeeded", None)]
+    assert query(
+        conn,
+        """
+        SELECT count(*), count(*) FILTER (WHERE outcome='succeeded')
+        FROM meta.asset_receipts
+        """,
+    ) == [(2, 2)]
+    assert query(conn, "SELECT count(*) FROM meta.asset_receipt_inputs") == [(1,)]
+    assert query(conn, "SELECT count(*) FROM meta.asset_current_generations") == [(2,)]
+
+
+def test_concurrent_compare_and_swap_has_one_winner_and_no_loser_receipts(publication_db):
+    conn, target = publication_db
+    expected = state(conn)
+    args = [
+        publication_args(conn, expected=expected, postgame=1518.0),
+        publication_args(conn, expected=expected, postgame=1522.0),
+    ]
+
+    def contender(call_args):
+        other = psycopg2.connect(target)
+        try:
+            try:
+                return ("ok", publisher_query(other, PUBLISH_SQL, call_args)[0])
+            except psycopg2.Error as exc:
+                other.rollback()
+                return ("error", str(exc))
+        finally:
+            other.close()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(contender, args))
+    assert sorted(result[0] for result in results) == ["error", "ok"]
+    assert "changed" in next(result[1] for result in results if result[0] == "error").lower()
+    assert query(conn, "SELECT count(*) FROM meta.asset_receipts") == [(2,)]
+    assert query(conn, "SELECT count(*) FROM meta.asset_current_generations") == [(2,)]
+
+
+def test_unfinished_schedule_change_changes_digest_and_rejects_stale_publication(publication_db):
+    conn, _ = publication_db
+    before = state(conn)
+    args = publication_args(conn, expected=before)
+    query(
+        conn,
+        """
+        UPDATE core.games
+        SET week=3, start_date='2025-09-13 19:30:00+00', start_time_tbd=true
+        WHERE id=102
+        """,
+    )
+    after = state(conn)
+    assert after[2] != before[2]
+    with pytest.raises(psycopg2.Error, match=r"core\.games changed|digest"):
+        publish(conn, args)
+    conn.rollback()
+    assert query(conn, "SELECT count(*) FROM meta.asset_receipts") == [(0,)]
+    assert query(conn, "SELECT count(*) FROM meta.asset_current_generations") == [(0,)]
+
+
+def test_committed_correction_while_publisher_waits_on_source_lock_is_detected(
+    publication_db,
+):
+    conn, target = publication_db
+    args = publication_args(conn)
+    writer = psycopg2.connect(target)
+    started = Event()
+    pool = ThreadPoolExecutor(max_workers=1)
+
+    def waiting_publisher():
+        other = psycopg2.connect(target, application_name="receipt-digest-waiter")
+        try:
+            started.set()
+            try:
+                publisher_query(other, PUBLISH_SQL, args)
+                return ("ok", "")
+            except psycopg2.Error as exc:
+                other.rollback()
+                return ("error", str(exc))
+        finally:
+            other.close()
+
+    try:
+        with writer.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE core.games
+                SET week=4, start_date='2025-09-20 20:00:00+00', start_time_tbd=true
+                WHERE id=102
+                """
+            )
+        future = pool.submit(waiting_publisher)
+        assert started.wait(timeout=5)
+        deadline = monotonic() + 5
+        while monotonic() < deadline:
+            blocked = query(
+                conn,
+                """
+                SELECT wait_event_type='Lock'
+                FROM pg_stat_activity
+                WHERE application_name='receipt-digest-waiter'
+                  AND state='active'
+                """,
+            )
+            if blocked == [(True,)]:
+                break
+            sleep(0.02)
+        else:
+            pytest.fail("publisher never waited for the core.games table lock")
+        writer.commit()
+        status, detail = future.result(timeout=10)
+        assert status == "error"
+        assert "core.games" in detail.lower() and "changed" in detail.lower()
+    finally:
+        writer.rollback()
+        writer.close()
+        pool.shutdown(wait=True)
+    assert query(conn, "SELECT count(*) FROM meta.asset_receipts") == [(0,)]
+    assert query(conn, "SELECT count(*) FROM meta.asset_current_generations") == [(0,)]
+
+
+def test_expected_no_data_atomically_clears_outputs_and_advances_eligible_pointers(
+    publication_db,
+):
+    conn, _ = publication_db
+    publish(conn, publication_args(conn))
+    query(conn, "UPDATE core.games SET completed=false, home_points=NULL, away_points=NULL")
+    expected = state(conn)
+    args = list(publication_args(conn, expected=expected))
+    args[6] = "[]"
+    args[7] = "[]"
+    result = publish(conn, tuple(args))
+    assert result[2:] == (False, 0, 0)
+    assert query(conn, "SELECT count(*) FROM analytics.house_elo_game") == [(0,)]
+    assert query(conn, "SELECT count(*) FROM analytics.house_elo_current") == [(0,)]
+    assert query(conn, "SELECT count(*) FROM marts.house_elo_game") == [(0,)]
+    assert query(
+        conn,
+        """
+        SELECT receipt.outcome,receipt.coverage->>'complete'
+        FROM meta.asset_current_generations pointer
+        JOIN meta.asset_receipts receipt USING(asset_key,coverage_key,generation_id)
+        ORDER BY receipt.asset_key
+        """,
+    ) == [("expected_no_data", "true"), ("expected_no_data", "true")]
+
+
+@pytest.mark.parametrize("malformation", ["missing", "duplicate", "required_null"])
+def test_malformed_or_incomplete_payload_cannot_publish(publication_db, malformation):
+    conn, _ = publication_db
+    args = list(publication_args(conn))
+    rows = game_rows()
+    if malformation == "missing":
+        rows = []
+    elif malformation == "duplicate":
+        rows = rows * 2
+    else:
+        rows[0]["home_team"] = None
+    args[6] = json.dumps(rows)
+    with pytest.raises(psycopg2.Error):
+        publish(conn, tuple(args))
+    conn.rollback()
+    assert query(conn, "SELECT count(*) FROM meta.asset_receipts") == [(0,)]
+    assert query(conn, "SELECT count(*) FROM meta.asset_current_generations") == [(0,)]
+    assert query(conn, "SELECT count(*) FROM analytics.house_elo_game") == [(0,)]
+
+
+def test_publisher_rejects_non_read_committed_transaction(publication_db):
+    conn, _ = publication_db
+    args = publication_args(conn)
+    with conn.cursor() as cur:
+        cur.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ")
+        cur.execute("SET LOCAL ROLE warehouse_publisher")
+        with pytest.raises(psycopg2.Error, match="READ COMMITTED|isolation"):
+            cur.execute(PUBLISH_SQL, args)
+    conn.rollback()
+    assert query(conn, "SELECT count(*) FROM meta.asset_receipts") == [(0,)]
+
+
+def test_exact_replay_does_not_repoint_after_a_newer_publication(publication_db):
+    conn, _ = publication_db
+    first = publication_args(conn)
+    first_result = publish(conn, first)
+    second = publication_args(conn, expected=state(conn), postgame=1524.0)
+    second_result = publish(conn, second)
+    pointers = query(
+        conn,
+        "SELECT asset_key,generation_id FROM meta.asset_current_generations ORDER BY asset_key",
+    )
+
+    replay = publish(conn, first)
+    assert replay[0:2] == first_result[0:2]
+    assert replay[2] is True
+    assert replay[3:] == (1, 1)
+    assert (
+        query(
+            conn,
+            "SELECT asset_key,generation_id FROM meta.asset_current_generations ORDER BY asset_key",
+        )
+        == pointers
+    )
+    assert pointers == [
+        ("analytics.house_elo_game", second_result[0]),
+        ("marts.house_elo_game", second_result[1]),
+    ]
+    assert query(conn, "SELECT count(*) FROM meta.asset_receipts") == [(4,)]
+
+
+def test_legacy_dml_invalidates_dependents_and_refresh_invalidates_the_mart(publication_db):
+    conn, _ = publication_db
+    publish(conn, publication_args(conn))
+
+    query(conn, "UPDATE analytics.house_elo_game SET home_postgame_elo=1600")
+    assert query(conn, "SELECT count(*) FROM meta.asset_current_generations") == [(0,)]
+
+    publish(conn, publication_args(conn, expected=state(conn), postgame=1519.0))
+    query(conn, "REFRESH MATERIALIZED VIEW marts.house_elo_game")
+    assert query(
+        conn, "SELECT asset_key FROM meta.asset_current_generations ORDER BY asset_key"
+    ) == [("analytics.house_elo_game",)]
+
+    publish(conn, publication_args(conn, expected=state(conn), postgame=1520.0))
+    query(conn, "REFRESH MATERIALIZED VIEW CONCURRENTLY marts.house_elo_game")
+    assert query(
+        conn, "SELECT asset_key FROM meta.asset_current_generations ORDER BY asset_key"
+    ) == [("analytics.house_elo_game",)]
+
+    query(conn, "TRUNCATE analytics.house_elo_game")
+    assert query(conn, "SELECT count(*) FROM meta.asset_current_generations") == [(0,)]
+
+
+def test_ddl_invalidation_and_disabled_source_guard_fail_closed(publication_db):
+    conn, _ = publication_db
+    publish(conn, publication_args(conn))
+    query(conn, "ALTER MATERIALIZED VIEW marts.house_elo_game RENAME TO house_elo_game_moved")
+    assert query(
+        conn, "SELECT asset_key FROM meta.asset_current_generations ORDER BY asset_key"
+    ) == [("analytics.house_elo_game",)]
+    query(conn, "ALTER MATERIALIZED VIEW marts.house_elo_game_moved RENAME TO house_elo_game")
+
+    query(conn, "ALTER TABLE analytics.house_elo_game DISABLE TRIGGER USER")
+    assert query(conn, "SELECT count(*) FROM meta.asset_current_generations") == [(0,)]
+    with pytest.raises(psycopg2.Error, match="trigger|guard|invalidation"):
+        publish(conn, publication_args(conn, expected=state(conn), postgame=1521.0))
+    conn.rollback()
+    assert query(conn, "SELECT count(*) FROM meta.asset_receipts") == [(2,)]
+    assert query(conn, "SELECT count(*) FROM meta.asset_current_generations") == [(0,)]
+
+
+def test_failed_receipts_are_append_only_and_never_advance_pointers(publication_db):
+    conn, _ = publication_db
+    run_id = start_run(conn)
+    source_generation = uuid.uuid4()
+    mart_generation = uuid.uuid4()
+    statement = """
+        SELECT * FROM warehouse_publication.record_house_elo_failure(%s,%s,%s,%s,%s)
+    """
+    values = (
+        str(run_id),
+        str(source_generation),
+        str(mart_generation),
+        "failed",
+        "publication_failed",
+    )
+    first = publisher_query(conn, statement, values)[0]
+    replay = publisher_query(conn, statement, values)[0]
+    assert first == (str(source_generation), str(mart_generation), False)
+    assert replay == (str(source_generation), str(mart_generation), True)
+    assert query(
+        conn,
+        "SELECT asset_key,outcome,error_summary FROM meta.asset_receipts ORDER BY asset_key",
+    ) == [
+        ("analytics.house_elo_game", "failed", "publication_failed"),
+        ("marts.house_elo_game", "failed", "publication_failed"),
+    ]
+    assert query(conn, "SELECT count(*) FROM meta.asset_current_generations") == [(0,)]
+
+    with pytest.raises(psycopg2.Error, match="eligible|successful|current"):
+        query(
+            conn,
+            """
+            INSERT INTO meta.asset_current_generations(asset_key,generation_id)
+            VALUES ('analytics.house_elo_game', %s)
+            """,
+            (str(source_generation),),
+        )
+    conn.rollback()
+
+    for command in (
+        "UPDATE meta.asset_receipts SET error_summary='rewritten'",
+        "DELETE FROM meta.asset_receipts",
+        "TRUNCATE meta.asset_receipts CASCADE",
+    ):
+        with pytest.raises(psycopg2.Error, match="append-only|cannot be"):
+            query(conn, command)
+        conn.rollback()
+
+
+@pytest.mark.parametrize(
+    ("schema", "remaining"),
+    [("analytics", []), ("marts", [("analytics.house_elo_game",)])],
+)
+def test_schema_rename_invalidates_canonical_asset_pointers(publication_db, schema, remaining):
+    conn, _ = publication_db
+    publish(conn, publication_args(conn))
+    query(conn, f"ALTER SCHEMA {schema} RENAME TO renamed_{schema}")
+    assert (
+        query(conn, "SELECT asset_key FROM meta.asset_current_generations ORDER BY asset_key")
+        == remaining
+    )
+    assert query(conn, "SELECT count(*) FROM meta.asset_receipts") == [(2,)]
+
+
+def test_refresh_queued_before_publication_commit_invalidates_the_new_mart_pointer(publication_db):
+    conn, target = publication_db
+    args = publication_args(conn)
+    observer = psycopg2.connect(target)
+    pool = ThreadPoolExecutor(max_workers=1)
+
+    def refresh():
+        other = psycopg2.connect(target, application_name="receipt-refresh-waiter")
+        try:
+            query(other, "SET statement_timeout='10s'")
+            query(other, "REFRESH MATERIALIZED VIEW marts.house_elo_game")
+        finally:
+            other.close()
+
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SET LOCAL ROLE warehouse_publisher")
+            cur.execute(PUBLISH_SQL, args)
+            cur.fetchone()
+        future = pool.submit(refresh)
+        deadline = monotonic() + 5
+        while monotonic() < deadline:
+            waiting = query(
+                observer,
+                "SELECT wait_event_type='Lock' FROM pg_stat_activity "
+                "WHERE datname=current_database() AND application_name='receipt-refresh-waiter'",
+            )
+            if waiting == [(True,)]:
+                break
+            sleep(0.02)
+        else:
+            pytest.fail("legacy refresh did not wait on the publishing transaction")
+        conn.commit()
+        future.result(timeout=10)
+        assert query(
+            observer, "SELECT asset_key FROM meta.asset_current_generations ORDER BY asset_key"
+        ) == [("analytics.house_elo_game",)]
+        assert query(observer, "SELECT count(*) FROM meta.asset_receipts") == [(2,)]
+    finally:
+        conn.rollback()
+        pool.shutdown(wait=True)
+        observer.close()
+
+
+def test_administrator_clears_pointers_before_disabling_event_guard(publication_db):
+    conn, _ = publication_db
+    publish(conn, publication_args(conn))
+    query(conn, "DELETE FROM meta.asset_current_generations")
+    query(conn, "ALTER EVENT TRIGGER warehouse_publication_invalidate_ddl DISABLE")
+    args = publication_args(conn)
+    with pytest.raises(psycopg2.Error, match="guard"):
+        publish(conn, args)
+    conn.rollback()
+    assert query(conn, "SELECT count(*) FROM meta.asset_receipts") == [(2,)]
+    assert query(conn, "SELECT count(*) FROM meta.asset_current_generations") == [(0,)]

--- a/tests/test_house_elo_publication.py
+++ b/tests/test_house_elo_publication.py
@@ -1,0 +1,135 @@
+"""Opt-in Elo producer ordering and commit-uncertainty behavior."""
+
+from datetime import UTC, datetime
+from unittest.mock import Mock
+
+import pytest
+
+from scripts import compute_house_elo as elo
+
+
+class Connection:
+    def __init__(self, *, fail_publish=False, fail_commit=False):
+        self.events = []
+        self.commits = 0
+        self.fail_publish = fail_publish
+        self.fail_commit = fail_commit
+        self.publication = None
+
+    def cursor(self):
+        return Cursor(self)
+
+    def commit(self):
+        self.commits += 1
+        self.events.append(("commit", self.commits))
+        if self.fail_commit and self.commits == 3:
+            raise OSError("sensitive connection details")
+
+    def rollback(self):
+        self.events.append(("rollback", None))
+
+
+class Cursor:
+    def __init__(self, conn):
+        self.conn = conn
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+    def execute(self, statement, args=None):
+        self.conn.events.append((statement, args))
+        if "publish_house_elo(" in statement:
+            self.conn.publication = args
+            if self.conn.fail_publish:
+                raise ValueError("sensitive server error")
+
+    def fetchone(self):
+        return (None, None, "fixture-digest")
+
+
+@pytest.fixture
+def inputs(monkeypatch):
+    game = {
+        "id": 1,
+        "season": 2026,
+        "week": 1,
+        "season_type": "regular",
+        "start_date": datetime(2026, 9, 1, tzinfo=UTC),
+        "neutral_site": False,
+        "home_team": "A",
+        "away_team": "B",
+        "home_points": 28,
+        "away_points": 14,
+        "home_pregame_elo": None,
+        "away_pregame_elo": None,
+    }
+    monkeypatch.setattr(elo, "fetch_max_season", lambda conn: 2026)
+    monkeypatch.setattr(elo, "load_games_by_season", lambda *args: {2026: [game]})
+    monkeypatch.setattr(elo, "fetch_scheduled_counts", lambda *args: {2026: {"A": 12, "B": 12}})
+    return game
+
+
+def test_full_publication_matches_legacy_engine_and_snapshot(inputs, monkeypatch):
+    legacy_seasons, legacy_snapshots = [], []
+    monkeypatch.setattr(elo, "write_season", lambda conn, season, rows: legacy_seasons.extend(rows))
+    monkeypatch.setattr(elo, "write_snapshot", lambda conn, rows: legacy_snapshots.extend(rows))
+    expected = elo.run_full(None, 1869, 2026)
+    conn = Connection()
+    assert elo.run_full_published(conn) == expected == legacy_seasons
+    args = conn.publication
+    assert args[6].adapted == expected
+    assert args[7].adapted == legacy_snapshots
+    assert b"2026-09-01T00:00:00+00:00" in args[6].getquoted()
+    statements = [event[0] for event in conn.events]
+    repeatable = statements.index("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ")
+    fresh = statements.index("SET TRANSACTION ISOLATION LEVEL READ COMMITTED")
+    assert "commit" in statements[repeatable:fresh]
+    assert conn.commits == 3
+    assert not any("record_house_elo_failure" in str(statement) for statement in statements)
+
+
+def test_known_failure_rolls_back_then_records_failure(inputs):
+    conn = Connection(fail_publish=True)
+    with pytest.raises(elo.PublicationError, match="publication failed") as error:
+        elo.run_full_published(conn)
+    assert "sensitive" not in str(error.value)
+    statements = [event[0] for event in conn.events]
+    failure = next(
+        i for i, statement in enumerate(statements) if "record_house_elo_failure" in statement
+    )
+    assert statements.index("rollback") < failure
+    assert conn.commits == 3
+
+
+def test_lost_commit_acknowledgement_never_records_contradictory_failure(inputs):
+    conn = Connection(fail_commit=True)
+    with pytest.raises(elo.PublicationError, match="inspect receipt IDs") as error:
+        elo.run_full_published(conn)
+    assert "sensitive" not in str(error.value)
+    assert not any("record_house_elo_failure" in str(event) for event in conn.events)
+    assert conn.commits == 3
+
+
+def test_empty_full_input_publishes_explicit_empty_replacement(inputs, monkeypatch):
+    monkeypatch.setattr(elo, "fetch_max_season", lambda conn: None)
+    monkeypatch.setattr(elo, "load_games_by_season", lambda *args: {})
+    conn = Connection()
+    assert elo.run_full_published(conn) == []
+    assert conn.publication[6].adapted == conn.publication[7].adapted == []
+    assert conn.publication[8:10] == (1869, 1869)
+
+
+@pytest.mark.parametrize("mode", [["--incremental"], ["--season", "2026"]])
+def test_partial_modes_cannot_opt_in_before_connecting(monkeypatch, mode):
+    import psycopg2
+
+    connect = Mock()
+    monkeypatch.setattr(psycopg2, "connect", connect)
+    monkeypatch.setattr("sys.argv", ["compute_house_elo.py", *mode, "--publish-receipts"])
+    with pytest.raises(SystemExit) as error:
+        elo.main()
+    assert error.value.code == 2
+    connect.assert_not_called()

--- a/tests/test_warehouse_bootstrap_sql.py
+++ b/tests/test_warehouse_bootstrap_sql.py
@@ -127,6 +127,9 @@ def _assert_catalog_shape(conn):
     # F14 adds three private tables and six indexes; keep baseline evidence immutable.
     expected_counts[("meta", "r")] += 3
     expected_counts[("meta", "i")] += 6
+    # The bounded house-Elo publication ledger adds four tables and nine indexes.
+    expected_counts[("meta", "r")] += 4
+    expected_counts[("meta", "i")] += 9
     assert query(
         conn,
         """
@@ -382,7 +385,7 @@ def test_managed_warehouse_catalog_data_and_access(
         _insert_representative_rows(conn)
         before_upgrade = _fixture_snapshot(conn)
         upgrade = apply_manifest(conn, manifest, mode="upgrade")
-        assert len(upgrade.pending) == 4
+        assert len(upgrade.pending) == 5
         assert [step.id for step in upgrade.pending] == [
             migration.id for migration in manifest.migrations[4:]
         ]


### PR DESCRIPTION
Full Elo runs currently write season batches and refresh their mart separately, so a successful compute run cannot identify one atomic publication. Add opt-in `--full --publish-receipts` to commit the game output, current-team snapshot, mart refresh, private receipts, dependency edge, and current-generation pointers together.

Migration 068 introduces a bounded publisher role and append-only evidence for `analytics.house_elo_game → marts.house_elo_game`. Publication revalidates the complete prepared input after acquiring locks, rejects stale generations and incomplete output, and supports replay without repointing old receipts. Legacy writes and relevant DDL invalidate current evidence; failures and uncertain commit acknowledgements cannot manufacture success. Scoped lifecycle wrappers restrict the publisher to its own Elo runs, and reviewed replacement pairs must match before coverage is complete. Existing workflows remain on their current path.

Validation:

- Final review-fix verification: **61 passed**, including Elo producer tests, 33 executed PostgreSQL publication cases and both fresh/upgrade bootstrap paths.
- Independent review findings resolved; Ruff and diff checks pass.

Prepared only: production migration, runtime role membership and workflow activation require a separate rollout. Full-history lock duration and production permissions are unmeasured. Completed games missing scores must be repaired before this mode can claim complete coverage. Trusted administrators must clear pointers before disabling protocol guards.

See [publication semantics and rollout](https://github.com/rstover-fo/cfb-database/blob/bd601f862391cc47f6513fa1452d9c8fb010d285/docs/plans/2026-09-09-f14-publication-receipts.md).





<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62049217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/formentera-operations/-/pull-requests/rstover-fo/cfb-database/140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Merge-safe: no outstanding issues require changes before merging.

<details><summary><h3>Summary</h3></summary>

- Computes House Elo from a repeatable-read snapshot, then revalidates the source under locks before publication.
- Commits game history, the current-team snapshot, the refreshed mart, immutable receipts, dependency evidence, generation pointers, and operation completion together.
- Introduces a bounded publisher role with scoped lifecycle and publication RPCs, plus DML and DDL invalidation guards.
- Adds manifest entries, operational documentation, CI coverage, and PostgreSQL integration tests for publication, replay, failure, access, and bootstrap behavior.
</details>

<!-- /greptile_comment -->