### PR TITLE
Add season-scoped SDV source publication receipts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - run: ./scripts/setup_dev.sh
       - name: Managed bootstrap and upgrade integration
-        run: .venv/bin/python -m pytest tests/test_warehouse_migrations_sql.py tests/test_warehouse_bootstrap_sql.py tests/test_adopt_warehouse_catalog_sql.py tests/test_f06_verification_transactions_sql.py tests/test_mart_release_sql.py tests/test_play_partitions.py tests/test_play_indexes_sql.py tests/test_operational_quota_sql.py tests/test_operational_quota_lifecycle_sql.py tests/test_cfbd_transport_admission_sql.py tests/test_asset_publication_sql.py tests/test_asset_freshness_sql.py tests/test_generation_refresh_sql.py -q --tb=short
+        run: .venv/bin/python -m pytest tests/test_warehouse_migrations_sql.py tests/test_warehouse_bootstrap_sql.py tests/test_adopt_warehouse_catalog_sql.py tests/test_f06_verification_transactions_sql.py tests/test_mart_release_sql.py tests/test_play_partitions.py tests/test_play_indexes_sql.py tests/test_operational_quota_sql.py tests/test_operational_quota_lifecycle_sql.py tests/test_cfbd_transport_admission_sql.py tests/test_asset_publication_sql.py tests/test_asset_freshness_sql.py tests/test_generation_refresh_sql.py tests/test_sdv_ratings_publication_sql.py -q --tb=short
         env:
           F06_TEST_DB_URL: postgresql://postgres:f06-disposable-ci@127.0.0.1:5432/postgres
           F06_REQUIRE_DB: "1"

--- a/docs/SCHEMA_CONTRACT.md
+++ b/docs/SCHEMA_CONTRACT.md
@@ -1282,6 +1282,22 @@ shape and legacy refresh behavior remain compatible. No public grants, runtime
 membership or scheduled activation are added. See the
 [protocol, concurrency and rollout](plans/2026-09-09-f11-generation-enforcement.md).
 
+### Source coverage receipts (prepared, not deployed)
+
+Migration `071_sdv_ratings_publication.sql` enrolls
+`ratings.sdv_ratings_weekly` with canonical `season:<YYYY>` coverage. Its opt-in
+flat-file adapter preserves the existing primary key and stages genuine dlt
+output before atomically replacing only the selected season with its receipt,
+current pointer, legacy load-ledger observation and terminal operation outcome.
+Other receipt assets retain source-wide coverage. Legacy mutations invalidate
+affected season pointers, and relevant DDL invalidates all pointers for this
+source. Private `warehouse_source` RPCs are bounded to the source publisher.
+
+Complete coverage describes the selected artifact's rows, not expected
+provider-wide coverage or prospective model eligibility. The existing public
+freshness RPC, consumer grants and automatic refresh behavior remain unchanged.
+See the [source publication contract](plans/2026-09-09-step7-sdv-ratings-publication.md).
+
 ### Raw Data Tables
 
 | Schema | Tables |

--- a/docs/plans/2026-09-04-main-codebase-audit.md
+++ b/docs/plans/2026-09-04-main-codebase-audit.md
@@ -311,6 +311,13 @@ Evidence: [file fetching](https://github.com/rstover-fo/cfb-database/blob/4a798f
 
 ### F17 — Hash-only load receipts prevent clean replay after parser or mapping fixes
 
+**Implementation progress (2026-09-09):** the first opt-in source publication
+adapter reparses and republishes `sdv_ratings_weekly` season artifacts even when
+the legacy hash ledger already contains those bytes. Its atomic receipt is
+bound to `sdv-ratings-v1` and the artifact hash. General version-aware skip and
+reprocessing across sources remain open. See the
+[step-7 source slice](2026-09-09-step7-sdv-ratings-publication.md).
+
 **P2 · Confirmed · M**
 
 An already-loaded decision uses only source and file SHA-256. Identical bytes remain skipped after a parser, schema, or team crosswalk changes. A previously accepted file with some dropped unmapped records is especially important: fixing the mapping alone does not make the source eligible again. The existing cadence override is not a complete content-reprocessing contract.

--- a/docs/plans/2026-09-08-f14-f19-operational-records.md
+++ b/docs/plans/2026-09-08-f14-f19-operational-records.md
@@ -363,6 +363,13 @@ foundation to solve this broader catalog.
 7. **Incremental migration:** register source coverage/correction metadata and
    adapt remaining dlt, flat-file, compute, and prediction-verification paths.
 
+Delivery progress (2026-09-09): steps 1–6 have merged through PR #142 with
+bounded opt-in adapters. The first step-7 slice is
+[SDV ratings season publication](2026-09-09-step7-sdv-ratings-publication.md):
+explicit source coverage metadata and staged dlt output published atomically
+for one season. Remaining sources, crossvalidation generation closure, public
+source freshness, and production activation remain separate work.
+
 Steps 2 and 4 share database primitives but should remain separate PRs so
 quota-safety review is not coupled to a broad freshness API change. Step 3 can
 start after step 2; step 4 requires registry asset keys. Steps 5 and 6 are

--- a/docs/plans/2026-09-09-step7-sdv-ratings-publication.md
+++ b/docs/plans/2026-09-09-step7-sdv-ratings-publication.md
@@ -1,0 +1,108 @@
+# Step 7: controlled publication of SDV weekly ratings
+
+Status: implemented and locally verified. Production migration, runtime permissions,
+and workflow activation are separate rollout decisions.
+
+## Bounded source contract
+
+The first source adapter enrolls `sdv_ratings_weekly`, which loads
+`ratings.sdv_ratings_weekly` from a season-specific sportsdataverse parquet file.
+Its primary key remains `(season, through_week, team_id)`. The source already
+feeds `marts.epa_crossvalidation` in the SQL refresh graph.
+
+`source_publication_assets.py` records the source's season coverage grain,
+replacement correction policy, nonempty-file requirement, SHA-256 watermark,
+parser contract, weekly fetching cadence, and non-CFBD admission policy. It is
+separate from the SQL refresh registry: source work units and whole-relation
+materialized views have different coverage boundaries.
+
+The opt-in command requires exactly one source and an explicit season:
+
+```bash
+python scripts/load_flat_files.py --source sdv_ratings_weekly \
+  --season 2025 --require-receipts --dry-run
+```
+
+Remove `--dry-run` only for a separately configured target. `--file` can supply
+the complete season artifact locally. The new mode rejects broad, mixed, and
+`--due` selection and never falls back to an older season. A missing file is
+deferred; an empty, malformed, mixed-season, duplicate-key, or partially parsed
+file cannot publish complete coverage. The legacy command keeps its existing
+merge and hash-skip behavior.
+
+Coverage means every validated row of the selected artifact for that season.
+It does not assert that every expected team/week exists upstream, that the
+season is finished, or that observations were available before a prediction.
+This mode deliberately reparses and stages unchanged bytes, so a parser fix or
+an invalidated current pointer remains reachable despite an old hash-ledger
+entry. Avoiding that repeated work is a later optimization.
+
+## Publication boundary
+
+Migration 071 extends the private receipt ledger with exactly this asset and
+canonical `season:<YYYY>` coverage. Existing house Elo assets remain restricted
+to `source-wide`; overlapping source-wide and season pointers for SDV ratings
+are forbidden. Each valid correction replaces only the selected season,
+including removal of keys absent from the corrected artifact.
+
+The adapter starts and commits an operation run before fetching. It validates
+the artifact, uses dlt to normalize and load a unique table in private
+`warehouse_source_stage`, and reads that staged output with its genuine dlt
+identifiers. The staging commit does not publish the target. Original dlt load
+metadata remains in the private staging namespace; receipts identify that
+namespace and the actual load IDs. Target column types and the sixteen source
+fields are checked rather than silently discarding new fields or variants.
+
+The bounded `warehouse_source` RPC locks the target and asset, compares the
+planned current generation, and commits the season replacement, receipt,
+current pointer, legacy flat-file ledger observation, and terminal operation
+outcome together. Successful replay is a lookup; it cannot restore an older
+generation after a later correction. `published_at` is a clock observation in
+the transaction, and `committed_at` remains unknown.
+
+Failed or deferred work keeps the previous current generation. A known failure
+after rollback receives separate failure evidence. Unknown operation-start or
+publication commit outcomes are reported with run/generation identifiers and
+are not converted into a false failure or automatically retried. Interruptions
+follow the same cleanup rules before propagating. An unresolved publication
+retains its staging table for investigation.
+
+Legacy row writes invalidate the affected season's pointer; moving a row
+between seasons invalidates both. Truncation or relevant DDL invalidates all
+SDV season pointers. Publication refuses missing or altered guards. Consumer
+reads of data and receipt need one shared database snapshot.
+
+## Access and limits
+
+The publisher role is a bounded NOLOGIN role with only this source's lifecycle
+and publication RPCs. It receives no generic operation or direct target/ledger
+write access. Migration grants no runtime membership. The staging namespace is
+private; the existing warehouse connection must separately have the staging
+capabilities needed by dlt. This is not a general-purpose dlt destination
+adapter or a claim that its broader connection is least-privileged.
+
+The public freshness RPC remains the existing two-asset house Elo projection.
+No SDV freshness SLA is activated and no consumer grant changes. Declared
+descendants are visible in the dry-run plan but are not refreshed or given
+generation receipts here. Generation enforcement for the whole crossvalidation
+mart must account for its other inputs and all required season scopes before
+that path can claim complete dependency coverage.
+
+## Verification
+
+Verification used local fixtures and a disposable PostgreSQL 17 database:
+
+- 124 adapter, source-plan, CLI and legacy flat-file tests passed.
+- 29 executed source-publication SQL cases passed, including real dlt staging
+  from local parquet, typed all-NULL optional fields, genuine load identifiers,
+  cleanup, actual caller roles, rollback, concurrent compare-and-swap, replay,
+  season corrections and mutation/DDL invalidation.
+- 123 existing bootstrap, operational-ledger, house Elo publication, freshness
+  and generation-refresh SQL checks passed. The two bootstrap checks passed
+  again after the final inheritance-guard correction.
+- Affected Python files passed Ruff lint and formatting checks.
+
+Independent review covered SQL and adapter correctness and access boundaries.
+No production publication or provider request was performed. Production lock
+duration, staging retention volume, and managed-platform privilege parity
+remain unmeasured.

--- a/docs/warehouse-operations.md
+++ b/docs/warehouse-operations.md
@@ -84,6 +84,18 @@ runs remain offline. This mode uses an ordinary refresh and blocks mart reads
 until commit. Existing refresh commands do not opt in automatically.
 See the [F11 protocol and recovery limits](plans/2026-09-09-f11-generation-enforcement.md).
 
+## Source receipt publication (prepared)
+
+After migration 071 and a separate runtime-permission rollout,
+`python scripts/load_flat_files.py --source sdv_ratings_weekly --season 2025 --require-receipts`
+stages the complete season file and atomically replaces that season with its
+receipt. Add `--dry-run` for an offline plan. This opt-in mode reparses unchanged
+bytes, rejects mixed source plans, and does not fall back to an older season.
+Missing files are deferred with a nonzero exit; empty or incomplete files cannot
+advance the current pointer. It does not refresh the crossvalidation mart or
+extend the public freshness RPC. See the
+[source contract and recovery limits](plans/2026-09-09-step7-sdv-ratings-publication.md).
+
 ## Plays partition rollover (F08)
 
 `run_plays_pipeline()` performs catalog preflight before constructing the source

--- a/scripts/load_flat_files.py
+++ b/scripts/load_flat_files.py
@@ -559,6 +559,14 @@ def main(argv: list[str] | None = None) -> int:
             REGISTRY[contract.source_name], file_path=args.file, season=args.season
         )
         print(_gate_line(result))
+        if result["status"] != "loaded":
+            print(
+                f"Receipt publication {result['status']}: "
+                f"{result.get('error') or 'No error detail was returned'}; "
+                f"run_id={result.get('run_id') or 'unavailable'}; "
+                f"generation_id={result.get('generation_id') or 'unavailable'}",
+                file=sys.stderr,
+            )
         return 0 if result["status"] == "loaded" else 1
 
     if args.file is not None and args.season is None:

--- a/scripts/load_flat_files.py
+++ b/scripts/load_flat_files.py
@@ -78,6 +78,7 @@ from datetime import UTC, date, datetime
 import dlt
 import httpx
 
