### PR TITLE
Enforce pinned generations for controlled mart refresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - run: ./scripts/setup_dev.sh
       - name: Managed bootstrap and upgrade integration
-        run: .venv/bin/python -m pytest tests/test_warehouse_migrations_sql.py tests/test_warehouse_bootstrap_sql.py tests/test_adopt_warehouse_catalog_sql.py tests/test_f06_verification_transactions_sql.py tests/test_mart_release_sql.py tests/test_play_partitions.py tests/test_play_indexes_sql.py tests/test_operational_quota_sql.py tests/test_operational_quota_lifecycle_sql.py tests/test_cfbd_transport_admission_sql.py tests/test_asset_publication_sql.py tests/test_asset_freshness_sql.py -q --tb=short
+        run: .venv/bin/python -m pytest tests/test_warehouse_migrations_sql.py tests/test_warehouse_bootstrap_sql.py tests/test_adopt_warehouse_catalog_sql.py tests/test_f06_verification_transactions_sql.py tests/test_mart_release_sql.py tests/test_play_partitions.py tests/test_play_indexes_sql.py tests/test_operational_quota_sql.py tests/test_operational_quota_lifecycle_sql.py tests/test_cfbd_transport_admission_sql.py tests/test_asset_publication_sql.py tests/test_asset_freshness_sql.py tests/test_generation_refresh_sql.py -q --tb=short
         env:
           F06_TEST_DB_URL: postgresql://postgres:f06-disposable-ci@127.0.0.1:5432/postgres
           F06_REQUIRE_DB: "1"

--- a/docs/SCHEMA_CONTRACT.md
+++ b/docs/SCHEMA_CONTRACT.md
@@ -1265,6 +1265,23 @@ no generic quota operation access. Superseded originals require a present,
 matching reviewed replacement before complete coverage is published. See the
 [publication protocol and rollout](plans/2026-09-09-f14-publication-receipts.md).
 
+### Generation-enforced refresh (prepared, not deployed)
+
+Migration `070_generation_enforced_refresh.sql` adds private `warehouse_refresh`
+RPCs and a bounded `warehouse_refresher` NOLOGIN role. The opt-in
+`refresh_marts.py --views marts.house_elo_game --require-receipts` path pins the
+exact `analytics.house_elo_game` input generation and declared source cadence,
+revalidates them under locks, and commits an ordinary mart refresh with its
+receipt, exact input edge, current pointer and terminal run outcome atomically.
+Missing, incomplete, stale or latest-unsuccessful source evidence blocks this
+path. Unknown source cadence also blocks; no policy is activated by migration.
+
+The proof stops at the declared house Elo source boundary: unversioned
+`core.games` still prevents a full upstream freshness claim. The F19 public RPC
+shape and legacy refresh behavior remain compatible. No public grants, runtime
+membership or scheduled activation are added. See the
+[protocol, concurrency and rollout](plans/2026-09-09-f11-generation-enforcement.md).
+
 ### Raw Data Tables
 
 | Schema | Tables |

--- a/docs/plans/2026-09-04-main-codebase-audit.md
+++ b/docs/plans/2026-09-04-main-codebase-audit.md
@@ -228,6 +228,13 @@ Evidence: [daily sequence](https://github.com/rstover-fo/cfb-database/blob/4a798
 
 **P1 for dependency gating; P2 for cost · Confirmed / Opportunity · L**
 
+**Implementation progress (2026-09-09):** an opt-in generation-enforced
+house Elo mart adapter is prepared in migration 070. It pins source/target
+receipts and source cadence, rejects invalid inputs, and publishes refresh data,
+receipt, dependency edge and current pointer atomically. This is a bounded
+source-wide edge; broader source generation coverage and production activation
+remain open. See the [F11 protocol](2026-09-09-f11-generation-enforcement.md).
+
 The loader can refresh marts after a source fails. The Python refresher continues after an upstream view fails, allowing descendants to refresh from old upstream contents. Per-view commits make mixed generations visible. The SQL refresh-all function uses a different, nonconcurrent transaction pattern. Separately, daily full refreshes repeatedly scan historical play data across several large marts.
 
 Evidence: [load failure/refresh flow](https://github.com/rstover-fo/cfb-database/blob/4a798fde40480ac01d60a4d08c9c4eba42bed2c2/scripts/load_season.py#L604), [refresh loop](https://github.com/rstover-fo/cfb-database/blob/4a798fde40480ac01d60a4d08c9c4eba42bed2c2/scripts/refresh_marts.py#L235), [SQL refresher](https://github.com/rstover-fo/cfb-database/blob/4a798fde40480ac01d60a4d08c9c4eba42bed2c2/src/schemas/functions/refresh_all_marts.sql), [game EPA aggregation](https://github.com/rstover-fo/cfb-database/blob/4a798fde40480ac01d60a4d08c9c4eba42bed2c2/src/schemas/marts/002_game_epa_calc.sql).

--- a/docs/plans/2026-09-09-f11-generation-enforcement.md
+++ b/docs/plans/2026-09-09-f11-generation-enforcement.md
@@ -83,6 +83,11 @@ bootstrap and production manifests. Runtime login membership and an appropriate
 source cadence must be separately configured before activation. No scheduled
 workflow is switched to the new mode by this change.
 
+Migration application rejects preexisting memberships in either direction for
+`warehouse_refresher`, including runtime logins already granted the role. A direct
+reapplication after activation therefore requires membership to be removed first;
+the managed runner normally skips an already recorded migration.
+
 The existing trusted-administrator boundary still applies: administrators must
 clear current pointers before disabling publication event guards. This protocol
 checks guard presence and refuses new publication when it cannot trust them;

--- a/docs/plans/2026-09-09-f11-generation-enforcement.md
+++ b/docs/plans/2026-09-09-f11-generation-enforcement.md
@@ -1,0 +1,115 @@
+# F11: generation-enforced house Elo refresh
+
+Status: prepared implementation; production migration, runtime membership and
+cadence declaration require a separate rollout. This is delivery step 6 after
+the receipt-backed freshness compatibility layer.
+
+## Bounded planner contract
+
+The existing registry still determines selection and dependency order. New
+`refresh_marts.py --views marts.house_elo_game --require-receipts` opts into a
+controlled adapter for the single declared input `analytics.house_elo_game` at
+`source-wide` grain. The adapter rejects unsupported or mixed selections before
+opening a database connection or executing any refresh. In particular,
+`--changed analytics.house_elo_game` also selects the unreceipted house Elo
+summary, so it cannot silently refresh only a supported subset in strict mode.
+The adapter checks that the registry still declares exactly its supported edge.
+Legacy refreshes and workflows retain their existing behavior.
+
+Dry runs are offline: they describe the bounded RPC sequence and explicitly do
+not claim to have validated live generations or cadence. Actual receipt-enforced
+refreshes use ordinary `REFRESH`, holding the mart read-blocking lock until
+commit, even when the legacy CLI defaults to concurrent refreshes.
+
+The database plan pins the source generation, expected current mart generation,
+source publication interval and fixed input boundary. It requires a current
+complete successful or evaluated `expected_no_data` source receipt, a declared
+positive source cadence, and an age inside that interval. A later failed,
+partial, deferred or blocked source attempt blocks this strict plan even if an
+older valid publication is still readable. The diagnostic freshness API can
+continue showing that older publication; publication admission is stricter.
+
+Only the house Elo source boundary is proven. `core.games` remains unversioned;
+this mode neither bypasses a required registered edge nor claims full provider
+freshness. An explicit refresh can create a new mart generation against the same
+source generation, but it retains that exact edge and cannot renew the source's
+publication age. Unknown source cadence blocks execution instead of inventing
+an SLA.
+
+## Atomic protocol and concurrency
+
+1. Read the eligible plan through the bounded read RPC.
+2. Start an operation with the exact plan and commit its parent record.
+3. In a fresh READ COMMITTED transaction, invoke the publication RPC. It checks
+   session ownership and scope, pins both source tables and registered assets,
+   locks the declared policy and current source pointer, and prevents concurrent
+   source-failure receipt insertion during admission/publication.
+4. Revalidate exact generations, policy, source completion, latest outcome,
+   source row coverage and installed invalidation guards. Refresh the mart,
+   recheck its registered OID and row coverage, and check that the source has not
+   aged past its interval while waiting or refreshing.
+5. Commit the refreshed mart, successful receipt, exact input edge, new mart
+   pointer and successful operation outcome together. The source generation and
+   timestamp do not advance.
+
+The lock order is operation -> both source tables -> ordered asset rows ->
+source policy -> receipt table -> source pointer -> ordinary mart refresh.
+Source and snapshot DML serialize with this path; a legacy write after commit
+invalidates the receipts normally. The mart pointer is not locked before
+REFRESH, avoiding a lock cycle with a legacy refresh's event-trigger deletion.
+The receipt-table SHARE lock is intentionally conservative because the earlier
+failure writer does not lock asset rows. This may delay other receipt writers;
+production contention and lock duration are unmeasured.
+
+Stale plans or invalid inputs cannot advance data or success pointers. A known
+failure rolls back the refresh, then records a failed or blocked mart receipt
+and terminal operation outcome in a separate transaction; it never records a
+source failure on behalf of the source producer. Exact publication replay is an
+immutable lookup, not a pointer update. Terminal runs cannot publish a second
+generation. An uncertain start/publication commit logs both IDs and stops;
+there is no automatic retry or contradictory failure receipt.
+
+## Access and rollout
+
+Migration 070 adds the owner-controlled `warehouse_refresh` routines namespace
+and a bounded `warehouse_refresher` NOLOGIN role. Only its four public protocol
+RPCs are executable by that role. The internal run validator, generic operation
+helpers, direct target/ledger mutation and consumer access remain excluded.
+There are no new consumer RPCs or changes to the F19 public response.
+
+Append-only receipts and operation semantics from 066–069 are reused without
+rewriting those migrations. The new migration follows 069 in the managed
+bootstrap and production manifests. Runtime login membership and an appropriate
+source cadence must be separately configured before activation. No scheduled
+workflow is switched to the new mode by this change.
+
+The existing trusted-administrator boundary still applies: administrators must
+clear current pointers before disabling publication event guards. This protocol
+checks guard presence and refuses new publication when it cannot trust them;
+it cannot defend against an administrator rewriting system catalogs.
+
+## Verification
+
+The final combined local regression suite passed **157 tests** in 20.29s:
+27 executed generation-enforcement SQL cases, 33 existing publication cases,
+17 freshness cases, two fresh/upgrade bootstrap cases, and 78 planner/adapter/
+migration unit checks. All four affected Python files passed Ruff lint and
+format checks; `git diff --check` was clean.
+
+The SQL cases ran on explicitly selected disposable PostgreSQL 17 databases.
+They exercised the real Python adapter, exact plan/edge evidence, atomic
+rollback, no-data coverage, all unsuccessful source outcomes, stale and changed
+policies, concurrent compare-and-swap, replay, source/snapshot writes and source
+failure receipts queued during publication, expiry while blocked on a mart,
+invalid guards/OIDs, actual caller roles, reapplication, and session ownership.
+
+Independent subagent reviews of code not authored by each reviewer found no
+remaining material issues after fixing receipt-writer serialization, direct
+read/mutation and unrelated RPC grants, and unexpected overload admission.
+The final role check also rejects PostgreSQL 17's direct `MAINTAIN` privilege,
+which can authorize [materialized-view refresh](https://www.postgresql.org/docs/17/sql-refreshmaterializedview.html)
+without ownership; a separate executed regression covers it.
+
+No production SQL, CFBD request, runtime membership, cadence declaration or
+workflow activation was performed. Production lock duration, contention and
+managed-platform privilege parity remain unmeasured.

--- a/docs/warehouse-operations.md
+++ b/docs/warehouse-operations.md
@@ -73,6 +73,17 @@ the six-column `get_data_freshness()` consumer RPC remain compatible.
 See the [evidence meanings and rollout limits](plans/2026-09-09-f19-receipt-freshness.md)
 before interpreting either surface as a source-freshness guarantee.
 
+## Generation-enforced refresh (prepared)
+
+After migration 070 and a separately authorized role/cadence rollout, use
+`python scripts/refresh_marts.py --views marts.house_elo_game --require-receipts`
+for atomic refresh and receipt publication at the house Elo source boundary.
+The source must have complete, current, non-stale receipt evidence and a
+successful latest attempt. Unsupported/mixed plans fail before execution; dry
+runs remain offline. This mode uses an ordinary refresh and blocks mart reads
+until commit. Existing refresh commands do not opt in automatically.
+See the [F11 protocol and recovery limits](plans/2026-09-09-f11-generation-enforcement.md).
+
 ## Plays partition rollover (F08)
 
 `run_plays_pipeline()` performs catalog preflight before constructing the source

--- a/scripts/refresh_marts.py
+++ b/scripts/refresh_marts.py
@@ -67,7 +67,7 @@ def _print_receipt_refresh_dry_run() -> None:
     print("  Live generation, cadence, and staleness validation is not run during --dry-run.")
 
 
-def _receipt_failure_outcome(exc: Exception) -> str:
+def _receipt_failure_outcome(exc: BaseException) -> str:
     """Generation races and no-longer-ready inputs are blocked, not failed."""
     return "blocked" if getattr(exc, "pgcode", None) in {"40001", "55000"} else "failed"
 
@@ -94,8 +94,8 @@ def _refresh_house_elo_game_with_receipts(conn) -> bool:
             cur.fetchone()
         start_commit_pending = True
         conn.commit()
-        start_commit_pending = False
         started = True
+        start_commit_pending = False
 
         with conn.cursor() as cur:
             cur.execute("SET TRANSACTION ISOLATION LEVEL READ COMMITTED")
@@ -116,7 +116,8 @@ def _refresh_house_elo_game_with_receipts(conn) -> bool:
             replayed,
         )
         return True
-    except Exception as exc:  # noqa: BLE001 - preserve definite vs uncertain commit outcomes
+    except BaseException as exc:  # noqa: BLE001 - interruptions need the same durable cleanup
+        interrupted = not isinstance(exc, Exception)
         try:
             conn.rollback()
         except Exception:  # noqa: BLE001 - a broken connection cannot be recovered here
@@ -129,6 +130,8 @@ def _refresh_house_elo_game_with_receipts(conn) -> bool:
                 run_id,
                 generation_id,
             )
+            if interrupted:
+                raise
             return False
         if publication_commit_pending:
             logger.error(
@@ -137,9 +140,13 @@ def _refresh_house_elo_game_with_receipts(conn) -> bool:
                 run_id,
                 generation_id,
             )
+            if interrupted:
+                raise
             return False
         if not started:
             logger.error("Receipt refresh could not start for %s: %s", RECEIPT_REFRESH_VIEW, exc)
+            if interrupted:
+                raise
             return False
 
         outcome = _receipt_failure_outcome(exc)
@@ -162,6 +169,8 @@ def _refresh_house_elo_game_with_receipts(conn) -> bool:
             generation_id,
             exc,
         )
