### PR TITLE
Add receipt-backed query-time freshness compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - run: ./scripts/setup_dev.sh
       - name: Managed bootstrap and upgrade integration
-        run: .venv/bin/python -m pytest tests/test_warehouse_migrations_sql.py tests/test_warehouse_bootstrap_sql.py tests/test_adopt_warehouse_catalog_sql.py tests/test_f06_verification_transactions_sql.py tests/test_mart_release_sql.py tests/test_play_partitions.py tests/test_play_indexes_sql.py tests/test_operational_quota_sql.py tests/test_operational_quota_lifecycle_sql.py tests/test_cfbd_transport_admission_sql.py tests/test_asset_publication_sql.py -q --tb=short
+        run: .venv/bin/python -m pytest tests/test_warehouse_migrations_sql.py tests/test_warehouse_bootstrap_sql.py tests/test_adopt_warehouse_catalog_sql.py tests/test_f06_verification_transactions_sql.py tests/test_mart_release_sql.py tests/test_play_partitions.py tests/test_play_indexes_sql.py tests/test_operational_quota_sql.py tests/test_operational_quota_lifecycle_sql.py tests/test_cfbd_transport_admission_sql.py tests/test_asset_publication_sql.py tests/test_asset_freshness_sql.py -q --tb=short
         env:
           F06_TEST_DB_URL: postgresql://postgres:f06-disposable-ci@127.0.0.1:5432/postgres
           F06_REQUIRE_DB: "1"

--- a/docs/SCHEMA_CONTRACT.md
+++ b/docs/SCHEMA_CONTRACT.md
@@ -4,7 +4,7 @@
 > only depend on objects listed here as **public**. Everything else is internal and may change
 > without notice.
 