+from src.pipelines.config.source_publication_assets import SDV_RATINGS_PUBLICATION
 from src.pipelines.sources.flat_files import (
     LOAD_SEASON_MONTHS,
     REGISTRY,
@@ -475,6 +476,12 @@ def build_arg_parser() -> argparse.ArgumentParser:
         "404 fallback -- a backfill request is never silently substituted.",
     )
     parser.add_argument(
+        "--require-receipts",
+        action="store_true",
+        help="Atomically publish one sdv_ratings_weekly season with a generation receipt; "
+        "requires --source sdv_ratings_weekly and an explicit --season",
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Print the planned sources (cadence, due-status, fetch target) and exit; "
@@ -522,6 +529,37 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.file is not None and (not args.source or len(args.source) != 1):
         parser.error("--file requires exactly one --source")
+
+    if args.require_receipts:
+        contract = SDV_RATINGS_PUBLICATION
+        if args.source != [contract.source_name] or args.due:
+            parser.error("--require-receipts supports exactly --source sdv_ratings_weekly")
+        try:
+            coverage_key = contract.coverage_key(args.season)
+        except ValueError as exc:
+            parser.error(str(exc))
+        if args.dry_run:
+            from src.pipelines.utils.refresh_plan import REFRESH_GRAPH
+
+            descendants = REFRESH_GRAPH.plan(changed=[contract.asset_key]).views
+            print(f"[DRY RUN] receipt publication: {contract.asset_key}/{coverage_key}")
+            print("  Stage and validate the complete file, then replace only the selected season.")
+            print("  Reparse unchanged bytes; no legacy hash skip or older-season fallback.")
+            fetch_target = _fetch_target_display(
+                REGISTRY[contract.source_name], args.file, args.season
+            )
+            print(f"  Fetch: {fetch_target}")
+            print(f"  Declared descendants (not refreshed): {', '.join(descendants)}")
+            print("  Live generation and schema validation is not run during --dry-run.")
+            return 0
+
+        from src.pipelines.utils.sdv_ratings_publication import run_sdv_ratings_publication
+
+        result = run_sdv_ratings_publication(
+            REGISTRY[contract.source_name], file_path=args.file, season=args.season
+        )
+        print(_gate_line(result))
+        return 0 if result["status"] == "loaded" else 1
 
     if args.file is not None and args.season is None:
         spec = REGISTRY[args.source[0]]

--- a/src/pipelines/config/source_publication_assets.py
+++ b/src/pipelines/config/source_publication_assets.py
@@ -1,0 +1,69 @@
+"""Coverage contracts for explicitly enrolled source publication adapters.
+
+This is separate from the SQL refresh registry: a season file is a source work
+unit, while its downstream materialized view still covers the whole relation.
+Cadence describes fetching policy; it does not configure a publication SLA.
+"""
+
+from dataclasses import dataclass
+from types import MappingProxyType
+
+
+@dataclass(frozen=True)
+class SourcePublicationAsset:
+    source_name: str
+    asset_key: str
+    coverage_grain: str
+    correction_policy: str
+    expected_no_data_policy: str
+    watermark_rule: str
+    provider: str
+    admission_policy: str
+    cadence: str
+    parser_contract: str
+    protocol: str
+    columns: tuple[str, ...]
+    primary_key: tuple[str, ...]
+
+    def coverage_key(self, season: int) -> str:
+        if type(season) is not int or not 1869 <= season <= 2200:
+            raise ValueError("receipt publication requires an explicit season from 1869 to 2200")
+        return f"season:{season}"
+
+
+SDV_RATINGS_PUBLICATION = SourcePublicationAsset(
+    source_name="sdv_ratings_weekly",
+    asset_key="ratings.sdv_ratings_weekly",
+    coverage_grain="season",
+    correction_policy="replace_selected_season_from_complete_file",
+    expected_no_data_policy="never; missing file is deferred, empty file is invalid",
+    watermark_rule="artifact_sha256",
+    provider="sportsdataverse_public_file",
+    admission_policy="not_cfbd; bounded flat-file fetch retries",
+    cadence="weekly",
+    parser_contract="sdv-ratings-v1",
+    protocol="sdv-ratings-season-v1",
+    columns=(
+        "season",
+        "through_week",
+        "team_id",
+        "adj_off_epa",
+        "adj_def_epa",
+        "adj_st_epa",
+        "adj_net",
+        "fei_off",
+        "fei_def",
+        "fei_net",
+        "off_pace",
+        "net_z",
+        "games",
+        "off_rank",
+        "def_rank",
+        "net_rank",
+    ),
+    primary_key=("season", "through_week", "team_id"),
+)
+
+SOURCE_PUBLICATION_ASSETS = MappingProxyType(
+    {SDV_RATINGS_PUBLICATION.source_name: SDV_RATINGS_PUBLICATION}
+)

--- a/src/pipelines/utils/sdv_ratings_publication.py
+++ b/src/pipelines/utils/sdv_ratings_publication.py
@@ -1,0 +1,683 @@
+"""Receipt-backed publication adapter for the SDV weekly ratings season file.
+
+The dlt load is deliberately confined to ``warehouse_source_stage``.  The
+bounded SQL publisher is the only code that changes the public target: its
+transaction replaces the selected season and records the load ledger row,
+publication receipt, and current-generation pointer together.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import logging
+import math
+import os
+import tempfile
+import time
+import uuid
+from dataclasses import dataclass, replace
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import dlt
+import httpx
+import psycopg2
+import pyarrow.parquet
+from dlt.destinations import postgres
+from psycopg2 import sql
+from psycopg2.extras import Json
+
+from src.pipelines.config.source_publication_assets import SDV_RATINGS_PUBLICATION
+from src.pipelines.sources.flat_files import (
+    REGISTRY,
+    FlatFileSpec,
+    ParseContext,
+    build_flat_file_source,
+    resolve_fetch_url,
+    resolve_parser,
+)
+from src.pipelines.utils.file_fetcher import fetch_file
+from src.pipelines.utils.load_ledger import get_db_url
+
+logger = logging.getLogger(__name__)
+
+STAGE_SCHEMA = "warehouse_source_stage"
+MAX_SOURCE_ROWS = 100_000
+ERROR_MESSAGE_LIMIT = 500
+_ROLE = "warehouse_source_publisher"
+_EXPECTED_PLAN_KEYS = frozenset(
+    {
+        "protocol",
+        "asset_key",
+        "coverage_key",
+        "season",
+        "expected_generation_id",
+        "parser_contract",
+    }
+)
+_INT_COLUMNS = frozenset(
+    {"season", "through_week", "team_id", "games", "off_rank", "def_rank", "net_rank"}
+)
+_FLOAT_COLUMNS = frozenset(SDV_RATINGS_PUBLICATION.columns) - _INT_COLUMNS
+_STAGE_SYSTEM_COLUMNS = ("_dlt_id", "_dlt_load_id")
+_EXPECTED_STAGE_COLUMNS = frozenset((*SDV_RATINGS_PUBLICATION.columns, *_STAGE_SYSTEM_COLUMNS))
+
+
+class SourcePublicationError(RuntimeError):
+    """A known pre-commit publication failure."""
+
+
+class UncertainCommitError(RuntimeError):
+    """The client cannot determine whether a mutating RPC committed."""
+
+
+class PostCommitError(RuntimeError):
+    """A non-transactional error occurred after a confirmed RPC commit."""
+
+
+@dataclass(frozen=True)
+class _StageResult:
+    table: str
+    rows: list[dict[str, Any]]
+    evidence: dict[str, Any]
+
+
+@dataclass
+class _MutationState:
+    start_pending: bool = False
+    started: bool = False
+    publish_pending: bool = False
+    published: bool = False
+    failure_pending: bool = False
+    failure_recorded: bool = False
+
+    def set_pending(self, phase: str) -> None:
+        setattr(self, f"{phase}_pending", True)
+
+    def set_committed(self, phase: str) -> None:
+        committed = {"start": "started", "publish": "published", "failure": "failure_recorded"}
+        setattr(self, committed[phase], True)
+        # Keep the conservative pending state until the confirmed state is set.
+        # An asynchronous interrupt between these assignments can therefore
+        # never make a successful commit look safe to relabel as failed.
+        setattr(self, f"{phase}_pending", False)
+
+
+def _base_result(run_id: str, generation_id: str) -> dict[str, Any]:
+    return {
+        "source": SDV_RATINGS_PUBLICATION.source_name,
+        "status": "failed",
+        "rows": 0,
+        "sha": None,
+        "duration_s": 0.0,
+        "error": None,
+        "unmapped": None,
+        "gaps": None,
+        "run_id": run_id,
+        "generation_id": generation_id,
+    }
+
+
+def _validate_supported_spec(spec: FlatFileSpec, season: int) -> None:
+    canonical = REGISTRY[SDV_RATINGS_PUBLICATION.source_name]
+    if spec is not canonical:
+        raise ValueError(
+            "receipt publication requires the canonical sdv_ratings_weekly registry spec"
+        )
+    if (
+        spec.schema != "ratings"
+        or spec.table != "sdv_ratings_weekly"
+        or spec.parser != "sportsdataverse.parse_ratings_weekly"
+        or tuple(spec.primary_key) != SDV_RATINGS_PUBLICATION.primary_key
+        or spec.write_disposition != "merge"
+        or spec.kind != "dlt"
+    ):
+        raise ValueError("sdv_ratings_weekly registry contract does not match the publisher")
+    SDV_RATINGS_PUBLICATION.coverage_key(season)
+
+
+def _validated_plan(value: Any, season: int) -> dict[str, Any]:
+    if not isinstance(value, dict) or frozenset(value) != _EXPECTED_PLAN_KEYS:
+        raise SourcePublicationError("publisher returned an invalid SDV ratings plan")
+    expected = {
+        "protocol": SDV_RATINGS_PUBLICATION.protocol,
+        "asset_key": SDV_RATINGS_PUBLICATION.asset_key,
+        "coverage_key": SDV_RATINGS_PUBLICATION.coverage_key(season),
+        "season": season,
+        "parser_contract": SDV_RATINGS_PUBLICATION.parser_contract,
+    }
+    if any(value.get(key) != expected_value for key, expected_value in expected.items()):
+        raise SourcePublicationError("publisher returned a mismatched SDV ratings plan")
+    generation = value["expected_generation_id"]
+    if generation is not None:
+        try:
+            if str(uuid.UUID(str(generation))) != str(generation):
+                raise ValueError
+        except (TypeError, ValueError, AttributeError) as error:
+            raise SourcePublicationError(
+                "publisher plan has an invalid expected generation"
+            ) from error
+    return value
+
+
+def _connect(dsn: str):
+    return psycopg2.connect(dsn, connect_timeout=10)
+
+
+def _rpc(
+    dsn: str,
+    statement: str,
+    args: tuple[Any, ...],
+    *,
+    mutating: bool,
+    state: _MutationState | None = None,
+    phase: str | None = None,
+) -> tuple[Any, ...] | None:
+    if mutating != (state is not None and phase in {"start", "publish", "failure"}):
+        raise ValueError("mutating RPCs require an explicit mutation phase and state")
+    conn = _connect(dsn)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(sql.SQL("SET LOCAL ROLE {}").format(sql.Identifier(_ROLE)))
+            cur.execute("SET LOCAL statement_timeout = '60s'")
+            cur.execute(statement, args)
+            row = cur.fetchone() if cur.description else None
+    except BaseException:
+        try:
+            conn.rollback()
+        except Exception:
+            pass
+        try:
+            conn.close()
+        except Exception:
+            pass
+        raise
+
+    if mutating:
+        assert state is not None and phase is not None
+        state.set_pending(phase)
+    try:
+        conn.commit()
+    except BaseException as error:
+        try:
+            conn.close()
+        except Exception:
+            pass
+        if mutating:
+            raise UncertainCommitError(
+                "source publication RPC commit outcome is uncertain"
+            ) from error
+        raise
+    if mutating:
+        state.set_committed(phase)
+    try:
+        conn.close()
+    except BaseException as error:
+        if mutating:
+            raise PostCommitError("source publication RPC committed before close failed") from error
+        raise
+    return row
+
+
+def _get_plan(dsn: str, season: int) -> dict[str, Any]:
+    row = _rpc(
+        dsn,
+        "SELECT warehouse_source.get_sdv_ratings_plan(%s)",
+        (season,),
+        mutating=False,
+    )
+    if row is None:
+        raise SourcePublicationError("publisher returned no SDV ratings plan")
+    return _validated_plan(row[0], season)
+
+
+def _start_run(dsn: str, run_id: str, plan: dict[str, Any], state: _MutationState) -> None:
+    row = _rpc(
+        dsn,
+        "SELECT warehouse_source.start_sdv_ratings_load(%s,%s)",
+        (run_id, Json(plan)),
+        mutating=True,
+        state=state,
+        phase="start",
+    )
+    if row is None or str(row[0]) != run_id:
+        # The RPC commit is confirmed, but its effect cannot safely be labeled.
+        raise UncertainCommitError("publisher committed an unrecognized operation result")
+
+
+def _publish(
+    dsn: str,
+    run_id: str,
+    generation_id: str,
+    sha256: str,
+    stage: _StageResult,
+    state: _MutationState,
+) -> tuple[str, bool, int]:
+    row = _rpc(
+        dsn,
+        "SELECT * FROM warehouse_source.publish_sdv_ratings_load(%s,%s,%s,%s,%s)",
+        (run_id, generation_id, sha256, Json(stage.rows), Json(stage.evidence)),
+        mutating=True,
+        state=state,
+        phase="publish",
+    )
+    if row is None or len(row) != 3:
+        raise UncertainCommitError("publisher committed an unrecognized publication result")
+    returned_generation, replayed, published_rows = row
+    if (
+        str(returned_generation) != generation_id
+        or type(replayed) is not bool
+        or type(published_rows) is not int
+        or published_rows != len(stage.rows)
+    ):
+        raise UncertainCommitError("publisher committed a mismatched publication result")
+    return str(returned_generation), replayed, published_rows
+
+
+def _fail_run(
+    dsn: str,
+    run_id: str,
+    generation_id: str,
+    outcome: str,
+    state: _MutationState,
+) -> None:
+    row = _rpc(
+        dsn,
+        "SELECT warehouse_source.fail_sdv_ratings_load(%s,%s,%s)",
+        (run_id, generation_id, outcome),
+        mutating=True,
+        state=state,
+        phase="failure",
+    )
+    if row is None or str(row[0]) != generation_id:
+        raise SourcePublicationError("publisher returned a mismatched failure generation id")
+
+
+def _raw_row_count(raw: bytes) -> int:
+    try:
+        return pyarrow.parquet.ParquetFile(io.BytesIO(raw)).metadata.num_rows
+    except Exception as error:
+        raise SourcePublicationError("sdv_ratings_weekly is not a readable parquet file") from error
+
+
+def _validate_parsed_rows(rows: list[dict[str, Any]], raw_count: int, season: int) -> None:
+    if raw_count == 0 or not rows:
+        raise SourcePublicationError("sdv_ratings_weekly season file must be nonempty")
+    if raw_count > MAX_SOURCE_ROWS or len(rows) > MAX_SOURCE_ROWS:
+        raise SourcePublicationError(f"sdv_ratings_weekly exceeds {MAX_SOURCE_ROWS} rows")
+    if len(rows) != raw_count:
+        raise SourcePublicationError("sdv_ratings_weekly parser dropped or added source rows")
+
+    expected_columns = frozenset(SDV_RATINGS_PUBLICATION.columns)
+    keys: set[tuple[Any, ...]] = set()
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict) or frozenset(row) != expected_columns:
+            raise SourcePublicationError(
+                f"sdv_ratings_weekly row {index} does not match the 16-column parser contract"
+            )
+        if row["season"] != season:
+            raise SourcePublicationError(
+                "sdv_ratings_weekly row season does not match requested season"
+            )
+        key = tuple(row[column] for column in SDV_RATINGS_PUBLICATION.primary_key)
+        if any(value is None for value in key):
+            raise SourcePublicationError("sdv_ratings_weekly contains a null primary-key value")
+        if key in keys:
+            raise SourcePublicationError("sdv_ratings_weekly contains a duplicate primary key")
+        keys.add(key)
+        for column in _INT_COLUMNS:
+            value = row[column]
+            if value is not None and (type(value) is not int):
+                raise SourcePublicationError(
+                    f"sdv_ratings_weekly column {column} is not an integer"
+                )
+        for column in _FLOAT_COLUMNS:
+            value = row[column]
+            if value is not None and (
+                isinstance(value, bool)
+                or not isinstance(value, (int, float))
+                or not math.isfinite(float(value))
+            ):
+                raise SourcePublicationError(f"sdv_ratings_weekly column {column} is not finite")
+
+
+def _column_hints() -> list[dict[str, Any]]:
+    return [
+        {
+            "name": name,
+            "data_type": "bigint" if name in _INT_COLUMNS else "double",
+            "nullable": name not in SDV_RATINGS_PUBLICATION.primary_key,
+        }
+        for name in SDV_RATINGS_PUBLICATION.columns
+    ]
+
+
+def _require_stage_schema(dsn: str) -> None:
+    conn = _connect(dsn)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT
+                    stage.nspowner = routines.nspowner AS owners_match,
+                    pg_catalog.has_schema_privilege(
+                        current_user, stage.oid, 'USAGE,CREATE'
+                    ) AS actor_can_stage,
+                    NOT EXISTS (
+                        SELECT 1 FROM pg_catalog.aclexplode(stage.nspacl) acl
+                        WHERE acl.grantee NOT IN (
+                            stage.nspowner,
+                            (SELECT oid FROM pg_catalog.pg_roles
+                             WHERE rolname = current_user)
+                        )
+                    ) AS grants_are_bounded,
+                    pg_catalog.to_regnamespace('warehouse_source_stage_staging') IS NULL
+                        AS no_secondary_stage
+                FROM pg_catalog.pg_namespace stage
+                JOIN pg_catalog.pg_namespace routines ON routines.nspname = 'warehouse_source'
+                WHERE stage.nspname = %s
+                """,
+                (STAGE_SCHEMA,),
+            )
+            row = cur.fetchone()
+        conn.rollback()
+    finally:
+        conn.close()
+    if row is None or row != (True, True, True, True):
+        raise SourcePublicationError("managed warehouse_source_stage boundary is unavailable")
+
+
+def _read_stage(dsn: str, table: str, expected_rows: int, artifact_origin: str) -> _StageResult:
+    conn = _connect(dsn)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT a.attname
+                FROM pg_catalog.pg_attribute a
+                WHERE a.attrelid = pg_catalog.to_regclass(%s)
+                  AND a.attnum > 0 AND NOT a.attisdropped
+                ORDER BY a.attnum
+                """,
+                (f"{STAGE_SCHEMA}.{table}",),
+            )
+            stage_columns = {name for (name,) in cur.fetchall()}
+            if stage_columns != _EXPECTED_STAGE_COLUMNS:
+                raise SourcePublicationError(
+                    "normalized staging columns violate the parser contract"
+                )
+
+            selected = [
+                sql.Identifier(name)
+                for name in (*SDV_RATINGS_PUBLICATION.columns, *_STAGE_SYSTEM_COLUMNS)
+            ]
+            order = [sql.Identifier(name) for name in SDV_RATINGS_PUBLICATION.primary_key]
+            cur.execute(
+                sql.SQL("SELECT {} FROM {}.{} ORDER BY {}").format(
+                    sql.SQL(",").join(selected),
+                    sql.Identifier(STAGE_SCHEMA),
+                    sql.Identifier(table),
+                    sql.SQL(",").join(order),
+                )
+            )
+            names = [description.name for description in cur.description]
+            rows = [dict(zip(names, values, strict=True)) for values in cur.fetchall()]
+            if len(rows) != expected_rows:
+                raise SourcePublicationError(
+                    "dlt staging row count does not match parsed source rows"
+                )
+            load_ids = sorted({row["_dlt_load_id"] for row in rows})
+            if not load_ids or any(
+                not isinstance(load_id, str) or not load_id for load_id in load_ids
+            ):
+                raise SourcePublicationError("dlt staging rows do not carry actual load ids")
+            if any(not isinstance(row["_dlt_id"], str) or not row["_dlt_id"] for row in rows):
+                raise SourcePublicationError("dlt staging rows do not carry actual row ids")
+            cur.execute(
+                sql.SQL(
+                    "SELECT load_id FROM {}._dlt_loads "
+                    "WHERE load_id = ANY(%s) AND status = 0 ORDER BY load_id"
+                ).format(sql.Identifier(STAGE_SCHEMA)),
+                (load_ids,),
+            )
+            recorded_load_ids = [load_id for (load_id,) in cur.fetchall()]
+            if recorded_load_ids != load_ids:
+                raise SourcePublicationError("dlt staging load evidence is incomplete")
+        conn.rollback()
+    finally:
+        conn.close()
+
+    evidence = {
+        "stage_schema": STAGE_SCHEMA,
+        "parser_contract": SDV_RATINGS_PUBLICATION.parser_contract,
+        "dlt_load_ids": load_ids,
+        "source_rows": len(rows),
+        "artifact_origin": artifact_origin,
+    }
+    return _StageResult(table=table, rows=rows, evidence=evidence)
+
+
+def _stage_table_name(run_id: str) -> str:
+    return f"sdv_ratings_{uuid.UUID(run_id).hex}"
+
+
+def _stage_rows(
+    dsn: str,
+    spec: FlatFileSpec,
+    raw: bytes,
+    ctx: ParseContext,
+    run_id: str,
+    expected_rows: int,
+    artifact_origin: str,
+) -> _StageResult:
+    _require_stage_schema(dsn)
+    run_hex = uuid.UUID(run_id).hex
+    table = _stage_table_name(run_id)
+    # The table is unique to this run, so append is sufficient. dlt merge would
+    # create a second ``warehouse_source_stage_staging`` schema outside the
+    # migration-owned private boundary.
+    stage_spec = replace(spec, table=table, write_disposition="append")
+    source = build_flat_file_source(stage_spec, raw, ctx, None)
+    resource = source.resources[table]
+    resource.apply_hints(
+        columns=_column_hints(),
+        schema_contract={"tables": "evolve", "columns": "freeze", "data_type": "freeze"},
+    )
+
+    pipeline_name = f"sdv_ratings_publication_{run_hex}"
+    with tempfile.TemporaryDirectory(prefix="sdv-ratings-dlt-") as pipelines_dir:
+        pipeline = dlt.pipeline(
+            pipeline_name=pipeline_name,
+            pipelines_dir=pipelines_dir,
+            destination=postgres(credentials=dsn),
+            dataset_name=STAGE_SCHEMA,
+        )
+        load_info = pipeline.run(source)
+        load_info.raise_on_failed_jobs()
+        normalized_count = pipeline.last_trace.last_normalize_info.row_counts.get(table, 0)
+    if normalized_count != expected_rows:
+        raise SourcePublicationError("dlt normalized row count does not match parsed source rows")
+    return _read_stage(dsn, table, expected_rows, artifact_origin)
+
+
+def _drop_stage_table(dsn: str, table: str) -> None:
+    conn = _connect(dsn)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                sql.SQL("DROP TABLE IF EXISTS {}.{}").format(
+                    sql.Identifier(STAGE_SCHEMA), sql.Identifier(table)
+                )
+            )
+        conn.commit()
+    except BaseException:
+        try:
+            conn.rollback()
+        except Exception:
+            pass
+        raise
+    finally:
+        conn.close()
+
+
+def _known_error_text(error: BaseException, run_id: str, generation_id: str) -> str:
+    if isinstance(error, SourcePublicationError):
+        detail = str(error)
+    elif isinstance(error, httpx.HTTPStatusError) and error.response.status_code == 404:
+        detail = "sdv_ratings_weekly season file is not published"
+    else:
+        detail = "sdv_ratings_weekly source publication failed"
+    return f"{detail}; run_id={run_id}; generation_id={generation_id}"[:ERROR_MESSAGE_LIMIT]
+
+
+def run_sdv_ratings_publication(
+    spec: FlatFileSpec,
+    *,
+    file_path: str | None = None,
+    season: int,
+) -> dict[str, Any]:
+    """Publish one complete SDV ratings season through the bounded SQL RPCs."""
+
+    started_at = time.monotonic()
+    run_id = str(uuid.uuid4())
+    generation_id = str(uuid.uuid4())
+    result = _base_result(run_id, generation_id)
+    stage_table: str | None = None
+    state = _MutationState()
+    terminal_confirmed = False
+
+    try:
+        _validate_supported_spec(spec, season)
+        dsn = get_db_url()
+        plan = _get_plan(dsn, season)
+        _start_run(dsn, run_id, plan, state)
+
+        if file_path is not None:
+            local_path = Path(file_path)
+            if "://" in file_path or not local_path.is_file():
+                raise SourcePublicationError("receipt file override must be an existing local file")
+            target = file_path
+            artifact_origin = "local_file"
+        else:
+            target = resolve_fetch_url(spec, season)
+            artifact_origin = "registered_url"
+        if not target:
+            raise SourcePublicationError("sdv_ratings_weekly has no fetch target")
+        fetched = fetch_file(target)
+        if fetched.sha256 != hashlib.sha256(fetched.content).hexdigest():
+            raise SourcePublicationError("fetched SDV ratings SHA-256 does not match its bytes")
+        result["sha"] = fetched.sha256
+        ctx = ParseContext(
+            source=spec.name,
+            snapshot_date=date.today(),
+            season=season,
+            source_url=fetched.source_url,
+            file_name=os.path.basename(fetched.source_url),
+        )
+        raw_count = _raw_row_count(fetched.content)
+        if raw_count > MAX_SOURCE_ROWS:
+            raise SourcePublicationError(f"sdv_ratings_weekly exceeds {MAX_SOURCE_ROWS} rows")
+        parser = resolve_parser(spec.parser)
+        parsed_rows = list(parser(fetched.content, ctx))
+        _validate_parsed_rows(parsed_rows, raw_count, season)
+
+        # Set before dlt starts so a known stage failure or interrupt can clean
+        # up a table created before pipeline.run returned to us.
+        stage_table = _stage_table_name(run_id)
+        stage = _stage_rows(
+            dsn,
+            spec,
+            fetched.content,
+            ctx,
+            run_id,
+            len(parsed_rows),
+            artifact_origin,
+        )
+        if stage.table != stage_table:
+            raise SourcePublicationError("dlt returned a mismatched staging table")
+        _, _, published_rows = _publish(dsn, run_id, generation_id, fetched.sha256, stage, state)
+        terminal_confirmed = True
+        result.update(status="loaded", rows=published_rows)
+        return result
+    except UncertainCommitError as error:
+        # Never retry or write a contradictory failure after an uncertain commit.
+        terminal_confirmed = state.published
+        logger.error(
+            "SDV ratings commit/result is uncertain; run_id=%s generation_id=%s",
+            run_id,
+            generation_id,
+        )
+        if isinstance(error.__cause__, (KeyboardInterrupt, SystemExit)):
+            raise error.__cause__
+        result["error"] = (f"{error}; run_id={run_id}; generation_id={generation_id}")[
+            :ERROR_MESSAGE_LIMIT
+        ]
+        logger.error(result["error"])
+        return result
+    except BaseException as error:
+        interrupt = (
+            error
+            if isinstance(error, (KeyboardInterrupt, SystemExit))
+            else error.__cause__
+            if isinstance(error.__cause__, (KeyboardInterrupt, SystemExit))
+            else None
+        )
+        deferred = isinstance(error, httpx.HTTPStatusError) and error.response.status_code == 404
+        blocked = isinstance(error, psycopg2.Error) and error.pgcode in {"40001", "55000"}
+        outcome = "deferred" if deferred else "blocked" if blocked else "failed"
+        result["status"] = "not_published" if deferred else outcome
+        result["error"] = _known_error_text(error, run_id, generation_id)
+        if state.published:
+            # The publish commit is authoritative even if connection close or
+            # local response handling was interrupted afterward.
+            terminal_confirmed = True
+        elif state.started and not state.publish_pending:
+            try:
+                _fail_run(dsn, run_id, generation_id, outcome, state)
+                terminal_confirmed = True
+            except UncertainCommitError as failure_error:
+                logger.error(
+                    "SDV ratings failure commit outcome is uncertain; run_id=%s generation_id=%s",
+                    run_id,
+                    generation_id,
+                )
+                if isinstance(failure_error.__cause__, (KeyboardInterrupt, SystemExit)):
+                    raise failure_error.__cause__
+            except PostCommitError as failure_error:
+                terminal_confirmed = state.failure_recorded
+                logger.error(
+                    "SDV ratings failure committed before connection close failed; "
+                    "run_id=%s generation_id=%s",
+                    run_id,
+                    generation_id,
+                )
+                if isinstance(failure_error.__cause__, (KeyboardInterrupt, SystemExit)):
+                    raise failure_error.__cause__
+            except Exception:
+                terminal_confirmed = state.failure_recorded
+                logger.error(
+                    "SDV ratings failure receipt was not confirmed; run_id=%s generation_id=%s",
+                    run_id,
+                    generation_id,
+                )
+        if interrupt is not None:
+            raise interrupt
+        return result
+    finally:
+        if stage_table is not None and (
+            terminal_confirmed or state.published or state.failure_recorded
+        ):
+            try:
+                _drop_stage_table(dsn, stage_table)
+            except Exception:
+                logger.warning(
+                    "Could not drop terminal SDV ratings stage table %s; run_id=%s",
+                    stage_table,
+                    run_id,
+                )
+        result["duration_s"] = time.monotonic() - started_at
+
+
+__all__ = ["run_sdv_ratings_publication"]

--- a/src/pipelines/utils/sdv_ratings_publication.py
+++ b/src/pipelines/utils/sdv_ratings_publication.py
@@ -216,8 +216,19 @@ def _rpc(
         conn.close()
     except BaseException as error:
         if mutating:
-            raise PostCommitError("source publication RPC committed before close failed") from error
-        raise
+            if isinstance(error, Exception):
+                logger.warning(
+                    "Source publication RPC committed but connection close failed; "
+                    "phase=%s error_type=%s",
+                    phase,
+                    type(error).__name__,
+                )
+            else:
+                raise PostCommitError(
+                    "source publication RPC committed before close was interrupted"
+                ) from error
+        else:
+            raise
     return row
 
 
@@ -297,9 +308,49 @@ def _fail_run(
 
 def _raw_row_count(raw: bytes) -> int:
     try:
-        return pyarrow.parquet.ParquetFile(io.BytesIO(raw)).metadata.num_rows
+        parquet_file = pyarrow.parquet.ParquetFile(io.BytesIO(raw))
+        row_count = parquet_file.metadata.num_rows
+        if row_count > MAX_SOURCE_ROWS:
+            raise SourcePublicationError(f"sdv_ratings_weekly exceeds {MAX_SOURCE_ROWS} rows")
+
+        # The legacy parser calls int(value), which truncates fractional Arrow
+        # values. Inspect only the seven integer-contract columns in bounded
+        # batches before materializing the full table in that parser.
+        columns = sorted(_INT_COLUMNS.intersection(parquet_file.schema_arrow.names))
+        row_offset = 0
+        for batch in parquet_file.iter_batches(batch_size=4_096, columns=columns):
+            for column_index, column in enumerate(columns):
+                for batch_index, value in enumerate(batch.column(column_index).to_pylist()):
+                    if not _is_lossless_bigint(value):
+                        raise SourcePublicationError(
+                            f"sdv_ratings_weekly raw column {column} has a non-integer "
+                            f"value at row {row_offset + batch_index}"
+                        )
+            row_offset += batch.num_rows
+        return row_count
+    except SourcePublicationError:
+        raise
     except Exception as error:
         raise SourcePublicationError("sdv_ratings_weekly is not a readable parquet file") from error
+
+
+def _is_lossless_bigint(value: Any) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, bool):
+        return False
+    try:
+        integer = int(value)
+    except (TypeError, ValueError, OverflowError):
+        return False
+    if integer < -(1 << 63) or integer >= 1 << 63:
+        return False
+    if isinstance(value, (str, bytes, bytearray)):
+        return bool(value.strip())
+    try:
+        return bool(value == integer)
+    except Exception:
+        return False
 
 
 def _validate_parsed_rows(rows: list[dict[str, Any]], raw_count: int, season: int) -> None:

--- a/src/schemas/migrations/071_sdv_ratings_publication.sql
+++ b/src/schemas/migrations/071_sdv_ratings_publication.sql
@@ -1,0 +1,1452 @@
+-- F14/F28 source publication: managed forward migration after 070.
+--
+-- This is an opt-in, season-scoped publisher for the cumulative contents of one
+-- sportsdataverse season file.  The existing F19 public freshness surface stays
+-- limited to its two house-Elo rows.  Runtime membership and workflow activation
+-- remain separate rollout steps.
+
+-- 068 deliberately admitted only source-wide house-Elo receipts.  Preserve that
+-- rule for those assets while admitting one canonical season key for this source.
+ALTER TABLE meta.asset_publication_locks
+    DROP CONSTRAINT IF EXISTS asset_publication_locks_asset_key_check;
+ALTER TABLE meta.asset_publication_locks
+    ADD CONSTRAINT asset_publication_locks_asset_key_check CHECK (asset_key IN (
+        'analytics.house_elo_game',
+        'marts.house_elo_game',
+        'ratings.sdv_ratings_weekly'
+    ));
+
+ALTER TABLE meta.asset_receipts
+    DROP CONSTRAINT IF EXISTS asset_receipts_coverage_key_check;
+ALTER TABLE meta.asset_receipts
+    ADD CONSTRAINT asset_receipts_coverage_key_check CHECK (
+        (asset_key IN ('analytics.house_elo_game', 'marts.house_elo_game')
+            AND coverage_key = 'source-wide')
+        OR
+        (asset_key = 'ratings.sdv_ratings_weekly'
+            AND coverage_key ~ '^season:(18(69|[7-9][0-9])|19[0-9]{2}|20[0-9]{2}|21[0-9]{2}|2200)$')
+    );
+
+ALTER TABLE meta.asset_current_generations
+    DROP CONSTRAINT IF EXISTS asset_current_generations_coverage_key_check;
+ALTER TABLE meta.asset_current_generations
+    ADD CONSTRAINT asset_current_generations_coverage_key_check CHECK (
+        (asset_key IN ('analytics.house_elo_game', 'marts.house_elo_game')
+            AND coverage_key = 'source-wide')
+        OR
+        (asset_key = 'ratings.sdv_ratings_weekly'
+            AND coverage_key ~ '^season:(18(69|[7-9][0-9])|19[0-9]{2}|20[0-9]{2}|21[0-9]{2}|2200)$')
+    );
+
+ALTER TABLE meta.asset_receipt_inputs
+    DROP CONSTRAINT IF EXISTS asset_receipt_inputs_input_coverage_key_check;
+ALTER TABLE meta.asset_receipt_inputs
+    ADD CONSTRAINT asset_receipt_inputs_input_coverage_key_check CHECK (
+        (input_asset_key IN ('analytics.house_elo_game', 'marts.house_elo_game')
+            AND input_coverage_key = 'source-wide')
+        OR
+        (input_asset_key = 'ratings.sdv_ratings_weekly'
+            AND input_coverage_key ~ '^season:(18(69|[7-9][0-9])|19[0-9]{2}|20[0-9]{2}|21[0-9]{2}|2200)$')
+    );
+
+-- Store the exact target identity.  A replacement relation may be adopted only
+-- after DDL invalidation has removed every current season pointer.
+DO $asset$
+DECLARE
+    current_oid oid := pg_catalog.to_regclass('ratings.sdv_ratings_weekly');
+    current_kind "char";
+    current_owner oid;
+    existing meta.asset_publication_locks%ROWTYPE;
+BEGIN
+    IF current_oid IS NULL THEN
+        RAISE EXCEPTION 'required publication relation ratings.sdv_ratings_weekly is missing';
+    END IF;
+    SELECT c.relkind, c.relowner INTO current_kind, current_owner
+    FROM pg_catalog.pg_class c WHERE c.oid = current_oid;
+    IF current_kind <> 'r'::"char"
+        OR current_owner <> (SELECT oid FROM pg_catalog.pg_roles WHERE rolname = current_user)
+        OR EXISTS (SELECT 1 FROM pg_catalog.pg_inherits i WHERE i.inhrelid = current_oid OR i.inhparent = current_oid)
+        OR EXISTS (
+            SELECT 1 FROM pg_catalog.pg_trigger t
+            WHERE t.tgrelid = current_oid AND NOT t.tgisinternal
+              AND NOT (
+                (t.tgname = 'invalidate_sdv_ratings_row_pointer' AND t.tgtype = 31
+                    AND t.tgfoid = pg_catalog.to_regprocedure(
+                        'warehouse_source.invalidate_sdv_ratings_row_pointer()'))
+                OR
+                (t.tgname = 'invalidate_sdv_ratings_truncate_pointer' AND t.tgtype = 34
+                    AND t.tgfoid = pg_catalog.to_regprocedure(
+                        'warehouse_source.invalidate_sdv_ratings_truncate_pointer()'))
+              )
+        ) THEN
+        RAISE EXCEPTION 'ratings.sdv_ratings_weekly must be a trusted migration-owned ordinary table';
+    END IF;
+
+    SELECT * INTO existing FROM meta.asset_publication_locks l
+    WHERE l.asset_key = 'ratings.sdv_ratings_weekly';
+    IF NOT FOUND THEN
+        INSERT INTO meta.asset_publication_locks(
+            asset_key, relation_schema, relation_name, relation_oid, relation_kind
+        ) VALUES ('ratings.sdv_ratings_weekly', 'ratings', 'sdv_ratings_weekly',
+            current_oid, 'r'::"char");
+    ELSIF existing.relation_schema IS DISTINCT FROM 'ratings'
+        OR existing.relation_name IS DISTINCT FROM 'sdv_ratings_weekly'
+        OR existing.relation_oid IS DISTINCT FROM current_oid
+        OR existing.relation_kind IS DISTINCT FROM 'r'::"char" THEN
+        IF EXISTS (SELECT 1 FROM meta.asset_current_generations p
+            WHERE p.asset_key = 'ratings.sdv_ratings_weekly') THEN
+            RAISE EXCEPTION 'cannot adopt replacement ratings.sdv_ratings_weekly while a current pointer exists';
+        END IF;
+        UPDATE meta.asset_publication_locks
+        SET relation_schema = 'ratings', relation_name = 'sdv_ratings_weekly',
+            relation_oid = current_oid, relation_kind = 'r'::"char"
+        WHERE asset_key = 'ratings.sdv_ratings_weekly';
+    END IF;
+END
+$asset$;
+
+DO $flat_file_ledger$
+DECLARE ledger_oid oid := pg_catalog.to_regclass('meta.flat_file_loads');
+BEGIN
+    IF ledger_oid IS NULL OR NOT EXISTS (
+        SELECT 1 FROM pg_catalog.pg_class c
+        WHERE c.oid = ledger_oid AND c.relkind = 'r'
+          AND c.relowner = (SELECT oid FROM pg_catalog.pg_roles WHERE rolname = current_user)
+    ) OR EXISTS (SELECT 1 FROM pg_catalog.pg_inherits i WHERE i.inhrelid = ledger_oid OR i.inhparent = ledger_oid)
+      OR EXISTS (SELECT 1 FROM pg_catalog.pg_trigger t
+          WHERE t.tgrelid = ledger_oid AND NOT t.tgisinternal) THEN
+        RAISE EXCEPTION 'meta.flat_file_loads must be a trusted migration-owned ordinary table';
+    END IF;
+END
+$flat_file_ledger$;
+
+-- dlt may materialize and inspect its own staging objects here using the existing
+-- wide pipeline credential.  The bounded publisher receives normalized JSON and
+-- never dynamically reads a caller-selected relation from this schema.
+DO $stage_namespace$
+DECLARE ns record; acl record; recipient text;
+BEGIN
+    SELECT oid, nspowner, nspacl INTO ns FROM pg_catalog.pg_namespace
+    WHERE nspname = 'warehouse_source_stage';
+    IF NOT FOUND THEN
+        CREATE SCHEMA warehouse_source_stage;
+        SELECT oid, nspowner, nspacl INTO ns FROM pg_catalog.pg_namespace
+        WHERE nspname = 'warehouse_source_stage';
+    ELSIF ns.nspowner <> (SELECT oid FROM pg_catalog.pg_roles WHERE rolname = current_user) THEN
+        RAISE EXCEPTION 'warehouse_source_stage must be owned by the migration role';
+    END IF;
+    FOR acl IN SELECT DISTINCT a.grantee FROM pg_catalog.aclexplode(ns.nspacl) a
+        WHERE a.grantee <> ns.nspowner LOOP
+        recipient := CASE WHEN acl.grantee = 0 THEN 'PUBLIC'
+            ELSE pg_catalog.quote_ident(pg_catalog.pg_get_userbyid(acl.grantee)) END;
+        EXECUTE pg_catalog.format('REVOKE ALL ON SCHEMA warehouse_source_stage FROM %s', recipient);
+    END LOOP;
+END
+$stage_namespace$;
+
+-- Separate routines-only namespace: adding routines to warehouse_publication
+-- would violate migration 068's exact routine whitelist on reapplication.
+DO $namespace$
+DECLARE ns record;
+BEGIN
+    SELECT oid, nspowner, nspacl INTO ns FROM pg_catalog.pg_namespace
+    WHERE nspname = 'warehouse_source';
+    IF NOT FOUND THEN
+        CREATE SCHEMA warehouse_source;
+    ELSE
+        IF ns.nspowner <> (SELECT oid FROM pg_catalog.pg_roles WHERE rolname = current_user)
+            OR EXISTS (SELECT 1 FROM pg_catalog.aclexplode(ns.nspacl) a
+                WHERE a.grantee <> ns.nspowner AND a.privilege_type = 'CREATE')
+            OR EXISTS (SELECT 1 FROM pg_catalog.pg_type WHERE typnamespace = ns.oid)
+            OR EXISTS (
+                SELECT 1 FROM pg_catalog.pg_proc p WHERE p.pronamespace = ns.oid
+                AND (p.proowner <> ns.nspowner OR p.prokind <> 'f'
+                    OR p.provariadic <> 0 OR p.pronargdefaults <> 0
+                    OR NOT COALESCE(p.oid = ANY(ARRAY[
+                        pg_catalog.to_regprocedure('warehouse_source.invalidate_sdv_ratings_row_pointer()'),
+                        pg_catalog.to_regprocedure('warehouse_source.invalidate_sdv_ratings_truncate_pointer()'),
+                        pg_catalog.to_regprocedure('warehouse_source.invalidate_sdv_ratings_ddl()'),
+                        pg_catalog.to_regprocedure('warehouse_source.invalidate_sdv_ratings_drop()'),
+                        pg_catalog.to_regprocedure('warehouse_source.get_sdv_ratings_plan(bigint)'),
+                        pg_catalog.to_regprocedure('warehouse_source.require_sdv_ratings_load(uuid)'),
+                        pg_catalog.to_regprocedure('warehouse_source.start_sdv_ratings_load(uuid,jsonb)'),
+                        pg_catalog.to_regprocedure('warehouse_source.publish_sdv_ratings_load(uuid,uuid,text,jsonb,jsonb)'),
+                        pg_catalog.to_regprocedure('warehouse_source.fail_sdv_ratings_load(uuid,uuid,text)')
+                    ]::oid[]), false))
+            ) THEN
+            RAISE EXCEPTION 'warehouse_source must be a trusted migration-owned routines namespace';
+        END IF;
+    END IF;
+END
+$namespace$;
+
+DO $role$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_roles
+        WHERE rolname = 'warehouse_source_publisher') THEN
+        CREATE ROLE warehouse_source_publisher NOLOGIN NOINHERIT NOSUPERUSER NOCREATEDB
+            NOCREATEROLE NOREPLICATION NOBYPASSRLS;
+    ELSIF EXISTS (
+        SELECT 1 FROM pg_catalog.pg_roles r
+        WHERE r.rolname = 'warehouse_source_publisher'
+          AND (r.rolcanlogin OR r.rolinherit OR r.rolsuper OR r.rolcreatedb
+            OR r.rolcreaterole OR r.rolreplication OR r.rolbypassrls
+            OR EXISTS (SELECT 1 FROM pg_catalog.pg_auth_members m
+                WHERE m.member = r.oid OR m.roleid = r.oid))
+    ) THEN
+        RAISE EXCEPTION 'warehouse_source_publisher must be a bounded membership-free NOLOGIN role';
+    END IF;
+END
+$role$;
+
+-- Migration 068 originally checked every later-registered asset identity in the
+-- house-Elo publisher.  Keep that protocol bounded to its own two assets so
+-- SDV target DDL cannot make an unrelated house-Elo publication impossible.
+CREATE OR REPLACE FUNCTION warehouse_publication.publish_house_elo(
+    p_operation_run_id uuid,
+    p_source_generation_id uuid,
+    p_mart_generation_id uuid,
+    p_expected_source_generation_id uuid,
+    p_expected_mart_generation_id uuid,
+    p_input_digest text,
+    p_rows jsonb,
+    p_snapshot jsonb,
+    p_start_season bigint,
+    p_end_season bigint,
+    p_excluded_game_ids bigint[]
+)
+RETURNS TABLE (
+    source_generation uuid,
+    mart_generation uuid,
+    replayed boolean,
+    source_rows bigint,
+    mart_rows bigint
+)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $function$
+DECLARE
+    reviewed_exclusions constant bigint[] := ARRAY[
+        401540999,401545766,401545768,401545773,401545780,401545781,
+        401549719,401550299,401552878,401552884,401640992,401833535,
+        401866625
+    ]::bigint[];
+    run_row meta.operation_runs%ROWTYPE;
+    source_receipt meta.asset_receipts%ROWTYPE;
+    mart_receipt meta.asset_receipts%ROWTYPE;
+    request_digest_value text;
+    fresh_input_digest text;
+    actual_source_generation uuid;
+    actual_mart_generation uuid;
+    old_source_rows bigint;
+    old_mart_rows bigint;
+    eligible_scheduled_rows bigint;
+    eligible_completed_rows bigint;
+    parsed_source_rows bigint;
+    parsed_snapshot_rows bigint;
+    refreshed_mart_rows bigint;
+    mismatch_rows bigint;
+    max_season bigint;
+    publication_time timestamptz;
+    publication_outcome text;
+    source_coverage jsonb;
+    mart_coverage jsonb;
+    observations jsonb;
+BEGIN
+    IF p_operation_run_id IS NULL OR p_source_generation_id IS NULL
+        OR p_mart_generation_id IS NULL OR p_source_generation_id = p_mart_generation_id
+        OR p_input_digest IS NULL OR p_input_digest !~ '^[0-9a-f]{32}$'
+        OR p_rows IS NULL OR pg_catalog.jsonb_typeof(p_rows) <> 'array'
+        OR p_snapshot IS NULL OR pg_catalog.jsonb_typeof(p_snapshot) <> 'array'
+        OR p_start_season IS DISTINCT FROM 1869 OR p_end_season IS NULL
+        OR p_end_season < p_start_season
+        OR p_excluded_game_ids IS DISTINCT FROM reviewed_exclusions THEN
+        RAISE EXCEPTION 'house Elo publication context is invalid' USING ERRCODE = '22023';
+    END IF;
+
+    request_digest_value := pg_catalog.md5(pg_catalog.jsonb_build_object(
+        'protocol', 'house-elo-full-v1',
+        'operation_run_id', p_operation_run_id,
+        'source_generation_id', p_source_generation_id,
+        'mart_generation_id', p_mart_generation_id,
+        'expected_source_generation_id', p_expected_source_generation_id,
+        'expected_mart_generation_id', p_expected_mart_generation_id,
+        'input_digest', p_input_digest, 'rows', p_rows, 'snapshot', p_snapshot,
+        'start_season', p_start_season, 'end_season', p_end_season,
+        'excluded_game_ids', pg_catalog.to_jsonb(p_excluded_game_ids)
+    )::text);
+
+    SELECT r.* INTO run_row FROM meta.operation_runs r
+    WHERE r.operation_run_id = p_operation_run_id FOR UPDATE;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'operation run is not configured' USING ERRCODE = '22023';
+    END IF;
+    IF run_row.operation_kind <> 'compute' OR run_row.recorded_by <> session_user
+        OR run_row.initiator <> 'compute_house_elo'
+        OR run_row.requested_scope->>'mode' IS DISTINCT FROM 'full'
+        OR run_row.requested_scope->>'start_season' IS DISTINCT FROM '1869'
+        OR run_row.requested_scope->'assets' IS DISTINCT FROM
+            '["analytics.house_elo_game", "marts.house_elo_game"]'::jsonb THEN
+        RAISE EXCEPTION 'operation run does not belong to this house Elo publisher'
+            USING ERRCODE = '22023';
+    END IF;
+
+    -- A matching immutable pair is a pure lookup. It never repoints after a
+    -- later correction and is allowed after the operation run became terminal.
+    SELECT r.* INTO source_receipt FROM meta.asset_receipts r
+    WHERE r.generation_id = p_source_generation_id;
+    SELECT r.* INTO mart_receipt FROM meta.asset_receipts r
+    WHERE r.generation_id = p_mart_generation_id;
+    IF source_receipt.generation_id IS NOT NULL OR mart_receipt.generation_id IS NOT NULL THEN
+        IF source_receipt.generation_id IS NULL OR mart_receipt.generation_id IS NULL
+            OR source_receipt.operation_run_id <> p_operation_run_id
+            OR mart_receipt.operation_run_id <> p_operation_run_id
+            OR source_receipt.asset_key <> 'analytics.house_elo_game'
+            OR mart_receipt.asset_key <> 'marts.house_elo_game'
+            OR source_receipt.outcome NOT IN ('succeeded', 'expected_no_data')
+            OR mart_receipt.outcome <> source_receipt.outcome
+            OR source_receipt.request_digest <> request_digest_value
+            OR mart_receipt.request_digest <> request_digest_value
+            OR NOT EXISTS (
+                SELECT 1 FROM meta.asset_receipt_inputs i
+                WHERE i.generation_id = p_mart_generation_id
+                  AND i.input_asset_key = 'analytics.house_elo_game'
+                  AND i.input_coverage_key = 'source-wide'
+                  AND i.input_generation_id = p_source_generation_id
+            ) THEN
+            RAISE EXCEPTION 'generation ID already has different publication context'
+                USING ERRCODE = '22023';
+        END IF;
+        RETURN QUERY SELECT p_source_generation_id, p_mart_generation_id, true,
+            (source_receipt.row_delta->>'published_rows')::bigint,
+            (mart_receipt.row_delta->>'published_rows')::bigint;
+        RETURN;
+    END IF;
+    IF run_row.outcome <> 'running' THEN
+        RAISE EXCEPTION 'operation run is already terminal' USING ERRCODE = '22023';
+    END IF;
+    IF current_setting('transaction_isolation') <> 'read committed'
+        OR current_setting('session_replication_role') <> 'origin'
+        OR COALESCE(current_setting('event_triggers', true), 'on') <> 'on' THEN
+        RAISE EXCEPTION 'house Elo publication requires a fresh READ COMMITTED transaction'
+            USING ERRCODE = '25001';
+    END IF;
+
+    -- Lock order: operation run -> unversioned input -> targets -> asset rows.
+    LOCK TABLE core.games IN SHARE MODE;
+    LOCK TABLE analytics.house_elo_game, analytics.house_elo_current IN EXCLUSIVE MODE;
+    -- PostgreSQL LOCK TABLE excludes materialized views. The ordinary REFRESH
+    -- below takes its AccessExclusiveLock; source/asset serialization makes it
+    -- the final target lock in the protocol.
+    PERFORM 1 FROM meta.asset_publication_locks l
+    WHERE l.asset_key IN ('analytics.house_elo_game', 'marts.house_elo_game')
+    ORDER BY l.asset_key FOR UPDATE;
+
+    -- Refuse to install future proof if any invalidation guard was altered.
+    IF EXISTS (
+        SELECT 1 FROM meta.asset_publication_locks l
+        WHERE l.asset_key IN ('analytics.house_elo_game', 'marts.house_elo_game')
+          AND l.relation_oid <> pg_catalog.to_regclass(
+            pg_catalog.format('%I.%I', l.relation_schema, l.relation_name))
+    ) OR NOT EXISTS (
+        SELECT 1 FROM pg_catalog.pg_trigger t
+        WHERE t.tgrelid = pg_catalog.to_regclass('analytics.house_elo_game')
+          AND t.tgname = 'invalidate_house_elo_game_pointer'
+          AND t.tgfoid = pg_catalog.to_regprocedure(
+              'warehouse_publication.invalidate_house_elo_pointers()')
+          AND t.tgtype = 62 AND t.tgenabled IN ('O', 'A') AND NOT t.tgisinternal
+    ) OR NOT EXISTS (
+        SELECT 1 FROM pg_catalog.pg_trigger t
+        WHERE t.tgrelid = pg_catalog.to_regclass('analytics.house_elo_current')
+          AND t.tgname = 'invalidate_house_elo_current_pointer'
+          AND t.tgfoid = pg_catalog.to_regprocedure(
+              'warehouse_publication.invalidate_house_elo_pointers()')
+          AND t.tgtype = 62 AND t.tgenabled IN ('O', 'A') AND NOT t.tgisinternal
+    ) OR NOT EXISTS (
+        SELECT 1 FROM pg_catalog.pg_event_trigger e
+        WHERE e.evtname = 'warehouse_publication_invalidate_ddl'
+          AND e.evtevent = 'ddl_command_end' AND e.evtenabled IN ('O', 'A')
+          AND e.evtfoid = pg_catalog.to_regprocedure(
+              'warehouse_publication.invalidate_asset_pointer_ddl()')
+    ) OR NOT EXISTS (
+        SELECT 1 FROM pg_catalog.pg_event_trigger e
+        WHERE e.evtname = 'warehouse_publication_invalidate_drop'
+          AND e.evtevent = 'sql_drop' AND e.evtenabled IN ('O', 'A')
+          AND e.evtfoid = pg_catalog.to_regprocedure(
+              'warehouse_publication.invalidate_asset_pointer_drop()')
+    ) THEN
+        RAISE EXCEPTION 'house Elo publication invalidation guards are missing or stale';
+    END IF;
+
+    SELECT p.generation_id INTO actual_source_generation
+    FROM meta.asset_current_generations p
+    WHERE p.asset_key = 'analytics.house_elo_game' AND p.coverage_key = 'source-wide';
+    SELECT p.generation_id INTO actual_mart_generation
+    FROM meta.asset_current_generations p
+    WHERE p.asset_key = 'marts.house_elo_game' AND p.coverage_key = 'source-wide';
+    IF actual_source_generation IS DISTINCT FROM p_expected_source_generation_id
+        OR actual_mart_generation IS DISTINCT FROM p_expected_mart_generation_id THEN
+        RAISE EXCEPTION 'house Elo current generation changed during preparation'
+            USING ERRCODE = '40001';
+    END IF;
+
+    PERFORM pg_catalog.set_config('TimeZone', 'UTC', true);
+    SELECT pg_catalog.md5(COALESCE(pg_catalog.string_agg(
+        pg_catalog.md5(pg_catalog.to_jsonb(g)::text), '' ORDER BY g.id), ''))
+    INTO fresh_input_digest FROM core.games g;
+    IF fresh_input_digest IS DISTINCT FROM p_input_digest THEN
+        RAISE EXCEPTION 'core.games changed during house Elo preparation'
+            USING ERRCODE = '40001';
+    END IF;
+
+    -- Excluding a reviewed postponed original is safe only while its reviewed
+    -- replacement is present and carries the same non-NULL game identity.
+    -- This mirrors select_canonical_game_rows() without changing raw rows.
+    IF EXISTS (
+        SELECT 1
+        FROM (VALUES
+            (401866625::bigint, 401917058::bigint),
+            (401549719::bigint, 401611307::bigint),
+            (401550299::bigint, 401611308::bigint),
+            (401552878::bigint, 401611306::bigint),
+            (401552884::bigint, 401612659::bigint)
+        ) mapping(original_id, replacement_id)
+        JOIN core.games original_game ON original_game.id = mapping.original_id
+        LEFT JOIN core.games replacement_game ON replacement_game.id = mapping.replacement_id
+        WHERE replacement_game.id IS NULL
+           OR original_game.season IS NULL
+           OR original_game.home_team IS NULL
+           OR original_game.away_team IS NULL
+           OR original_game.season IS DISTINCT FROM replacement_game.season
+           OR original_game.home_team IS DISTINCT FROM replacement_game.home_team
+           OR original_game.away_team IS DISTINCT FROM replacement_game.away_team
+    ) THEN
+        RAISE EXCEPTION 'reviewed superseded game is missing a matching replacement'
+            USING ERRCODE = '22023';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM core.games g WHERE g.id <> ALL(reviewed_exclusions)
+          AND (g.season IS NULL OR g.season < p_start_season OR g.season > p_end_season)
+    ) THEN
+        RAISE EXCEPTION 'house Elo publication scope does not cover every eligible game'
+            USING ERRCODE = '22023';
+    END IF;
+    SELECT max(g.season), count(*) INTO max_season, eligible_scheduled_rows
+    FROM core.games g WHERE g.id <> ALL(reviewed_exclusions);
+    IF max_season IS NOT NULL AND p_end_season < max_season THEN
+        RAISE EXCEPTION 'house Elo publication end season does not cover current schedule'
+            USING ERRCODE = '22023';
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM core.games g
+        WHERE g.id <> ALL(reviewed_exclusions) AND g.completed = true
+          AND (g.home_points IS NULL OR g.away_points IS NULL
+               OR g.home_team IS NULL OR g.away_team IS NULL)
+    ) THEN
+        RAISE EXCEPTION 'completed eligible games require teams and final scores'
+            USING ERRCODE = '22023';
+    END IF;
+    SELECT count(*) INTO eligible_completed_rows FROM core.games g
+    WHERE g.id <> ALL(reviewed_exclusions) AND g.completed = true
+      AND g.home_points IS NOT NULL AND g.away_points IS NOT NULL;
+
+    IF EXISTS (
+        SELECT 1 FROM pg_catalog.jsonb_array_elements(p_rows) e(value)
+        WHERE pg_catalog.jsonb_typeof(value) <> 'object'
+           OR NOT value ?& ARRAY[
+                'game_id','season','week','season_type','start_date','neutral_site',
+                'home_team','away_team','home_pregame_elo','away_pregame_elo',
+                'home_postgame_elo','away_postgame_elo','home_win_prob',
+                'expected_home_margin','actual_home_margin','mov_multiplier',
+                'cfbd_home_pregame_elo','cfbd_away_pregame_elo'
+              ]
+           OR value - ARRAY[
+                'game_id','season','week','season_type','start_date','neutral_site',
+                'home_team','away_team','home_pregame_elo','away_pregame_elo',
+                'home_postgame_elo','away_postgame_elo','home_win_prob',
+                'expected_home_margin','actual_home_margin','mov_multiplier',
+                'cfbd_home_pregame_elo','cfbd_away_pregame_elo'
+              ] <> '{}'::jsonb
+    ) THEN
+        RAISE EXCEPTION 'house Elo row payload has an invalid object shape'
+            USING ERRCODE = '22023';
+    END IF;
+
+    SELECT count(*), count(*) - count(DISTINCT r.game_id)
+    INTO parsed_source_rows, mismatch_rows
+    FROM pg_catalog.jsonb_populate_recordset(NULL::analytics.house_elo_game, p_rows) r;
+    IF mismatch_rows <> 0 OR parsed_source_rows <> eligible_completed_rows THEN
+        RAISE EXCEPTION 'house Elo row payload has duplicate or missing game IDs'
+            USING ERRCODE = '22023';
+    END IF;
+    IF EXISTS (
+        SELECT 1
+        FROM pg_catalog.jsonb_populate_recordset(NULL::analytics.house_elo_game, p_rows) r
+        WHERE r.game_id IS NULL OR r.season IS NULL OR r.neutral_site IS NULL
+           OR r.home_team IS NULL OR length(pg_catalog.btrim(r.home_team)) = 0
+           OR r.away_team IS NULL OR length(pg_catalog.btrim(r.away_team)) = 0
+           OR r.home_pregame_elo IS NULL OR r.away_pregame_elo IS NULL
+           OR r.home_postgame_elo IS NULL OR r.away_postgame_elo IS NULL
+           OR r.home_win_prob IS NULL OR r.home_win_prob < 0 OR r.home_win_prob > 1
+           OR r.expected_home_margin IS NULL OR r.actual_home_margin IS NULL
+           OR r.mov_multiplier IS NULL OR r.mov_multiplier < 0
+           OR r.home_pregame_elo::text IN ('NaN','Infinity','-Infinity')
+           OR r.away_pregame_elo::text IN ('NaN','Infinity','-Infinity')
+           OR r.home_postgame_elo::text IN ('NaN','Infinity','-Infinity')
+           OR r.away_postgame_elo::text IN ('NaN','Infinity','-Infinity')
+           OR r.home_win_prob::text IN ('NaN','Infinity','-Infinity')
+           OR r.expected_home_margin::text IN ('NaN','Infinity','-Infinity')
+           OR r.mov_multiplier::text IN ('NaN','Infinity','-Infinity')
+    ) THEN
+        RAISE EXCEPTION 'house Elo row payload contains invalid values'
+            USING ERRCODE = '22023';
+    END IF;
+
+    SELECT count(*) INTO mismatch_rows
+    FROM pg_catalog.jsonb_populate_recordset(NULL::analytics.house_elo_game, p_rows) r
+    FULL JOIN (
+        SELECT * FROM core.games source_game
+        WHERE source_game.id <> ALL(reviewed_exclusions)
+          AND source_game.completed = true
+          AND source_game.home_points IS NOT NULL
+          AND source_game.away_points IS NOT NULL
+    ) g ON g.id = r.game_id
+    WHERE r.game_id IS NULL OR g.id IS NULL
+       OR r.season IS DISTINCT FROM g.season OR r.week IS DISTINCT FROM g.week
+       OR r.season_type IS DISTINCT FROM g.season_type
+       OR r.start_date IS DISTINCT FROM g.start_date
+       OR r.neutral_site IS DISTINCT FROM COALESCE(g.neutral_site, false)
+       OR r.home_team IS DISTINCT FROM g.home_team OR r.away_team IS DISTINCT FROM g.away_team
+       OR r.actual_home_margin IS DISTINCT FROM (g.home_points - g.away_points)
+       OR r.cfbd_home_pregame_elo IS DISTINCT FROM g.home_pregame_elo
+       OR r.cfbd_away_pregame_elo IS DISTINCT FROM g.away_pregame_elo;
+    IF mismatch_rows <> 0 THEN
+        RAISE EXCEPTION 'house Elo row payload does not match the locked source rows'
+            USING ERRCODE = '22023';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM pg_catalog.jsonb_array_elements(p_snapshot) e(value)
+        WHERE pg_catalog.jsonb_typeof(value) <> 'object'
+           OR NOT value ?& ARRAY[
+                'team','season','rating','games_played','last_game_id',
+                'last_game_date','low_confidence'
+              ]
+           OR value - ARRAY[
+                'team','season','rating','games_played','last_game_id',
+                'last_game_date','low_confidence'
+              ] <> '{}'::jsonb
+    ) THEN
+        RAISE EXCEPTION 'house Elo snapshot payload has an invalid object shape'
+            USING ERRCODE = '22023';
+    END IF;
+    SELECT count(*), count(*) - count(DISTINCT s.team)
+    INTO parsed_snapshot_rows, mismatch_rows
+    FROM pg_catalog.jsonb_to_recordset(p_snapshot) AS s(
+        team text, season bigint, rating numeric, games_played bigint,
+        last_game_id bigint, last_game_date timestamptz, low_confidence boolean
+    );
+    IF mismatch_rows <> 0 THEN
+        RAISE EXCEPTION 'house Elo snapshot payload has duplicate teams'
+            USING ERRCODE = '22023';
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM pg_catalog.jsonb_to_recordset(p_snapshot) AS s(
+            team text, season bigint, rating numeric, games_played bigint,
+            last_game_id bigint, last_game_date timestamptz, low_confidence boolean
+        )
+        WHERE s.team IS NULL OR length(pg_catalog.btrim(s.team)) = 0
+           OR s.season IS NULL OR s.rating IS NULL
+           OR s.rating::text IN ('NaN','Infinity','-Infinity')
+           OR s.games_played IS NULL OR s.games_played < 0
+           OR s.last_game_id IS NULL OR s.low_confidence IS NULL
+    ) THEN
+        RAISE EXCEPTION 'house Elo snapshot payload contains invalid values'
+            USING ERRCODE = '22023';
+    END IF;
+
+    WITH payload_teams AS (
+        SELECT s.team, s.season
+        FROM pg_catalog.jsonb_to_recordset(p_snapshot) AS s(
+            team text, season bigint, rating numeric, games_played bigint,
+            last_game_id bigint, last_game_date timestamptz, low_confidence boolean
+        )
+    ), source_teams AS (
+        SELECT team, max(season) AS season FROM (
+            SELECT r.home_team AS team, r.season
+            FROM pg_catalog.jsonb_populate_recordset(NULL::analytics.house_elo_game, p_rows) r
+            UNION ALL
+            SELECT r.away_team AS team, r.season
+            FROM pg_catalog.jsonb_populate_recordset(NULL::analytics.house_elo_game, p_rows) r
+        ) sides GROUP BY team
+    )
+    SELECT count(*) INTO mismatch_rows
+    FROM payload_teams p FULL JOIN source_teams s USING (team)
+    WHERE p.team IS NULL OR s.team IS NULL OR p.season IS DISTINCT FROM s.season;
+    IF mismatch_rows <> 0 THEN
+        RAISE EXCEPTION 'house Elo snapshot does not cover the computed team set'
+            USING ERRCODE = '22023';
+    END IF;
+
+    SELECT count(*) INTO old_source_rows FROM analytics.house_elo_game;
+    SELECT count(*) INTO old_mart_rows FROM marts.house_elo_game;
+
+    DELETE FROM analytics.house_elo_game;
+    INSERT INTO analytics.house_elo_game(
+        game_id, season, week, season_type, start_date, neutral_site,
+        home_team, away_team, home_pregame_elo, away_pregame_elo,
+        home_postgame_elo, away_postgame_elo, home_win_prob,
+        expected_home_margin, actual_home_margin, mov_multiplier,
+        cfbd_home_pregame_elo, cfbd_away_pregame_elo
+    )
+    SELECT game_id, season, week, season_type, start_date, neutral_site,
+        home_team, away_team, home_pregame_elo, away_pregame_elo,
+        home_postgame_elo, away_postgame_elo, home_win_prob,
+        expected_home_margin, actual_home_margin, mov_multiplier,
+        cfbd_home_pregame_elo, cfbd_away_pregame_elo
+    FROM pg_catalog.jsonb_populate_recordset(NULL::analytics.house_elo_game, p_rows);
+
+    DELETE FROM analytics.house_elo_current;
+    INSERT INTO analytics.house_elo_current(
+        team, season, rating, games_played, last_game_id,
+        last_game_date, low_confidence, updated_at
+    )
+    SELECT s.team, s.season, s.rating, s.games_played, s.last_game_id,
+        s.last_game_date, s.low_confidence, pg_catalog.clock_timestamp()
+    FROM pg_catalog.jsonb_to_recordset(p_snapshot) AS s(
+        team text, season bigint, rating numeric, games_played bigint,
+        last_game_id bigint, last_game_date timestamptz, low_confidence boolean
+    );
+
+    REFRESH MATERIALIZED VIEW marts.house_elo_game;
+    -- REFRESH now retains AccessExclusiveLock through commit. Recheck the
+    -- registered identity to close the pre-refresh DROP/rename/recreate race.
+    IF (SELECT l.relation_oid FROM meta.asset_publication_locks l
+            WHERE l.asset_key = 'marts.house_elo_game')
+        IS DISTINCT FROM pg_catalog.to_regclass('marts.house_elo_game') THEN
+        RAISE EXCEPTION 'house Elo mart relation changed during publication'
+            USING ERRCODE = '40001';
+    END IF;
+    SELECT count(*) INTO refreshed_mart_rows FROM marts.house_elo_game;
+    IF refreshed_mart_rows <> parsed_source_rows THEN
+        RAISE EXCEPTION 'house Elo mart row count differs from its source';
+    END IF;
+
+    publication_time := pg_catalog.clock_timestamp();
+    publication_outcome := CASE WHEN eligible_completed_rows = 0
+        THEN 'expected_no_data' ELSE 'succeeded' END;
+    source_coverage := pg_catalog.jsonb_build_object(
+        'complete', true, 'mode', 'full', 'scope', 'source-wide',
+        'start_season', p_start_season, 'end_season', p_end_season,
+        'eligible_scheduled_games', eligible_scheduled_rows,
+        'eligible_completed_games', eligible_completed_rows,
+        'excluded_game_ids', pg_catalog.to_jsonb(p_excluded_game_ids));
+    mart_coverage := source_coverage || pg_catalog.jsonb_build_object(
+        'input_generation_id', p_source_generation_id);
+    observations := pg_catalog.jsonb_build_object(
+        'publisher', 'compute_house_elo', 'mode', 'full',
+        'input_asset', 'core.games', 'input_digest', p_input_digest,
+        'expected_source_generation_id', p_expected_source_generation_id,
+        'expected_mart_generation_id', p_expected_mart_generation_id,
+        'excluded_game_ids', pg_catalog.to_jsonb(p_excluded_game_ids));
+
+    INSERT INTO meta.asset_receipts(
+        generation_id, operation_run_id, asset_key, outcome, coverage,
+        source_watermark, input_observations, row_delta, request_digest, published_at
+    ) VALUES (
+        p_source_generation_id, p_operation_run_id, 'analytics.house_elo_game',
+        publication_outcome, source_coverage, p_input_digest, observations,
+        pg_catalog.jsonb_build_object('previous_rows', old_source_rows,
+            'published_rows', parsed_source_rows, 'snapshot_rows', parsed_snapshot_rows),
+        request_digest_value, publication_time
+    ), (
+        p_mart_generation_id, p_operation_run_id, 'marts.house_elo_game',
+        publication_outcome, mart_coverage, p_input_digest, observations,
+        pg_catalog.jsonb_build_object('observed_previous_rows', old_mart_rows,
+            'published_rows', refreshed_mart_rows), request_digest_value, publication_time
+    );
+
+    INSERT INTO meta.asset_receipt_inputs(
+        generation_id, input_asset_key, input_coverage_key, input_generation_id
+    ) VALUES (p_mart_generation_id, 'analytics.house_elo_game', 'source-wide',
+        p_source_generation_id);
+
+    INSERT INTO meta.asset_current_generations(asset_key, coverage_key, generation_id)
+    VALUES
+        ('analytics.house_elo_game', 'source-wide', p_source_generation_id),
+        ('marts.house_elo_game', 'source-wide', p_mart_generation_id)
+    ON CONFLICT (asset_key, coverage_key) DO UPDATE
+    SET generation_id = EXCLUDED.generation_id;
+
+    RETURN QUERY SELECT p_source_generation_id, p_mart_generation_id, false,
+        parsed_source_rows, refreshed_mart_rows;
+END
+$function$;
+CREATE OR REPLACE FUNCTION warehouse_source.invalidate_sdv_ratings_row_pointer()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $function$
+BEGIN
+    DELETE FROM meta.asset_current_generations p
+    WHERE p.asset_key = 'ratings.sdv_ratings_weekly'
+      AND p.coverage_key IN (
+          CASE WHEN TG_OP IN ('UPDATE', 'DELETE') THEN 'season:' || OLD.season::text END,
+          CASE WHEN TG_OP IN ('UPDATE', 'INSERT') THEN 'season:' || NEW.season::text END
+      );
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION warehouse_source.invalidate_sdv_ratings_truncate_pointer()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $function$
+BEGIN
+    DELETE FROM meta.asset_current_generations p
+    WHERE p.asset_key = 'ratings.sdv_ratings_weekly';
+    RETURN NULL;
+END
+$function$;
+
+DROP TRIGGER IF EXISTS invalidate_sdv_ratings_row_pointer ON ratings.sdv_ratings_weekly;
+CREATE TRIGGER invalidate_sdv_ratings_row_pointer
+    BEFORE INSERT OR UPDATE OR DELETE ON ratings.sdv_ratings_weekly
+    FOR EACH ROW EXECUTE FUNCTION warehouse_source.invalidate_sdv_ratings_row_pointer();
+DROP TRIGGER IF EXISTS invalidate_sdv_ratings_truncate_pointer ON ratings.sdv_ratings_weekly;
+CREATE TRIGGER invalidate_sdv_ratings_truncate_pointer
+    BEFORE TRUNCATE ON ratings.sdv_ratings_weekly
+    FOR EACH STATEMENT EXECUTE FUNCTION warehouse_source.invalidate_sdv_ratings_truncate_pointer();
+
+CREATE OR REPLACE FUNCTION warehouse_source.invalidate_sdv_ratings_ddl()
+RETURNS event_trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $function$
+DECLARE command record; changed boolean := false;
+BEGIN
+    FOR command IN SELECT * FROM pg_catalog.pg_event_trigger_ddl_commands() LOOP
+        IF command.object_identity LIKE 'warehouse_source.%'
+            OR command.object_identity IN (
+                'warehouse_source_invalidate_ddl', 'warehouse_source_invalidate_drop')
+            OR command.object_identity LIKE '%invalidate_sdv_ratings_%pointer%'
+            OR EXISTS (
+                SELECT 1 FROM meta.asset_publication_locks l
+                WHERE l.asset_key = 'ratings.sdv_ratings_weekly'
+                  AND (command.objid = l.relation_oid OR command.objid =
+                    pg_catalog.to_regclass(pg_catalog.format('%I.%I',
+                        l.relation_schema, l.relation_name)))
+            ) THEN
+            changed := true;
+        END IF;
+    END LOOP;
+    IF EXISTS (SELECT 1 FROM pg_catalog.pg_inherits i
+        WHERE i.inhrelid = pg_catalog.to_regclass('ratings.sdv_ratings_weekly')
+           OR i.inhparent = pg_catalog.to_regclass('ratings.sdv_ratings_weekly')) THEN
+        changed := true;
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM meta.asset_publication_locks l
+        WHERE l.asset_key = 'ratings.sdv_ratings_weekly'
+          AND l.relation_oid IS DISTINCT FROM pg_catalog.to_regclass(
+              pg_catalog.format('%I.%I', l.relation_schema, l.relation_name))
+    ) THEN
+        changed := true;
+    END IF;
+    IF changed THEN
+        DELETE FROM meta.asset_current_generations p
+        WHERE p.asset_key = 'ratings.sdv_ratings_weekly';
+    END IF;
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION warehouse_source.invalidate_sdv_ratings_drop()
+RETURNS event_trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $function$
+DECLARE dropped record; changed boolean := false;
+BEGIN
+    FOR dropped IN SELECT * FROM pg_catalog.pg_event_trigger_dropped_objects() LOOP
+        IF dropped.object_identity LIKE 'warehouse_source.%'
+            OR dropped.object_identity IN (
+                'warehouse_source_invalidate_ddl', 'warehouse_source_invalidate_drop')
+            OR 'invalidate_sdv_ratings_row_pointer' = ANY(dropped.address_names)
+            OR 'invalidate_sdv_ratings_truncate_pointer' = ANY(dropped.address_names)
+            OR EXISTS (
+                SELECT 1 FROM meta.asset_publication_locks l
+                WHERE l.asset_key = 'ratings.sdv_ratings_weekly'
+                  AND (dropped.objid = l.relation_oid OR
+                    (dropped.address_names[1] = l.relation_schema
+                        AND dropped.address_names[2] = l.relation_name))
+            ) THEN
+            changed := true;
+        END IF;
+    END LOOP;
+    IF EXISTS (SELECT 1 FROM pg_catalog.pg_inherits i
+        WHERE i.inhrelid = pg_catalog.to_regclass('ratings.sdv_ratings_weekly')
+           OR i.inhparent = pg_catalog.to_regclass('ratings.sdv_ratings_weekly')) THEN
+        changed := true;
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM meta.asset_publication_locks l
+        WHERE l.asset_key = 'ratings.sdv_ratings_weekly'
+          AND l.relation_oid IS DISTINCT FROM pg_catalog.to_regclass(
+              pg_catalog.format('%I.%I', l.relation_schema, l.relation_name))
+    ) THEN
+        changed := true;
+    END IF;
+    IF changed THEN
+        DELETE FROM meta.asset_current_generations p
+        WHERE p.asset_key = 'ratings.sdv_ratings_weekly';
+    END IF;
+END
+$function$;
+
+DROP EVENT TRIGGER IF EXISTS warehouse_source_invalidate_ddl;
+CREATE EVENT TRIGGER warehouse_source_invalidate_ddl ON ddl_command_end
+    EXECUTE FUNCTION warehouse_source.invalidate_sdv_ratings_ddl();
+DROP EVENT TRIGGER IF EXISTS warehouse_source_invalidate_drop;
+CREATE EVENT TRIGGER warehouse_source_invalidate_drop ON sql_drop
+    EXECUTE FUNCTION warehouse_source.invalidate_sdv_ratings_drop();
+
+CREATE OR REPLACE FUNCTION warehouse_source.get_sdv_ratings_plan(p_season bigint)
+RETURNS jsonb LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = '' AS $function$
+DECLARE coverage text; current_generation uuid;
+BEGIN
+    IF p_season IS NULL OR p_season < 1869 OR p_season > 2200 THEN
+        RAISE EXCEPTION 'sdv ratings season must be between 1869 and 2200'
+            USING ERRCODE = '22023';
+    END IF;
+    coverage := 'season:' || p_season::text;
+    SELECT p.generation_id INTO current_generation
+    FROM meta.asset_current_generations p
+    WHERE p.asset_key = 'ratings.sdv_ratings_weekly' AND p.coverage_key = coverage;
+    RETURN pg_catalog.jsonb_build_object(
+        'protocol', 'sdv-ratings-season-v1',
+        'asset_key', 'ratings.sdv_ratings_weekly',
+        'coverage_key', coverage,
+        'season', p_season,
+        'expected_generation_id', current_generation,
+        'parser_contract', 'sdv-ratings-v1'
+    );
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION warehouse_source.require_sdv_ratings_load(p_run_id uuid)
+RETURNS meta.operation_runs LANGUAGE plpgsql SET search_path = '' AS $function$
+DECLARE run_row meta.operation_runs%ROWTYPE; expected jsonb; season_value bigint;
+BEGIN
+    IF p_run_id IS NULL THEN
+        RAISE EXCEPTION 'operation run ID is required' USING ERRCODE = '22023';
+    END IF;
+    SELECT * INTO run_row FROM meta.operation_runs r
+    WHERE r.operation_run_id = p_run_id FOR UPDATE;
+    IF NOT FOUND OR run_row.recorded_by <> session_user
+        OR run_row.operation_kind <> 'load' OR run_row.initiator <> 'load_flat_files'
+        OR run_row.code_revision IS NOT NULL THEN
+        RAISE EXCEPTION 'operation does not belong to this source publisher'
+            USING ERRCODE = '22023';
+    END IF;
+    BEGIN
+        season_value := (run_row.requested_scope->>'season')::bigint;
+    EXCEPTION WHEN OTHERS THEN
+        RAISE EXCEPTION 'stored source publication scope is invalid' USING ERRCODE = '22023';
+    END;
+    expected := pg_catalog.jsonb_build_object(
+        'protocol', 'sdv-ratings-season-v1',
+        'asset_key', 'ratings.sdv_ratings_weekly',
+        'coverage_key', 'season:' || season_value::text,
+        'season', season_value,
+        'expected_generation_id',
+            CASE WHEN run_row.requested_scope->>'expected_generation_id' IS NULL
+                THEN NULL::uuid
+                ELSE (run_row.requested_scope->>'expected_generation_id')::uuid END,
+        'parser_contract', 'sdv-ratings-v1'
+    );
+    IF season_value < 1869 OR season_value > 2200
+        OR run_row.requested_scope IS DISTINCT FROM expected
+        OR run_row.plan_digest IS DISTINCT FROM pg_catalog.md5(expected::text) THEN
+        RAISE EXCEPTION 'stored source publication scope is invalid' USING ERRCODE = '22023';
+    END IF;
+    RETURN run_row;
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION warehouse_source.start_sdv_ratings_load(
+    p_run_id uuid, p_plan jsonb
+)
+RETURNS uuid LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $function$
+DECLARE season_value bigint; current_plan jsonb;
+BEGIN
+    IF p_run_id IS NULL OR p_plan IS NULL OR pg_catalog.jsonb_typeof(p_plan) <> 'object' THEN
+        RAISE EXCEPTION 'source publication start context is invalid' USING ERRCODE = '22023';
+    END IF;
+    BEGIN
+        season_value := (p_plan->>'season')::bigint;
+    EXCEPTION WHEN OTHERS THEN
+        RAISE EXCEPTION 'source publication plan is invalid' USING ERRCODE = '22023';
+    END;
+    current_plan := warehouse_source.get_sdv_ratings_plan(season_value);
+    IF p_plan IS DISTINCT FROM current_plan THEN
+        RAISE EXCEPTION 'source publication plan is stale or invalid' USING ERRCODE = '40001';
+    END IF;
+    PERFORM warehouse_quota.start_operation_run(
+        p_run_id, 'load', 'load_flat_files', p_plan, pg_catalog.md5(p_plan::text), NULL
+    );
+    PERFORM warehouse_source.require_sdv_ratings_load(p_run_id);
+    RETURN p_run_id;
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION warehouse_source.publish_sdv_ratings_load(
+    p_run_id uuid,
+    p_generation_id uuid,
+    p_source_sha256 text,
+    p_rows jsonb,
+    p_dlt_evidence jsonb
+)
+RETURNS TABLE (generation_id uuid, replayed boolean, published_rows bigint)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $function$
+DECLARE
+    run_row meta.operation_runs%ROWTYPE;
+    existing meta.asset_receipts%ROWTYPE;
+    season_value bigint;
+    coverage_value text;
+    expected_generation uuid;
+    actual_generation uuid;
+    request_digest_value text;
+    row_count_value bigint;
+    previous_rows bigint;
+    inserted_rows bigint;
+    deleted_rows bigint;
+    changed_rows bigint;
+    publication_time timestamptz;
+    actual_load_ids jsonb;
+    catalog_shape jsonb;
+    ledger_inserted integer;
+    ledger_source_url text;
+    expected_keys constant text[] := ARRAY[
+        '_dlt_id','_dlt_load_id','adj_def_epa','adj_net','adj_off_epa','adj_st_epa',
+        'def_rank','fei_def','fei_net','fei_off','games','net_rank','net_z','off_pace',
+        'off_rank','season','team_id','through_week'
+    ]::text[];
+BEGIN
+    IF p_run_id IS NULL OR p_generation_id IS NULL
+        OR p_source_sha256 IS NULL OR p_source_sha256 !~ '^[0-9a-f]{64}$'
+        OR p_rows IS NULL OR pg_catalog.jsonb_typeof(p_rows) <> 'array'
+        OR p_dlt_evidence IS NULL OR pg_catalog.jsonb_typeof(p_dlt_evidence) <> 'object' THEN
+        RAISE EXCEPTION 'source publication input is invalid' USING ERRCODE = '22023';
+    END IF;
+    IF pg_catalog.octet_length(p_rows::text) > 134217728 THEN
+        RAISE EXCEPTION 'source publication payload exceeds 128 MiB' USING ERRCODE = '54000';
+    END IF;
+
+    run_row := warehouse_source.require_sdv_ratings_load(p_run_id);
+    season_value := (run_row.requested_scope->>'season')::bigint;
+    coverage_value := run_row.requested_scope->>'coverage_key';
+    expected_generation := (run_row.requested_scope->>'expected_generation_id')::uuid;
+    request_digest_value := pg_catalog.md5(pg_catalog.jsonb_build_object(
+        'run_id', p_run_id, 'generation_id', p_generation_id,
+        'source_sha256', p_source_sha256, 'plan', run_row.requested_scope,
+        'rows', p_rows, 'dlt_evidence', p_dlt_evidence
+    )::text);
+
+    SELECT * INTO existing FROM meta.asset_receipts r
+    WHERE r.generation_id = p_generation_id;
+    IF FOUND THEN
+        IF existing.operation_run_id <> p_run_id
+            OR existing.asset_key <> 'ratings.sdv_ratings_weekly'
+            OR existing.coverage_key <> coverage_value
+            OR existing.outcome <> 'succeeded'
+            OR existing.source_watermark <> p_source_sha256
+            OR existing.request_digest <> request_digest_value
+            OR run_row.outcome <> 'succeeded' THEN
+            RAISE EXCEPTION 'generation ID already has different source publication context'
+                USING ERRCODE = '22023';
+        END IF;
+        RETURN QUERY SELECT p_generation_id, true,
+            (existing.row_delta->>'published_rows')::bigint;
+        RETURN;
+    END IF;
+    IF run_row.outcome <> 'running' THEN
+        RAISE EXCEPTION 'source publication operation is terminal' USING ERRCODE = '22023';
+    END IF;
+
+    SELECT count(*) INTO row_count_value FROM pg_catalog.jsonb_array_elements(p_rows);
+    IF row_count_value < 1 OR row_count_value > 100000 THEN
+        RAISE EXCEPTION 'source publication requires between 1 and 100000 rows'
+            USING ERRCODE = '22023';
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM pg_catalog.jsonb_array_elements(p_rows) item
+        WHERE pg_catalog.jsonb_typeof(item) <> 'object'
+           OR ARRAY(SELECT k FROM pg_catalog.jsonb_object_keys(item) k ORDER BY k COLLATE "C")
+                IS DISTINCT FROM expected_keys
+    ) THEN
+        RAISE EXCEPTION 'source publication rows have unexpected or missing fields'
+            USING ERRCODE = '22023';
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM pg_catalog.jsonb_array_elements(p_rows) item
+        WHERE pg_catalog.jsonb_typeof(item->'season') <> 'number'
+           OR pg_catalog.jsonb_typeof(item->'through_week') <> 'number'
+           OR pg_catalog.jsonb_typeof(item->'team_id') <> 'number'
+           OR pg_catalog.jsonb_typeof(item->'_dlt_id') <> 'string'
+           OR pg_catalog.jsonb_typeof(item->'_dlt_load_id') <> 'string'
+           OR item->>'_dlt_id' = '' OR item->>'_dlt_load_id' = ''
+           OR pg_catalog.length(item->>'_dlt_id') > 256
+           OR pg_catalog.length(item->>'_dlt_load_id') > 256
+           OR EXISTS (
+               SELECT 1 FROM pg_catalog.jsonb_each(item) field
+               WHERE field.key IN ('adj_off_epa','adj_def_epa','adj_st_epa','adj_net',
+                       'fei_off','fei_def','fei_net','games','off_pace','off_rank',
+                       'def_rank','net_rank','net_z')
+                 AND pg_catalog.jsonb_typeof(field.value) NOT IN ('number','null')
+           )
+    ) THEN
+        RAISE EXCEPTION 'source publication row types are invalid' USING ERRCODE = '22023';
+    END IF;
+
+    BEGIN
+        IF EXISTS (
+            SELECT 1 FROM pg_catalog.jsonb_to_recordset(p_rows) AS r(
+                season bigint, through_week bigint, team_id bigint,
+                adj_off_epa double precision, adj_def_epa double precision,
+                adj_st_epa double precision, adj_net double precision,
+                fei_off double precision, fei_def double precision,
+                fei_net double precision, games bigint, off_pace double precision,
+                off_rank bigint, def_rank bigint, net_rank bigint, net_z double precision,
+                _dlt_id text, _dlt_load_id text
+            )
+            WHERE r.season IS DISTINCT FROM season_value OR r.through_week < 0
+                OR r.team_id <= 0 OR r.games < 0
+                OR r.adj_off_epa IN ('Infinity'::double precision, '-Infinity'::double precision, 'NaN'::double precision)
+                OR r.adj_def_epa IN ('Infinity'::double precision, '-Infinity'::double precision, 'NaN'::double precision)
+                OR r.adj_st_epa IN ('Infinity'::double precision, '-Infinity'::double precision, 'NaN'::double precision)
+                OR r.adj_net IN ('Infinity'::double precision, '-Infinity'::double precision, 'NaN'::double precision)
+                OR r.fei_off IN ('Infinity'::double precision, '-Infinity'::double precision, 'NaN'::double precision)
+                OR r.fei_def IN ('Infinity'::double precision, '-Infinity'::double precision, 'NaN'::double precision)
+                OR r.fei_net IN ('Infinity'::double precision, '-Infinity'::double precision, 'NaN'::double precision)
+                OR r.off_pace IN ('Infinity'::double precision, '-Infinity'::double precision, 'NaN'::double precision)
+                OR r.net_z IN ('Infinity'::double precision, '-Infinity'::double precision, 'NaN'::double precision)
+        ) THEN
+            RAISE EXCEPTION 'source publication contains an invalid season, key, or numeric value'
+                USING ERRCODE = '22023';
+        END IF;
+    EXCEPTION WHEN invalid_text_representation OR numeric_value_out_of_range THEN
+        RAISE EXCEPTION 'source publication contains an invalid numeric value'
+            USING ERRCODE = '22023';
+    END;
+
+    IF EXISTS (
+        SELECT 1 FROM pg_catalog.jsonb_to_recordset(p_rows) AS r(
+            season bigint, through_week bigint, team_id bigint, _dlt_id text
+        ) GROUP BY season, through_week, team_id HAVING count(*) > 1
+    ) OR EXISTS (
+        SELECT 1 FROM pg_catalog.jsonb_to_recordset(p_rows) AS r(_dlt_id text)
+        GROUP BY _dlt_id HAVING count(*) > 1
+    ) THEN
+        RAISE EXCEPTION 'source publication payload contains duplicate keys'
+            USING ERRCODE = '22023';
+    END IF;
+
+    SELECT pg_catalog.jsonb_agg(v ORDER BY v COLLATE "C") INTO actual_load_ids
+    FROM (SELECT DISTINCT item->>'_dlt_load_id' AS v
+        FROM pg_catalog.jsonb_array_elements(p_rows) item) ids;
+    IF ARRAY(SELECT k FROM pg_catalog.jsonb_object_keys(p_dlt_evidence) k
+            ORDER BY k COLLATE "C")
+            IS DISTINCT FROM ARRAY[
+                'artifact_origin','dlt_load_ids','parser_contract','source_rows','stage_schema'
+            ]::text[]
+        OR pg_catalog.jsonb_typeof(p_dlt_evidence->'artifact_origin') <> 'string'
+        OR p_dlt_evidence->>'artifact_origin' NOT IN ('registered_url','local_file')
+        OR p_dlt_evidence->>'stage_schema' IS DISTINCT FROM 'warehouse_source_stage'
+        OR p_dlt_evidence->>'parser_contract' IS DISTINCT FROM 'sdv-ratings-v1'
+        OR pg_catalog.jsonb_typeof(p_dlt_evidence->'dlt_load_ids') <> 'array'
+        OR p_dlt_evidence->'dlt_load_ids' IS DISTINCT FROM actual_load_ids
+        OR pg_catalog.jsonb_typeof(p_dlt_evidence->'source_rows') <> 'number'
+        OR (p_dlt_evidence->>'source_rows')::bigint IS DISTINCT FROM row_count_value THEN
+        RAISE EXCEPTION 'dlt evidence does not match the normalized payload'
+            USING ERRCODE = '22023';
+    END IF;
+
+    IF pg_catalog.current_setting('transaction_isolation') <> 'read committed'
+        OR pg_catalog.current_setting('session_replication_role') <> 'origin'
+        OR COALESCE(pg_catalog.current_setting('event_triggers', true), 'on') <> 'on' THEN
+        RAISE EXCEPTION 'source publication requires READ COMMITTED and active guards'
+            USING ERRCODE = '25001';
+    END IF;
+
+    LOCK TABLE ratings.sdv_ratings_weekly IN EXCLUSIVE MODE;
+    PERFORM 1 FROM meta.asset_publication_locks l
+    WHERE l.asset_key = 'ratings.sdv_ratings_weekly' FOR UPDATE;
+
+    SELECT pg_catalog.jsonb_agg(pg_catalog.jsonb_build_object(
+        'name', a.attname, 'type', pg_catalog.format_type(a.atttypid, a.atttypmod),
+        'not_null', a.attnotnull) ORDER BY a.attnum)
+    INTO catalog_shape
+    FROM pg_catalog.pg_attribute a
+    WHERE a.attrelid = 'ratings.sdv_ratings_weekly'::pg_catalog.regclass
+      AND a.attnum > 0 AND NOT a.attisdropped;
+    IF catalog_shape IS DISTINCT FROM '[
+        {"name":"season","type":"bigint","not_null":true},
+        {"name":"through_week","type":"bigint","not_null":true},
+        {"name":"team_id","type":"bigint","not_null":true},
+        {"name":"adj_off_epa","type":"double precision","not_null":false},
+        {"name":"adj_def_epa","type":"double precision","not_null":false},
+        {"name":"adj_st_epa","type":"double precision","not_null":false},
+        {"name":"adj_net","type":"double precision","not_null":false},
+        {"name":"fei_off","type":"double precision","not_null":false},
+        {"name":"fei_def","type":"double precision","not_null":false},
+        {"name":"fei_net","type":"double precision","not_null":false},
+        {"name":"games","type":"bigint","not_null":false},
+        {"name":"off_pace","type":"double precision","not_null":false},
+        {"name":"off_rank","type":"bigint","not_null":false},
+        {"name":"def_rank","type":"bigint","not_null":false},
+        {"name":"net_rank","type":"bigint","not_null":false},
+        {"name":"net_z","type":"double precision","not_null":false},
+        {"name":"loaded_at","type":"timestamp with time zone","not_null":true},
+        {"name":"_dlt_load_id","type":"character varying","not_null":true},
+        {"name":"_dlt_id","type":"character varying","not_null":true}
+    ]'::jsonb
+        OR NOT EXISTS (SELECT 1 FROM pg_catalog.pg_class c
+            WHERE c.oid = 'ratings.sdv_ratings_weekly'::pg_catalog.regclass
+              AND c.relkind = 'r'
+              AND c.relowner = (SELECT oid FROM pg_catalog.pg_roles
+                  WHERE rolname = current_user))
+        OR EXISTS (SELECT 1 FROM pg_catalog.pg_inherits i
+            WHERE i.inhrelid = 'ratings.sdv_ratings_weekly'::pg_catalog.regclass
+              OR i.inhparent = 'ratings.sdv_ratings_weekly'::pg_catalog.regclass)
+        OR NOT EXISTS (SELECT 1 FROM pg_catalog.pg_constraint c
+            WHERE c.conrelid = 'ratings.sdv_ratings_weekly'::pg_catalog.regclass
+              AND c.contype = 'p'
+              AND pg_catalog.pg_get_constraintdef(c.oid) =
+                  'PRIMARY KEY (season, through_week, team_id)')
+        OR NOT EXISTS (SELECT 1 FROM pg_catalog.pg_constraint c
+            WHERE c.conrelid = 'ratings.sdv_ratings_weekly'::pg_catalog.regclass
+              AND c.contype = 'u'
+              AND pg_catalog.pg_get_constraintdef(c.oid) = 'UNIQUE (_dlt_id)') THEN
+        RAISE EXCEPTION 'ratings.sdv_ratings_weekly catalog differs from the reviewed contract'
+            USING ERRCODE = '55000';
+    END IF;
+    IF (SELECT l.relation_oid FROM meta.asset_publication_locks l
+            WHERE l.asset_key = 'ratings.sdv_ratings_weekly')
+            IS DISTINCT FROM pg_catalog.to_regclass('ratings.sdv_ratings_weekly')
+        OR NOT EXISTS (SELECT 1 FROM pg_catalog.pg_trigger t
+            WHERE t.tgrelid = 'ratings.sdv_ratings_weekly'::pg_catalog.regclass
+              AND t.tgname = 'invalidate_sdv_ratings_row_pointer' AND t.tgtype = 31
+              AND t.tgenabled IN ('O','A') AND NOT t.tgisinternal
+              AND t.tgfoid = pg_catalog.to_regprocedure(
+                  'warehouse_source.invalidate_sdv_ratings_row_pointer()'))
+        OR NOT EXISTS (SELECT 1 FROM pg_catalog.pg_trigger t
+            WHERE t.tgrelid = 'ratings.sdv_ratings_weekly'::pg_catalog.regclass
+              AND t.tgname = 'invalidate_sdv_ratings_truncate_pointer' AND t.tgtype = 34
+              AND t.tgenabled IN ('O','A') AND NOT t.tgisinternal
+              AND t.tgfoid = pg_catalog.to_regprocedure(
+                  'warehouse_source.invalidate_sdv_ratings_truncate_pointer()'))
+        OR NOT EXISTS (SELECT 1 FROM pg_catalog.pg_event_trigger e
+            WHERE e.evtname = 'warehouse_source_invalidate_ddl'
+              AND e.evtevent = 'ddl_command_end' AND e.evtenabled IN ('O','A')
+              AND e.evtfoid = pg_catalog.to_regprocedure(
+                  'warehouse_source.invalidate_sdv_ratings_ddl()'))
+        OR NOT EXISTS (SELECT 1 FROM pg_catalog.pg_event_trigger e
+            WHERE e.evtname = 'warehouse_source_invalidate_drop'
+              AND e.evtevent = 'sql_drop' AND e.evtenabled IN ('O','A')
+              AND e.evtfoid = pg_catalog.to_regprocedure(
+                  'warehouse_source.invalidate_sdv_ratings_drop()')) THEN
+        RAISE EXCEPTION 'source publication guards or asset identity are invalid'
+            USING ERRCODE = '55000';
+    END IF;
+    IF EXISTS (SELECT 1 FROM pg_catalog.pg_trigger t
+        WHERE t.tgrelid = 'ratings.sdv_ratings_weekly'::pg_catalog.regclass
+          AND NOT t.tgisinternal
+          AND t.tgname NOT IN (
+              'invalidate_sdv_ratings_row_pointer',
+              'invalidate_sdv_ratings_truncate_pointer'
+          )) THEN
+        RAISE EXCEPTION 'ratings.sdv_ratings_weekly has an unexpected trigger'
+            USING ERRCODE = '55000';
+    END IF;
+
+    SELECT p.generation_id INTO actual_generation
+    FROM meta.asset_current_generations p
+    WHERE p.asset_key = 'ratings.sdv_ratings_weekly'
+      AND p.coverage_key = coverage_value FOR UPDATE;
+    IF actual_generation IS DISTINCT FROM expected_generation THEN
+        RAISE EXCEPTION 'source generation changed; replan required' USING ERRCODE = '40001';
+    END IF;
+
+    SELECT count(*) INTO previous_rows FROM ratings.sdv_ratings_weekly r
+    WHERE r.season = season_value;
+    WITH incoming AS (
+        SELECT * FROM pg_catalog.jsonb_to_recordset(p_rows) AS r(
+            season bigint, through_week bigint, team_id bigint,
+            adj_off_epa double precision, adj_def_epa double precision,
+            adj_st_epa double precision, adj_net double precision,
+            fei_off double precision, fei_def double precision,
+            fei_net double precision, games bigint, off_pace double precision,
+            off_rank bigint, def_rank bigint, net_rank bigint, net_z double precision,
+            _dlt_id text, _dlt_load_id text
+        )
+    )
+    SELECT
+        count(*) FILTER (WHERE old.season IS NULL),
+        count(*) FILTER (WHERE new.season IS NULL),
+        count(*) FILTER (WHERE old.season IS NOT NULL AND new.season IS NOT NULL
+            AND ROW(old.adj_off_epa,old.adj_def_epa,old.adj_st_epa,old.adj_net,
+                    old.fei_off,old.fei_def,old.fei_net,old.games,old.off_pace,
+                    old.off_rank,old.def_rank,old.net_rank,old.net_z)
+                IS DISTINCT FROM
+                ROW(new.adj_off_epa,new.adj_def_epa,new.adj_st_epa,new.adj_net,
+                    new.fei_off,new.fei_def,new.fei_net,new.games,new.off_pace,
+                    new.off_rank,new.def_rank,new.net_rank,new.net_z))
+    INTO inserted_rows, deleted_rows, changed_rows
+    FROM ratings.sdv_ratings_weekly old
+    FULL JOIN incoming new USING (season, through_week, team_id)
+    WHERE COALESCE(old.season, new.season) = season_value;
+
+    DELETE FROM ratings.sdv_ratings_weekly WHERE season = season_value;
+    publication_time := pg_catalog.clock_timestamp();
+    INSERT INTO ratings.sdv_ratings_weekly(
+        season, through_week, team_id, adj_off_epa, adj_def_epa, adj_st_epa,
+        adj_net, fei_off, fei_def, fei_net, games, off_pace, off_rank, def_rank,
+        net_rank, net_z, loaded_at, _dlt_load_id, _dlt_id
+    )
+    SELECT season, through_week, team_id, adj_off_epa, adj_def_epa, adj_st_epa,
+        adj_net, fei_off, fei_def, fei_net, games, off_pace, off_rank, def_rank,
+        net_rank, net_z, publication_time, _dlt_load_id, _dlt_id
+    FROM pg_catalog.jsonb_to_recordset(p_rows) AS r(
+        season bigint, through_week bigint, team_id bigint,
+        adj_off_epa double precision, adj_def_epa double precision,
+        adj_st_epa double precision, adj_net double precision,
+        fei_off double precision, fei_def double precision,
+        fei_net double precision, games bigint, off_pace double precision,
+        off_rank bigint, def_rank bigint, net_rank bigint, net_z double precision,
+        _dlt_id text, _dlt_load_id text
+    );
+    IF (SELECT count(*) FROM ratings.sdv_ratings_weekly
+            WHERE season = season_value) <> row_count_value THEN
+        RAISE EXCEPTION 'published season coverage differs from the normalized file';
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_class c
+        WHERE c.oid = 'meta.flat_file_loads'::pg_catalog.regclass
+          AND c.relkind = 'r'
+          AND c.relowner = (SELECT oid FROM pg_catalog.pg_roles
+              WHERE rolname = current_user))
+        OR EXISTS (SELECT 1 FROM pg_catalog.pg_inherits i
+            WHERE i.inhrelid = 'meta.flat_file_loads'::pg_catalog.regclass
+              OR i.inhparent = 'meta.flat_file_loads'::pg_catalog.regclass)
+        OR EXISTS (SELECT 1 FROM pg_catalog.pg_trigger t
+            WHERE t.tgrelid = 'meta.flat_file_loads'::pg_catalog.regclass
+              AND NOT t.tgisinternal) THEN
+        RAISE EXCEPTION 'meta.flat_file_loads is not a trusted publication ledger'
+            USING ERRCODE = '55000';
+    END IF;
+
+    INSERT INTO meta.asset_receipts(
+        generation_id, operation_run_id, asset_key, coverage_key, outcome, coverage,
+        source_watermark, input_observations, row_delta, request_digest, published_at
+    ) VALUES (
+        p_generation_id, p_run_id, 'ratings.sdv_ratings_weekly', coverage_value,
+        'succeeded', pg_catalog.jsonb_build_object(
+            'complete', true, 'scope', 'season', 'season', season_value,
+            'mode', 'full_file_for_season', 'source_rows', row_count_value,
+            'published_rows', row_count_value),
+        p_source_sha256, pg_catalog.jsonb_build_object(
+            'publisher', 'load_flat_files', 'protocol', 'sdv-ratings-season-v1',
+            'parser_contract', 'sdv-ratings-v1',
+            'stage_schema', 'warehouse_source_stage',
+            'artifact_origin', p_dlt_evidence->>'artifact_origin',
+            'dlt_load_ids', actual_load_ids),
+        pg_catalog.jsonb_build_object(
+            'previous_rows', previous_rows, 'published_rows', row_count_value,
+            'inserted_rows', inserted_rows, 'deleted_rows', deleted_rows,
+            'changed_rows', changed_rows),
+        request_digest_value, publication_time
+    );
+    INSERT INTO meta.asset_current_generations(asset_key, coverage_key, generation_id)
+    VALUES ('ratings.sdv_ratings_weekly', coverage_value, p_generation_id)
+    ON CONFLICT (asset_key, coverage_key) DO UPDATE
+        SET generation_id = EXCLUDED.generation_id;
+
+    ledger_source_url := CASE WHEN p_dlt_evidence->>'artifact_origin' = 'registered_url'
+        THEN 'https://github.com/sportsdataverse/sportsdataverse-data/releases/download/'
+            || 'cfb_ratings_weekly/cfb_ratings_weekly_' || season_value::text || '.parquet'
+        ELSE NULL END;
+    INSERT INTO meta.flat_file_loads(source, file_sha256, source_url, row_count, status, error)
+    VALUES ('sdv_ratings_weekly:' || season_value::text, p_source_sha256,
+        ledger_source_url,
+        row_count_value::integer, 'loaded', NULL)
+    ON CONFLICT (source, file_sha256) WHERE status = 'loaded' DO NOTHING;
+    GET DIAGNOSTICS ledger_inserted = ROW_COUNT;
+    IF ledger_inserted = 0 THEN
+        INSERT INTO meta.flat_file_loads(
+            source, file_sha256, source_url, row_count, status, error
+        ) VALUES ('sdv_ratings_weekly:' || season_value::text, p_source_sha256,
+            ledger_source_url,
+            row_count_value::integer, 'skipped', NULL);
+    END IF;
+
+    PERFORM warehouse_quota.finish_operation_run(p_run_id, 'succeeded', NULL);
+    RETURN QUERY SELECT p_generation_id, false, row_count_value;
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION warehouse_source.fail_sdv_ratings_load(
+    p_run_id uuid, p_generation_id uuid, p_outcome text
+)
+RETURNS uuid LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $function$
+DECLARE
+    run_row meta.operation_runs%ROWTYPE;
+    existing meta.asset_receipts%ROWTYPE;
+    season_value bigint;
+    coverage_value text;
+    operation_outcome text;
+    digest text;
+BEGIN
+    IF p_generation_id IS NULL OR p_outcome IS NULL
+        OR p_outcome NOT IN ('failed','deferred','blocked') THEN
+        RAISE EXCEPTION 'invalid source publication failure outcome' USING ERRCODE = '22023';
+    END IF;
+    run_row := warehouse_source.require_sdv_ratings_load(p_run_id);
+    season_value := (run_row.requested_scope->>'season')::bigint;
+    coverage_value := run_row.requested_scope->>'coverage_key';
+    operation_outcome := CASE WHEN p_outcome = 'deferred' THEN 'blocked' ELSE p_outcome END;
+    digest := pg_catalog.md5(pg_catalog.jsonb_build_object(
+        'run_id', p_run_id, 'generation_id', p_generation_id,
+        'plan', run_row.requested_scope, 'outcome', p_outcome,
+        'error_category', 'source_publication_failed')::text);
+
+    SELECT * INTO existing FROM meta.asset_receipts r
+    WHERE r.generation_id = p_generation_id;
+    IF FOUND THEN
+        IF existing.operation_run_id <> p_run_id
+            OR existing.asset_key <> 'ratings.sdv_ratings_weekly'
+            OR existing.coverage_key <> coverage_value
+            OR existing.outcome <> p_outcome
+            OR existing.request_digest <> digest
+            OR existing.error_summary <> 'source_publication_failed'
+            OR run_row.outcome <> operation_outcome THEN
+            RAISE EXCEPTION 'generation ID already has different source failure context'
+                USING ERRCODE = '22023';
+        END IF;
+        RETURN p_generation_id;
+    END IF;
+    IF run_row.outcome <> 'running' THEN
+        RAISE EXCEPTION 'source publication operation is terminal' USING ERRCODE = '22023';
+    END IF;
+
+    INSERT INTO meta.asset_receipts(
+        generation_id, operation_run_id, asset_key, coverage_key, outcome,
+        coverage, input_observations, request_digest, error_summary
+    ) VALUES (
+        p_generation_id, p_run_id, 'ratings.sdv_ratings_weekly', coverage_value,
+        p_outcome, pg_catalog.jsonb_build_object(
+            'complete', false, 'scope', 'season', 'season', season_value,
+            'mode', 'full_file_for_season'),
+        pg_catalog.jsonb_build_object(
+            'publisher', 'load_flat_files', 'protocol', 'sdv-ratings-season-v1',
+            'parser_contract', 'sdv-ratings-v1'),
+        digest, 'source_publication_failed'
+    );
+    PERFORM warehouse_quota.finish_operation_run(
+        p_run_id, operation_outcome, 'source_publication_failed');
+    RETURN p_generation_id;
+END
+$function$;
+
+-- Remove host defaults and any pre-existing grants before exposing only the four
+-- bounded protocol entrypoints to the NOLOGIN runtime role.
+DO $acl$
+DECLARE item record; recipient text;
+BEGIN
+    FOR item IN
+        SELECT 'SCHEMA' AS kind, pg_catalog.format('%I', n.nspname) AS name, a.grantee
+        FROM pg_catalog.pg_namespace n
+        CROSS JOIN LATERAL pg_catalog.aclexplode(n.nspacl) a
+        WHERE n.nspname IN ('warehouse_source','warehouse_source_stage')
+          AND a.grantee <> n.nspowner
+        UNION
+        SELECT 'FUNCTION', p.oid::pg_catalog.regprocedure::text, a.grantee
+        FROM pg_catalog.pg_proc p JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+        CROSS JOIN LATERAL pg_catalog.aclexplode(
+            COALESCE(p.proacl, pg_catalog.acldefault('f', p.proowner))) a
+        WHERE n.nspname = 'warehouse_source' AND a.grantee <> p.proowner
+    LOOP
+        recipient := CASE WHEN item.grantee = 0 THEN 'PUBLIC'
+            ELSE pg_catalog.quote_ident(pg_catalog.pg_get_userbyid(item.grantee)) END;
+        EXECUTE pg_catalog.format('REVOKE ALL ON %s %s FROM %s', item.kind, item.name, recipient);
+    END LOOP;
+END
+$acl$;
+
+REVOKE ALL ON ratings.sdv_ratings_weekly,
+    meta.asset_publication_locks, meta.asset_receipts,
+    meta.asset_current_generations, meta.asset_receipt_inputs,
+    meta.operation_runs, meta.flat_file_loads
+FROM warehouse_source_publisher;
+REVOKE USAGE ON SCHEMA warehouse_quota, warehouse_publication, warehouse_refresh,
+    warehouse_source_stage FROM warehouse_source_publisher;
+REVOKE EXECUTE ON ALL FUNCTIONS IN SCHEMA warehouse_quota,
+    warehouse_publication, warehouse_refresh FROM warehouse_source_publisher;
+
+GRANT USAGE ON SCHEMA warehouse_source TO warehouse_source_publisher;
+GRANT EXECUTE ON FUNCTION
+    warehouse_source.get_sdv_ratings_plan(bigint),
+    warehouse_source.start_sdv_ratings_load(uuid,jsonb),
+    warehouse_source.publish_sdv_ratings_load(uuid,uuid,text,jsonb,jsonb),
+    warehouse_source.fail_sdv_ratings_load(uuid,uuid,text)
+TO warehouse_source_publisher;
+
+DO $boundary$
+DECLARE relation_name text;
+BEGIN
+    FOREACH relation_name IN ARRAY ARRAY[
+        'ratings.sdv_ratings_weekly','meta.asset_publication_locks',
+        'meta.asset_receipts','meta.asset_current_generations',
+        'meta.asset_receipt_inputs','meta.operation_runs','meta.flat_file_loads'
+    ] LOOP
+        IF pg_catalog.current_setting('server_version_num')::integer >= 170000 THEN
+            IF pg_catalog.has_table_privilege(
+                    'warehouse_source_publisher', relation_name, 'MAINTAIN') THEN
+                RAISE EXCEPTION 'warehouse_source_publisher has unsafe maintenance access to %',
+                    relation_name;
+            END IF;
+        END IF;
+        IF (SELECT c.relowner FROM pg_catalog.pg_class c
+                WHERE c.oid = pg_catalog.to_regclass(relation_name)) =
+                (SELECT oid FROM pg_catalog.pg_roles
+                    WHERE rolname = 'warehouse_source_publisher')
+            OR pg_catalog.has_table_privilege('warehouse_source_publisher', relation_name,
+                'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER') THEN
+            RAISE EXCEPTION 'warehouse_source_publisher has unsafe direct access to %',
+                relation_name;
+        END IF;
+    END LOOP;
+    IF pg_catalog.has_schema_privilege(
+            'warehouse_source_publisher','warehouse_source','CREATE')
+        OR pg_catalog.has_schema_privilege(
+            'warehouse_source_publisher','warehouse_source_stage','USAGE,CREATE')
+        OR EXISTS (
+            SELECT 1 FROM pg_catalog.pg_proc p
+            JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+            WHERE n.nspname IN ('warehouse_quota','warehouse_publication','warehouse_refresh')
+              AND pg_catalog.has_function_privilege(
+                  'warehouse_source_publisher', p.oid, 'EXECUTE')
+        ) OR EXISTS (
+            SELECT 1 FROM pg_catalog.pg_proc p
+            JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+            WHERE n.nspname = 'warehouse_source'
+              AND p.oid <> ALL(ARRAY[
+                  'warehouse_source.get_sdv_ratings_plan(bigint)'::pg_catalog.regprocedure,
+                  'warehouse_source.start_sdv_ratings_load(uuid,jsonb)'::pg_catalog.regprocedure,
+                  'warehouse_source.publish_sdv_ratings_load(uuid,uuid,text,jsonb,jsonb)'::pg_catalog.regprocedure,
+                  'warehouse_source.fail_sdv_ratings_load(uuid,uuid,text)'::pg_catalog.regprocedure
+              ]::oid[])
+              AND pg_catalog.has_function_privilege(
+                  'warehouse_source_publisher', p.oid, 'EXECUTE')
+        ) THEN
+        RAISE EXCEPTION 'warehouse_source_publisher has unrelated or internal access';
+    END IF;
+END
+$boundary$;
+
+COMMENT ON SCHEMA warehouse_source_stage IS
+    'Private dlt staging namespace for the SDV season publisher; bounded RPCs never dynamically read it.';
+COMMENT ON FUNCTION warehouse_source.get_sdv_ratings_plan(bigint) IS
+    'Returns the exact current generation CAS plan for one canonical SDV ratings season.';
+COMMENT ON FUNCTION warehouse_source.publish_sdv_ratings_load(uuid,uuid,text,jsonb,jsonb) IS
+    'Atomically replaces one complete nonempty SDV ratings season and records its private source generation.';

--- a/src/schemas/production-manifest.json
+++ b/src/schemas/production-manifest.json
@@ -29,6 +29,11 @@
       "id": "warehouse.f11.070",
       "path": "src/schemas/migrations/070_generation_enforced_refresh.sql",
       "kind": "immutable"
+    },
+    {
+      "id": "warehouse.source.071",
+      "path": "src/schemas/migrations/071_sdv_ratings_publication.sql",
+      "kind": "immutable"
     }
   ],
   "version": 1

--- a/src/schemas/warehouse-manifest.json
+++ b/src/schemas/warehouse-manifest.json
@@ -55,6 +55,11 @@
       "id": "warehouse.f11.070",
       "path": "src/schemas/migrations/070_generation_enforced_refresh.sql",
       "kind": "immutable"
+    },
+    {
+      "id": "warehouse.source.071",
+      "path": "src/schemas/migrations/071_sdv_ratings_publication.sql",
+      "kind": "immutable"
     }
   ]
 }

--- a/tests/test_sdv_ratings_publication.py
+++ b/tests/test_sdv_ratings_publication.py
@@ -8,6 +8,8 @@ from dataclasses import replace
 
 import httpx
 import psycopg2
+import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
 
 from src.pipelines.config.source_publication_assets import SDV_RATINGS_PUBLICATION
@@ -40,6 +42,14 @@ def source_row(**overrides):
     }
     row.update(overrides)
     return row
+
+
+def raw_parquet(**overrides):
+    row = source_row(team_id="333")
+    row.update(overrides)
+    buffer = publication.io.BytesIO()
+    pq.write_table(pa.Table.from_pylist([row]), buffer)
+    return buffer.getvalue()
 
 
 def plan(season=2025):
@@ -358,6 +368,65 @@ def test_oversized_parquet_is_rejected_before_parser_materialization(monkeypatch
     assert failures == ["failed"]
 
 
+@pytest.mark.parametrize(
+    ("column", "value"),
+    [
+        ("season", 2025.5),
+        ("through_week", 1.5),
+        ("team_id", 333.5),
+        ("games", 1.5),
+        ("off_rank", 2.5),
+        ("def_rank", 3.5),
+        ("net_rank", 1.5),
+    ],
+)
+def test_raw_parquet_fractional_integer_columns_are_rejected_before_parser(
+    monkeypatch, tmp_path, column, value
+):
+    real_raw_row_count = publication._raw_row_count
+    events = []
+    path, _ = install_success_fakes(monkeypatch, tmp_path, events)
+    raw = raw_parquet(**{column: value})
+    path.write_bytes(raw)
+    failures = []
+    monkeypatch.setattr(publication, "_raw_row_count", real_raw_row_count)
+    monkeypatch.setattr(
+        publication,
+        "fetch_file",
+        lambda target: FetchedFile(
+            content=raw,
+            sha256=hashlib.sha256(raw).hexdigest(),
+            source_url=str(path),
+        ),
+    )
+    monkeypatch.setattr(
+        publication,
+        "resolve_parser",
+        lambda ref: pytest.fail("fractional raw integers must be rejected before parsing"),
+    )
+    monkeypatch.setattr(
+        publication,
+        "_fail_run",
+        lambda dsn, run_id, generation_id, outcome, state: failures.append(outcome),
+    )
+
+    result = publication.run_sdv_ratings_publication(
+        REGISTRY["sdv_ratings_weekly"], file_path=str(path), season=2025
+    )
+
+    assert result["status"] == "failed"
+    assert column in result["error"]
+    assert "non-integer" in result["error"]
+    assert failures == ["failed"]
+    assert not any(event[0] == "stage" for event in events)
+
+
+def test_raw_parquet_accepts_lossless_string_float_and_null_integer_values():
+    raw = raw_parquet(season=2025.0, through_week=1.0, games=None)
+
+    assert publication._raw_row_count(raw) == 1
+
+
 def test_404_is_deferred_and_never_staged(monkeypatch, tmp_path):
     events = []
     install_success_fakes(monkeypatch, tmp_path, events)
@@ -623,3 +692,65 @@ def test_publish_close_interrupt_preserves_confirmed_commit_state(monkeypatch):
     assert state.published is True
     assert state.publish_pending is False
     assert conn.closed is True
+
+
+class _CommittedRowCloseFailureConnection(_CommitFailureConnection):
+    def __init__(self, row):
+        self.row = row
+
+    @property
+    def description(self):
+        return (object(),)
+
+    def fetchone(self):
+        return self.row
+
+    def commit(self):
+        return None
+
+    def close(self):
+        raise OSError("socket close failed")
+
+
+def test_confirmed_publish_close_error_returns_loaded_rows(monkeypatch, tmp_path, caplog):
+    real_publish = publication._publish
+    events = []
+    path, _ = install_success_fakes(monkeypatch, tmp_path, events)
+    monkeypatch.setattr(publication, "_publish", real_publish)
+    monkeypatch.setattr(
+        publication,
+        "_connect",
+        lambda dsn: _CommittedRowCloseFailureConnection((GENERATION_ID, False, 1)),
+    )
+
+    with caplog.at_level("WARNING"):
+        result = publication.run_sdv_ratings_publication(
+            REGISTRY["sdv_ratings_weekly"], file_path=str(path), season=2025
+        )
+
+    assert result["status"] == "loaded"
+    assert result["rows"] == 1
+    assert result["error"] is None
+    assert events[-1] == ("drop", publication._stage_table_name(RUN_ID))
+    assert "committed but connection close failed" in caplog.text
+
+
+def test_malformed_publish_response_after_close_error_is_not_success(monkeypatch, tmp_path):
+    real_publish = publication._publish
+    events = []
+    path, _ = install_success_fakes(monkeypatch, tmp_path, events)
+    monkeypatch.setattr(publication, "_publish", real_publish)
+    monkeypatch.setattr(
+        publication,
+        "_connect",
+        lambda dsn: _CommittedRowCloseFailureConnection((GENERATION_ID, False, 2)),
+    )
+
+    result = publication.run_sdv_ratings_publication(
+        REGISTRY["sdv_ratings_weekly"], file_path=str(path), season=2025
+    )
+
+    assert result["status"] == "failed"
+    assert result["rows"] == 0
+    assert "mismatched publication result" in result["error"]
+    assert events[-1] == ("drop", publication._stage_table_name(RUN_ID))

--- a/tests/test_sdv_ratings_publication.py
+++ b/tests/test_sdv_ratings_publication.py
@@ -1,0 +1,625 @@
+"""Unit coverage for the receipt-backed SDV ratings publication adapter."""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+from dataclasses import replace
+
+import httpx
+import psycopg2
+import pytest
+
+from src.pipelines.config.source_publication_assets import SDV_RATINGS_PUBLICATION
+from src.pipelines.sources.flat_files import REGISTRY
+from src.pipelines.utils import sdv_ratings_publication as publication
+from src.pipelines.utils.file_fetcher import FetchedFile
+
+RUN_ID = "11111111-1111-4111-8111-111111111111"
+GENERATION_ID = "22222222-2222-4222-8222-222222222222"
+
+
+def source_row(**overrides):
+    row = {
+        "season": 2025,
+        "through_week": 1,
+        "team_id": 333,
+        "adj_off_epa": 0.1,
+        "adj_def_epa": -0.2,
+        "adj_st_epa": None,
+        "adj_net": 0.3,
+        "fei_off": None,
+        "fei_def": None,
+        "fei_net": None,
+        "off_pace": 2.5,
+        "net_z": 1.1,
+        "games": 1,
+        "off_rank": 2,
+        "def_rank": 3,
+        "net_rank": 1,
+    }
+    row.update(overrides)
+    return row
+
+
+def plan(season=2025):
+    return {
+        "protocol": "sdv-ratings-season-v1",
+        "asset_key": "ratings.sdv_ratings_weekly",
+        "coverage_key": f"season:{season}",
+        "season": season,
+        "expected_generation_id": None,
+        "parser_contract": "sdv-ratings-v1",
+    }
+
+
+def staged(run_id=RUN_ID, *, origin="local_file"):
+    row = {
+        **source_row(),
+        "_dlt_id": "row-id",
+        "_dlt_load_id": "load-id",
+    }
+    return publication._StageResult(
+        table=publication._stage_table_name(run_id),
+        rows=[row],
+        evidence={
+            "stage_schema": "warehouse_source_stage",
+            "parser_contract": "sdv-ratings-v1",
+            "dlt_load_ids": ["load-id"],
+            "source_rows": 1,
+            "artifact_origin": origin,
+        },
+    )
+
+
+def install_ids(monkeypatch):
+    values = iter((uuid.UUID(RUN_ID), uuid.UUID(GENERATION_ID)))
+    monkeypatch.setattr(publication.uuid, "uuid4", lambda: next(values))
+
+
+def install_success_fakes(monkeypatch, tmp_path, events):
+    install_ids(monkeypatch)
+    raw = b"fixture parquet bytes"
+    sha = hashlib.sha256(raw).hexdigest()
+    path = tmp_path / "ratings.parquet"
+    path.write_bytes(raw)
+
+    monkeypatch.setattr(publication, "get_db_url", lambda: "postgres://fixture")
+    monkeypatch.setattr(publication, "_get_plan", lambda dsn, season: plan(season))
+
+    def start(dsn, run_id, selected_plan, state):
+        state.started = True
+        events.append(("start", run_id, selected_plan))
+
+    def fetch(target):
+        events.append(("fetch", target))
+        return FetchedFile(content=raw, sha256=sha, source_url=str(path))
+
+    monkeypatch.setattr(publication, "_start_run", start)
+    monkeypatch.setattr(publication, "fetch_file", fetch)
+    monkeypatch.setattr(publication, "resolve_parser", lambda ref: lambda raw, ctx: [source_row()])
+    monkeypatch.setattr(publication, "_raw_row_count", lambda raw: 1)
+
+    def stage(dsn, spec, content, ctx, run_id, expected_rows, artifact_origin):
+        events.append(("stage", artifact_origin, run_id, expected_rows))
+        return staged(run_id, origin=artifact_origin)
+
+    monkeypatch.setattr(publication, "_stage_rows", stage)
+    monkeypatch.setattr(
+        publication,
+        "_publish",
+        lambda dsn, run_id, generation_id, fetched_sha, stage_result, state: (
+            generation_id,
+            False,
+            len(stage_result.rows),
+        ),
+    )
+    monkeypatch.setattr(
+        publication,
+        "_drop_stage_table",
+        lambda dsn, table: events.append(("drop", table)),
+    )
+    return path, sha
+
+
+def test_success_starts_before_fetch_and_drops_only_run_stage(monkeypatch, tmp_path):
+    events = []
+    path, sha = install_success_fakes(monkeypatch, tmp_path, events)
+
+    result = publication.run_sdv_ratings_publication(
+        REGISTRY["sdv_ratings_weekly"], file_path=str(path), season=2025
+    )
+
+    assert result == {
+        "source": "sdv_ratings_weekly",
+        "status": "loaded",
+        "rows": 1,
+        "sha": sha,
+        "duration_s": result["duration_s"],
+        "error": None,
+        "unmapped": None,
+        "gaps": None,
+        "run_id": RUN_ID,
+        "generation_id": GENERATION_ID,
+    }
+    assert result["duration_s"] >= 0
+    assert [event[0] for event in events] == ["start", "fetch", "stage", "drop"]
+    assert events[2][1] == "local_file"
+    assert events[3][1] == f"sdv_ratings_{uuid.UUID(RUN_ID).hex}"
+
+
+def test_registered_fetch_has_registered_origin(monkeypatch, tmp_path):
+    events = []
+    install_success_fakes(monkeypatch, tmp_path, events)
+
+    result = publication.run_sdv_ratings_publication(REGISTRY["sdv_ratings_weekly"], season=2025)
+
+    assert result["status"] == "loaded"
+    assert events[1][1].endswith("cfb_ratings_weekly_2025.parquet")
+    assert events[2][1] == "registered_url"
+
+
+def test_only_canonical_registry_spec_is_supported():
+    with pytest.raises(ValueError, match="canonical"):
+        publication._validate_supported_spec(replace(REGISTRY["sdv_ratings_weekly"]), 2025)
+    with pytest.raises(ValueError, match="1869 to 2200"):
+        publication._validate_supported_spec(REGISTRY["sdv_ratings_weekly"], 2201)
+
+
+def test_plan_requires_exact_protocol_and_keys():
+    assert publication._validated_plan(plan(), 2025) == plan()
+    with pytest.raises(publication.SourcePublicationError, match="invalid.*plan"):
+        publication._validated_plan({**plan(), "extra": True}, 2025)
+    with pytest.raises(publication.SourcePublicationError, match="mismatched"):
+        publication._validated_plan({**plan(), "coverage_key": "season:2024"}, 2025)
+    with pytest.raises(publication.SourcePublicationError, match="invalid expected"):
+        publication._validated_plan({**plan(), "expected_generation_id": "not-a-uuid"}, 2025)
+
+
+@pytest.mark.parametrize(
+    "rows,raw_count,message",
+    [
+        ([], 0, "nonempty"),
+        ([source_row()], 2, "dropped or added"),
+        ([source_row(season=2024)], 1, "season does not match"),
+        ([source_row(team_id=None)], 1, "null primary-key"),
+        ([source_row(), source_row()], 2, "duplicate primary key"),
+        ([source_row(adj_net=float("nan"))], 1, "not finite"),
+        ([source_row(adj_net=float("inf"))], 1, "not finite"),
+        ([source_row(games=1.5)], 1, "not an integer"),
+    ],
+)
+def test_source_snapshot_validation_rejects_incomplete_or_unsafe_rows(rows, raw_count, message):
+    with pytest.raises(publication.SourcePublicationError, match=message):
+        publication._validate_parsed_rows(rows, raw_count, 2025)
+
+
+def test_source_snapshot_requires_all_and_only_known_columns():
+    missing = source_row()
+    missing.pop("fei_net")
+    with pytest.raises(publication.SourcePublicationError, match="16-column"):
+        publication._validate_parsed_rows([missing], 1, 2025)
+    with pytest.raises(publication.SourcePublicationError, match="16-column"):
+        publication._validate_parsed_rows([source_row(surprise=1)], 1, 2025)
+
+
+def test_column_hints_type_all_optional_null_columns():
+    hints = {hint["name"]: hint for hint in publication._column_hints()}
+    assert tuple(hints) == SDV_RATINGS_PUBLICATION.columns
+    assert hints["season"] == {"name": "season", "data_type": "bigint", "nullable": False}
+    assert hints["adj_st_epa"] == {
+        "name": "adj_st_epa",
+        "data_type": "double",
+        "nullable": True,
+    }
+    assert len(hints) == 16
+
+
+def test_stage_uses_append_with_unique_table_and_explicit_hints(monkeypatch):
+    captured = {}
+
+    class Resource:
+        def apply_hints(self, **hints):
+            captured["hints"] = hints
+
+    class Source:
+        resources = {publication._stage_table_name(RUN_ID): Resource()}
+
+    class LoadInfo:
+        def raise_on_failed_jobs(self):
+            captured["checked_failures"] = True
+
+    class NormalizeInfo:
+        row_counts = {publication._stage_table_name(RUN_ID): 1}
+
+    class Trace:
+        last_normalize_info = NormalizeInfo()
+
+    class Pipeline:
+        last_trace = Trace()
+
+        def run(self, source):
+            return LoadInfo()
+
+    monkeypatch.setattr(publication, "_require_stage_schema", lambda dsn: None)
+
+    def build(spec, raw, ctx, resolver):
+        captured["spec"] = spec
+        return Source()
+
+    monkeypatch.setattr(publication, "build_flat_file_source", build)
+    monkeypatch.setattr(
+        publication.dlt,
+        "pipeline",
+        lambda **kwargs: captured.update(pipeline=kwargs) or Pipeline(),
+    )
+    monkeypatch.setattr(publication, "postgres", lambda credentials: ("postgres", credentials))
+    expected = staged(origin="local_file")
+    monkeypatch.setattr(publication, "_read_stage", lambda *args: expected)
+
+    result = publication._stage_rows(
+        "postgres://fixture",
+        REGISTRY["sdv_ratings_weekly"],
+        b"raw",
+        object(),
+        RUN_ID,
+        1,
+        "local_file",
+    )
+
+    assert result is expected
+    assert captured["spec"].write_disposition == "append"
+    assert captured["spec"].table == publication._stage_table_name(RUN_ID)
+    assert captured["hints"]["schema_contract"] == {
+        "tables": "evolve",
+        "columns": "freeze",
+        "data_type": "freeze",
+    }
+    assert len(captured["hints"]["columns"]) == 16
+    assert captured["pipeline"]["dataset_name"] == "warehouse_source_stage"
+    assert captured["pipeline"]["destination"] == ("postgres", "postgres://fixture")
+    assert captured["checked_failures"] is True
+
+
+def test_file_override_must_be_an_existing_local_file(monkeypatch):
+    install_ids(monkeypatch)
+    failures = []
+    monkeypatch.setattr(publication, "get_db_url", lambda: "postgres://fixture")
+    monkeypatch.setattr(publication, "_get_plan", lambda dsn, season: plan())
+
+    def start(dsn, run_id, selected_plan, state):
+        state.started = True
+
+    monkeypatch.setattr(publication, "_start_run", start)
+    monkeypatch.setattr(
+        publication,
+        "_fail_run",
+        lambda dsn, run_id, generation_id, outcome, state: failures.append(outcome),
+    )
+
+    result = publication.run_sdv_ratings_publication(
+        REGISTRY["sdv_ratings_weekly"],
+        file_path="https://untrusted.example/ratings.parquet",
+        season=2025,
+    )
+
+    assert result["status"] == "failed"
+    assert "existing local file" in result["error"]
+    assert failures == ["failed"]
+
+
+def test_fetched_hash_must_match_bytes(monkeypatch, tmp_path):
+    events = []
+    path, _ = install_success_fakes(monkeypatch, tmp_path, events)
+    failures = []
+    monkeypatch.setattr(
+        publication,
+        "fetch_file",
+        lambda target: FetchedFile(content=b"actual", sha256="0" * 64, source_url=str(path)),
+    )
+    monkeypatch.setattr(
+        publication,
+        "_fail_run",
+        lambda dsn, run_id, generation_id, outcome, state: failures.append(outcome),
+    )
+
+    result = publication.run_sdv_ratings_publication(
+        REGISTRY["sdv_ratings_weekly"], file_path=str(path), season=2025
+    )
+
+    assert result["status"] == "failed"
+    assert "SHA-256" in result["error"]
+    assert failures == ["failed"]
+    assert not any(event[0] in {"stage", "drop"} for event in events)
+
+
+def test_oversized_parquet_is_rejected_before_parser_materialization(monkeypatch, tmp_path):
+    events = []
+    path, _ = install_success_fakes(monkeypatch, tmp_path, events)
+    failures = []
+    monkeypatch.setattr(publication, "_raw_row_count", lambda raw: 100_001)
+    monkeypatch.setattr(
+        publication,
+        "resolve_parser",
+        lambda ref: pytest.fail("oversized input must be bounded before parser materialization"),
+    )
+    monkeypatch.setattr(
+        publication,
+        "_fail_run",
+        lambda dsn, run_id, generation_id, outcome, state: failures.append(outcome),
+    )
+
+    result = publication.run_sdv_ratings_publication(
+        REGISTRY["sdv_ratings_weekly"], file_path=str(path), season=2025
+    )
+
+    assert result["status"] == "failed"
+    assert "100000" in result["error"]
+    assert failures == ["failed"]
+
+
+def test_404_is_deferred_and_never_staged(monkeypatch, tmp_path):
+    events = []
+    install_success_fakes(monkeypatch, tmp_path, events)
+    failures = []
+    request = httpx.Request("GET", "https://example.test/ratings.parquet")
+    response = httpx.Response(404, request=request)
+    monkeypatch.setattr(
+        publication,
+        "fetch_file",
+        lambda target: (_ for _ in ()).throw(
+            httpx.HTTPStatusError("404", request=request, response=response)
+        ),
+    )
+    monkeypatch.setattr(
+        publication,
+        "_fail_run",
+        lambda dsn, run_id, generation_id, outcome, state: failures.append(outcome),
+    )
+
+    result = publication.run_sdv_ratings_publication(REGISTRY["sdv_ratings_weekly"], season=2025)
+
+    assert result["status"] == "not_published"
+    assert failures == ["deferred"]
+    assert not any(event[0] in {"stage", "drop"} for event in events)
+
+
+def test_uncertain_publish_is_not_retried_failed_or_cleaned(monkeypatch, tmp_path):
+    events = []
+    path, _ = install_success_fakes(monkeypatch, tmp_path, events)
+    monkeypatch.setattr(
+        publication,
+        "_publish",
+        lambda *args: (_ for _ in ()).throw(
+            publication.UncertainCommitError("publication commit outcome is uncertain")
+        ),
+    )
+    monkeypatch.setattr(
+        publication,
+        "_fail_run",
+        lambda *args: pytest.fail("uncertain publication must not record failure"),
+    )
+
+    result = publication.run_sdv_ratings_publication(
+        REGISTRY["sdv_ratings_weekly"], file_path=str(path), season=2025
+    )
+
+    assert result["status"] == "failed"
+    assert "uncertain" in result["error"]
+    assert not any(event[0] == "drop" for event in events)
+
+
+def test_malformed_committed_publish_response_is_not_relabeled_failed(monkeypatch, tmp_path):
+    events = []
+    path, _ = install_success_fakes(monkeypatch, tmp_path, events)
+
+    def malformed_publish(dsn, run_id, generation_id, sha, stage_result, state):
+        state.published = True
+        raise publication.UncertainCommitError("committed an unrecognized publication result")
+
+    monkeypatch.setattr(publication, "_publish", malformed_publish)
+    monkeypatch.setattr(
+        publication,
+        "_fail_run",
+        lambda *args: pytest.fail("committed publication must not record failure"),
+    )
+
+    result = publication.run_sdv_ratings_publication(
+        REGISTRY["sdv_ratings_weekly"], file_path=str(path), season=2025
+    )
+
+    assert result["status"] == "failed"
+    assert events[-1] == ("drop", publication._stage_table_name(RUN_ID))
+
+
+class _BlockedSqlError(psycopg2.Error):
+    @property
+    def pgcode(self):
+        return "40001"
+
+
+def test_cas_readiness_error_records_blocked(monkeypatch, tmp_path):
+    events = []
+    path, _ = install_success_fakes(monkeypatch, tmp_path, events)
+    failures = []
+    monkeypatch.setattr(
+        publication,
+        "_publish",
+        lambda *args: (_ for _ in ()).throw(_BlockedSqlError("replan")),
+    )
+    monkeypatch.setattr(
+        publication,
+        "_fail_run",
+        lambda dsn, run_id, generation_id, outcome, state: failures.append(outcome),
+    )
+
+    result = publication.run_sdv_ratings_publication(
+        REGISTRY["sdv_ratings_weekly"], file_path=str(path), season=2025
+    )
+
+    assert result["status"] == "blocked"
+    assert failures == ["blocked"]
+    assert events[-1] == ("drop", publication._stage_table_name(RUN_ID))
+
+
+def test_known_stage_failure_records_failure_and_drops_run_table(monkeypatch, tmp_path):
+    events = []
+    path, _ = install_success_fakes(monkeypatch, tmp_path, events)
+    failures = []
+    monkeypatch.setattr(
+        publication,
+        "_stage_rows",
+        lambda *args: (_ for _ in ()).throw(publication.SourcePublicationError("stage failed")),
+    )
+    monkeypatch.setattr(
+        publication,
+        "_fail_run",
+        lambda dsn, run_id, generation_id, outcome, state: failures.append(outcome),
+    )
+
+    result = publication.run_sdv_ratings_publication(
+        REGISTRY["sdv_ratings_weekly"], file_path=str(path), season=2025
+    )
+
+    assert result["status"] == "failed"
+    assert failures == ["failed"]
+    assert events[-1] == ("drop", publication._stage_table_name(RUN_ID))
+
+
+def test_committed_failure_with_malformed_response_still_drops_stage(monkeypatch, tmp_path):
+    events = []
+    path, _ = install_success_fakes(monkeypatch, tmp_path, events)
+    monkeypatch.setattr(
+        publication,
+        "_stage_rows",
+        lambda *args: (_ for _ in ()).throw(publication.SourcePublicationError("stage failed")),
+    )
+
+    def malformed_failure(dsn, run_id, generation_id, outcome, state):
+        state.failure_recorded = True
+        raise publication.SourcePublicationError("mismatched failure response")
+
+    monkeypatch.setattr(publication, "_fail_run", malformed_failure)
+
+    result = publication.run_sdv_ratings_publication(
+        REGISTRY["sdv_ratings_weekly"], file_path=str(path), season=2025
+    )
+
+    assert result["status"] == "failed"
+    assert events[-1] == ("drop", publication._stage_table_name(RUN_ID))
+
+
+def test_keyboard_interrupt_records_failure_cleans_stage_and_rethrows(monkeypatch, tmp_path):
+    events = []
+    path, _ = install_success_fakes(monkeypatch, tmp_path, events)
+    failures = []
+    monkeypatch.setattr(
+        publication,
+        "_stage_rows",
+        lambda *args: (_ for _ in ()).throw(KeyboardInterrupt()),
+    )
+    monkeypatch.setattr(
+        publication,
+        "_fail_run",
+        lambda dsn, run_id, generation_id, outcome, state: failures.append(outcome),
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        publication.run_sdv_ratings_publication(
+            REGISTRY["sdv_ratings_weekly"], file_path=str(path), season=2025
+        )
+
+    assert failures == ["failed"]
+    assert events[-1] == ("drop", publication._stage_table_name(RUN_ID))
+
+
+class _CommitFailureConnection:
+    def cursor(self):
+        return self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    @property
+    def description(self):
+        return None
+
+    def execute(self, statement, args=()):
+        return None
+
+    def commit(self):
+        raise OSError("lost commit response")
+
+    def rollback(self):
+        pytest.fail("uncertain mutating commit must not be relabeled by rollback")
+
+    def close(self):
+        return None
+
+
+def test_mutating_rpc_converts_commit_failure_to_uncertain(monkeypatch):
+    monkeypatch.setattr(publication, "_connect", lambda dsn: _CommitFailureConnection())
+
+    with pytest.raises(publication.UncertainCommitError):
+        publication._rpc(
+            "postgres://fixture",
+            "SELECT do_work()",
+            (),
+            mutating=True,
+            state=publication._MutationState(),
+            phase="publish",
+        )
+
+
+def test_keyboard_interrupt_during_mutating_commit_is_not_swallowed(monkeypatch, tmp_path):
+    events = []
+    path, _ = install_success_fakes(monkeypatch, tmp_path, events)
+    interrupt = KeyboardInterrupt()
+
+    def interrupted_publish(*args):
+        raise publication.UncertainCommitError("uncertain") from interrupt
+
+    monkeypatch.setattr(publication, "_publish", interrupted_publish)
+
+    with pytest.raises(KeyboardInterrupt):
+        publication.run_sdv_ratings_publication(
+            REGISTRY["sdv_ratings_weekly"], file_path=str(path), season=2025
+        )
+
+    assert not any(event[0] == "drop" for event in events)
+
+
+class _PostCommitCloseInterruptConnection(_CommitFailureConnection):
+    def __init__(self):
+        self.closed = False
+
+    def commit(self):
+        return None
+
+    def close(self):
+        self.closed = True
+        raise KeyboardInterrupt()
+
+
+def test_publish_close_interrupt_preserves_confirmed_commit_state(monkeypatch):
+    conn = _PostCommitCloseInterruptConnection()
+    monkeypatch.setattr(publication, "_connect", lambda dsn: conn)
+    state = publication._MutationState()
+
+    with pytest.raises(publication.PostCommitError) as raised:
+        publication._rpc(
+            "postgres://fixture",
+            "SELECT do_work()",
+            (),
+            mutating=True,
+            state=state,
+            phase="publish",
+        )
+
+    assert isinstance(raised.value.__cause__, KeyboardInterrupt)
+    assert state.published is True
+    assert state.publish_pending is False
+    assert conn.closed is True

--- a/tests/test_sdv_ratings_publication_sql.py
+++ b/tests/test_sdv_ratings_publication_sql.py
@@ -1,0 +1,802 @@
+"""Executed season-scoped SDV ratings publication checks on PostgreSQL 17."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import psycopg2
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from psycopg2 import sql
+from psycopg2.extensions import parse_dsn
+
+from tests.test_asset_freshness_sql import freshness_db as _freshness_db  # noqa: F401
+from tests.test_asset_publication_sql import publication_args as elo_publication_args
+from tests.test_asset_publication_sql import publication_db as _publication_db  # noqa: F401
+from tests.test_asset_publication_sql import publish as publish_elo
+from tests.test_generation_refresh_sql import generation_db as _generation_db  # noqa: F401
+from tests.test_warehouse_migrations_sql import query
+from tests.test_warehouse_migrations_sql import warehouse_db as _warehouse_db  # noqa: F401
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATION = ROOT / "src/schemas/migrations/071_sdv_ratings_publication.sql"
+ASSET = "ratings.sdv_ratings_weekly"
+PROTOCOL = "sdv-ratings-season-v1"
+PARSER_CONTRACT = "sdv-ratings-v1"
+
+SOURCE_OBJECTS = """
+CREATE SCHEMA ratings;
+CREATE TABLE ratings.sdv_ratings_weekly (
+    season bigint NOT NULL,
+    through_week bigint NOT NULL,
+    team_id bigint NOT NULL,
+    adj_off_epa double precision,
+    adj_def_epa double precision,
+    adj_st_epa double precision,
+    adj_net double precision,
+    fei_off double precision,
+    fei_def double precision,
+    fei_net double precision,
+    games bigint,
+    off_pace double precision,
+    off_rank bigint,
+    def_rank bigint,
+    net_rank bigint,
+    net_z double precision,
+    loaded_at timestamptz NOT NULL DEFAULT now(),
+    _dlt_load_id varchar NOT NULL,
+    _dlt_id varchar NOT NULL,
+    PRIMARY KEY (season, through_week, team_id),
+    UNIQUE (_dlt_id)
+);
+CREATE INDEX idx_sdv_ratings_weekly_team
+    ON ratings.sdv_ratings_weekly(team_id, season);
+
+CREATE TABLE meta.flat_file_loads (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    source text NOT NULL,
+    file_sha256 text NOT NULL,
+    source_url text,
+    loaded_at timestamptz NOT NULL DEFAULT now(),
+    row_count integer,
+    status text NOT NULL CHECK (status IN ('loaded', 'skipped', 'failed')),
+    error text
+);
+CREATE UNIQUE INDEX uq_flat_file_loads_loaded
+    ON meta.flat_file_loads(source, file_sha256) WHERE status='loaded';
+CREATE INDEX idx_flat_file_loads_source_time
+    ON meta.flat_file_loads(source, loaded_at DESC);
+"""
+
+PUBLISH_SQL = """
+SELECT * FROM warehouse_source.publish_sdv_ratings_load(
+    %s, %s, %s, %s::jsonb, %s::jsonb
+)
+"""
+
+
+@pytest.fixture
+def sdv_db(request):
+    conn, target = request.getfixturevalue("_generation_db")
+    query(conn, SOURCE_OBJECTS)
+    query(conn, MIGRATION.read_text())
+    return conn, target
+
+
+def source_query(conn, statement, values=None, *, commit=True):
+    with conn.cursor() as cur:
+        cur.execute("SET LOCAL ROLE warehouse_source_publisher")
+        cur.execute(statement, values)
+        result = cur.fetchall() if cur.description else None
+    if commit:
+        conn.commit()
+    return result
+
+
+def plan(conn, season=2025):
+    return source_query(conn, "SELECT warehouse_source.get_sdv_ratings_plan(%s)", (season,))[0][0]
+
+
+def start_load(conn, load_plan, run_id=None):
+    run_id = str(run_id or uuid.uuid4())
+    result = source_query(
+        conn,
+        "SELECT warehouse_source.start_sdv_ratings_load(%s,%s::jsonb)",
+        (run_id, json.dumps(load_plan)),
+    )[0][0]
+    assert str(result) == run_id
+    return run_id
+
+
+def rating_row(season=2025, through_week=1, team_id=1, *, adj_net=1.25, suffix="a"):
+    return {
+        "season": season,
+        "through_week": through_week,
+        "team_id": team_id,
+        "adj_off_epa": 0.25 + team_id,
+        "adj_def_epa": -0.1 - team_id,
+        "adj_st_epa": 0.05,
+        "adj_net": adj_net,
+        "fei_off": 0.4,
+        "fei_def": -0.3,
+        "fei_net": 0.7,
+        "games": 1,
+        "off_pace": 70.5,
+        "off_rank": team_id,
+        "def_rank": team_id + 1,
+        "net_rank": team_id,
+        "net_z": 0.2,
+        "_dlt_load_id": f"load-{season}-{suffix}",
+        "_dlt_id": f"row-{season}-{through_week}-{team_id}-{suffix}",
+    }
+
+
+def rows_for(season=2025, *, adj_net=1.25, suffix="a"):
+    return [
+        rating_row(season, 1, 1, adj_net=adj_net, suffix=suffix),
+        rating_row(season, 1, 2, adj_net=adj_net + 1, suffix=suffix),
+    ]
+
+
+def evidence(rows, *, artifact_origin="registered_url"):
+    return {
+        "artifact_origin": artifact_origin,
+        "stage_schema": "warehouse_source_stage",
+        "parser_contract": PARSER_CONTRACT,
+        "dlt_load_ids": sorted({row["_dlt_load_id"] for row in rows}),
+        "source_rows": len(rows),
+    }
+
+
+def publication_args(
+    conn,
+    *,
+    season=2025,
+    rows=None,
+    generation_id=None,
+    sha=None,
+    load_plan=None,
+    artifact_origin="registered_url",
+):
+    rows = rows if rows is not None else rows_for(season)
+    load_plan = load_plan or plan(conn, season)
+    return (
+        start_load(conn, load_plan),
+        str(generation_id or uuid.uuid4()),
+        sha or (f"{season:04x}" * 16)[:64],
+        json.dumps(rows),
+        json.dumps(evidence(rows, artifact_origin=artifact_origin)),
+    )
+
+
+def publish(conn, args, *, commit=True):
+    return source_query(conn, PUBLISH_SQL, args, commit=commit)[0]
+
+
+def current(conn, season=None):
+    values = (f"season:{season}",) if season is not None else None
+    where = " AND coverage_key=%s" if season is not None else ""
+    return query(
+        conn,
+        "SELECT coverage_key,generation_id::text FROM meta.asset_current_generations "
+        f"WHERE asset_key='{ASSET}'{where} ORDER BY coverage_key",
+        values,
+    )
+
+
+def denied(conn, role, statement):
+    try:
+        with conn.cursor() as cur:
+            cur.execute(sql.SQL("SET LOCAL ROLE {}").format(sql.Identifier(role)))
+            with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+                cur.execute(statement)
+    finally:
+        conn.rollback()
+
+
+def test_plan_is_canonical_season_scoped_and_has_no_freshness_claim(sdv_db):
+    conn, _ = sdv_db
+    assert plan(conn) == {
+        "protocol": PROTOCOL,
+        "asset_key": ASSET,
+        "coverage_key": "season:2025",
+        "season": 2025,
+        "expected_generation_id": None,
+        "parser_contract": PARSER_CONTRACT,
+    }
+    assert query(
+        conn,
+        "SELECT count(*) FROM meta.asset_freshness_policies "
+        "WHERE asset_key='ratings.sdv_ratings_weekly'",
+    ) == [(0,)]
+    with pytest.raises(psycopg2.Error):
+        plan(conn, 1868)
+    conn.rollback()
+    with pytest.raises(psycopg2.Error):
+        plan(conn, 2201)
+    conn.rollback()
+
+
+def test_correction_replaces_one_season_and_commits_exact_receipt_and_ledger(sdv_db):
+    conn, _ = sdv_db
+    other_args = publication_args(conn, season=2024, rows=rows_for(2024), sha="4" * 64)
+    publish(conn, other_args)
+    first_rows = rows_for(2025)
+    first_args = publication_args(conn, rows=first_rows, sha="a" * 64)
+    first = publish(conn, first_args)
+    corrected = [rating_row(2025, 1, 1, adj_net=9.5, suffix="b")]
+    corrected_args = publication_args(conn, rows=corrected, sha="b" * 64)
+    result = publish(conn, corrected_args)
+
+    assert first == (first_args[1], False, 2)
+    assert result == (corrected_args[1], False, 1)
+    assert query(
+        conn,
+        "SELECT season,through_week,team_id,adj_net,_dlt_id "
+        "FROM ratings.sdv_ratings_weekly ORDER BY season,team_id",
+    ) == [
+        (2024, 1, 1, 1.25, "row-2024-1-1-a"),
+        (2024, 1, 2, 2.25, "row-2024-1-2-a"),
+        (2025, 1, 1, 9.5, "row-2025-1-1-b"),
+    ]
+    assert current(conn) == [
+        ("season:2024", other_args[1]),
+        ("season:2025", corrected_args[1]),
+    ]
+    receipt = query(
+        conn,
+        """
+        SELECT r.asset_key,r.coverage_key,r.outcome,r.source_watermark,
+               r.coverage,r.input_observations,r.row_delta,
+               o.operation_kind,o.initiator,o.outcome
+        FROM meta.asset_receipts r
+        JOIN meta.operation_runs o USING(operation_run_id)
+        WHERE r.generation_id=%s
+        """,
+        (corrected_args[1],),
+    )[0]
+    assert receipt[:4] == (ASSET, "season:2025", "succeeded", "b" * 64)
+    assert receipt[4] == {
+        "complete": True,
+        "scope": "season",
+        "season": 2025,
+        "mode": "full_file_for_season",
+        "source_rows": 1,
+        "published_rows": 1,
+    }
+    assert receipt[5] == {
+        "publisher": "load_flat_files",
+        "protocol": PROTOCOL,
+        "artifact_origin": "registered_url",
+        "stage_schema": "warehouse_source_stage",
+        "parser_contract": PARSER_CONTRACT,
+        "dlt_load_ids": ["load-2025-b"],
+    }
+    assert receipt[6] == {
+        "previous_rows": 2,
+        "published_rows": 1,
+        "inserted_rows": 0,
+        "deleted_rows": 1,
+        "changed_rows": 1,
+    }
+    assert receipt[7:] == ("load", "load_flat_files", "succeeded")
+    assert query(conn, "SELECT count(*) FROM meta.asset_receipt_inputs") == [(0,)]
+    assert query(
+        conn,
+        "SELECT source,file_sha256,source_url,row_count,status,error "
+        "FROM meta.flat_file_loads ORDER BY id",
+    ) == [
+        (
+            "sdv_ratings_weekly:2024",
+            "4" * 64,
+            "https://github.com/sportsdataverse/sportsdataverse-data/releases/download/"
+            "cfb_ratings_weekly/cfb_ratings_weekly_2024.parquet",
+            2,
+            "loaded",
+            None,
+        ),
+        (
+            "sdv_ratings_weekly:2025",
+            "a" * 64,
+            "https://github.com/sportsdataverse/sportsdataverse-data/releases/download/"
+            "cfb_ratings_weekly/cfb_ratings_weekly_2025.parquet",
+            2,
+            "loaded",
+            None,
+        ),
+        (
+            "sdv_ratings_weekly:2025",
+            "b" * 64,
+            "https://github.com/sportsdataverse/sportsdataverse-data/releases/download/"
+            "cfb_ratings_weekly/cfb_ratings_weekly_2025.parquet",
+            1,
+            "loaded",
+            None,
+        ),
+    ]
+
+
+def test_data_receipt_pointer_and_ledger_are_rollback_atomic(sdv_db):
+    conn, target = sdv_db
+    original = publication_args(conn, sha="a" * 64)
+    publish(conn, original)
+    before = query(
+        conn,
+        "SELECT team_id,adj_net FROM ratings.sdv_ratings_weekly ORDER BY team_id",
+    )
+    changed_rows = [rating_row(2025, 1, 1, adj_net=8.0, suffix="rollback")]
+    changed = publication_args(conn, rows=changed_rows, sha="c" * 64)
+    observer = psycopg2.connect(target)
+    try:
+        result = publish(conn, changed, commit=False)
+        assert result == (changed[1], False, 1)
+        assert (
+            query(
+                observer,
+                "SELECT team_id,adj_net FROM ratings.sdv_ratings_weekly ORDER BY team_id",
+            )
+            == before
+        )
+        conn.rollback()
+        assert (
+            query(
+                observer,
+                "SELECT team_id,adj_net FROM ratings.sdv_ratings_weekly ORDER BY team_id",
+            )
+            == before
+        )
+        assert current(observer, 2025) == [("season:2025", original[1])]
+        assert query(
+            observer,
+            "SELECT count(*) FROM meta.asset_receipts WHERE generation_id=%s",
+            (changed[1],),
+        ) == [(0,)]
+        assert query(
+            observer,
+            "SELECT count(*) FROM meta.flat_file_loads WHERE file_sha256=%s",
+            (changed[2],),
+        ) == [(0,)]
+    finally:
+        observer.close()
+
+
+def test_exact_replay_never_restores_an_older_pointer_or_data(sdv_db):
+    conn, _ = sdv_db
+    first = publication_args(conn, rows=rows_for(2025, adj_net=1.0), sha="a" * 64)
+    first_result = publish(conn, first)
+    second = publication_args(conn, rows=rows_for(2025, adj_net=5.0, suffix="new"), sha="b" * 64)
+    publish(conn, second)
+    rows_before = query(
+        conn, "SELECT team_id,adj_net FROM ratings.sdv_ratings_weekly ORDER BY team_id"
+    )
+
+    replay = publish(conn, first)
+    assert replay == (first_result[0], True, 2)
+    assert current(conn, 2025) == [("season:2025", second[1])]
+    assert (
+        query(conn, "SELECT team_id,adj_net FROM ratings.sdv_ratings_weekly ORDER BY team_id")
+        == rows_before
+    )
+    assert query(conn, "SELECT count(*) FROM meta.asset_receipts WHERE asset_key=%s", (ASSET,)) == [
+        (2,)
+    ]
+    assert query(conn, "SELECT status FROM meta.flat_file_loads ORDER BY id") == [
+        ("loaded",),
+        ("loaded",),
+    ]
+
+
+def test_new_generation_reparses_same_hash_and_records_a_skipped_ledger_check(sdv_db):
+    conn, _ = sdv_db
+    rows = rows_for(2025)
+    first = publication_args(conn, rows=rows, sha="a" * 64)
+    publish(conn, first)
+    second = publication_args(conn, rows=rows, sha="a" * 64)
+    result = publish(conn, second)
+
+    assert result == (second[1], False, 2)
+    assert current(conn, 2025) == [("season:2025", second[1])]
+    assert query(
+        conn,
+        "SELECT status,row_count FROM meta.flat_file_loads ORDER BY id",
+    ) == [("loaded", 2), ("skipped", 2)]
+    assert query(conn, "SELECT count(*) FROM meta.asset_receipts WHERE asset_key=%s", (ASSET,)) == [
+        (2,)
+    ]
+
+
+@pytest.mark.parametrize(
+    "malformation",
+    ["duplicate", "required_null", "wrong_season", "nonfinite", "extra", "missing"],
+)
+def test_malformed_payload_is_rejected_before_any_publication(malformation, sdv_db):
+    conn, _ = sdv_db
+    rows = rows_for(2025)
+    if malformation == "duplicate":
+        rows.append(dict(rows[0], _dlt_id="different-dlt-id"))
+    elif malformation == "required_null":
+        rows[0]["team_id"] = None
+    elif malformation == "wrong_season":
+        rows[0]["season"] = 2024
+    elif malformation == "nonfinite":
+        rows[0]["adj_net"] = "Infinity"
+    elif malformation == "extra":
+        rows[0]["unexpected"] = 1
+    else:
+        del rows[0]["adj_net"]
+    args = publication_args(conn, rows=rows, sha="d" * 64)
+    if malformation == "nonfinite":
+        args = (*args[:3], args[3].replace('"adj_net": "Infinity"', '"adj_net": 1e10000'), args[4])
+
+    with pytest.raises(psycopg2.Error):
+        publish(conn, args)
+    conn.rollback()
+    assert query(conn, "SELECT count(*) FROM ratings.sdv_ratings_weekly") == [(0,)]
+    assert current(conn) == []
+    assert query(conn, "SELECT count(*) FROM meta.asset_receipts WHERE asset_key=%s", (ASSET,)) == [
+        (0,)
+    ]
+    assert query(conn, "SELECT count(*) FROM meta.flat_file_loads") == [(0,)]
+
+
+def test_local_file_provenance_records_no_provider_url_and_unknown_origin_is_rejected(sdv_db):
+    conn, _ = sdv_db
+    local = publication_args(conn, artifact_origin="local_file", sha="a" * 64)
+    publish(conn, local)
+    assert query(
+        conn,
+        "SELECT source_url FROM meta.flat_file_loads WHERE file_sha256=%s",
+        (local[2],),
+    ) == [(None,)]
+    assert query(
+        conn,
+        "SELECT input_observations->>'artifact_origin' FROM meta.asset_receipts "
+        "WHERE generation_id=%s",
+        (local[1],),
+    ) == [("local_file",)]
+
+    bad = list(publication_args(conn, sha="b" * 64))
+    bad_evidence = json.loads(bad[4])
+    bad_evidence["artifact_origin"] = "unknown"
+    bad[4] = json.dumps(bad_evidence)
+    with pytest.raises(psycopg2.Error, match="evidence"):
+        publish(conn, tuple(bad))
+    conn.rollback()
+    assert current(conn, 2025) == [("season:2025", local[1])]
+    assert query(conn, "SELECT count(*) FROM meta.flat_file_loads") == [(1,)]
+
+
+def test_publisher_role_has_only_bounded_rpc_access(sdv_db):
+    conn, _ = sdv_db
+    query(conn, MIGRATION.read_text())
+    assert query(
+        conn,
+        "SELECT rolcanlogin,rolinherit,rolsuper,rolcreatedb,rolcreaterole,"
+        "rolreplication,rolbypassrls FROM pg_roles WHERE rolname='warehouse_source_publisher'",
+    ) == [(False, False, False, False, False, False, False)]
+    for role in ("anon", "authenticated", "analyst_ro", "publication_bystander"):
+        denied(conn, role, "SELECT warehouse_source.get_sdv_ratings_plan(2025)")
+        assert query(
+            conn,
+            "SELECT has_schema_privilege(%s,'warehouse_source_stage','USAGE,CREATE')",
+            (role,),
+        ) == [(False,)]
+    for relation in (
+        "ratings.sdv_ratings_weekly",
+        "meta.flat_file_loads",
+        "meta.asset_receipts",
+        "meta.asset_current_generations",
+        "meta.operation_runs",
+    ):
+        assert query(
+            conn,
+            "SELECT has_table_privilege('warehouse_source_publisher',%s,"
+            "'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')",
+            (relation,),
+        ) == [(False,)]
+    denied(conn, "warehouse_source_publisher", "UPDATE ratings.sdv_ratings_weekly SET games=9")
+    denied(conn, "warehouse_source_publisher", "SELECT * FROM meta.asset_receipts")
+    assert query(
+        conn,
+        "SELECT has_schema_privilege(current_user,'warehouse_source_stage','USAGE,CREATE'),"
+        "has_schema_privilege('warehouse_source_publisher','warehouse_source_stage',"
+        "'USAGE,CREATE'),has_function_privilege('warehouse_source_publisher',"
+        "'warehouse_source.require_sdv_ratings_load(uuid)','EXECUTE')",
+    ) == [(True, False, False)]
+    for statement in (
+        "SELECT warehouse_quota.start_operation_run("
+        "gen_random_uuid(),'load','forged','{}',NULL,NULL)",
+        "SELECT warehouse_quota.finish_operation_run(gen_random_uuid(),'failed','forged')",
+    ):
+        denied(conn, "warehouse_source_publisher", statement)
+
+
+def test_different_seasons_have_independent_canonical_pointers(sdv_db):
+    conn, _ = sdv_db
+    one = publication_args(conn, season=2024, rows=rows_for(2024), sha="4" * 64)
+    two = publication_args(conn, season=2025, rows=rows_for(2025), sha="5" * 64)
+    publish(conn, one)
+    publish(conn, two)
+    assert current(conn) == [("season:2024", one[1]), ("season:2025", two[1])]
+    assert query(
+        conn,
+        "SELECT count(*) FROM meta.asset_current_generations p "
+        "JOIN meta.asset_receipts r USING(asset_key,coverage_key,generation_id) "
+        "WHERE p.asset_key=%s AND r.outcome='succeeded' AND r.coverage->>'complete'='true'",
+        (ASSET,),
+    ) == [(2,)]
+
+
+@pytest.mark.parametrize(
+    "asset_key,coverage_key",
+    [(ASSET, "source-wide"), ("analytics.house_elo_game", "season:2025")],
+)
+def test_cross_grain_receipt_scope_is_rejected(sdv_db, asset_key, coverage_key):
+    conn, _ = sdv_db
+    run_id = str(uuid.uuid4())
+    query(
+        conn,
+        "SELECT warehouse_quota.start_operation_run(%s,'load','fixture','{}',NULL,NULL)",
+        (run_id,),
+    )
+    with pytest.raises(psycopg2.Error):
+        query(
+            conn,
+            """
+            INSERT INTO meta.asset_receipts(
+                generation_id,operation_run_id,asset_key,coverage_key,outcome,
+                coverage,request_digest,error_summary
+            ) VALUES (%s,%s,%s,%s,'failed','{"complete":false}',%s,'fixture')
+            """,
+            (str(uuid.uuid4()), run_id, asset_key, coverage_key, "0" * 32),
+        )
+    conn.rollback()
+
+
+def test_concurrent_first_publication_compare_and_swap_has_one_winner(sdv_db):
+    conn, target = sdv_db
+    expected = plan(conn)
+    args = [
+        publication_args(
+            conn,
+            load_plan=expected,
+            rows=rows_for(2025, adj_net=value, suffix=str(value)),
+            sha=char * 64,
+        )
+        for value, char in ((1.0, "a"), (2.0, "b"))
+    ]
+
+    def contender(call_args):
+        other = psycopg2.connect(target)
+        try:
+            try:
+                return "ok", source_query(other, PUBLISH_SQL, call_args)[0]
+            except psycopg2.Error as exc:
+                other.rollback()
+                return "error", str(exc)
+        finally:
+            other.close()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(contender, args))
+    assert sorted(status for status, _ in results) == ["error", "ok"]
+    assert "changed" in next(detail for status, detail in results if status == "error").lower()
+    winner = next(detail for status, detail in results if status == "ok")
+    assert current(conn, 2025) == [("season:2025", str(winner[0]))]
+    assert query(conn, "SELECT count(*) FROM meta.asset_receipts WHERE asset_key=%s", (ASSET,)) == [
+        (1,)
+    ]
+    assert query(conn, "SELECT count(*) FROM meta.flat_file_loads") == [(1,)]
+
+
+@pytest.mark.parametrize("outcome", ["failed", "deferred"])
+def test_failure_finishes_run_and_never_repoints(outcome, sdv_db):
+    conn, _ = sdv_db
+    good = publication_args(conn, sha="a" * 64)
+    publish(conn, good)
+    before = current(conn, 2025)
+    failed_plan = plan(conn)
+    run_id = start_load(conn, failed_plan)
+    generation_id = str(uuid.uuid4())
+    result = source_query(
+        conn,
+        "SELECT warehouse_source.fail_sdv_ratings_load(%s,%s,%s)",
+        (run_id, generation_id, outcome),
+    )[0][0]
+    assert str(result) == generation_id
+    assert current(conn, 2025) == before
+    assert query(
+        conn,
+        "SELECT r.outcome,r.published_at,r.coverage->>'complete',r.error_summary,"
+        "o.outcome FROM meta.asset_receipts r JOIN meta.operation_runs o USING(operation_run_id) "
+        "WHERE r.generation_id=%s",
+        (generation_id,),
+    ) == [
+        (
+            outcome,
+            None,
+            "false",
+            "source_publication_failed",
+            "blocked" if outcome == "deferred" else outcome,
+        )
+    ]
+
+
+def test_legacy_row_writes_invalidate_only_affected_seasons_and_truncate_all(sdv_db):
+    conn, _ = sdv_db
+    publish(conn, publication_args(conn, season=2024, rows=rows_for(2024), sha="4" * 64))
+    publish(conn, publication_args(conn, season=2025, rows=rows_for(2025), sha="5" * 64))
+    query(conn, "UPDATE ratings.sdv_ratings_weekly SET adj_net=8 WHERE season=2025")
+    assert [row[0] for row in current(conn)] == ["season:2024"]
+
+    publish(conn, publication_args(conn, season=2025, rows=rows_for(2025), sha="6" * 64))
+    query(conn, "DELETE FROM ratings.sdv_ratings_weekly WHERE season=2024 AND team_id=1")
+    assert [row[0] for row in current(conn)] == ["season:2025"]
+
+    query(conn, "TRUNCATE ratings.sdv_ratings_weekly")
+    assert current(conn) == []
+
+
+@pytest.mark.parametrize(
+    "statement",
+    [
+        "ALTER TABLE ratings.sdv_ratings_weekly RENAME TO sdv_ratings_weekly_moved",
+        "DROP TABLE ratings.sdv_ratings_weekly",
+        "ALTER TABLE ratings.sdv_ratings_weekly DISABLE TRIGGER USER",
+    ],
+)
+def test_ddl_changes_and_disabled_guard_invalidate_all_seasons(sdv_db, statement):
+    conn, _ = sdv_db
+    publish(conn, publication_args(conn, season=2024, rows=rows_for(2024), sha="4" * 64))
+    publish(conn, publication_args(conn, season=2025, rows=rows_for(2025), sha="5" * 64))
+    query(conn, statement)
+    assert current(conn) == []
+
+
+def test_catalog_drift_fails_closed_without_installing_a_receipt(sdv_db):
+    conn, _ = sdv_db
+    args = publication_args(conn)
+    query(conn, "ALTER TABLE ratings.sdv_ratings_weekly ADD COLUMN drifted text")
+    with pytest.raises(psycopg2.Error, match="catalog|contract"):
+        publish(conn, args)
+    conn.rollback()
+    assert query(conn, "SELECT count(*) FROM ratings.sdv_ratings_weekly") == [(0,)]
+    assert current(conn) == []
+    assert query(conn, "SELECT count(*) FROM meta.asset_receipts WHERE asset_key=%s", (ASSET,)) == [
+        (0,)
+    ]
+
+
+def test_inherited_child_invalidates_pointer_and_blocks_unsupported_topology(sdv_db):
+    conn, _ = sdv_db
+    first = publication_args(conn)
+    publish(conn, first)
+    query(
+        conn,
+        "CREATE TABLE ratings.sdv_ratings_weekly_child () INHERITS (ratings.sdv_ratings_weekly)",
+    )
+    query(
+        conn,
+        """
+        INSERT INTO ratings.sdv_ratings_weekly_child(
+            season,through_week,team_id,loaded_at,_dlt_load_id,_dlt_id
+        ) VALUES (2025,2,99,now(),'inherited-load','inherited-row')
+        """,
+    )
+    assert current(conn) == []
+
+    retry = publication_args(conn, rows=rows_for(2025, suffix="retry"), sha="b" * 64)
+    with pytest.raises(psycopg2.Error, match="catalog|contract|inherit"):
+        publish(conn, retry)
+    conn.rollback()
+    assert current(conn) == []
+    assert query(conn, "SELECT count(*) FROM meta.asset_receipts WHERE asset_key=%s", (ASSET,)) == [
+        (1,)
+    ]
+    assert query(conn, "SELECT count(*) FROM ONLY ratings.sdv_ratings_weekly_child") == [(1,)]
+
+
+@pytest.mark.parametrize(
+    "statement",
+    [
+        "ALTER TABLE ratings.sdv_ratings_weekly RENAME TO sdv_ratings_weekly_moved",
+        "DROP TABLE ratings.sdv_ratings_weekly",
+    ],
+)
+def test_unrelated_sdv_ddl_does_not_block_house_elo_publication(sdv_db, statement):
+    conn, _ = sdv_db
+    publish(conn, publication_args(conn))
+    query(conn, statement)
+
+    args = elo_publication_args(conn)
+    result = publish_elo(conn, args)
+    assert result[:3] == (args[1], args[2], False)
+    assert query(
+        conn,
+        "SELECT asset_key,coverage_key FROM meta.asset_current_generations ORDER BY asset_key",
+    ) == [
+        ("analytics.house_elo_game", "source-wide"),
+        ("marts.house_elo_game", "source-wide"),
+    ]
+
+
+def test_public_freshness_contract_remains_house_elo_only(sdv_db):
+    conn, _ = sdv_db
+    publish(conn, publication_args(conn))
+    assert query(
+        conn,
+        "SELECT asset_key,coverage_key,expected_refresh_interval "
+        "FROM public.get_asset_freshness() ORDER BY asset_key",
+    ) == [
+        ("analytics.house_elo_game", "source-wide", None),
+        ("marts.house_elo_game", "source-wide", None),
+    ]
+
+
+def test_real_python_adapter_stages_local_parquet_and_publishes_typed_nulls(
+    sdv_db, monkeypatch, tmp_path
+):
+    from src.pipelines.sources.flat_files import REGISTRY
+    from src.pipelines.utils import sdv_ratings_publication as adapter
+
+    conn, target = sdv_db
+    schema = pq.read_schema(ROOT / "tests/fixtures/flatfiles/sdv_ratings_weekly_sample.parquet")
+    raw_row = {name: None for name in schema.names}
+    raw_row.update(season=2025, through_week=1, team_id="333")
+    local_file = tmp_path / "sdv-ratings-null-optionals.parquet"
+    pq.write_table(pa.Table.from_pylist([raw_row], schema=schema), local_file)
+    dsn = parse_dsn(target)
+    target_url = (
+        f"postgresql://{dsn['user']}:{dsn['password']}@{dsn['host']}:{dsn['port']}/{dsn['dbname']}"
+    )
+    monkeypatch.setattr(adapter, "get_db_url", lambda: target_url)
+
+    result = adapter.run_sdv_ratings_publication(
+        REGISTRY["sdv_ratings_weekly"], file_path=str(local_file), season=2025
+    )
+
+    assert result["error"] is None
+    assert result["status"] == "loaded"
+    assert result["rows"] == 1
+    row = query(
+        conn,
+        """
+        SELECT season,through_week,team_id,adj_off_epa,adj_def_epa,adj_st_epa,
+               adj_net,fei_off,fei_def,fei_net,games,off_pace,off_rank,def_rank,
+               net_rank,net_z,_dlt_load_id,_dlt_id
+        FROM ratings.sdv_ratings_weekly
+        """,
+    )[0]
+    assert row[:3] == (2025, 1, 333)
+    assert row[3:16] == (None,) * 13
+    assert all(isinstance(value, str) and value for value in row[16:])
+    receipt = query(
+        conn,
+        "SELECT generation_id::text,input_observations,source_watermark "
+        "FROM meta.asset_receipts WHERE asset_key=%s",
+        (ASSET,),
+    )[0]
+    assert receipt[0] == result["generation_id"]
+    assert receipt[1]["artifact_origin"] == "local_file"
+    assert receipt[1]["dlt_load_ids"] == [row[16]]
+    assert receipt[2] == result["sha"]
+    assert query(
+        conn,
+        "SELECT count(*) FROM warehouse_source_stage._dlt_loads WHERE load_id=%s",
+        (row[16],),
+    ) == [(1,)]
+    stage_name = f"warehouse_source_stage.sdv_ratings_{uuid.UUID(result['run_id']).hex}"
+    assert query(
+        conn,
+        "SELECT pg_catalog.to_regclass(%s),"
+        "pg_catalog.to_regnamespace('warehouse_source_stage_staging')",
+        (stage_name,),
+    ) == [(None, None)]
+    assert query(
+        conn,
+        "SELECT source_url,status,row_count FROM meta.flat_file_loads",
+    ) == [(None, "loaded", 1)]