+        if interrupted:
+            raise
         return False
 
 

--- a/scripts/refresh_marts.py
+++ b/scripts/refresh_marts.py
@@ -9,11 +9,13 @@ Usage:
     python scripts/refresh_marts.py --dry-run          # Print SQL without executing
     python scripts/refresh_marts.py --views marts.house_elo,marts.house_elo_game
     python scripts/refresh_marts.py --changed ratings.sdv_ratings_weekly --dry-run
+    python scripts/refresh_marts.py --views marts.house_elo_game --require-receipts
 """
 
 import argparse
 import logging
 import sys
+import uuid
 from datetime import datetime
 
 import dlt
@@ -27,6 +29,140 @@ logger = logging.getLogger(__name__)
 
 MARTS_VIEWS = list(REFRESH_GRAPH.plan(schema="marts").views)
 ANALYTICS_VIEWS = list(REFRESH_GRAPH.plan(schema="analytics").views)
+
+RECEIPT_REFRESH_VIEW = "marts.house_elo_game"
+RECEIPT_REFRESH_INPUT = "analytics.house_elo_game"
+
+
+def _validate_receipt_refresh_plan(views: tuple[str, ...]) -> None:
+    """Keep the first receipt-enforced adapter intentionally narrow."""
+    if views != (RECEIPT_REFRESH_VIEW,):
+        raise ValueError(
+            "--require-receipts supports only --views marts.house_elo_game; "
+            "mixed, schema, full, and changed-relation plans are not yet supported"
+        )
+    dependency = REFRESH_GRAPH.assets[RECEIPT_REFRESH_VIEW].depends_on
+    if dependency != (RECEIPT_REFRESH_INPUT,):
+        raise ValueError(
+            f"{RECEIPT_REFRESH_VIEW} receipt adapter requires the sole declared input "
+            f"{RECEIPT_REFRESH_INPUT}; found {dependency}"
+        )
+
+
+def _print_receipt_refresh_dry_run() -> None:
+    print(
+        f"  [DRY RUN] receipt-required ordinary refresh: {RECEIPT_REFRESH_VIEW} "
+        f"<= {RECEIPT_REFRESH_INPUT}/source-wide"
+    )
+    print("  SELECT warehouse_refresh.get_house_elo_game_plan();")
+    print("  SELECT warehouse_refresh.start_house_elo_game_refresh(<run_id>, <opaque_plan>);")
+    print(
+        "  SELECT * FROM warehouse_refresh.publish_house_elo_game_refresh("
+        "<run_id>, <generation_id>);"
+    )
+    print(
+        "  On a known failure after rollback: "
+        "warehouse_refresh.fail_house_elo_game_refresh(<run_id>, <generation_id>, <outcome>)"
+    )
+    print("  Live generation, cadence, and staleness validation is not run during --dry-run.")
+
+
+def _receipt_failure_outcome(exc: Exception) -> str:
+    """Generation races and no-longer-ready inputs are blocked, not failed."""
+    return "blocked" if getattr(exc, "pgcode", None) in {"40001", "55000"} else "failed"
+
+
+def _refresh_house_elo_game_with_receipts(conn) -> bool:
+    """Refresh the supported mart through the atomic generation RPC protocol."""
+    from psycopg2.extras import Json
+
+    run_id = str(uuid.uuid4())
+    generation_id = str(uuid.uuid4())
+    started = False
+    start_commit_pending = False
+    publication_commit_pending = False
+
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SET LOCAL ROLE warehouse_refresher")
+            cur.execute("SELECT warehouse_refresh.get_house_elo_game_plan()")
+            plan = cur.fetchone()[0]
+            cur.execute(
+                "SELECT warehouse_refresh.start_house_elo_game_refresh(%s,%s::jsonb)",
+                (run_id, Json(plan)),
+            )
+            cur.fetchone()
+        start_commit_pending = True
+        conn.commit()
+        start_commit_pending = False
+        started = True
+
+        with conn.cursor() as cur:
+            cur.execute("SET TRANSACTION ISOLATION LEVEL READ COMMITTED")
+            cur.execute("SET LOCAL ROLE warehouse_refresher")
+            cur.execute(
+                "SELECT * FROM warehouse_refresh.publish_house_elo_game_refresh(%s,%s)",
+                (run_id, generation_id),
+            )
+            published_generation, replayed, published_rows = cur.fetchone()
+        publication_commit_pending = True
+        conn.commit()
+        publication_commit_pending = False
+        logger.info(
+            "Receipt publication committed for %s: generation=%s rows=%s replayed=%s",
+            RECEIPT_REFRESH_VIEW,
+            published_generation,
+            published_rows,
+            replayed,
+        )
+        return True
+    except Exception as exc:  # noqa: BLE001 - preserve definite vs uncertain commit outcomes
+        try:
+            conn.rollback()
+        except Exception:  # noqa: BLE001 - a broken connection cannot be recovered here
+            pass
+
+        if start_commit_pending:
+            logger.error(
+                "Receipt refresh operation start has an unknown commit outcome: run=%s "
+                "generation=%s; inspect durable records before retrying",
+                run_id,
+                generation_id,
+            )
+            return False
+        if publication_commit_pending:
+            logger.error(
+                "Receipt refresh publication has an unknown commit outcome: run=%s "
+                "generation=%s; inspect the generation before retrying",
+                run_id,
+                generation_id,
+            )
+            return False
+        if not started:
+            logger.error("Receipt refresh could not start for %s: %s", RECEIPT_REFRESH_VIEW, exc)
+            return False
+
+        outcome = _receipt_failure_outcome(exc)
+        try:
+            with conn.cursor() as cur:
+                cur.execute("SET LOCAL ROLE warehouse_refresher")
+                cur.execute(
+                    "SELECT warehouse_refresh.fail_house_elo_game_refresh(%s,%s,%s)",
+                    (run_id, generation_id, outcome),
+                )
+                cur.fetchone()
+            conn.commit()
+        except Exception:  # noqa: BLE001 - retain the original publication error
+            logger.exception("Could not persist receipt refresh failure for run=%s", run_id)
+        logger.error(
+            "Receipt refresh %s for %s: run=%s generation=%s: %s",
+            outcome,
+            RECEIPT_REFRESH_VIEW,
+            run_id,
+            generation_id,
+            exc,
+        )
+        return False
 
 
 def get_db_url() -> str:
@@ -95,6 +231,7 @@ def refresh_marts(
     dry_run: bool = False,
     views: list[str] | None = None,
     changed: list[str] | None = None,
+    require_receipts: bool = False,
 ) -> int:
     """Refresh selected SQL descendants; return failed plus blocked count.
 
@@ -109,17 +246,28 @@ def refresh_marts(
         logger.error("Invalid refresh plan: %s", exc)
         return 1
     views = list(plan.views)
+    if require_receipts:
+        try:
+            _validate_receipt_refresh_plan(plan.views)
+        except ValueError as exc:
+            logger.error("Invalid receipt refresh plan: %s", exc)
+            return 1
     if not views:
         logger.info("No dependent materialized views require refresh")
         return 0
 
     logger.info(f"Refreshing {len(views)} materialized view(s)")
-    if concurrently:
+    if require_receipts:
+        logger.info("Receipt-required publication uses an ordinary atomic refresh (reads block)")
+    elif concurrently:
         logger.info("Using CONCURRENTLY (reads not blocked)")
     else:
         logger.info("Not using CONCURRENTLY (reads blocked during refresh)")
 
     if dry_run:
+        if require_receipts:
+            _print_receipt_refresh_dry_run()
+            return 0
         for view in views:
             refresh_view(view, conn=None, concurrently=concurrently, dry_run=True)
         return 0
@@ -143,16 +291,19 @@ def refresh_marts(
             _cur.execute("SET statement_timeout = 0")
         conn.commit()
 
-        unsuccessful: set[str] = set()
-        for view in views:
-            blocked_by = REFRESH_GRAPH.ancestors(view).intersection(unsuccessful)
-            if blocked_by:
-                logger.error("Blocked %s after upstream failure: %s", view, sorted(blocked_by))
-                unsuccessful.add(view)
-                failures += 1
-            elif not refresh_view(view, conn, concurrently, dry_run):
-                unsuccessful.add(view)
-                failures += 1
+        if require_receipts:
+            failures = 0 if _refresh_house_elo_game_with_receipts(conn) else 1
+        else:
+            unsuccessful: set[str] = set()
+            for view in views:
+                blocked_by = REFRESH_GRAPH.ancestors(view).intersection(unsuccessful)
+                if blocked_by:
+                    logger.error("Blocked %s after upstream failure: %s", view, sorted(blocked_by))
+                    unsuccessful.add(view)
+                    failures += 1
+                elif not refresh_view(view, conn, concurrently, dry_run):
+                    unsuccessful.add(view)
+                    failures += 1
     finally:
         conn.close()
 
@@ -192,6 +343,11 @@ def main() -> None:
         "--changed",
         help="Committed relations; refresh SQL descendants (overrides --schema)",
     )
+    parser.add_argument(
+        "--require-receipts",
+        action="store_true",
+        help="Require atomic generation validation/publication (marts.house_elo_game only)",
+    )
     args = parser.parse_args()
     if args.views is not None and args.changed is not None:
         parser.error("--views and --changed cannot be combined")
@@ -208,6 +364,7 @@ def main() -> None:
         changed=[v.strip() for v in args.changed.split(",") if v.strip()]
         if args.changed is not None
         else None,
+        require_receipts=args.require_receipts,
     )
     sys.exit(failures)
 