-Last updated: 2026-09-07
+Last updated: 2026-09-09
 
 > **Note on cfb-analytics:** the retired OU-only app (rstover-fo/cfb-analytics) was never a
 > warehouse consumer -- it ran its own DuckDB ingestion. Its unique features (rivals page,
@@ -14,6 +14,15 @@ Last updated: 2026-09-07
 ---
 
 ## Recent Contract Changes
+
+- **2026-09-09 — F19 receipt freshness (prepared, not deployed).**
+  Migration `069_receipt_backed_freshness.sql` adds the separate
+  `public.get_asset_freshness()` RPC for the two controlled house Elo assets.
+  It exposes query-time publication age and exact recorded dependency evidence,
+  with NULL cadence/stale policy until declared. Unversioned `core.games`
+  prevents a complete upstream freshness claim. The existing six-column
+  `get_data_freshness()` RPC and its maintenance heuristic remain compatible.
+  See the [receipt freshness contract and rollout](plans/2026-09-09-f19-receipt-freshness.md).
 
 - **2026-09-07 — F06 managed bootstrap and explicit production adoption.**
   `src/schemas/warehouse-manifest.json` reconstructs the reviewed catalog and
@@ -1111,8 +1120,33 @@ Server-side functions callable via `supabase.rpc()`.
 | `get_available_weeks` | `public` | `(p_season)` | List of weeks for a given season |
 | `is_garbage_time` | `public` | `(period, score_diff)` | Returns true if play is in garbage time |
 | `get_conference_head_to_head` | `public` | `(p_conf1, p_conf2, p_season_start?, p_season_end?)` | Conference vs conference head-to-head records by season. Flips results to match caller's conference order. |
-| `get_data_freshness` | `public` | `()` | Returns data freshness status for all tracked tables. Useful for cfb-app "data last updated" indicators. |
+| `get_data_freshness` | `public` | `()` | Legacy six-column maintenance heuristic for 24 tracked tables; vacuum/analyze activity does not prove publication freshness. Existing cfb-app/MCP contract preserved. |
+| `get_asset_freshness` | `public` | `()` | **Prepared, not deployed.** Query-time publication evidence for the two source-wide house Elo assets; see the contract below. |
 | `run_analyst_query` | `public` | `(query_sql text)` | Guarded free-form read-only SQL for the cfb-app MCP `run_sql` tool (added 2026-07-22). Single SELECT/WITH statement only; executes as the `analyst_ro` role (SELECT on `api` schema only, read-only transaction); rows hard-capped at 200; returns a `jsonb` array. Timeout is enforced by the calling role's Supabase statement_timeout, not in-function. Defined in `src/schemas/public/012_run_analyst_query.sql`. |
+
+### Receipt freshness compatibility (prepared, not deployed)
+
+`public.get_asset_freshness()` returns one row per `asset_key, coverage_key` for
+`analytics.house_elo_game` and `marts.house_elo_game` (`source-wide`). It is an
+invoker RPC over an ordinary owner-rights view, with SELECT/EXECUTE granted to
+`anon` and `authenticated`. Consumers receive no private ledger/policy access.
+
+| Fields | Meaning |
+|---|---|
+| `asset_key`, `coverage_key` | Stable asset identity and receipt grain. |
+| `generation_id`, `published_at`, `current_outcome`, `coverage`, `row_delta` | Exact current complete receipt only; absent pointers do not fall back to historic successes. `expected_no_data` is evaluated empty coverage. |
+| `age_seconds`, `expected_refresh_interval`, `is_stale` | Statement-time age as numeric seconds; nullable interval and nullable age-based stale flag. No declared interval or no current publication means unknown, not fresh. |
+| `publication_state` | `unrecorded`, `unpublished` (history exists but no current pointer), or `current`. |
+| `source_watermark` | For these producers, opaque `core.games` input digest; not a provider timestamp. |
+| `required_input_generations`, `recorded_inputs_current` | Recorded mart-to-source generation comparison; source/no-current input comparison is NULL. A missing or mismatched required mart edge is false. |
+| `input_closure_current`, `unversioned_input_assets` | Closure is unknown because `core.games` is unversioned, or false for a known broken mart edge. Never claims complete provider freshness. |
+| `latest_outcome`, `latest_recorded_at` | Latest attempt diagnostic; does not select current data. |
+| `last_failure_at`, `last_failure_outcome`, `last_failure_category` | Most recent failed/partial/deferred/blocked receipt, retained after recovery. Category is allowlisted; raw errors and operation scopes are private. |
+
+The private `meta.asset_freshness_policies` table stores optional positive
+publication intervals. Neither runtime policy configuration nor workflow
+activation is part of applying the prepared code. See the
+[implementation and rollout limits](plans/2026-09-09-f19-receipt-freshness.md).
 
 ### Reference Tables (Direct Access Allowed)
 

--- a/docs/plans/2026-09-04-main-codebase-audit.md
+++ b/docs/plans/2026-09-04-main-codebase-audit.md
@@ -332,6 +332,13 @@ Evidence: [flat-file retry loop](https://github.com/rstover-fo/cfb-database/blob
 
 **P1 for trustworthy monitoring · Confirmed · M/L**
 
+**Implementation progress (2026-09-09):** the receipt compatibility slice is
+prepared in migration 069: query-time publication age, separate failure evidence,
+recorded house Elo dependency checks, and incremental verifier adoption. The
+legacy six-column RPC remains compatible. This does not close F19: the remaining
+sources still need receipts, cadence declarations, generation enforcement, and
+consumer cutover. See the [bounded implementation](2026-09-09-f19-receipt-freshness.md).
+
 The freshness mart infers loading from vacuum/analyze timestamps, with a server-start fallback. Maintenance can occur without fresh source data, and fresh ingestion need not immediately trigger maintenance. More fundamentally, days-since-activity and is_stale are stored in a materialized view: if the refresher stops, their values stop aging. The tracked-table list also trails the expanding source surface. Existing load verification does not consistently prove that outputs belong to the latest required generation.
 
 Evidence: [freshness definition](https://github.com/rstover-fo/cfb-database/blob/4a798fde40480ac01d60a4d08c9c4eba42bed2c2/src/schemas/marts/028_data_freshness.sql#L65), [cached age/status](https://github.com/rstover-fo/cfb-database/blob/4a798fde40480ac01d60a4d08c9c4eba42bed2c2/src/schemas/marts/028_data_freshness.sql#L108), [load verification](https://github.com/rstover-fo/cfb-database/blob/4a798fde40480ac01d60a4d08c9c4eba42bed2c2/scripts/verify_load.py).

--- a/docs/plans/2026-09-09-f19-receipt-freshness.md
+++ b/docs/plans/2026-09-09-f19-receipt-freshness.md
@@ -1,0 +1,93 @@
+# F19: receipt-backed freshness compatibility
+
+Status: prepared implementation, not a production rollout. This is delivery
+step 5 after the controlled house Elo publication receipts in migration 068.
+
+## Scope and compatibility
+
+Migration `069_receipt_backed_freshness.sql` adds a query-time receipt surface
+for exactly `analytics.house_elo_game` and `marts.house_elo_game`, each at
+`source-wide` grain. `public.get_asset_freshness()` exposes a safe projection
+through the ordinary owner-rights `marts.asset_receipt_freshness` view.
+
+The existing `public.get_data_freshness()` six-column RPC and its underlying
+`marts.data_freshness` materialized view remain compatible. The app's dashboard,
+sidebar and MCP mappings, and this repository's MCP tool, consume that older
+shape. Its vacuum/analyze statistics are maintenance heuristics; neither the
+old RPC nor its 24 tracked tables acquires receipt evidence through this change.
+Consumers can adopt the new RPC separately without a breaking cutover.
+
+## Evidence semantics
+
+Only an exact current pointer joined to a complete successful or evaluated
+`expected_no_data` receipt establishes a current publication. Historical
+successes are not substituted when a pointer is absent. A later failed,
+partial, blocked or deferred attempt remains separate diagnostic evidence and
+does not replace the current generation. No receipt is distinct from no data.
+
+Publication age uses the start of the current SQL statement, so it advances
+between queries, including within a long-running transaction, without refreshing
+any materialized view. Receipt timestamps describe an observation inside the
+publishing transaction, not its exact commit time. Transaction isolation still
+determines which committed generation the statement can observe.
+
+No publication cadence has been declared for this opt-in producer. Initial
+expected intervals and age-based stale results are therefore NULL. An owner can
+set a positive interval in the private policy table during a reviewed rollout;
+reapplying the migration preserves that policy. A missing pointer has no age and
+no age-based stale result. Publication state and dependency status convey that
+absence independently.
+
+The mart records the exact house Elo source generation it consumed. Its
+recorded-input comparison can establish whether that generation is still
+current, or identify a missing/mismatched dependency. The source has no
+versioned input edge. Both assets ultimately depend on unversioned `core.games`,
+so full upstream closure remains unknown even when the mart's recorded edge
+matches. The `source_watermark` field in this slice is an opaque input digest,
+not a provider timestamp or a CFBD generation. Coverage describes the observed
+warehouse input; it does not prove provider completeness or a requested season's
+expected game set.
+
+## Verification and access
+
+`verify_load.py` reads the additive receipt surface after its existing legacy
+freshness check. Missing migration or as-yet-unrecorded optional publications
+warn without activating a new production publishing requirement. Known broken
+recorded dependencies fail; an explicitly declared stale interval follows the
+existing in-season/strict severity rule. Unknown cadence and unversioned input
+closure remain visible rather than becoming a freshness PASS. Recent failed
+attempts remain diagnostic even while an older current publication is readable.
+
+Only the safe public projection is granted to `anon` and `authenticated`.
+Private receipt, operation and policy tables remain unavailable to consumers;
+raw operation scopes, input observations and arbitrary error text are excluded.
+The migration follows 068 in the managed bootstrap and production manifests.
+No runtime memberships, publication workflows or production policy values are
+activated by this development task.
+
+## Executed validation
+
+The final local warehouse regression run passed 164 tests: 68 verifier tests,
+17 executed receipt-freshness cases, 33 controlled-publication cases, 40 managed
+migration unit cases, two fresh/upgrade bootstrap cases, and four verification
+transaction cases. The three legacy freshness MCP tests passed in their separate
+test invocation. Ruff lint and format checks passed for all four affected Python
+files; `git diff --check` was clean.
+
+The SQL cases used explicitly selected disposable PostgreSQL 17 databases,
+including actual anon/authenticated queries, private-table and DML denials,
+reapplication, age advancing within a transaction, empty coverage, failure
+recovery, missing/mismatched input evidence, and hostile precreated policy-table
+rejection before any attacker trigger executes. The old RPC retained its exact
+six-column result, definition and callable access. The real verifier also read
+the new RPC and failed a deliberately broken recorded dependency.
+
+Independent subagent review found and resolved two issues: ownership must be
+validated before inserting into a possibly precreated policy table, and the
+verifier must independently honor unversioned inputs even if a closure flag is
+inconsistent. Both have regression coverage.
+
+No production migration, caller-role rollout, CFBD request or cadence activation
+was performed. Query performance and receipt-volume costs on representative
+production history are unmeasured. Fresh/upgrade catalog tests prove the local
+PostgreSQL contract, not managed-platform deployment parity.

--- a/docs/warehouse-operations.md
+++ b/docs/warehouse-operations.md
@@ -61,6 +61,18 @@ do not acquire these workflow dependencies automatically. See the
 [F10 plan](plans/2026-09-08-f10-workflow-dependencies.md) for scope and verification
 limits; historical schedule descriptions later in this document predate F10.
 
+## Receipt-backed freshness (prepared)
+
+Migration 069 adds `public.get_asset_freshness()` for the two controlled house
+Elo assets. It reports publication age at query time, current generation,
+recorded dependency status and separate failure diagnostics. Initial cadence
+policy and full upstream freshness remain unknown; `core.games` has no receipt.
+`verify_load.py` checks this surface when installed and warns when the optional
+receipts or policy are absent. Existing maintenance-based freshness checks and
+the six-column `get_data_freshness()` consumer RPC remain compatible.
+See the [evidence meanings and rollout limits](plans/2026-09-09-f19-receipt-freshness.md)
+before interpreting either surface as a source-freshness guarantee.
+
 ## Plays partition rollover (F08)
 
 `run_plays_pipeline()` performs catalog preflight before constructing the source

--- a/scripts/verify_load.py
+++ b/scripts/verify_load.py
@@ -20,11 +20,13 @@ Checks:
     5. marts.data_freshness is_stale flags -- heuristic only: the matview infers
        freshness from pg_stat vacuum/analyze timestamps, so staleness WARNs
        off-season and FAILs in-season (or with --strict)
-    6. ratings.massey_composite has a recent, full-coverage snapshot for the
+    6. Optional house Elo receipts: publication age and exact recorded inputs;
+       unknown cadence/upstream closure WARN, broken required inputs FAIL
+    7. ratings.massey_composite has a recent, full-coverage snapshot for the
        season (in-season only; WARNs if migration 041 isn't applied yet)
-    7. meta.flat_file_loads has a recent successful 'availability' load
+    8. meta.flat_file_loads has a recent successful 'availability' load
        (in-season only; never FAILs -- external conference sites are flaky)
-    8. no unexpected dlt VARIANT (__v_double) twin has appeared on a
+    9. no unexpected dlt VARIANT (__v_double) twin has appeared on a
        charting source table since the mart(s) reading it were authored
        (KTD7 tripwire; see src/pipelines/utils/variant_twins.py) -- FAILs
        naming the column, since it means a metric is silently reading NULL
@@ -530,6 +532,84 @@ def check_freshness(cur, in_season: bool, strict: bool, report: Report) -> None:
         )
 
 
+RECEIPT_FRESHNESS_ASSETS = ("analytics.house_elo_game", "marts.house_elo_game")
+NONCURRENT_RECEIPT_OUTCOMES = {"failed", "deferred", "partial", "blocked"}
+
+
+def check_receipt_freshness(cur, in_season: bool, strict: bool, report: Report) -> None:
+    """Inspect optional source-wide publication evidence, not season/provider coverage."""
+    cur.execute("SELECT to_regprocedure('public.get_asset_freshness()')")
+    if cur.fetchone()[0] is None:
+        report.record(WARN, "receipt_freshness", "receipt freshness migration is not installed")
+        return
+    # A permission/transport/query error must propagate as a failed verification,
+    # not be swallowed or leave a silently aborted transaction for later checks.
+    cur.execute("SELECT to_jsonb(f) FROM public.get_asset_freshness() f")
+    rows = [row[0] for row in cur.fetchall()]
+    keys = [(row.get("asset_key"), row.get("coverage_key")) for row in rows]
+    expected = {(asset, "source-wide") for asset in RECEIPT_FRESHNESS_ASSETS}
+    if len(keys) != len(expected) or set(keys) != expected:
+        report.record(
+            FAIL, "receipt_freshness", "expected exactly both source-wide house Elo assets"
+        )
+        return
+
+    for row in rows:
+        asset = row["asset_key"]
+        if row.get("latest_outcome") in NONCURRENT_RECEIPT_OUTCOMES:
+            report.record(
+                WARN,
+                "receipt_attempt",
+                f"{asset}: latest attempt {row['latest_outcome']}; "
+                "this does not replace current publication evidence",
+            )
+        state = row.get("publication_state")
+        if state == "unrecorded" and row.get("generation_id") is None:
+            report.record(WARN, "receipt_freshness", f"{asset}: optional publisher has no receipts")
+            continue
+        if state == "unpublished" and row.get("generation_id") is None:
+            report.record(
+                FAIL if strict else WARN,
+                "receipt_freshness",
+                f"{asset}: receipt history exists but no valid current publication",
+            )
+            continue
+        if (
+            state != "current"
+            or not row.get("generation_id")
+            or not row.get("published_at")
+            or row.get("current_outcome") not in {"succeeded", "expected_no_data"}
+            or (row.get("coverage") or {}).get("complete") is not True
+        ):
+            report.record(FAIL, "receipt_freshness", f"{asset}: invalid current receipt evidence")
+            continue
+        if (
+            row.get("recorded_inputs_current") is False
+            or row.get("input_closure_current") is False
+            or (asset == "marts.house_elo_game" and row.get("recorded_inputs_current") is not True)
+        ):
+            report.record(
+                FAIL, "receipt_freshness", f"{asset}: required input generation is not current"
+            )
+            continue
+        details = [f"{asset}: current {row['current_outcome']} publication"]
+        status = PASS
+        if row.get("is_stale") is True:
+            status = FAIL if in_season or strict else WARN
+            details.append(f"age {row.get('age_seconds')}s exceeds declared publication interval")
+        elif row.get("is_stale") is None or row.get("expected_refresh_interval") is None:
+            status = WARN
+            details.append("publication age policy is undeclared")
+        if (
+            row.get("input_closure_current") is not True
+            or row.get("unversioned_input_assets") != []
+        ):
+            if status == PASS:
+                status = WARN
+            details.append("upstream closure unverified (core.games is unversioned)")
+        report.record(status, "receipt_freshness", "; ".join(details))
+
+
 def verify(season: int, strict: bool) -> int:
     """Run all checks. Returns the number of failures."""
     from datetime import datetime
@@ -551,6 +631,7 @@ def verify(season: int, strict: bool) -> int:
             check_fitted_coverage(cur, report)
             check_backtest_freshness(cur, report)
             check_freshness(cur, in_season, strict, report)
+            check_receipt_freshness(cur, in_season, strict, report)
             check_variant_twins(cur, report)
             check_massey_composite(cur, season, report)
             check_availability_archive(cur, season, report)
@@ -575,7 +656,7 @@ def main() -> None:
     parser.add_argument(
         "--strict",
         action="store_true",
-        help="Treat weekly-table staleness as failure even off-season",
+        help="Fail weekly staleness off-season and missing current receipt publications",
     )
     args = parser.parse_args()
 

--- a/src/schemas/migrations/069_receipt_backed_freshness.sql
+++ b/src/schemas/migrations/069_receipt_backed_freshness.sql
@@ -1,0 +1,169 @@
+-- F19 additive receipt freshness. Managed forward migration after 068.
+-- Prepared, not a production rollout. The existing get_data_freshness() and
+-- its maintenance-statistics matview remain unchanged for existing consumers.
+
+CREATE TABLE IF NOT EXISTS meta.asset_freshness_policies (
+    asset_key text NOT NULL REFERENCES meta.asset_publication_locks(asset_key),
+    coverage_key text NOT NULL DEFAULT 'source-wide' CHECK (coverage_key = 'source-wide'),
+    expected_refresh_interval interval CHECK (expected_refresh_interval > interval '0 seconds'),
+    PRIMARY KEY (asset_key, coverage_key),
+    CHECK (asset_key IN ('analytics.house_elo_game', 'marts.house_elo_game'))
+);
+-- meta can retain CREATE for existing warehouse writers. Reject a precreated
+-- relation before INSERT could fire its untrusted triggers as the migration role.
+DO $policy_owner$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_catalog.pg_class c
+        WHERE c.oid = 'meta.asset_freshness_policies'::regclass
+            AND c.relkind = 'r'
+            AND c.relowner = (SELECT oid FROM pg_catalog.pg_roles WHERE rolname = current_user)
+    ) THEN
+        RAISE EXCEPTION 'freshness policy must be a migration-owned ordinary table';
+    END IF;
+END
+$policy_owner$;
+ALTER TABLE meta.asset_freshness_policies ENABLE ROW LEVEL SECURITY;
+
+-- The optional full publisher has no declared SLA yet. Reapply preserves an
+-- owner's later policy declaration; missing policy never removes an asset.
+INSERT INTO meta.asset_freshness_policies(asset_key)
+VALUES ('analytics.house_elo_game'), ('marts.house_elo_game')
+ON CONFLICT DO NOTHING;
+
+CREATE INDEX IF NOT EXISTS asset_receipts_latest_idx
+    ON meta.asset_receipts(asset_key, coverage_key, recorded_at DESC, generation_id DESC);
+CREATE INDEX IF NOT EXISTS asset_receipts_failure_idx
+    ON meta.asset_receipts(asset_key, coverage_key, recorded_at DESC, generation_id DESC)
+    WHERE outcome IN ('failed', 'partial', 'deferred', 'blocked');
+
+-- Deliberately owner-rights: consumers read this safe projection, not private
+-- receipt/operation/policy records. No security_invoker setting is introduced.
+CREATE OR REPLACE VIEW marts.asset_receipt_freshness AS
+WITH assets(asset_key, coverage_key) AS (
+    VALUES ('analytics.house_elo_game'::text, 'source-wide'::text),
+           ('marts.house_elo_game'::text, 'source-wide'::text)
+), evidence AS (
+    SELECT a.asset_key, a.coverage_key, r.generation_id, r.published_at,
+        EXTRACT(EPOCH FROM (pg_catalog.statement_timestamp() - r.published_at)) AS age_seconds,
+        policy.expected_refresh_interval,
+        CASE WHEN r.generation_id IS NULL OR policy.expected_refresh_interval IS NULL
+            THEN NULL::boolean
+            ELSE pg_catalog.statement_timestamp() - r.published_at > policy.expected_refresh_interval
+        END AS is_stale,
+        CASE WHEN r.generation_id IS NOT NULL THEN 'current'
+             WHEN latest.generation_id IS NOT NULL THEN 'unpublished'
+             ELSE 'unrecorded' END AS publication_state,
+        r.outcome AS current_outcome, r.coverage, r.source_watermark, r.row_delta,
+        COALESCE(inputs.generations, '[]'::jsonb) AS required_input_generations,
+        CASE WHEN r.generation_id IS NULL OR a.asset_key = 'analytics.house_elo_game'
+            THEN NULL::boolean
+            ELSE COALESCE(inputs.input_count = 1 AND inputs.expected_input_current, false)
+        END AS recorded_inputs_current,
+        latest.outcome AS latest_outcome, latest.recorded_at AS latest_recorded_at,
+        failure.recorded_at AS last_failure_at, failure.outcome AS last_failure_outcome,
+        CASE WHEN failure.error_summary = 'publication_failed'
+             THEN 'publication_failed'::text ELSE NULL::text END AS last_failure_category
+    FROM assets a
+    LEFT JOIN meta.asset_freshness_policies policy USING (asset_key, coverage_key)
+    LEFT JOIN meta.asset_current_generations pointer USING (asset_key, coverage_key)
+    LEFT JOIN meta.asset_receipts r
+        ON r.asset_key = pointer.asset_key AND r.coverage_key = pointer.coverage_key
+        AND r.generation_id = pointer.generation_id
+        AND r.outcome IN ('succeeded', 'expected_no_data')
+        AND r.coverage->'complete' = 'true'::jsonb AND r.published_at IS NOT NULL
+    LEFT JOIN LATERAL (
+        SELECT receipt.generation_id, receipt.outcome, receipt.recorded_at
+        FROM meta.asset_receipts receipt
+        WHERE receipt.asset_key = a.asset_key AND receipt.coverage_key = a.coverage_key
+        ORDER BY receipt.recorded_at DESC, receipt.generation_id DESC LIMIT 1
+    ) latest ON true
+    LEFT JOIN LATERAL (
+        SELECT receipt.recorded_at, receipt.outcome, receipt.error_summary
+        FROM meta.asset_receipts receipt
+        WHERE receipt.asset_key = a.asset_key AND receipt.coverage_key = a.coverage_key
+            AND receipt.outcome IN ('failed', 'partial', 'deferred', 'blocked')
+        ORDER BY receipt.recorded_at DESC, receipt.generation_id DESC LIMIT 1
+    ) failure ON true
+    LEFT JOIN LATERAL (
+        SELECT count(*) AS input_count,
+            bool_and(edge.input_asset_key = 'analytics.house_elo_game'
+                AND edge.input_coverage_key = 'source-wide'
+                AND current_input.generation_id IS NOT NULL
+                AND current_input.generation_id = edge.input_generation_id) AS expected_input_current,
+            pg_catalog.jsonb_agg(pg_catalog.jsonb_build_object(
+                'asset_key', edge.input_asset_key, 'coverage_key', edge.input_coverage_key,
+                'generation_id', edge.input_generation_id,
+                'current_generation_id', current_input.generation_id,
+                'is_current', current_input.generation_id IS NOT NULL
+                    AND current_input.generation_id = edge.input_generation_id
+            ) ORDER BY edge.input_asset_key, edge.input_coverage_key) AS generations
+        FROM meta.asset_receipt_inputs edge
+        LEFT JOIN meta.asset_current_generations current_input
+            ON current_input.asset_key = edge.input_asset_key
+            AND current_input.coverage_key = edge.input_coverage_key
+        WHERE edge.generation_id = r.generation_id
+    ) inputs ON true
+)
+SELECT asset_key, coverage_key, generation_id, published_at, age_seconds,
+    expected_refresh_interval, is_stale, publication_state, current_outcome,
+    coverage, source_watermark, row_delta, required_input_generations,
+    recorded_inputs_current,
+    CASE WHEN recorded_inputs_current = false THEN false ELSE NULL::boolean END AS input_closure_current,
+    '["core.games"]'::jsonb AS unversioned_input_assets,
+    latest_outcome, latest_recorded_at, last_failure_at, last_failure_outcome, last_failure_category
+FROM evidence;
+
+CREATE OR REPLACE FUNCTION public.get_asset_freshness()
+RETURNS SETOF marts.asset_receipt_freshness
+LANGUAGE sql STABLE SECURITY INVOKER SET search_path = ''
+AS $function$
+    SELECT * FROM marts.asset_receipt_freshness ORDER BY asset_key, coverage_key;
+$function$;
+
+COMMENT ON TABLE meta.asset_freshness_policies IS
+'Private owner-declared publication cadence. NULL is undeclared; intervals measure publication age, not provider freshness.';
+COMMENT ON VIEW marts.asset_receipt_freshness IS
+'Query-time current publication evidence for the two controlled Elo assets. core.games remains unversioned; source_watermark is an opaque input digest, not a provider timestamp.';
+COMMENT ON FUNCTION public.get_asset_freshness() IS
+'Additive safe receipt evidence; ages advance each SQL statement. Does not replace legacy get_data_freshness or prove complete upstream freshness.';
+
+-- Normalize only these new objects, including hostile inherited default grants.
+-- No broad schema revokes or grants may alter existing public consumers.
+DO $access$
+DECLARE obj record; grantee record; owner_id oid;
+BEGIN
+    SELECT oid INTO owner_id FROM pg_catalog.pg_roles WHERE rolname = current_user;
+    FOR obj IN SELECT c.oid, n.nspname, c.relname, c.relowner, c.relacl
+        FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE (n.nspname, c.relname) IN (
+            ('meta', 'asset_freshness_policies'), ('marts', 'asset_receipt_freshness')
+        ) LOOP
+        IF obj.relowner <> owner_id THEN
+            RAISE EXCEPTION 'freshness object %.% must be migration-owned', obj.nspname, obj.relname;
+        END IF;
+        EXECUTE pg_catalog.format('REVOKE ALL ON TABLE %I.%I FROM PUBLIC', obj.nspname, obj.relname);
+        FOR grantee IN SELECT DISTINCT role.rolname FROM pg_catalog.aclexplode(obj.relacl) acl
+            JOIN pg_catalog.pg_roles role ON role.oid = acl.grantee WHERE acl.grantee <> owner_id
+        LOOP
+            EXECUTE pg_catalog.format('REVOKE ALL ON TABLE %I.%I FROM %I',
+                obj.nspname, obj.relname, grantee.rolname);
+        END LOOP;
+    END LOOP;
+    SELECT p.proowner, p.proacl INTO obj FROM pg_catalog.pg_proc p
+        WHERE p.oid = 'public.get_asset_freshness()'::regprocedure;
+    IF obj.proowner <> owner_id THEN
+        RAISE EXCEPTION 'freshness RPC must be migration-owned';
+    END IF;
+    REVOKE ALL ON FUNCTION public.get_asset_freshness() FROM PUBLIC;
+    FOR grantee IN SELECT DISTINCT role.rolname FROM pg_catalog.aclexplode(obj.proacl) acl
+        JOIN pg_catalog.pg_roles role ON role.oid = acl.grantee WHERE acl.grantee <> owner_id
+    LOOP
+        EXECUTE pg_catalog.format('REVOKE ALL ON FUNCTION public.get_asset_freshness() FROM %I', grantee.rolname);
+    END LOOP;
+END
+$access$;
+
+GRANT USAGE ON SCHEMA public, marts TO anon, authenticated;
+GRANT SELECT ON marts.asset_receipt_freshness TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_asset_freshness() TO anon, authenticated;

--- a/src/schemas/production-manifest.json
+++ b/src/schemas/production-manifest.json
@@ -19,6 +19,11 @@
       "id": "warehouse.f14.068",
       "path": "src/schemas/migrations/068_asset_publication_receipts.sql",
       "kind": "immutable"
+    },
+    {
+      "id": "warehouse.f19.069",
+      "path": "src/schemas/migrations/069_receipt_backed_freshness.sql",
+      "kind": "immutable"
     }
   ],
   "version": 1