--- a/tests/test_source_publication_plan.py
+++ b/tests/test_source_publication_plan.py
@@ -82,14 +82,24 @@ def test_receipt_dry_run_is_offline_and_does_not_refresh_descendants(monkeypatch
 
 
 @pytest.mark.parametrize(
-    "status,exit_code", [("loaded", 0), ("failed", 1), ("deferred", 1), ("blocked", 1)]
+    "status,exit_code",
+    [("loaded", 0), ("failed", 1), ("deferred", 1), ("not_published", 1), ("blocked", 1)],
 )
-def test_receipt_cli_routes_exact_scope_and_fails_closed(monkeypatch, status, exit_code):
+def test_receipt_cli_routes_exact_scope_and_fails_closed(monkeypatch, capsys, status, exit_code):
     calls = []
 
     def adapter(spec, **kwargs):
         calls.append((spec, kwargs))
-        return {"source": spec.name, "status": status, "rows": 2, "sha": None, "duration_s": 0.1}
+        return {
+            "source": spec.name,
+            "status": status,
+            "rows": 2,
+            "sha": None,
+            "duration_s": 0.1,
+            "error": None if status == "loaded" else "Selected artifact cannot be published",
+            "run_id": "run-fixture",
+            "generation_id": "generation-fixture",
+        }
 
     monkeypatch.setitem(
         sys.modules,
@@ -113,3 +123,12 @@ def test_receipt_cli_routes_exact_scope_and_fails_closed(monkeypatch, status, ex
     assert calls == [
         (REGISTRY["sdv_ratings_weekly"], {"season": 2025, "file_path": "fixture.parquet"})
     ]
+    output = capsys.readouterr()
+    assert "sdv_ratings_weekly" in output.out
+    if exit_code:
+        assert "Selected artifact cannot be published" in output.err
+        assert "run_id=run-fixture" in output.err
+        assert "generation_id=generation-fixture" in output.err
+        assert status in output.err
+    else:
+        assert output.err == ""

--- a/tests/test_source_publication_plan.py
+++ b/tests/test_source_publication_plan.py
@@ -1,0 +1,115 @@
+"""Source coverage contracts and the opt-in flat-file CLI boundary."""
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from scripts import load_flat_files
+from src.pipelines.config.source_publication_assets import (
+    SDV_RATINGS_PUBLICATION,
+    SOURCE_PUBLICATION_ASSETS,
+)
+from src.pipelines.sources.flat_files import REGISTRY
+from src.pipelines.utils.refresh_plan import REFRESH_GRAPH
+
+
+def test_source_contract_matches_loader_and_declared_dependencies():
+    contract = SDV_RATINGS_PUBLICATION
+    spec = REGISTRY[contract.source_name]
+    assert set(SOURCE_PUBLICATION_ASSETS) == {spec.name}
+    assert contract.asset_key == f"{spec.schema}.{spec.table}"
+    assert contract.primary_key == spec.primary_key
+    assert contract.cadence == spec.cadence
+    assert len(contract.columns) == len(set(contract.columns)) == 16
+    assert set(contract.primary_key) <= set(contract.columns)
+    assert contract.coverage_key(2025) == "season:2025"
+    assert REFRESH_GRAPH.plan(changed=[contract.asset_key]).views == ("marts.epa_crossvalidation",)
+
+
+@pytest.mark.parametrize("season", [None, True, "2025", 2025.0, 1868, 2201])
+def test_invalid_source_coverage_is_rejected(season):
+    with pytest.raises(ValueError, match="explicit season"):
+        SDV_RATINGS_PUBLICATION.coverage_key(season)
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        [],
+        ["--due", "--season", "2025"],
+        ["--source", "massey", "--season", "2025"],
+        ["--source", "sdv_ratings_weekly"],
+        ["--source", "sdv_ratings_weekly", "--season", "2201"],
+        ["--source", "sdv_ratings_weekly", "--source", "sdv_fpi_weekly", "--season", "2025"],
+    ],
+)
+def test_receipt_cli_rejects_unsupported_plans_before_work(monkeypatch, args):
+    def forbidden(*_args, **_kwargs):
+        pytest.fail("unsupported receipt plans must not plan, fetch or query the ledger")
+
+    monkeypatch.setattr(load_flat_files, "_planned_sources", forbidden)
+    monkeypatch.setattr(load_flat_files, "fetch_file", forbidden)
+    monkeypatch.setattr(load_flat_files, "last_checked", forbidden)
+    with pytest.raises(SystemExit) as error:
+        load_flat_files.main(["--require-receipts", *args])
+    assert error.value.code == 2
+
+
+def test_receipt_dry_run_is_offline_and_does_not_refresh_descendants(monkeypatch, capsys):
+    def forbidden(*_args, **_kwargs):
+        pytest.fail("receipt dry-run must be offline")
+
+    monkeypatch.setattr(load_flat_files, "last_checked", forbidden)
+    monkeypatch.setattr(load_flat_files, "run_source", forbidden)
+    assert (
+        load_flat_files.main(
+            [
+                "--require-receipts",
+                "--source",
+                "sdv_ratings_weekly",
+                "--season",
+                "2025",
+                "--dry-run",
+            ]
+        )
+        == 0
+    )
+    output = capsys.readouterr().out
+    assert "ratings.sdv_ratings_weekly/season:2025" in output
+    assert "not refreshed" in output
+    assert "Live generation and schema validation is not run" in output
+
+
+@pytest.mark.parametrize(
+    "status,exit_code", [("loaded", 0), ("failed", 1), ("deferred", 1), ("blocked", 1)]
+)
+def test_receipt_cli_routes_exact_scope_and_fails_closed(monkeypatch, status, exit_code):
+    calls = []
+
+    def adapter(spec, **kwargs):
+        calls.append((spec, kwargs))
+        return {"source": spec.name, "status": status, "rows": 2, "sha": None, "duration_s": 0.1}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "src.pipelines.utils.sdv_ratings_publication",
+        SimpleNamespace(run_sdv_ratings_publication=adapter),
+    )
+    assert (
+        load_flat_files.main(
+            [
+                "--require-receipts",
+                "--source",
+                "sdv_ratings_weekly",
+                "--season",
+                "2025",
+                "--file",
+                "fixture.parquet",
+            ]
+        )
+        == exit_code
+    )
+    assert calls == [
+        (REGISTRY["sdv_ratings_weekly"], {"season": 2025, "file_path": "fixture.parquet"})
+    ]