--- a/src/schemas/migrations/070_generation_enforced_refresh.sql
+++ b/src/schemas/migrations/070_generation_enforced_refresh.sql
@@ -37,7 +37,8 @@ BEGIN
     ELSIF EXISTS (SELECT 1 FROM pg_catalog.pg_roles r WHERE r.rolname='warehouse_refresher'
         AND (r.rolcanlogin OR r.rolinherit OR r.rolsuper OR r.rolcreatedb
             OR r.rolcreaterole OR r.rolreplication OR r.rolbypassrls
-            OR EXISTS (SELECT 1 FROM pg_catalog.pg_auth_members WHERE member=r.oid))) THEN
+            OR EXISTS (SELECT 1 FROM pg_catalog.pg_auth_members
+                WHERE member=r.oid OR roleid=r.oid))) THEN
         RAISE EXCEPTION 'warehouse_refresher must be a bounded NOLOGIN role';
     END IF;
 END

--- a/src/schemas/migrations/070_generation_enforced_refresh.sql
+++ b/src/schemas/migrations/070_generation_enforced_refresh.sql
@@ -1,0 +1,335 @@
+-- F11 generation-enforced refresh: managed forward migration after 069.
+-- Opt-in standalone refresh of marts.house_elo_game only. The validated input
+-- boundary is analytics.house_elo_game, not unversioned upstream core.games.
+
+DO $namespace$
+DECLARE ns record;
+BEGIN
+    SELECT oid,nspowner,nspacl INTO ns FROM pg_catalog.pg_namespace
+    WHERE nspname='warehouse_refresh';
+    IF NOT FOUND THEN
+        CREATE SCHEMA warehouse_refresh;
+    ELSE
+        IF ns.nspowner <> (SELECT oid FROM pg_catalog.pg_roles WHERE rolname=current_user)
+            OR EXISTS (SELECT 1 FROM pg_catalog.aclexplode(ns.nspacl) a
+                WHERE a.grantee<>ns.nspowner AND a.privilege_type='CREATE')
+            OR EXISTS (SELECT 1 FROM pg_catalog.pg_type WHERE typnamespace=ns.oid)
+            OR EXISTS (SELECT 1 FROM pg_catalog.pg_proc p WHERE p.pronamespace=ns.oid
+                AND (p.proowner<>ns.nspowner OR p.prokind<>'f' OR p.provariadic<>0
+                    OR p.pronargdefaults<>0 OR NOT COALESCE(p.oid=ANY(ARRAY[
+                        pg_catalog.to_regprocedure('warehouse_refresh.get_house_elo_game_plan()'),
+                        pg_catalog.to_regprocedure('warehouse_refresh.start_house_elo_game_refresh(uuid,jsonb)'),
+                        pg_catalog.to_regprocedure('warehouse_refresh.require_house_elo_refresh_run(uuid)'),
+                        pg_catalog.to_regprocedure('warehouse_refresh.publish_house_elo_game_refresh(uuid,uuid)'),
+                        pg_catalog.to_regprocedure('warehouse_refresh.fail_house_elo_game_refresh(uuid,uuid,text)')
+                    ]::oid[]),false))) THEN
+            RAISE EXCEPTION 'warehouse_refresh must be a trusted migration-owned routines namespace';
+        END IF;
+    END IF;
+END
+$namespace$;
+
+DO $role$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname='warehouse_refresher') THEN
+        CREATE ROLE warehouse_refresher NOLOGIN NOINHERIT NOSUPERUSER NOCREATEDB
+            NOCREATEROLE NOREPLICATION NOBYPASSRLS;
+    ELSIF EXISTS (SELECT 1 FROM pg_catalog.pg_roles r WHERE r.rolname='warehouse_refresher'
+        AND (r.rolcanlogin OR r.rolinherit OR r.rolsuper OR r.rolcreatedb
+            OR r.rolcreaterole OR r.rolreplication OR r.rolbypassrls
+            OR EXISTS (SELECT 1 FROM pg_catalog.pg_auth_members WHERE member=r.oid))) THEN
+        RAISE EXCEPTION 'warehouse_refresher must be a bounded NOLOGIN role';
+    END IF;
+END
+$role$;
+
+CREATE OR REPLACE FUNCTION warehouse_refresh.get_house_elo_game_plan()
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path='' AS $function$
+DECLARE source_receipt meta.asset_receipts%ROWTYPE; target_generation uuid;
+    cadence interval; latest_outcome text;
+BEGIN
+    SELECT r.* INTO source_receipt FROM meta.asset_current_generations p
+    JOIN meta.asset_receipts r USING(asset_key,coverage_key,generation_id)
+    WHERE p.asset_key='analytics.house_elo_game' AND p.coverage_key='source-wide';
+    IF NOT FOUND OR source_receipt.outcome NOT IN ('succeeded','expected_no_data')
+        OR source_receipt.coverage->'complete' IS DISTINCT FROM 'true'::jsonb
+        OR source_receipt.published_at IS NULL THEN
+        RAISE EXCEPTION 'required source has no current complete generation' USING ERRCODE='55000';
+    END IF;
+    SELECT r.outcome INTO latest_outcome FROM meta.asset_receipts r
+    WHERE r.asset_key='analytics.house_elo_game' AND r.coverage_key='source-wide'
+    ORDER BY r.recorded_at DESC,r.generation_id DESC LIMIT 1;
+    IF latest_outcome IS NULL OR latest_outcome NOT IN ('succeeded','expected_no_data') THEN
+        RAISE EXCEPTION 'latest source attempt is unsuccessful' USING ERRCODE='55000';
+    END IF;
+    SELECT expected_refresh_interval INTO cadence FROM meta.asset_freshness_policies
+    WHERE asset_key='analytics.house_elo_game' AND coverage_key='source-wide';
+    IF cadence IS NULL OR cadence<=interval '0 seconds' THEN
+        RAISE EXCEPTION 'source publication cadence is undeclared' USING ERRCODE='55000';
+    END IF;
+    IF pg_catalog.clock_timestamp()-source_receipt.published_at>cadence THEN
+        RAISE EXCEPTION 'required source generation is stale' USING ERRCODE='55000';
+    END IF;
+    SELECT generation_id INTO target_generation FROM meta.asset_current_generations
+    WHERE asset_key='marts.house_elo_game' AND coverage_key='source-wide';
+    RETURN pg_catalog.jsonb_build_object(
+        'protocol','house-elo-game-refresh-v1','assets','["marts.house_elo_game"]'::jsonb,
+        'coverage_key','source-wide','input_asset','analytics.house_elo_game',
+        'source_generation_id',source_receipt.generation_id,'mart_generation_id',target_generation,
+        'expected_refresh_interval',cadence::text,'unversioned_input_assets','["core.games"]'::jsonb);
+END
+$function$;
+
+-- Private shared validator. Fixed scope prevents use of these wrappers to
+-- finish another job or impersonate another session's refresh invocation.
+CREATE OR REPLACE FUNCTION warehouse_refresh.require_house_elo_refresh_run(p_run_id uuid)
+RETURNS meta.operation_runs LANGUAGE plpgsql SET search_path='' AS $function$
+DECLARE r meta.operation_runs%ROWTYPE; expected jsonb; cadence interval;
+BEGIN
+    SELECT * INTO r FROM meta.operation_runs WHERE operation_run_id=p_run_id FOR UPDATE;
+    IF NOT FOUND OR r.recorded_by<>session_user OR r.operation_kind<>'refresh'
+        OR r.initiator<>'refresh_marts' OR r.code_revision IS NOT NULL THEN
+        RAISE EXCEPTION 'operation does not belong to this refresher' USING ERRCODE='22023';
+    END IF;
+    cadence := (r.requested_scope->>'expected_refresh_interval')::interval;
+    IF cadence IS NULL OR cadence<=interval '0 seconds'
+        OR r.requested_scope->>'source_generation_id' IS NULL THEN
+        RAISE EXCEPTION 'invalid pinned refresh input' USING ERRCODE='22023';
+    END IF;
+    expected := pg_catalog.jsonb_build_object(
+        'protocol','house-elo-game-refresh-v1','assets','["marts.house_elo_game"]'::jsonb,
+        'coverage_key','source-wide','input_asset','analytics.house_elo_game',
+        'source_generation_id',(r.requested_scope->>'source_generation_id')::uuid,
+        'mart_generation_id',(r.requested_scope->>'mart_generation_id')::uuid,
+        'expected_refresh_interval',r.requested_scope->>'expected_refresh_interval',
+        'unversioned_input_assets','["core.games"]'::jsonb);
+    IF r.requested_scope IS DISTINCT FROM expected
+        OR r.plan_digest IS DISTINCT FROM pg_catalog.md5(expected::text) THEN
+        RAISE EXCEPTION 'invalid pinned refresh scope' USING ERRCODE='22023';
+    END IF;
+    RETURN r;
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION warehouse_refresh.start_house_elo_game_refresh(p_run_id uuid,p_plan jsonb)
+RETURNS uuid LANGUAGE plpgsql SECURITY DEFINER SET search_path='' AS $function$
+BEGIN
+    PERFORM warehouse_quota.start_operation_run(p_run_id,'refresh','refresh_marts',p_plan,
+        pg_catalog.md5(p_plan::text),NULL);
+    PERFORM warehouse_refresh.require_house_elo_refresh_run(p_run_id);
+    RETURN p_run_id;
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION warehouse_refresh.publish_house_elo_game_refresh(p_run_id uuid,p_generation uuid)
+RETURNS TABLE(generation_id uuid,replayed boolean,published_rows bigint)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path='' AS $function$
+DECLARE run_row meta.operation_runs%ROWTYPE; existing meta.asset_receipts%ROWTYPE;
+    source_receipt meta.asset_receipts%ROWTYPE; expected_source uuid; expected_mart uuid;
+    current_source uuid; plan_now jsonb; request_digest_value text; source_rows bigint;
+    previous_rows bigint; result_rows bigint; publication_time timestamptz;
+BEGIN
+    IF p_generation IS NULL THEN
+        RAISE EXCEPTION 'generation ID is required' USING ERRCODE='22023';
+    END IF;
+    run_row := warehouse_refresh.require_house_elo_refresh_run(p_run_id);
+    expected_source := (run_row.requested_scope->>'source_generation_id')::uuid;
+    expected_mart := (run_row.requested_scope->>'mart_generation_id')::uuid;
+    request_digest_value := pg_catalog.md5(pg_catalog.jsonb_build_object(
+        'run_id',p_run_id,'generation_id',p_generation,'plan',run_row.requested_scope)::text);
+    SELECT * INTO existing FROM meta.asset_receipts r WHERE r.generation_id=p_generation;
+    IF FOUND THEN
+        IF existing.operation_run_id<>p_run_id OR existing.asset_key<>'marts.house_elo_game'
+            OR existing.request_digest<>request_digest_value
+            OR existing.outcome NOT IN ('succeeded','expected_no_data')
+            OR run_row.outcome<>'succeeded'
+            OR NOT EXISTS (SELECT 1 FROM meta.asset_receipt_inputs i
+                WHERE i.generation_id=p_generation AND i.input_asset_key='analytics.house_elo_game'
+                    AND i.input_coverage_key='source-wide' AND i.input_generation_id=expected_source) THEN
+            RAISE EXCEPTION 'generation ID already has different refresh context' USING ERRCODE='22023';
+        END IF;
+        RETURN QUERY SELECT p_generation,true,(existing.row_delta->>'published_rows')::bigint;
+        RETURN;
+    END IF;
+    IF run_row.outcome<>'running' THEN
+        RAISE EXCEPTION 'refresh operation is terminal' USING ERRCODE='22023';
+    END IF;
+    IF pg_catalog.current_setting('transaction_isolation')<>'read committed'
+        OR pg_catalog.current_setting('session_replication_role')<>'origin'
+        OR COALESCE(pg_catalog.current_setting('event_triggers',true),'on')<>'on' THEN
+        RAISE EXCEPTION 'refresh publication requires READ COMMITTED and active guards' USING ERRCODE='25001';
+    END IF;
+
+    -- Matches 068's source-before-asset order. Snapshot writes also invalidate
+    -- source evidence, so both source targets are pinned against ordinary DML.
+    LOCK TABLE analytics.house_elo_game,analytics.house_elo_current IN SHARE MODE;
+    PERFORM 1 FROM meta.asset_publication_locks
+    WHERE asset_key IN ('analytics.house_elo_game','marts.house_elo_game') ORDER BY asset_key FOR UPDATE;
+    PERFORM 1 FROM meta.asset_freshness_policies WHERE asset_key='analytics.house_elo_game'
+        AND coverage_key='source-wide' FOR SHARE;
+    -- 068 failure receipts do not lock asset rows. Block those inserts too,
+    -- so a newly failed input cannot race the latest-outcome eligibility check.
+    LOCK TABLE meta.asset_receipts IN SHARE MODE;
+    SELECT p.generation_id INTO current_source FROM meta.asset_current_generations p
+    WHERE p.asset_key='analytics.house_elo_game' AND p.coverage_key='source-wide' FOR SHARE;
+
+    IF (SELECT count(*) FROM meta.asset_publication_locks l
+            WHERE l.asset_key IN ('analytics.house_elo_game','marts.house_elo_game')
+                AND l.relation_oid=pg_catalog.to_regclass(l.asset_key))<>2
+        OR NOT EXISTS (SELECT 1 FROM pg_catalog.pg_trigger t
+            WHERE t.tgrelid='analytics.house_elo_game'::regclass
+                AND t.tgname='invalidate_house_elo_game_pointer' AND t.tgtype=62
+                AND t.tgenabled IN ('O','A') AND NOT t.tgisinternal
+                AND t.tgfoid=pg_catalog.to_regprocedure('warehouse_publication.invalidate_house_elo_pointers()'))
+        OR NOT EXISTS (SELECT 1 FROM pg_catalog.pg_trigger t
+            WHERE t.tgrelid='analytics.house_elo_current'::regclass
+                AND t.tgname='invalidate_house_elo_current_pointer' AND t.tgtype=62
+                AND t.tgenabled IN ('O','A') AND NOT t.tgisinternal
+                AND t.tgfoid=pg_catalog.to_regprocedure('warehouse_publication.invalidate_house_elo_pointers()'))
+        OR NOT EXISTS (SELECT 1 FROM pg_catalog.pg_event_trigger e
+            WHERE e.evtname='warehouse_publication_invalidate_ddl' AND e.evtevent='ddl_command_end'
+                AND e.evtenabled IN ('O','A') AND e.evtfoid=pg_catalog.to_regprocedure(
+                    'warehouse_publication.invalidate_asset_pointer_ddl()'))
+        OR NOT EXISTS (SELECT 1 FROM pg_catalog.pg_event_trigger e
+            WHERE e.evtname='warehouse_publication_invalidate_drop' AND e.evtevent='sql_drop'
+                AND e.evtenabled IN ('O','A') AND e.evtfoid=pg_catalog.to_regprocedure(
+                    'warehouse_publication.invalidate_asset_pointer_drop()')) THEN
+        RAISE EXCEPTION 'publication guards or asset identities are invalid' USING ERRCODE='55000';
+    END IF;
+    plan_now := warehouse_refresh.get_house_elo_game_plan();
+    IF plan_now IS DISTINCT FROM run_row.requested_scope OR current_source IS DISTINCT FROM expected_source THEN
+        RAISE EXCEPTION 'pinned generation or cadence changed; replan required' USING ERRCODE='40001';
+    END IF;
+    SELECT * INTO STRICT source_receipt FROM meta.asset_receipts r WHERE r.generation_id=expected_source;
+    SELECT count(*) INTO source_rows FROM analytics.house_elo_game;
+    IF source_rows IS DISTINCT FROM (source_receipt.row_delta->>'published_rows')::bigint
+        OR (source_receipt.outcome='expected_no_data') IS DISTINCT FROM (source_rows=0) THEN
+        RAISE EXCEPTION 'source coverage and data disagree' USING ERRCODE='55000';
+    END IF;
+    SELECT count(*) INTO previous_rows FROM marts.house_elo_game;
+    -- Do not lock the mart pointer before this: a queued legacy refresh holds
+    -- the mart lock while its event guard deletes that pointer.
+    REFRESH MATERIALIZED VIEW marts.house_elo_game;
+    IF (SELECT relation_oid FROM meta.asset_publication_locks WHERE asset_key='marts.house_elo_game')
+            IS DISTINCT FROM pg_catalog.to_regclass('marts.house_elo_game') THEN
+        RAISE EXCEPTION 'mart identity changed during refresh' USING ERRCODE='40001';
+    END IF;
+    SELECT count(*) INTO result_rows FROM marts.house_elo_game;
+    publication_time := pg_catalog.clock_timestamp();
+    IF result_rows<>source_rows THEN
+        RAISE EXCEPTION 'refreshed coverage differs from source' USING ERRCODE='55000';
+    END IF;
+    IF publication_time-source_receipt.published_at>
+            (run_row.requested_scope->>'expected_refresh_interval')::interval THEN
+        RAISE EXCEPTION 'source became stale during refresh' USING ERRCODE='55000';
+    END IF;
+    INSERT INTO meta.asset_receipts(generation_id,operation_run_id,asset_key,outcome,coverage,
+        source_watermark,input_observations,row_delta,request_digest,published_at)
+    VALUES(p_generation,p_run_id,'marts.house_elo_game',source_receipt.outcome,
+        source_receipt.coverage||pg_catalog.jsonb_build_object('input_generation_id',expected_source),
+        source_receipt.source_watermark,
+        pg_catalog.jsonb_build_object('publisher','refresh_marts','protocol','house-elo-game-refresh-v1',
+            'input_boundary','analytics.house_elo_game','unversioned_input_assets','["core.games"]'::jsonb,
+            'expected_refresh_interval',run_row.requested_scope->>'expected_refresh_interval'),
+        pg_catalog.jsonb_build_object('observed_previous_rows',previous_rows,'published_rows',result_rows),
+        request_digest_value,publication_time);
+    INSERT INTO meta.asset_receipt_inputs(generation_id,input_asset_key,input_generation_id)
+    VALUES(p_generation,'analytics.house_elo_game',expected_source);
+    INSERT INTO meta.asset_current_generations(asset_key,generation_id)
+    VALUES('marts.house_elo_game',p_generation)
+    ON CONFLICT(asset_key,coverage_key) DO UPDATE SET generation_id=EXCLUDED.generation_id;
+    PERFORM warehouse_quota.finish_operation_run(p_run_id,'succeeded',NULL);
+    RETURN QUERY SELECT p_generation,false,result_rows;
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION warehouse_refresh.fail_house_elo_game_refresh(
+    p_run_id uuid,p_generation uuid,p_outcome text)
+RETURNS integer LANGUAGE plpgsql SECURITY DEFINER SET search_path='' AS $function$
+DECLARE run_row meta.operation_runs%ROWTYPE; existing meta.asset_receipts%ROWTYPE; digest text;
+BEGIN
+    IF p_generation IS NULL OR p_outcome IS NULL OR p_outcome NOT IN ('failed','blocked') THEN
+        RAISE EXCEPTION 'invalid refresh failure outcome' USING ERRCODE='22023';
+    END IF;
+    run_row := warehouse_refresh.require_house_elo_refresh_run(p_run_id);
+    digest := pg_catalog.md5(pg_catalog.jsonb_build_object('run_id',p_run_id,
+        'generation_id',p_generation,'plan',run_row.requested_scope,'outcome',p_outcome)::text);
+    SELECT * INTO existing FROM meta.asset_receipts r WHERE r.generation_id=p_generation;
+    IF FOUND THEN
+        IF existing.operation_run_id<>p_run_id OR existing.asset_key<>'marts.house_elo_game'
+            OR existing.outcome<>p_outcome OR existing.request_digest<>digest THEN
+            RAISE EXCEPTION 'generation ID has different failure context' USING ERRCODE='22023';
+        END IF;
+        RETURN 0;
+    END IF;
+    IF run_row.outcome<>'running' THEN
+        RAISE EXCEPTION 'refresh operation is terminal' USING ERRCODE='22023';
+    END IF;
+    INSERT INTO meta.asset_receipts(generation_id,operation_run_id,asset_key,outcome,coverage,
+        input_observations,request_digest,error_summary)
+    VALUES(p_generation,p_run_id,'marts.house_elo_game',p_outcome,
+        '{"complete":false,"scope":"source-wide"}'::jsonb,run_row.requested_scope,digest,'publication_failed');
+    RETURN warehouse_quota.finish_operation_run(p_run_id,p_outcome,'publication_failed');
+END
+$function$;
+
+DO $acl$
+DECLARE item record; recipient text;
+BEGIN
+    FOR item IN
+        SELECT 'SCHEMA' AS kind,'warehouse_refresh' AS name,a.grantee
+        FROM pg_catalog.pg_namespace n CROSS JOIN LATERAL pg_catalog.aclexplode(n.nspacl) a
+        WHERE n.nspname='warehouse_refresh' AND a.grantee<>n.nspowner
+        UNION
+        SELECT 'FUNCTION',p.oid::pg_catalog.regprocedure::text,a.grantee
+        FROM pg_catalog.pg_proc p JOIN pg_catalog.pg_namespace n ON n.oid=p.pronamespace
+        CROSS JOIN LATERAL pg_catalog.aclexplode(COALESCE(p.proacl,pg_catalog.acldefault('f',p.proowner))) a
+        WHERE n.nspname='warehouse_refresh' AND a.grantee<>p.proowner
+    LOOP
+        recipient := CASE WHEN item.grantee=0 THEN 'PUBLIC'
+            ELSE pg_catalog.quote_ident(pg_catalog.pg_get_userbyid(item.grantee)) END;
+        EXECUTE pg_catalog.format('REVOKE ALL ON %s %s FROM %s',item.kind,item.name,recipient);
+    END LOOP;
+END
+$acl$;
+GRANT USAGE ON SCHEMA warehouse_refresh TO warehouse_refresher;
+GRANT EXECUTE ON FUNCTION warehouse_refresh.get_house_elo_game_plan(),
+    warehouse_refresh.start_house_elo_game_refresh(uuid,jsonb),
+    warehouse_refresh.publish_house_elo_game_refresh(uuid,uuid),
+    warehouse_refresh.fail_house_elo_game_refresh(uuid,uuid,text) TO warehouse_refresher;
+
+-- A pre-existing role can have unsafe direct grants even without memberships.
+-- Refuse activation rather than silently retaining a route around the gates.
+DO $boundary$
+DECLARE relation_name text;
+BEGIN
+    FOREACH relation_name IN ARRAY ARRAY[
+        'analytics.house_elo_game','analytics.house_elo_current','marts.house_elo_game',
+        'meta.asset_receipts','meta.asset_current_generations','meta.asset_receipt_inputs',
+        'meta.asset_freshness_policies','meta.operation_runs'
+    ] LOOP
+        -- PostgreSQL 17 permits direct REFRESH with MAINTAIN even without
+        -- ownership or DML grants. Earlier servers require ownership instead.
+        IF pg_catalog.current_setting('server_version_num')::integer>=170000 THEN
+            IF pg_catalog.has_table_privilege('warehouse_refresher',relation_name,'MAINTAIN') THEN
+                RAISE EXCEPTION 'warehouse_refresher has unsafe maintenance access to %',relation_name;
+            END IF;
+        END IF;
+        IF pg_catalog.has_table_privilege('warehouse_refresher',relation_name,
+                'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
+            OR (SELECT relowner FROM pg_catalog.pg_class
+                WHERE oid=pg_catalog.to_regclass(relation_name)) =
+                    (SELECT oid FROM pg_catalog.pg_roles WHERE rolname='warehouse_refresher') THEN
+            RAISE EXCEPTION 'warehouse_refresher has unsafe direct access to %',relation_name;
+        END IF;
+    END LOOP;
+    IF EXISTS (
+        SELECT 1 FROM pg_catalog.pg_proc p
+        JOIN pg_catalog.pg_namespace n ON n.oid=p.pronamespace
+        WHERE n.nspname IN ('warehouse_quota','warehouse_publication')
+            AND pg_catalog.has_function_privilege('warehouse_refresher',p.oid,'EXECUTE')
+    ) THEN
+        RAISE EXCEPTION 'warehouse_refresher has unrelated quota or publication access';
+    END IF;
+END
+$boundary$;

--- a/src/schemas/production-manifest.json
+++ b/src/schemas/production-manifest.json
@@ -24,6 +24,11 @@
       "id": "warehouse.f19.069",
       "path": "src/schemas/migrations/069_receipt_backed_freshness.sql",
       "kind": "immutable"
+    },
+    {
+      "id": "warehouse.f11.070",
+      "path": "src/schemas/migrations/070_generation_enforced_refresh.sql",
+      "kind": "immutable"
     }
   ],
   "version": 1