--- a/src/schemas/warehouse-manifest.json
+++ b/src/schemas/warehouse-manifest.json
@@ -45,6 +45,11 @@
       "id": "warehouse.f14.068",
       "path": "src/schemas/migrations/068_asset_publication_receipts.sql",
       "kind": "immutable"
+    },
+    {
+      "id": "warehouse.f19.069",
+      "path": "src/schemas/migrations/069_receipt_backed_freshness.sql",
+      "kind": "immutable"
     }
   ]
 }

--- a/tests/test_asset_freshness_sql.py
+++ b/tests/test_asset_freshness_sql.py
@@ -1,0 +1,366 @@
+"""Executed query-time receipt freshness and public compatibility on disposable PG17."""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import psycopg2
+import pytest
+from psycopg2 import sql
+
+from tests.test_asset_publication_sql import (
+    publication_args,
+    publish,
+    publisher_query,
+    start_run,
+    state,
+)
+from tests.test_asset_publication_sql import publication_db as _publication_db  # noqa: F401
+from tests.test_warehouse_migrations_sql import query
+from tests.test_warehouse_migrations_sql import warehouse_db as _warehouse_db  # noqa: F401
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATION = ROOT / "src/schemas/migrations/069_receipt_backed_freshness.sql"
+SOURCE = "analytics.house_elo_game"
+MART = "marts.house_elo_game"
+
+
+@pytest.fixture
+def freshness_db(request):
+    conn, target = request.getfixturevalue("_publication_db")
+    query(conn, MIGRATION.read_text())
+    return conn, target
+
+
+def rows(conn, role="anon"):
+    with conn.cursor() as cur:
+        cur.execute(sql.SQL("SET LOCAL ROLE {}").format(sql.Identifier(role)))
+        cur.execute("SELECT to_jsonb(f) FROM public.get_asset_freshness() f")
+        result = {row[0]["asset_key"]: row[0] for row in cur.fetchall()}
+    conn.commit()
+    return result
+
+
+def record_failure(conn, outcome="failed"):
+    publisher_query(
+        conn,
+        "SELECT * FROM warehouse_publication.record_house_elo_failure(%s,%s,%s,%s,%s)",
+        (str(start_run(conn)), str(uuid.uuid4()), str(uuid.uuid4()), outcome, "publication_failed"),
+    )
+
+
+def denied(conn, role, statement, error=psycopg2.errors.InsufficientPrivilege):
+    try:
+        with conn.cursor() as cur:
+            cur.execute(sql.SQL("SET LOCAL ROLE {}").format(sql.Identifier(role)))
+            with pytest.raises(error):
+                cur.execute(statement)
+    finally:
+        conn.rollback()
+
+
+def test_unrecorded_is_unknown_not_empty_or_fresh(freshness_db):
+    conn, _ = freshness_db
+    for role in ("anon", "authenticated"):
+        result = rows(conn, role)
+        assert set(result) == {SOURCE, MART}
+        for row in result.values():
+            assert row["coverage_key"] == "source-wide"
+            assert row["publication_state"] == "unrecorded"
+            assert row["generation_id"] is None
+            assert row["current_outcome"] is None
+            assert row["published_at"] is None
+            assert row["age_seconds"] is None
+            assert row["is_stale"] is None
+            assert row["expected_refresh_interval"] is None
+            assert row["recorded_inputs_current"] is None
+            assert row["input_closure_current"] is None
+            assert row["unversioned_input_assets"] == ["core.games"]
+
+
+def test_complete_publication_has_exact_input_evidence_without_provider_claim(freshness_db):
+    conn, _ = freshness_db
+    args = publication_args(conn)
+    publish(conn, args)
+    result = rows(conn)
+    source, mart = result[SOURCE], result[MART]
+    assert source["generation_id"] == args[1]
+    assert mart["generation_id"] == args[2]
+    for row in result.values():
+        assert row["publication_state"] == "current"
+        assert row["current_outcome"] == "succeeded"
+        assert row["coverage"]["complete"] is True
+        assert row["row_delta"]["published_rows"] == 1
+        assert row["source_watermark"] == args[5]
+        assert row["age_seconds"] >= 0
+        assert row["is_stale"] is None
+        assert row["input_closure_current"] is None
+        assert "input_observations" not in row
+        assert "operation_run_id" not in row
+        assert "error_summary" not in row
+    assert source["recorded_inputs_current"] is None
+    assert source["required_input_generations"] == []
+    assert mart["recorded_inputs_current"] is True
+    assert mart["required_input_generations"] == [
+        {
+            "asset_key": SOURCE,
+            "coverage_key": "source-wide",
+            "generation_id": args[1],
+            "current_generation_id": args[1],
+            "is_current": True,
+        }
+    ]
+
+
+def test_age_advances_inside_transaction_without_mart_refresh(freshness_db):
+    conn, _ = freshness_db
+    publish(conn, publication_args(conn))
+    query(conn, "UPDATE meta.asset_freshness_policies SET expected_refresh_interval='0.3 seconds'")
+    with conn.cursor() as cur:
+        cur.execute("SET LOCAL ROLE anon")
+        cur.execute(
+            "SELECT generation_id,age_seconds FROM public.get_asset_freshness() ORDER BY asset_key"
+        )
+        before = cur.fetchall()
+        cur.execute("SELECT pg_sleep(0.35)")
+        cur.execute(
+            "SELECT generation_id,age_seconds,is_stale "
+            "FROM public.get_asset_freshness() ORDER BY asset_key"
+        )
+        after = cur.fetchall()
+    conn.commit()
+    assert [r[0] for r in before] == [r[0] for r in after]
+    for old, new in zip(before, after, strict=True):
+        assert new[1] - old[1] >= 0.3
+        assert new[2] is True
+    query(conn, "ANALYZE analytics.house_elo_game")
+    assert all(r["is_stale"] is True for r in rows(conn).values())
+    query(conn, "UPDATE meta.asset_freshness_policies SET expected_refresh_interval='100 years'")
+    assert all(r["is_stale"] is False for r in rows(conn).values())
+
+
+@pytest.mark.parametrize("outcome", ["failed", "partial", "deferred", "blocked"])
+def test_failed_attempt_does_not_replace_current_publication(freshness_db, outcome):
+    conn, _ = freshness_db
+    args = publication_args(conn)
+    publish(conn, args)
+    record_failure(conn, outcome)
+    for key, generation in ((SOURCE, args[1]), (MART, args[2])):
+        row = rows(conn)[key]
+        assert row["generation_id"] == generation
+        assert row["publication_state"] == "current"
+        assert row["current_outcome"] == "succeeded"
+        assert row["latest_outcome"] == outcome
+        assert row["last_failure_outcome"] == outcome
+        assert row["last_failure_category"] == "publication_failed"
+        assert row["last_failure_at"] is not None
+    publish(conn, publication_args(conn, expected=state(conn)))
+    assert all(row["latest_outcome"] == "succeeded" for row in rows(conn).values())
+    assert all(row["last_failure_outcome"] == outcome for row in rows(conn).values())
+
+
+def test_failure_without_publication_is_not_expected_no_data(freshness_db):
+    conn, _ = freshness_db
+    record_failure(conn)
+    for row in rows(conn).values():
+        assert row["publication_state"] == "unpublished"
+        assert row["generation_id"] is None
+        assert row["current_outcome"] is None
+        assert row["latest_outcome"] == "failed"
+        assert row["is_stale"] is None
+
+
+def test_empty_eligible_completed_set_is_evaluated_no_data(freshness_db):
+    conn, _ = freshness_db
+    query(conn, "UPDATE core.games SET completed=false,home_points=NULL,away_points=NULL")
+    args = list(publication_args(conn))
+    args[6], args[7] = "[]", "[]"
+    publish(conn, tuple(args))
+    for row in rows(conn).values():
+        assert row["publication_state"] == "current"
+        assert row["current_outcome"] == "expected_no_data"
+        assert row["row_delta"]["published_rows"] == 0
+        assert row["coverage"]["complete"] is True
+        assert row["input_closure_current"] is None
+
+
+def test_legacy_write_invalidates_and_history_cannot_resurrect_pointer(freshness_db):
+    conn, _ = freshness_db
+    publish(conn, publication_args(conn))
+    query(conn, "UPDATE analytics.house_elo_game SET home_postgame_elo=1519")
+    for row in rows(conn).values():
+        assert row["publication_state"] == "unpublished"
+        assert row["latest_outcome"] == "succeeded"
+        assert row["generation_id"] is None
+        assert row["age_seconds"] is None
+        assert row["recorded_inputs_current"] is None
+
+
+@pytest.mark.parametrize("change", ["absent", "mismatch", "missing_edge"])
+def test_mart_detects_missing_or_changed_input_pointer(freshness_db, change):
+    conn, _ = freshness_db
+    first = publication_args(conn)
+    publish(conn, first)
+    if change == "mismatch":
+        publish(conn, publication_args(conn, expected=state(conn)))
+        query(
+            conn,
+            "UPDATE meta.asset_current_generations SET generation_id=%s WHERE asset_key=%s",
+            (first[1], SOURCE),
+        )
+    elif change == "missing_edge":
+        # Model a defective owner-written receipt: its required edge was never recorded.
+        incomplete_generation = str(uuid.uuid4())
+        query(
+            conn,
+            """
+            INSERT INTO meta.asset_receipts (
+                generation_id,operation_run_id,asset_key,coverage_key,outcome,coverage,
+                source_watermark,input_observations,row_delta,request_digest,published_at
+            ) SELECT %s,operation_run_id,asset_key,coverage_key,outcome,coverage,
+                source_watermark,input_observations,row_delta,request_digest,published_at
+            FROM meta.asset_receipts WHERE generation_id=%s
+            """,
+            (incomplete_generation, first[2]),
+        )
+        query(
+            conn,
+            "UPDATE meta.asset_current_generations SET generation_id=%s WHERE asset_key=%s",
+            (incomplete_generation, MART),
+        )
+    else:
+        query(conn, "DELETE FROM meta.asset_current_generations WHERE asset_key=%s", (SOURCE,))
+    mart = rows(conn)[MART]
+    assert mart["publication_state"] == "current"
+    assert mart["recorded_inputs_current"] is False
+    assert mart["input_closure_current"] is False
+    if change != "missing_edge":
+        assert mart["required_input_generations"][0]["is_current"] is False
+
+
+def test_policy_reapply_and_access_boundary(freshness_db):
+    conn, _ = freshness_db
+    query(conn, "UPDATE meta.asset_freshness_policies SET expected_refresh_interval='2 days'")
+    query(conn, MIGRATION.read_text())
+    assert all(row["expected_refresh_interval"] == "2 days" for row in rows(conn).values())
+    for role in (
+        "anon",
+        "authenticated",
+        "analyst_ro",
+        "publication_bystander",
+        "warehouse_publisher",
+    ):
+        for table in (
+            "asset_receipts",
+            "asset_current_generations",
+            "asset_receipt_inputs",
+            "asset_freshness_policies",
+            "operation_runs",
+        ):
+            denied(conn, role, f"SELECT * FROM meta.{table}")
+        denied(
+            conn,
+            role,
+            "UPDATE meta.asset_freshness_policies SET expected_refresh_interval='1 hour'",
+        )
+        assert query(
+            conn,
+            "SELECT has_table_privilege(%s,'marts.asset_receipt_freshness',"
+            "'INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')",
+            (role,),
+        ) == [(False,)]
+        denied(
+            conn,
+            role,
+            "DELETE FROM marts.asset_receipt_freshness",
+            (psycopg2.errors.InsufficientPrivilege, psycopg2.errors.ObjectNotInPrerequisiteState),
+        )
+    for role in ("analyst_ro", "publication_bystander", "warehouse_publisher"):
+        denied(conn, role, "SELECT * FROM public.get_asset_freshness()")
+    with pytest.raises(psycopg2.errors.CheckViolation):
+        query(
+            conn, "UPDATE meta.asset_freshness_policies SET expected_refresh_interval='0 seconds'"
+        )
+    conn.rollback()
+    query(conn, "DELETE FROM meta.asset_freshness_policies")
+    assert set(rows(conn)) == {SOURCE, MART}
+
+
+def test_migration_preserves_legacy_rpc_definition_results_and_grants(request):
+    conn, _ = request.getfixturevalue("_publication_db")
+    query(conn, (ROOT / "src/schemas/marts/028_data_freshness.sql").read_text())
+    query(conn, (ROOT / "src/schemas/public/011_data_freshness_function.sql").read_text())
+    query(conn, "GRANT USAGE ON SCHEMA marts TO anon,authenticated")
+
+    def legacy():
+        with conn.cursor() as cur:
+            cur.execute("SET LOCAL ROLE anon")
+            cur.execute("SELECT * FROM public.get_data_freshness()")
+            result = cur.fetchall()
+            columns = [(col.name, col.type_code) for col in cur.description]
+        conn.commit()
+        definition = query(
+            conn, "SELECT pg_get_functiondef('public.get_data_freshness()'::regprocedure)"
+        )
+        return result, columns, definition
+
+    before = legacy()
+    query(conn, MIGRATION.read_text())
+    query(conn, MIGRATION.read_text())
+    assert legacy() == before
+    assert len(before[0]) == 24
+    assert len(before[1]) == 6
+
+
+def test_verifier_reads_real_rpc_and_does_not_claim_upstream_freshness(freshness_db, capsys):
+    from scripts.verify_load import Report, check_receipt_freshness
+
+    conn, _ = freshness_db
+    publish(conn, publication_args(conn))
+    report = Report()
+    with conn.cursor() as cur:
+        check_receipt_freshness(cur, in_season=True, strict=False, report=report)
+    conn.rollback()
+    output = capsys.readouterr().out
+    assert report.failures == 0
+    assert SOURCE in output and MART in output
+    assert "[WARN]" in output
+    assert "[PASS]" not in output
+    query(conn, "DELETE FROM meta.asset_current_generations WHERE asset_key=%s", (SOURCE,))
+    with conn.cursor() as cur:
+        check_receipt_freshness(cur, in_season=True, strict=False, report=report)
+    conn.rollback()
+    assert report.failures >= 1
+    assert "[FAIL]" in capsys.readouterr().out
+
+
+def test_untrusted_precreated_policy_rejected_before_trigger_can_fire(request):
+    conn, _ = request.getfixturevalue("_publication_db")
+    # Sequence increments survive rollback, so an aborted INSERT cannot conceal
+    # that the attacker-controlled trigger executed under the migration identity.
+    query(conn, "CREATE SEQUENCE public.freshness_attack_marker")
+    query(conn, "GRANT USAGE ON SEQUENCE public.freshness_attack_marker TO publication_bystander")
+    query(conn, "GRANT CREATE ON SCHEMA meta TO publication_bystander")
+    query(
+        conn,
+        """
+        SET ROLE publication_bystander;
+        CREATE TABLE meta.asset_freshness_policies (
+            asset_key text PRIMARY KEY, coverage_key text DEFAULT 'source-wide',
+            expected_refresh_interval interval
+        );
+        CREATE FUNCTION meta.freshness_attack() RETURNS trigger
+        LANGUAGE plpgsql AS $$ BEGIN
+            PERFORM nextval('public.freshness_attack_marker'); RETURN NEW;
+        END $$;
+        CREATE TRIGGER attack BEFORE INSERT ON meta.asset_freshness_policies
+            FOR EACH ROW EXECUTE FUNCTION meta.freshness_attack();
+        RESET ROLE;
+    """,
+    )
+    with pytest.raises(psycopg2.Error, match="migration-owned"):
+        query(conn, MIGRATION.read_text())
+    conn.rollback()
+    assert query(conn, "SELECT is_called FROM public.freshness_attack_marker") == [(False,)]
+    assert query(conn, "SELECT to_regprocedure('public.get_asset_freshness()')") == [(None,)]