--- a/tests/test_warehouse_bootstrap_sql.py
+++ b/tests/test_warehouse_bootstrap_sql.py
@@ -389,7 +389,7 @@ def test_managed_warehouse_catalog_data_and_access(
         _insert_representative_rows(conn)
         before_upgrade = _fixture_snapshot(conn)
         upgrade = apply_manifest(conn, manifest, mode="upgrade")
-        assert len(upgrade.pending) == 7
+        assert len(upgrade.pending) == 8
         assert [step.id for step in upgrade.pending] == [
             migration.id for migration in manifest.migrations[4:]
         ]


### PR DESCRIPTION
SDV weekly ratings currently use the legacy merge/hash ledger, which cannot atomically identify a complete season publication and can skip unchanged bytes after parser corrections. This adds an opt-in `--source sdv_ratings_weekly --season YYYY --require-receipts` path: validate and stage the season artifact with dlt, then replace that season together with its generation receipt, current pointer, load-ledger observation and terminal operation outcome.

Migration 071 adds bounded private source RPCs, season-scoped compare-and-swap, replay protection and invalidation for legacy writes and DDL. The adapter preserves genuine dlt identifiers, rejects partial or malformed files, reparses unchanged bytes, and retains evidence after uncertain commits. Source metadata records coverage and correction policies. Bootstrap manifests, CI and operating contracts include the slice.

Validation: 124 adapter/CLI/legacy flat-file tests; 29 executed PostgreSQL 17 source-publication cases, including real dlt staging, corrections, concurrency, rollback and actual caller roles; 123 existing warehouse bootstrap/publication/freshness/generation SQL checks, with bootstrap rerun after the final guard fix. Affected Ruff lint/format checks passed. Independent SQL and adapter reviews found no remaining material issues.

Production rollout and runtime membership remain separate. This does not activate source freshness or refresh crossvalidation descendants; their complete dependency coverage remains future work. Production lock duration and managed-platform privilege parity are unmeasured.




<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62156768"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/formentera-operations/-/pull-requests/rstover-fo/cfb-database/143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge; there are no outstanding blocking issues.

<details><summary><h3>Summary</h3></summary>

- This change adds receipt-backed, season-scoped publication for SDV weekly ratings, including validation, staging, atomic replacement, publication receipts, replay protection, bounded publisher operations, migrations, documentation, and test coverage. The previously reported post-commit cleanup behavior is fixed: a confirmed publication remains successful if later local cleanup fails.
</details>

<!-- /greptile_comment -->