--- a/src/schemas/warehouse-manifest.json
+++ b/src/schemas/warehouse-manifest.json
@@ -50,6 +50,11 @@
       "id": "warehouse.f19.069",
       "path": "src/schemas/migrations/069_receipt_backed_freshness.sql",
       "kind": "immutable"
+    },
+    {
+      "id": "warehouse.f11.070",
+      "path": "src/schemas/migrations/070_generation_enforced_refresh.sql",
+      "kind": "immutable"
     }
   ]
 }

--- a/tests/test_generation_refresh.py
+++ b/tests/test_generation_refresh.py
@@ -50,14 +50,16 @@ class _Connection:
         self,
         *,
         plan=None,
-        plan_error: Exception | None = None,
-        publish_error: Exception | None = None,
+        plan_error: BaseException | None = None,
+        publish_error: BaseException | None = None,
         fail_on_commit: int | None = None,
+        commit_error: BaseException | None = None,
     ):
         self.plan = plan if plan is not None else {"opaque": {"generation": "source-a"}}
         self.plan_error = plan_error
         self.publish_error = publish_error
         self.fail_on_commit = fail_on_commit
+        self.commit_error = commit_error or ConnectionError("commit acknowledgement lost")
         self.events = []
         self.commits = 0
         self.rollbacks = 0