--- a/tests/test_verify_load.py
+++ b/tests/test_verify_load.py
@@ -588,3 +588,177 @@ class TestCheckVariantTwinsSavepoint:
         assert report.failures == 0
         out = capsys.readouterr().out
         assert "[WARN] variant_twins:" in out
+
+
+class ReceiptCursor:
+    def __init__(self, rows, installed=True, error=None):
+        self.rows = rows
+        self.installed = installed
+        self.error = error
+        self.queries = []
+
+    def execute(self, statement):
+        self.queries.append(statement)
+        if self.error and "to_jsonb" in statement:
+            raise self.error
+
+    def fetchone(self):
+        return ("get_asset_freshness()" if self.installed else None,)
+
+    def fetchall(self):
+        return [(row,) for row in self.rows]
+
+
+def receipt_rows(**changes):
+    result = []
+    for asset in ("analytics.house_elo_game", "marts.house_elo_game"):
+        row = {
+            "asset_key": asset,
+            "coverage_key": "source-wide",
+            "generation_id": "generation",
+            "published_at": "2026-09-09T00:00:00Z",
+            "age_seconds": 5,
+            "expected_refresh_interval": None,
+            "is_stale": None,
+            "publication_state": "current",
+            "current_outcome": "succeeded",
+            "coverage": {"complete": True},
+            "recorded_inputs_current": True if asset.startswith("marts.") else None,
+            "input_closure_current": None,
+            "latest_outcome": "succeeded",
+        }
+        row.update(changes)
+        result.append(row)
+    return result
+
+
+def receipt_check(rows=None, *, installed=True, strict=False, in_season=True):
+    from scripts.verify_load import Report, check_receipt_freshness
+
+    report = Report()
+    cur = ReceiptCursor(receipt_rows() if rows is None else rows, installed=installed)
+    check_receipt_freshness(cur, in_season=in_season, strict=strict, report=report)
+    return report, cur
+
+
+def test_receipt_missing_migration_warns_without_querying_missing_rpc(capsys):
+    report, cur = receipt_check(installed=False, strict=True)
+    assert report.failures == 0
+    assert len(cur.queries) == 1
+    assert "[WARN]" in capsys.readouterr().out
+
+
+def test_receipt_unknown_cadence_and_closure_never_claim_freshness(capsys):
+    report, _ = receipt_check()
+    assert report.failures == 0
+    output = capsys.readouterr().out
+    assert "[PASS]" not in output
+    assert "policy is undeclared" in output
+    assert "upstream closure unverified" in output
+
+
+def test_receipt_unrecorded_stays_optional_under_strict(capsys):
+    report, _ = receipt_check(
+        receipt_rows(publication_state="unrecorded", generation_id=None), strict=True
+    )
+    assert report.failures == 0
+    assert "optional publisher has no receipts" in capsys.readouterr().out
+
+
+def test_receipt_missing_current_with_history_is_strict_failure(capsys):
+    values = receipt_rows(publication_state="unpublished", generation_id=None)
+    assert receipt_check(values)[0].failures == 0
+    assert receipt_check(values, strict=True)[0].failures == 2
+    assert "no valid current publication" in capsys.readouterr().out
+
+
+def test_receipt_incomplete_or_failed_current_is_never_valid():
+    assert receipt_check(receipt_rows(coverage={"complete": False}))[0].failures == 2
+    assert receipt_check(receipt_rows(current_outcome="failed"))[0].failures == 2
+    assert receipt_check(receipt_rows(published_at=None))[0].failures == 2
+
+
+def test_receipt_expected_no_data_is_not_failure(capsys):
+    assert receipt_check(receipt_rows(current_outcome="expected_no_data"))[0].failures == 0
+    assert "expected_no_data" in capsys.readouterr().out
+
+
+def test_receipt_broken_or_unverified_required_mart_edge_fails():
+    assert receipt_check(receipt_rows(recorded_inputs_current=False))[0].failures == 2
+    assert receipt_check(receipt_rows(recorded_inputs_current=None))[0].failures == 1
+    assert receipt_check(receipt_rows(input_closure_current=False))[0].failures == 2
+
+
+def test_receipt_declared_staleness_respects_existing_severity_rule():
+    values = receipt_rows(is_stale=True, expected_refresh_interval="1 day")
+    assert receipt_check(values, in_season=True)[0].failures == 2
+    assert receipt_check(values, in_season=False)[0].failures == 0
+    assert receipt_check(values, in_season=False, strict=True)[0].failures == 2
+
+
+def test_receipt_failed_attempt_warns_without_replacing_current(capsys):
+    for outcome in ("failed", "deferred", "blocked", "partial"):
+        assert receipt_check(receipt_rows(latest_outcome=outcome))[0].failures == 0
+        output = capsys.readouterr().out
+        assert f"latest attempt {outcome}" in output
+        assert "current succeeded publication" in output
+
+
+def test_receipt_missing_duplicate_or_wrong_grain_rows_fail():
+    values = receipt_rows()
+    for bad in ([], values[:1], [values[0], values[0]], receipt_rows(coverage_key="season")):
+        assert receipt_check(bad)[0].failures == 1
+
+
+def test_receipt_rpc_error_propagates_instead_of_silent_pass():
+    import pytest
+
+    from scripts.verify_load import Report, check_receipt_freshness
+
+    cur = ReceiptCursor([], error=RuntimeError("permission denied"))
+    with pytest.raises(RuntimeError, match="permission denied"):
+        check_receipt_freshness(cur, in_season=True, strict=False, report=Report())
+
+
+def test_verify_includes_receipt_check_after_legacy_check(monkeypatch):
+    from unittest.mock import MagicMock
+
+    import psycopg2
+
+    from scripts import refresh_marts, verify_load
+
+    checks = [
+        "check_partition",
+        "check_game_counts",
+        "check_completed_have_team_stats",
+        "check_completed_have_plays",
+        "check_fitted_coverage",
+        "check_backtest_freshness",
+        "check_freshness",
+        "check_receipt_freshness",
+        "check_variant_twins",
+        "check_massey_composite",
+        "check_availability_archive",
+    ]
+    seen = []
+    for name in checks:
+        monkeypatch.setattr(verify_load, name, lambda *args, _name=name: seen.append(_name))
+    conn = MagicMock()
+    monkeypatch.setattr(psycopg2, "connect", lambda _: conn)
+    monkeypatch.setattr(refresh_marts, "get_db_url", lambda: "unused")
+    assert verify_load.verify(2026, strict=False) == 0
+    assert seen == checks
+    conn.close.assert_called_once()
+
+
+def test_receipt_unversioned_inputs_prevent_pass_even_if_closure_claim_disagrees(capsys):
+    values = receipt_rows(
+        is_stale=False,
+        expected_refresh_interval="1 day",
+        input_closure_current=True,
+        unversioned_input_assets=["core.games"],
+    )
+    assert receipt_check(values)[0].failures == 0
+    output = capsys.readouterr().out
+    assert "[PASS]" not in output
+    assert "upstream closure unverified" in output