@@ -70,7 +72,7 @@ class _Connection:
         self.commits += 1
         self.events.append(("commit", self.commits))
         if self.commits == self.fail_on_commit:
-            raise ConnectionError("commit acknowledgement lost")
+            raise self.commit_error
 
     def rollback(self):
         self.rollbacks += 1
@@ -200,6 +202,24 @@ def test_definite_refresh_failure_records_failed(monkeypatch):
     assert failure[2][2] == "failed"
 
 
+def test_keyboard_interrupt_during_publication_records_failure_then_reraises(monkeypatch):
+    connection = _Connection(publish_error=KeyboardInterrupt())
+
+    with pytest.raises(KeyboardInterrupt):
+        _run(monkeypatch, connection)
+
+    failures = [
+        event
+        for event in connection.events
+        if event[0] == "execute" and "fail_house_elo_game_refresh" in event[1]
+    ]
+    assert len(failures) == 1
+    assert failures[0][2][2] == "failed"
+    assert connection.rollbacks == 1
+    assert connection.commits == 3  # setup, durable operation start, failure receipt
+    assert connection.closed
+
+
 def test_unknown_publication_commit_never_records_failure_or_retries(monkeypatch, caplog):
     connection = _Connection(fail_on_commit=3)
 
@@ -230,4 +250,38 @@ def test_unknown_operation_start_commit_stops_before_publication(monkeypatch, ca
     assert not any("publish_house_elo_game_refresh" in statement for statement in statements)
     assert not any("fail_house_elo_game_refresh" in statement for statement in statements)
     assert "operation start has an unknown commit outcome" in caplog.text
+    assert connection.closed
+
+
+@pytest.mark.parametrize("commit_number", [2, 3])
+def test_keyboard_interrupt_during_uncertain_commit_never_records_failure(
+    monkeypatch, commit_number
+):
+    connection = _Connection(
+        fail_on_commit=commit_number,
+        commit_error=KeyboardInterrupt(),
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        _run(monkeypatch, connection)
+
+    statements = [event[1] for event in connection.events if event[0] == "execute"]
+    assert sum("start_house_elo_game_refresh" in statement for statement in statements) == 1
+    assert sum("publish_house_elo_game_refresh" in statement for statement in statements) == (
+        commit_number == 3
+    )
+    assert not any("fail_house_elo_game_refresh" in statement for statement in statements)
+    assert connection.closed
+
+
+def test_keyboard_interrupt_before_start_reraises_without_failure_receipt(monkeypatch):
+    connection = _Connection(plan_error=KeyboardInterrupt())
+
+    with pytest.raises(KeyboardInterrupt):
+        _run(monkeypatch, connection)
+
+    statements = [event[1] for event in connection.events if event[0] == "execute"]
+    assert any("get_house_elo_game_plan" in statement for statement in statements)
+    assert not any("start_house_elo_game_refresh" in statement for statement in statements)
+    assert not any("fail_house_elo_game_refresh" in statement for statement in statements)
     assert connection.closed

--- a/tests/test_generation_refresh.py
+++ b/tests/test_generation_refresh.py
@@ -1,0 +1,233 @@
+"""Focused tests for the opt-in receipt-required mart refresh path."""
+
+from unittest.mock import MagicMock
+
+import psycopg2
+import pytest
+
+from scripts import refresh_marts as runner
+
+
+class _SqlError(RuntimeError):
+    def __init__(self, message: str, pgcode: str | None = None):
+        super().__init__(message)
+        self.pgcode = pgcode
+
+
+class _Cursor:
+    def __init__(self, connection):
+        self.connection = connection
+        self.result = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def execute(self, sql, params=None):
+        self.connection.events.append(("execute", " ".join(sql.split()), params))
+        if "get_house_elo_game_plan" in sql:
+            if self.connection.plan_error is not None:
+                raise self.connection.plan_error
+            self.result = (self.connection.plan,)
+        elif "start_house_elo_game_refresh" in sql:
+            self.result = (params[0],)
+        elif "publish_house_elo_game_refresh" in sql:
+            if self.connection.publish_error is not None:
+                raise self.connection.publish_error
+            self.result = (params[1], False, 42)
+        elif "fail_house_elo_game_refresh" in sql:
+            self.result = (1,)
+
+    def fetchone(self):
+        result, self.result = self.result, None
+        return result
+
+
+class _Connection:
+    def __init__(
+        self,
+        *,
+        plan=None,
+        plan_error: Exception | None = None,
+        publish_error: Exception | None = None,
+        fail_on_commit: int | None = None,
+    ):
+        self.plan = plan if plan is not None else {"opaque": {"generation": "source-a"}}
+        self.plan_error = plan_error
+        self.publish_error = publish_error
+        self.fail_on_commit = fail_on_commit
+        self.events = []
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+
+    def cursor(self):
+        return _Cursor(self)
+
+    def commit(self):
+        self.commits += 1
+        self.events.append(("commit", self.commits))
+        if self.commits == self.fail_on_commit:
+            raise ConnectionError("commit acknowledgement lost")
+
+    def rollback(self):
+        self.rollbacks += 1
+        self.events.append(("rollback", self.rollbacks))
+
+    def close(self):
+        self.closed = True
+
+
+def _run(monkeypatch, connection, **kwargs):
+    monkeypatch.setattr(runner, "get_db_url", lambda: "postgresql://test")
+    monkeypatch.setattr(psycopg2, "connect", lambda _url: connection)
+    return runner.refresh_marts(views=["marts.house_elo_game"], require_receipts=True, **kwargs)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"views": ["marts.house_elo", "marts.house_elo_game"]},
+        {"changed": ["analytics.house_elo_game"]},
+    ],
+)
+def test_receipt_mode_rejects_full_mixed_and_changed_plans_before_database(monkeypatch, kwargs):
+    monkeypatch.setattr(
+        runner,
+        "get_db_url",
+        lambda: pytest.fail("invalid receipt plans must not resolve database credentials"),
+    )
+    assert runner.refresh_marts(require_receipts=True, **kwargs) == 1
+
+
+def test_receipt_dry_run_is_offline_and_does_not_claim_live_validation(monkeypatch, capsys):
+    monkeypatch.setattr(
+        runner,
+        "get_db_url",
+        lambda: pytest.fail("dry-run must remain offline"),
+    )
+
+    assert (
+        runner.refresh_marts(views=["marts.house_elo_game"], require_receipts=True, dry_run=True)
+        == 0
+    )
+
+    output = capsys.readouterr().out
+    assert "receipt-required ordinary refresh" in output
+    assert "analytics.house_elo_game/source-wide" in output
+    assert "get_house_elo_game_plan" in output
+    assert "fail_house_elo_game_refresh" in output
+    assert "start_house_elo_game_refresh" in output
+    assert "publish_house_elo_game_refresh" in output
+    assert "Live generation, cadence, and staleness validation is not run" in output
+    assert "CONCURRENTLY" not in output
+
+
+def test_legacy_refresh_path_is_unchanged(monkeypatch):
+    connection = MagicMock()
+    monkeypatch.setattr(runner, "get_db_url", lambda: "postgresql://test")
+    monkeypatch.setattr(psycopg2, "connect", lambda _url: connection)
+    calls = []
+
+    def refresh_view(name, conn, concurrently, dry_run):
+        calls.append((name, conn, concurrently, dry_run))
+        return True
+
+    monkeypatch.setattr(runner, "refresh_view", refresh_view)
+
+    assert runner.refresh_marts(views=["marts.house_elo_game"]) == 0
+    assert calls == [("marts.house_elo_game", connection, True, False)]
+    setup_cursor = connection.cursor.return_value.__enter__.return_value
+    executed = [call.args[0] for call in setup_cursor.execute.call_args_list]
+    assert not any("warehouse_refresh" in sql for sql in executed)
+    connection.close.assert_called_once()
+
+
+def test_plan_is_opaque_and_start_commits_before_publication(monkeypatch):
+    plan = {"opaque": ["source-generation", {"policy": "3 days"}]}
+    connection = _Connection(plan=plan)
+
+    assert _run(monkeypatch, connection) == 0
+
+    start_index = next(
+        index
+        for index, event in enumerate(connection.events)
+        if event[0] == "execute" and "start_house_elo_game_refresh" in event[1]
+    )
+    publish_index = next(
+        index
+        for index, event in enumerate(connection.events)
+        if event[0] == "execute" and "publish_house_elo_game_refresh" in event[1]
+    )
+    start_params = connection.events[start_index][2]
+    assert start_params[1].adapted is plan
+    assert any(event[0] == "commit" for event in connection.events[start_index:publish_index])
+    assert connection.commits == 3  # session setup, durable operation start, publication
+    assert connection.rollbacks == 0
+    assert connection.closed
+
+
+@pytest.mark.parametrize("pgcode", ["40001", "55000"])
+def test_definite_generation_or_readiness_failure_records_blocked(monkeypatch, pgcode):
+    connection = _Connection(publish_error=_SqlError("input changed", pgcode))
+
+    assert _run(monkeypatch, connection) == 1
+
+    failures = [
+        event
+        for event in connection.events
+        if event[0] == "execute" and "fail_house_elo_game_refresh" in event[1]
+    ]
+    assert len(failures) == 1
+    assert failures[0][2][2] == "blocked"
+    assert connection.rollbacks == 1
+    assert connection.commits == 3  # setup, durable operation start, blocked receipt
+
+
+def test_definite_refresh_failure_records_failed(monkeypatch):
+    connection = _Connection(publish_error=_SqlError("refresh failed", "XX000"))
+
+    assert _run(monkeypatch, connection) == 1
+
+    failure = next(
+        event
+        for event in connection.events
+        if event[0] == "execute" and "fail_house_elo_game_refresh" in event[1]
+    )
+    assert failure[2][2] == "failed"
+
+
+def test_unknown_publication_commit_never_records_failure_or_retries(monkeypatch, caplog):
+    connection = _Connection(fail_on_commit=3)
+
+    assert _run(monkeypatch, connection) == 1
+
+    statements = [event[1] for event in connection.events if event[0] == "execute"]
+    assert sum("publish_house_elo_game_refresh" in sql for sql in statements) == 1
+    assert not any("fail_house_elo_game_refresh" in sql for sql in statements)
+    assert "unknown commit outcome" in caplog.text
+
+
+def test_preplan_failure_does_not_start_or_record_a_receipt(monkeypatch):
+    connection = _Connection(plan_error=_SqlError("source cadence is undeclared", "55000"))
+
+    assert _run(monkeypatch, connection) == 1
+
+    statements = [event[1] for event in connection.events if event[0] == "execute"]
+    assert any("get_house_elo_game_plan" in sql for sql in statements)
+    assert not any("start_house_elo_game_refresh" in sql for sql in statements)
+    assert not any("fail_house_elo_game_refresh" in sql for sql in statements)
+
+
+def test_unknown_operation_start_commit_stops_before_publication(monkeypatch, caplog):
+    connection = _Connection(fail_on_commit=2)
+    assert _run(monkeypatch, connection) == 1
+    statements = [event[1] for event in connection.events if event[0] == "execute"]
+    assert sum("start_house_elo_game_refresh" in statement for statement in statements) == 1
+    assert not any("publish_house_elo_game_refresh" in statement for statement in statements)
+    assert not any("fail_house_elo_game_refresh" in statement for statement in statements)
+    assert "operation start has an unknown commit outcome" in caplog.text
+    assert connection.closed

--- a/tests/test_generation_refresh_sql.py
+++ b/tests/test_generation_refresh_sql.py
@@ -1,0 +1,699 @@
+"""Executed dependency-generation refresh checks on disposable PostgreSQL 17."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from threading import Event
+from time import monotonic, sleep
+
+import psycopg2
+import pytest
+from psycopg2 import sql
+
+from tests.test_asset_freshness_sql import freshness_db as _freshness_db  # noqa: F401
+from tests.test_asset_publication_sql import (
+    publication_args,
+    publish,
+    publisher_query,
+    start_run,
+)
+from tests.test_asset_publication_sql import publication_db as _publication_db  # noqa: F401
+from tests.test_warehouse_migrations_sql import query
+from tests.test_warehouse_migrations_sql import warehouse_db as _warehouse_db  # noqa: F401
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATION = ROOT / "src/schemas/migrations/070_generation_enforced_refresh.sql"
+SOURCE = "analytics.house_elo_game"
+MART = "marts.house_elo_game"
+PROTOCOL = "house-elo-game-refresh-v1"
+
+
+@pytest.fixture
+def generation_db(request):
+    conn, target = request.getfixturevalue("_freshness_db")
+    query(conn, MIGRATION.read_text())
+    return conn, target
+
+
+def refresher_query(conn, statement, values=None, *, commit=True):
+    with conn.cursor() as cur:
+        cur.execute("SET LOCAL ROLE warehouse_refresher")
+        cur.execute(statement, values)
+        result = cur.fetchall() if cur.description else None
+    if commit:
+        conn.commit()
+    return result
+
+
+def set_source_policy(conn, value="100 years"):
+    query(
+        conn,
+        "UPDATE meta.asset_freshness_policies "
+        "SET expected_refresh_interval=%s WHERE asset_key=%s AND coverage_key='source-wide'",
+        (value, SOURCE),
+    )
+
+
+def get_plan(conn):
+    return refresher_query(conn, "SELECT warehouse_refresh.get_house_elo_game_plan()")[0][0]
+
+
+def start_refresh(conn, plan, run_id=None):
+    run_id = str(run_id or uuid.uuid4())
+    result = refresher_query(
+        conn,
+        "SELECT warehouse_refresh.start_house_elo_game_refresh(%s,%s::jsonb)",
+        (run_id, json.dumps(plan)),
+    )[0][0]
+    assert str(result) == run_id
+    return run_id
+
+
+def finish_refresh(conn, run_id, generation_id=None, *, commit=True):
+    generation_id = str(generation_id or uuid.uuid4())
+    result = refresher_query(
+        conn,
+        "SELECT * FROM warehouse_refresh.publish_house_elo_game_refresh(%s,%s)",
+        (run_id, generation_id),
+        commit=commit,
+    )[0]
+    return generation_id, result
+
+
+def fail_refresh(conn, run_id, generation_id=None, outcome="failed"):
+    generation_id = str(generation_id or uuid.uuid4())
+    result = refresher_query(
+        conn,
+        "SELECT warehouse_refresh.fail_house_elo_game_refresh(%s,%s,%s)",
+        (run_id, generation_id, outcome),
+    )[0][0]
+    return generation_id, result
+
+
+def record_source_failure(conn, outcome="failed"):
+    run_id = start_run(conn)
+    source_generation, mart_generation = str(uuid.uuid4()), str(uuid.uuid4())
+    publisher_query(
+        conn,
+        "SELECT * FROM warehouse_publication.record_house_elo_failure(%s,%s,%s,%s,%s)",
+        (str(run_id), source_generation, mart_generation, outcome, "publication_failed"),
+    )
+    return source_generation, mart_generation
+
+
+def prepare_refresh(conn, *, policy="100 years"):
+    source_args = publication_args(conn)
+    publish(conn, source_args)
+    set_source_policy(conn, policy)
+    plan = get_plan(conn)
+    run_id = start_refresh(conn, plan)
+    return source_args, plan, run_id
+
+
+def current_generations(conn):
+    return dict(
+        query(
+            conn,
+            "SELECT asset_key,generation_id::text FROM meta.asset_current_generations "
+            "ORDER BY asset_key",
+        )
+    )
+
+
+def wait_for_lock(conn, application_name):
+    deadline = monotonic() + 5
+    while monotonic() < deadline:
+        if query(
+            conn,
+            "SELECT wait_event_type='Lock' FROM pg_stat_activity "
+            "WHERE datname=current_database() AND application_name=%s AND state='active'",
+            (application_name,),
+        ) == [(True,)]:
+            return
+        sleep(0.02)
+    pytest.fail(f"{application_name} never waited for the controlled refresh lock")
+
+
+def denied(conn, role, statement):
+    try:
+        with conn.cursor() as cur:
+            cur.execute(sql.SQL("SET LOCAL ROLE {}").format(sql.Identifier(role)))
+            with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+                cur.execute(statement)
+    finally:
+        conn.rollback()
+
+
+def test_plan_is_fixed_and_pins_current_generations(generation_db):
+    conn, _ = generation_db
+    source_args = publication_args(conn)
+    publish(conn, source_args)
+    set_source_policy(conn, "2 days")
+
+    plan = get_plan(conn)
+    assert plan == {
+        "protocol": PROTOCOL,
+        "assets": [MART],
+        "coverage_key": "source-wide",
+        "input_asset": SOURCE,
+        "source_generation_id": source_args[1],
+        "mart_generation_id": source_args[2],
+        "expected_refresh_interval": "2 days",
+        "unversioned_input_assets": ["core.games"],
+    }
+
+
+def test_plan_blocks_missing_input_or_undeclared_policy(generation_db):
+    conn, _ = generation_db
+    with pytest.raises(psycopg2.Error, match="source|current|generation|input"):
+        get_plan(conn)
+    conn.rollback()
+
+    publish(conn, publication_args(conn))
+    with pytest.raises(psycopg2.Error, match="cadence|interval|policy"):
+        get_plan(conn)
+    conn.rollback()
+
+
+def test_refresh_atomically_records_exact_input_and_keeps_source_pointer(generation_db):
+    conn, _ = generation_db
+    source_args, plan, run_id = prepare_refresh(conn)
+    before_source = current_generations(conn)[SOURCE]
+    generation_id, result = finish_refresh(conn, run_id)
+
+    assert str(result[0]) == generation_id
+    assert result[1] is False
+    assert result[2] == 1
+    pointers = current_generations(conn)
+    assert pointers[SOURCE] == before_source == source_args[1]
+    assert pointers[MART] == generation_id
+    assert query(
+        conn,
+        """
+        SELECT r.asset_key,r.outcome,r.coverage->>'complete',
+               i.input_asset_key,i.input_generation_id::text,
+               o.operation_kind,o.outcome
+        FROM meta.asset_receipts r
+        JOIN meta.asset_receipt_inputs i USING (generation_id)
+        JOIN meta.operation_runs o USING (operation_run_id)
+        WHERE r.generation_id=%s
+        """,
+        (generation_id,),
+    ) == [(MART, "succeeded", "true", SOURCE, plan["source_generation_id"], "refresh", "succeeded")]
+
+
+def test_refresh_rollback_exposes_no_partial_receipt_edge_or_pointer(generation_db):
+    conn, _ = generation_db
+    _, _, run_id = prepare_refresh(conn)
+    before = current_generations(conn)
+    receipt_count = query(conn, "SELECT count(*) FROM meta.asset_receipts")[0][0]
+    edge_count = query(conn, "SELECT count(*) FROM meta.asset_receipt_inputs")[0][0]
+
+    generation_id, _ = finish_refresh(conn, run_id, commit=False)
+    conn.rollback()
+    assert current_generations(conn) == before
+    assert query(conn, "SELECT count(*) FROM meta.asset_receipts") == [(receipt_count,)]
+    assert query(conn, "SELECT count(*) FROM meta.asset_receipt_inputs") == [(edge_count,)]
+    assert query(
+        conn, "SELECT count(*) FROM meta.asset_receipts WHERE generation_id=%s", (generation_id,)
+    ) == [(0,)]
+
+
+def test_expected_no_data_refresh_is_complete_and_keeps_zero_rows(generation_db):
+    conn, _ = generation_db
+    query(conn, "UPDATE core.games SET completed=false,home_points=NULL,away_points=NULL")
+    args = list(publication_args(conn))
+    args[6], args[7] = "[]", "[]"
+    publish(conn, tuple(args))
+    set_source_policy(conn)
+    plan = get_plan(conn)
+    run_id = start_refresh(conn, plan)
+
+    generation_id, result = finish_refresh(conn, run_id)
+    assert str(result[0]) == generation_id
+    assert result[1:] == (False, 0)
+    assert query(
+        conn,
+        "SELECT outcome,coverage->>'complete',row_delta->>'published_rows' "
+        "FROM meta.asset_receipts WHERE generation_id=%s",
+        (generation_id,),
+    ) == [("expected_no_data", "true", "0")]
+    assert query(conn, "SELECT count(*) FROM marts.house_elo_game") == [(0,)]
+
+
+@pytest.mark.parametrize("outcome", ["failed", "partial", "deferred", "blocked"])
+def test_latest_failed_input_blocks_a_pinned_refresh(generation_db, outcome):
+    conn, _ = generation_db
+    _, plan, run_id = prepare_refresh(conn)
+    before = current_generations(conn)
+    record_source_failure(conn, outcome)
+
+    generation_id = str(uuid.uuid4())
+    with pytest.raises(psycopg2.Error, match="latest|input|source|failed|blocked"):
+        finish_refresh(conn, run_id, generation_id)
+    conn.rollback()
+    assert current_generations(conn) == before
+    assert query(
+        conn, "SELECT count(*) FROM meta.asset_receipts WHERE generation_id=%s", (generation_id,)
+    ) == [(0,)]
+    assert plan["source_generation_id"] == before[SOURCE]
+
+
+@pytest.mark.parametrize("outcome", ["failed", "blocked"])
+def test_refresh_failure_receipt_is_mart_only_and_never_repoints(generation_db, outcome):
+    conn, _ = generation_db
+    _, _, run_id = prepare_refresh(conn)
+    before = current_generations(conn)
+    generation_id, result = fail_refresh(conn, run_id, outcome=outcome)
+
+    assert result >= 0
+    assert current_generations(conn) == before
+    assert query(
+        conn,
+        "SELECT asset_key,outcome,published_at,coverage->>'complete' "
+        "FROM meta.asset_receipts WHERE generation_id=%s",
+        (generation_id,),
+    ) == [(MART, outcome, None, "false")]
+    assert query(
+        conn,
+        "SELECT count(*) FROM meta.asset_receipt_inputs WHERE generation_id=%s",
+        (generation_id,),
+    ) == [(0,)]
+    assert query(
+        conn,
+        "SELECT operation_kind,outcome FROM meta.operation_runs WHERE operation_run_id=%s",
+        (run_id,),
+    ) == [("refresh", outcome)]
+
+
+def test_policy_change_and_stale_source_both_fail_closed(generation_db):
+    conn, _ = generation_db
+    _, _, run_id = prepare_refresh(conn)
+    set_source_policy(conn, "99 years")
+    generation_id = str(uuid.uuid4())
+    with pytest.raises(psycopg2.Error, match="policy|interval|plan|changed"):
+        finish_refresh(conn, run_id, generation_id)
+    conn.rollback()
+    assert query(
+        conn, "SELECT count(*) FROM meta.asset_receipts WHERE generation_id=%s", (generation_id,)
+    ) == [(0,)]
+
+    set_source_policy(conn, "1 microsecond")
+    sleep(0.01)
+    with pytest.raises(psycopg2.Error, match="stale|cadence|interval"):
+        get_plan(conn)
+    conn.rollback()
+
+
+def test_two_refreshes_pinned_to_one_mart_generation_have_one_winner(generation_db):
+    conn, target = generation_db
+    _, plan, _ = prepare_refresh(conn)
+    run_ids = [start_refresh(conn, plan), start_refresh(conn, plan)]
+    generation_ids = [str(uuid.uuid4()), str(uuid.uuid4())]
+
+    def contender(values):
+        other = psycopg2.connect(target)
+        try:
+            try:
+                result = refresher_query(
+                    other,
+                    "SELECT * FROM warehouse_refresh.publish_house_elo_game_refresh(%s,%s)",
+                    values,
+                )[0]
+                return "ok", result
+            except psycopg2.Error as exc:
+                other.rollback()
+                return "error", str(exc)
+        finally:
+            other.close()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(contender, zip(run_ids, generation_ids, strict=True)))
+    assert sorted(status for status, _ in results) == ["error", "ok"]
+    assert "changed" in next(detail for status, detail in results if status == "error").lower()
+    winner = next(result for status, result in results if status == "ok")
+    assert current_generations(conn)[MART] == str(winner[0])
+    assert query(conn, "SELECT count(*) FROM meta.asset_receipts WHERE asset_key=%s", (MART,)) == [
+        (2,)
+    ]
+
+
+def test_exact_replay_never_restores_an_older_mart_pointer(generation_db):
+    conn, _ = generation_db
+    _, _, first_run = prepare_refresh(conn)
+    first_generation, first_result = finish_refresh(conn, first_run)
+
+    second_plan = get_plan(conn)
+    second_run = start_refresh(conn, second_plan)
+    second_generation, _ = finish_refresh(conn, second_run)
+    assert current_generations(conn)[MART] == second_generation
+
+    replay_generation, replay = finish_refresh(conn, first_run, first_generation)
+    assert replay_generation == first_generation
+    assert str(replay[0]) == str(first_result[0]) == first_generation
+    assert replay[1] is True
+    assert current_generations(conn)[MART] == second_generation
+
+
+@pytest.mark.parametrize(
+    "statement",
+    [
+        "UPDATE analytics.house_elo_game SET home_postgame_elo=1600",
+        "UPDATE analytics.house_elo_current SET rating=1600",
+    ],
+)
+def test_source_dml_queued_during_refresh_invalidates_child_after_commit(generation_db, statement):
+    conn, target = generation_db
+    _, _, run_id = prepare_refresh(conn)
+    generation_id, _ = finish_refresh(conn, run_id, commit=False)
+    application_name = "generation-refresh-source-writer"
+    started = Event()
+    observer = psycopg2.connect(target)
+
+    def source_writer():
+        other = psycopg2.connect(target, application_name=application_name)
+        try:
+            with other.cursor() as cur:
+                cur.execute("SET statement_timeout='10s'")
+                started.set()
+                cur.execute(statement)
+            other.commit()
+        finally:
+            other.close()
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        try:
+            future = pool.submit(source_writer)
+            assert started.wait(timeout=5)
+            wait_for_lock(observer, application_name)
+            conn.commit()
+            future.result(timeout=10)
+        finally:
+            conn.rollback()
+            observer.close()
+
+    assert query(
+        conn, "SELECT count(*) FROM meta.asset_receipts WHERE generation_id=%s", (generation_id,)
+    ) == [(1,)]
+    assert current_generations(conn) == {}
+
+
+def test_source_failure_receipt_waits_until_refresh_admission_commits(generation_db):
+    conn, target = generation_db
+    _, _, run_id = prepare_refresh(conn)
+    failure_run = start_run(conn)
+    source_failure, mart_failure = str(uuid.uuid4()), str(uuid.uuid4())
+    generation_id, _ = finish_refresh(conn, run_id, commit=False)
+    application_name = "generation-refresh-failure-writer"
+    started = Event()
+    observer = psycopg2.connect(target)
+
+    def failure_writer():
+        other = psycopg2.connect(target, application_name=application_name)
+        try:
+            with other.cursor() as cur:
+                cur.execute("SET statement_timeout='10s'")
+            started.set()
+            publisher_query(
+                other,
+                "SELECT * FROM warehouse_publication.record_house_elo_failure(%s,%s,%s,%s,%s)",
+                (
+                    str(failure_run),
+                    source_failure,
+                    mart_failure,
+                    "failed",
+                    "publication_failed",
+                ),
+            )
+        finally:
+            other.close()
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        try:
+            future = pool.submit(failure_writer)
+            assert started.wait(timeout=5)
+            wait_for_lock(observer, application_name)
+            conn.commit()
+            future.result(timeout=10)
+        finally:
+            conn.rollback()
+            observer.close()
+
+    assert current_generations(conn)[MART] == generation_id
+    assert query(
+        conn,
+        "SELECT asset_key,outcome FROM meta.asset_receipts "
+        "WHERE generation_id IN (%s,%s) ORDER BY asset_key",
+        (source_failure, mart_failure),
+    ) == [(SOURCE, "failed"), (MART, "failed")]
+
+
+def test_source_expiring_while_refresh_waits_cannot_publish(generation_db):
+    conn, target = generation_db
+    source_args = publication_args(conn)
+    publish(conn, source_args)
+    set_source_policy(conn, "2 seconds")
+    plan = get_plan(conn)
+    run_id = start_refresh(conn, plan)
+    generation_id = str(uuid.uuid4())
+    application_name = "generation-refresh-expiry-waiter"
+    started = Event()
+    blocker = psycopg2.connect(target)
+    observer = psycopg2.connect(target)
+
+    def waiting_refresh():
+        other = psycopg2.connect(target, application_name=application_name)
+        try:
+            with other.cursor() as cur:
+                cur.execute("SET statement_timeout='10s'")
+            started.set()
+            try:
+                finish_refresh(other, run_id, generation_id)
+                return "ok", None, ""
+            except psycopg2.Error as exc:
+                other.rollback()
+                return "error", exc.pgcode, str(exc)
+        finally:
+            other.close()
+
+    try:
+        with blocker.cursor() as cur:
+            cur.execute("REFRESH MATERIALIZED VIEW marts.house_elo_game")
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(waiting_refresh)
+            try:
+                assert started.wait(timeout=5)
+                wait_for_lock(observer, application_name)
+                sleep(2.1)
+                blocker.commit()
+                status, pgcode, detail = future.result(timeout=10)
+            finally:
+                blocker.rollback()
+    finally:
+        blocker.rollback()
+        blocker.close()
+        observer.close()
+
+    assert (status, pgcode) == ("error", "55000")
+    assert "became stale" in detail.lower()
+    assert query(
+        conn, "SELECT count(*) FROM meta.asset_receipts WHERE generation_id=%s", (generation_id,)
+    ) == [(0,)]
+    assert query(
+        conn, "SELECT outcome FROM meta.operation_runs WHERE operation_run_id=%s", (run_id,)
+    ) == [("running",)]
+    assert current_generations(conn) == {SOURCE: source_args[1]}
+
+
+@pytest.mark.parametrize("change", ["disabled_event_guard", "asset_oid_mismatch"])
+def test_invalid_guard_or_registered_oid_blocks_refresh(generation_db, change):
+    conn, _ = generation_db
+    _, _, run_id = prepare_refresh(conn)
+    before = current_generations(conn)
+    if change == "disabled_event_guard":
+        query(conn, "ALTER EVENT TRIGGER warehouse_publication_invalidate_ddl DISABLE")
+    else:
+        query(
+            conn,
+            "UPDATE meta.asset_publication_locks "
+            "SET relation_oid='analytics.house_elo_current'::regclass "
+            "WHERE asset_key=%s",
+            (MART,),
+        )
+
+    generation_id = str(uuid.uuid4())
+    with pytest.raises(psycopg2.Error, match="guard|identity|invalid"):
+        finish_refresh(conn, run_id, generation_id)
+    conn.rollback()
+    assert current_generations(conn) == before
+    assert query(
+        conn, "SELECT count(*) FROM meta.asset_receipts WHERE generation_id=%s", (generation_id,)
+    ) == [(0,)]
+
+
+def test_migration_is_idempotent_and_role_has_only_bounded_rpc_access(generation_db):
+    conn, _ = generation_db
+    query(conn, MIGRATION.read_text())
+    assert query(
+        conn,
+        "SELECT rolcanlogin,rolinherit,rolsuper,rolcreatedb,rolcreaterole,"
+        "rolreplication,rolbypassrls FROM pg_roles WHERE rolname='warehouse_refresher'",
+    ) == [(False, False, False, False, False, False, False)]
+    for relation in (
+        "analytics.house_elo_game",
+        "analytics.house_elo_current",
+        "marts.house_elo_game",
+        "meta.asset_receipts",
+        "meta.asset_current_generations",
+        "meta.asset_receipt_inputs",
+        "meta.asset_freshness_policies",
+        "meta.operation_runs",
+    ):
+        assert query(
+            conn,
+            "SELECT has_table_privilege('warehouse_refresher',%s,"
+            "'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')",
+            (relation,),
+        ) == [(False,)]
+    assert query(
+        conn,
+        "SELECT has_function_privilege('warehouse_refresher',"
+        "'warehouse_refresh.require_house_elo_refresh_run(uuid)','EXECUTE'),"
+        "has_function_privilege('warehouse_refresher',"
+        "'warehouse_quota.start_operation_run(uuid,text,text,jsonb,text,text)','EXECUTE'),"
+        "has_function_privilege('warehouse_refresher',"
+        "'warehouse_quota.finish_operation_run(uuid,text,text)','EXECUTE')",
+    ) == [(False, False, False)]
+    for role in (
+        "anon",
+        "authenticated",
+        "analyst_ro",
+        "publication_bystander",
+        "warehouse_publisher",
+    ):
+        denied(conn, role, "SELECT warehouse_refresh.get_house_elo_game_plan()")
+    denied(conn, "warehouse_refresher", "SELECT * FROM meta.asset_receipts")
+
+
+def test_reapply_rejects_preexisting_refresher_direct_read_access(generation_db):
+    conn, _ = generation_db
+    query(conn, "GRANT SELECT ON meta.asset_receipts TO warehouse_refresher")
+    with pytest.raises(psycopg2.Error, match="unsafe direct access"):
+        query(conn, MIGRATION.read_text())
+    conn.rollback()
+
+
+def test_reapply_rejects_preexisting_publication_rpc_access(generation_db):
+    conn, _ = generation_db
+    query(conn, "GRANT USAGE ON SCHEMA warehouse_publication TO warehouse_refresher")
+    query(
+        conn,
+        "GRANT EXECUTE ON FUNCTION warehouse_publication.start_house_elo_run(uuid) "
+        "TO warehouse_refresher",
+    )
+    with pytest.raises(psycopg2.Error, match="unrelated quota or publication access"):
+        query(conn, MIGRATION.read_text())
+    conn.rollback()
+
+
+def test_reapply_rejects_unexpected_same_name_overload(generation_db):
+    conn, _ = generation_db
+    query(
+        conn,
+        "CREATE FUNCTION warehouse_refresh.get_house_elo_game_plan(text) "
+        "RETURNS jsonb LANGUAGE sql AS $$ SELECT '{}'::jsonb $$",
+    )
+    with pytest.raises(psycopg2.Error, match="trusted migration-owned routines namespace"):
+        query(conn, MIGRATION.read_text())
+    conn.rollback()
+
+
+def test_start_replay_is_exact_and_other_session_cannot_adopt_run(generation_db):
+    conn, target = generation_db
+    source_args = publication_args(conn)
+    publish(conn, source_args)
+    set_source_policy(conn)
+    plan = get_plan(conn)
+    run_id = str(uuid.uuid4())
+    start_refresh(conn, plan, run_id)
+    start_refresh(conn, plan, run_id)
+
+    changed_plan = plan | {"source_generation_id": str(uuid.uuid4())}
+    with pytest.raises(psycopg2.Error, match="different|invalid|scope|operation"):
+        start_refresh(conn, changed_plan, run_id)
+    conn.rollback()
+
+    other_role = "generation_caller_" + uuid.uuid4().hex
+    query(
+        conn, sql.SQL("CREATE ROLE {} NOLOGIN").format(sql.Identifier(other_role)).as_string(conn)
+    )
+    query(
+        conn,
+        sql.SQL("GRANT warehouse_refresher TO {}")
+        .format(sql.Identifier(other_role))
+        .as_string(conn),
+    )
+    other = psycopg2.connect(target)
+    other_run = str(uuid.uuid4())
+    try:
+        query(
+            other,
+            sql.SQL("SET SESSION AUTHORIZATION {}")
+            .format(sql.Identifier(other_role))
+            .as_string(other),
+        )
+        start_refresh(other, plan, other_run)
+        with pytest.raises(psycopg2.Error, match="belong|session|operation"):
+            start_refresh(conn, plan, other_run)
+        conn.rollback()
+        with pytest.raises(psycopg2.Error, match="belong|session|operation"):
+            fail_refresh(conn, other_run)
+        conn.rollback()
+        assert query(
+            conn,
+            "SELECT recorded_by,outcome FROM meta.operation_runs WHERE operation_run_id=%s",
+            (other_run,),
+        ) == [(other_role, "running")]
+    finally:
+        other.close()
+        query(conn, sql.SQL("DROP ROLE {}").format(sql.Identifier(other_role)).as_string(conn))
+
+
+def test_real_python_adapter_publishes_one_atomic_refresh(generation_db, monkeypatch):
+    from scripts import refresh_marts as runner
+
+    conn, target = generation_db
+    source_args = publication_args(conn)
+    publish(conn, source_args)
+    set_source_policy(conn)
+    before = current_generations(conn)
+    monkeypatch.setattr(runner, "get_db_url", lambda: target)
+
+    assert runner.refresh_marts(views=[MART], require_receipts=True) == 0
+
+    after = current_generations(conn)
+    assert after[SOURCE] == before[SOURCE] == source_args[1]
+    assert after[MART] != before[MART]
+    assert query(
+        conn,
+        """
+        SELECT r.outcome,r.coverage->>'complete',i.input_asset_key,
+               i.input_generation_id::text,o.operation_kind,o.outcome
+        FROM meta.asset_receipts r
+        JOIN meta.asset_receipt_inputs i USING(generation_id)
+        JOIN meta.operation_runs o USING(operation_run_id)
+        WHERE r.generation_id=%s
+        """,
+        (after[MART],),
+    ) == [("succeeded", "true", SOURCE, before[SOURCE], "refresh", "succeeded")]
+
+
+def test_reapply_rejects_direct_maintain_refresh_bypass(generation_db):
+    conn, _ = generation_db
+    query(conn, "GRANT MAINTAIN ON marts.house_elo_game TO warehouse_refresher")
+    with pytest.raises(psycopg2.Error, match="unsafe maintenance access"):
+        query(conn, MIGRATION.read_text())
+    conn.rollback()

--- a/tests/test_generation_refresh_sql.py
+++ b/tests/test_generation_refresh_sql.py
@@ -578,6 +578,42 @@ def test_migration_is_idempotent_and_role_has_only_bounded_rpc_access(generation
     denied(conn, "warehouse_refresher", "SELECT * FROM meta.asset_receipts")
 
 
+@pytest.mark.parametrize("reapply", [False, True])
+@pytest.mark.parametrize("direction", ["member", "parent"])
+def test_migration_rejects_existing_memberships(request, reapply, direction):
+    conn, _ = request.getfixturevalue("_freshness_db")
+    if reapply:
+        query(conn, MIGRATION.read_text())
+    else:
+        query(
+            conn,
+            "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles "
+            "WHERE rolname='warehouse_refresher') THEN "
+            "CREATE ROLE warehouse_refresher NOLOGIN NOINHERIT; END IF; END $$",
+        )
+    other_role = "generation_member_" + uuid.uuid4().hex
+    query(conn, sql.SQL("CREATE ROLE {} LOGIN").format(sql.Identifier(other_role)))
+    granted, member = (
+        ("warehouse_refresher", other_role)
+        if direction == "member"
+        else (other_role, "warehouse_refresher")
+    )
+    try:
+        query(
+            conn, sql.SQL("GRANT {} TO {}").format(sql.Identifier(granted), sql.Identifier(member))
+        )
+        with pytest.raises(psycopg2.Error, match="bounded NOLOGIN role"):
+            query(conn, MIGRATION.read_text())
+        conn.rollback()
+        if not reapply:
+            assert query(
+                conn, "SELECT to_regprocedure('warehouse_refresh.get_house_elo_game_plan()')"
+            ) == [(None,)]
+    finally:
+        conn.rollback()
+        query(conn, sql.SQL("DROP ROLE {}").format(sql.Identifier(other_role)))
+
+
 def test_reapply_rejects_preexisting_refresher_direct_read_access(generation_db):
     conn, _ = generation_db
     query(conn, "GRANT SELECT ON meta.asset_receipts TO warehouse_refresher")

--- a/tests/test_warehouse_bootstrap_sql.py
+++ b/tests/test_warehouse_bootstrap_sql.py
@@ -389,7 +389,7 @@ def test_managed_warehouse_catalog_data_and_access(
         _insert_representative_rows(conn)
         before_upgrade = _fixture_snapshot(conn)
         upgrade = apply_manifest(conn, manifest, mode="upgrade")
-        assert len(upgrade.pending) == 6
+        assert len(upgrade.pending) == 7
         assert [step.id for step in upgrade.pending] == [
             migration.id for migration in manifest.migrations[4:]
         ]


### PR DESCRIPTION
## Change

Add opt-in `refresh_marts.py --views marts.house_elo_game --require-receipts`. The planner pins the exact house Elo source/current-mart generations and declared source cadence, rejects unsupported/mixed plans before any execution, and uses a bounded SQL adapter to publish the refreshed mart, receipt, input edge, pointer and successful operation atomically.

Missing/incomplete/stale source evidence, undeclared cadence and a latest unsuccessful source attempt block publication. The source timestamp is preserved; unversioned core.games remains explicitly outside the validated boundary. Ordinary refresh locks are used, and existing refresh workflows remain unchanged.

Migration 070 adds a private routines namespace and bounded NOLOGIN refresh role. It validates session ownership, exact replay, active guards, identities, policy and generation races. Known failures record mart-only failed/blocked receipts; uncertain commits stop without retries or contradictory failure records. Independent reviews resolved receipt-write serialization and privilege/overload findings, including PostgreSQL 17 MAINTAIN access.

## Validation

- 157 focused tests passed: 27 executed generation SQL, 33 publication SQL, 17 freshness SQL, two bootstrap/upgrade cases and 78 planner/adapter/migration unit checks.
- Real Python-to-SQL publication, concurrent input writes/failures, source expiry while waiting, CAS/replay, caller roles and hostile pre-existing privileges were exercised on disposable PostgreSQL 17.
- Ruff lint/format and diff checks passed; independent reviews have no remaining findings.

Production migration, runtime membership, cadence and workflow activation remain separate. No production SQL or CFBD calls were made; production lock duration and contention remain unmeasured. Protocol and evidence: `docs/plans/2026-09-09-f11-generation-enforcement.md`.




<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62116589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/formentera-operations/-/pull-requests/rstover-fo/cfb-database/142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge; there are no outstanding blocking issues.

<details><summary><h3>Summary</h3></summary>

- Adds a receipt-backed, generation-enforced refresh process for `marts.house_elo_game`.
- Pins refreshes to a complete and current `analytics.house_elo_game` generation, then records publication evidence atomically.
- Restricts controlled refresh access to the bounded `warehouse_refresher` role.
</details>

<!-- /greptile_comment -->