--- a/tests/test_warehouse_bootstrap_sql.py
+++ b/tests/test_warehouse_bootstrap_sql.py
@@ -130,6 +130,10 @@ def _assert_catalog_shape(conn):
     # The bounded house-Elo publication ledger adds four tables and nine indexes.
     expected_counts[("meta", "r")] += 4
     expected_counts[("meta", "i")] += 9
+    # F19 policy plus two receipt lookup indexes and the ordinary public projection.
+    expected_counts[("meta", "r")] += 1
+    expected_counts[("meta", "i")] += 3
+    expected_counts[("marts", "v")] = expected_counts.get(("marts", "v"), 0) + 1
     assert query(
         conn,
         """
@@ -385,7 +389,7 @@ def test_managed_warehouse_catalog_data_and_access(
         _insert_representative_rows(conn)
         before_upgrade = _fixture_snapshot(conn)
         upgrade = apply_manifest(conn, manifest, mode="upgrade")
-        assert len(upgrade.pending) == 5
+        assert len(upgrade.pending) == 6
         assert [step.id for step in upgrade.pending] == [
             migration.id for migration in manifest.migrations[4:]
         ]


### PR DESCRIPTION
## Change

Add `public.get_asset_freshness()` for the two controlled house Elo assets, backed by an ordinary owner-rights view. Publication age advances with each SQL statement; current-pointer evidence, failed attempts and exact recorded mart dependencies remain distinct. Preserve the existing six-column `get_data_freshness()` RPC and its consumers.

Initial cadence and age-based stale flags are NULL until declared. Upstream `core.games` remains explicitly unversioned. `verify_load.py` incrementally reads the new surface: optional absent receipts warn, broken recorded inputs fail, and unknown cadence/closure cannot become a freshness PASS.

Migration 069 follows 068 in the managed manifests and keeps policy/receipt tables private. Independent review findings about precreated policy-table ownership and inconsistent unversioned-input claims were fixed with regressions.

## Validation

- 164 warehouse tests passed: verifier 68, executed freshness SQL 17, publication SQL 33, migration unit 40, fresh/upgrade bootstrap 2, verification transactions 4.
- Legacy freshness MCP tests: 3 passed separately.
- Ruff lint/format passed for all four affected Python files; diff check clean.
- Actual PostgreSQL 17 caller roles, reapplication, aging without refresh, failure/no-data distinction, broken dependency evidence and hostile precreated policy-table rejection were exercised on disposable local databases.

Production migration, runtime activation and cadence declaration remain separate. No production SQL or CFBD calls were made. Production-scale query cost remains unmeasured. Full evidence and rollout semantics: `docs/plans/2026-09-09-f19-receipt-freshness.md`.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62097787"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/formentera-operations/-/pull-requests/rstover-fo/cfb-database/141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge: the managed migration path, public freshness interface, and role-based access behavior completed successfully.

What we checked:
- Executed the receipt freshness chain validation using the general-contract-validation script and confirmed the run finished with exit code 0. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<details><summary><h3>Summary</h3></summary>

- This change adds receipt-backed freshness information for the controlled house Elo assets while preserving the existing freshness interface. It introduces a consumer-safe freshness RPC and view, tracks publication age and input-generation status, and adds verification coverage for lifecycle, access, migration, and backward compatibility.
</details>

<!-- /greptile_comment -->