### PR TITLE
Publish remaining SDV season files with atomic receipts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - run: ./scripts/setup_dev.sh
       - name: Managed bootstrap and upgrade integration
-        run: .venv/bin/python -m pytest tests/test_warehouse_migrations_sql.py tests/test_warehouse_bootstrap_sql.py tests/test_adopt_warehouse_catalog_sql.py tests/test_f06_verification_transactions_sql.py tests/test_mart_release_sql.py tests/test_play_partitions.py tests/test_play_indexes_sql.py tests/test_operational_quota_sql.py tests/test_operational_quota_lifecycle_sql.py tests/test_cfbd_transport_admission_sql.py tests/test_asset_publication_sql.py tests/test_asset_freshness_sql.py tests/test_generation_refresh_sql.py tests/test_sdv_ratings_publication_sql.py -q --tb=short
+        run: .venv/bin/python -m pytest tests/test_warehouse_migrations_sql.py tests/test_warehouse_bootstrap_sql.py tests/test_adopt_warehouse_catalog_sql.py tests/test_f06_verification_transactions_sql.py tests/test_mart_release_sql.py tests/test_play_partitions.py tests/test_play_indexes_sql.py tests/test_operational_quota_sql.py tests/test_operational_quota_lifecycle_sql.py tests/test_cfbd_transport_admission_sql.py tests/test_asset_publication_sql.py tests/test_asset_freshness_sql.py tests/test_generation_refresh_sql.py tests/test_sdv_ratings_publication_sql.py tests/test_flat_file_publication_sql.py -q --tb=short
         env:
           F06_TEST_DB_URL: postgresql://postgres:f06-disposable-ci@127.0.0.1:5432/postgres
           F06_REQUIRE_DB: "1"

--- a/docs/SCHEMA_CONTRACT.md
+++ b/docs/SCHEMA_CONTRACT.md
@@ -1298,6 +1298,15 @@ provider-wide coverage or prospective model eligibility. The existing public
 freshness RPC, consumer grants and automatic refresh behavior remain unchanged.
 See the [source publication contract](plans/2026-09-09-step7-sdv-ratings-publication.md).
 
+Migration `072_sdv_source_batch_publication.sql` extends season receipts to
+`ratings.espn_fpi_weekly`, `ref.team_id_xwalk` and `ref.game_id_xwalk` through
+the private, fixed-source `warehouse_source_batch` RPCs. Existing keys, nullable
+provider IDs, source timestamps and consumer grants are preserved. The
+crosswalk files have no season column: receipts label scope assigned from the
+registered artifact name or explicitly declared by the local-file caller.
+Selecting several sources creates independent source/season publications and
+separate outcomes. See the [batch contract](plans/2026-09-09-step7-sdv-source-batch.md).
+
 ### Raw Data Tables
 
 | Schema | Tables |

--- a/docs/plans/2026-09-08-f14-f19-operational-records.md
+++ b/docs/plans/2026-09-08-f14-f19-operational-records.md
@@ -364,11 +364,14 @@ foundation to solve this broader catalog.
    adapt remaining dlt, flat-file, compute, and prediction-verification paths.
 
 Delivery progress (2026-09-09): steps 1–6 have merged through PR #142 with
-bounded opt-in adapters. The first step-7 slice is
+bounded opt-in adapters. The first step-7 slice merged in PR #143 is
 [SDV ratings season publication](2026-09-09-step7-sdv-ratings-publication.md):
 explicit source coverage metadata and staged dlt output published atomically
 for one season. Remaining sources, crossvalidation generation closure, public
-source freshness, and production activation remain separate work.
+source freshness, and production activation remain separate work. The next
+[three-source SDV batch](2026-09-09-step7-sdv-source-batch.md) extends season
+publication to weekly FPI and the team/game crosswalks using shared plumbing
+and independent source outcomes.
 
 Steps 2 and 4 share database primitives but should remain separate PRs so
 quota-safety review is not coupled to a broad freshness API change. Step 3 can

--- a/docs/plans/2026-09-09-step7-sdv-source-batch.md
+++ b/docs/plans/2026-09-09-step7-sdv-source-batch.md
@@ -1,0 +1,96 @@
+# Step 7: SDV source publication batch
+
+Status: implemented and independently reviewed. This follows the first source
+slice merged in PR #143. Production migration, runtime membership and scheduled
+activation remain separate rollout decisions.
+
+## Enrolled sources
+
+| Source | Target | Preserved primary key | Season evidence |
+|---|---|---|---|
+| `sdv_fpi_weekly` | `ratings.espn_fpi_weekly` | `season, season_type, week, team_id` | In-file season on every row |
+| `sdv_team_xwalk` | `ref.team_id_xwalk` | `season, xwalk_key` | Registered artifact name or explicit caller declaration |
+| `sdv_game_xwalk` | `ref.game_id_xwalk` | `season, matchup_key, yahoo_date` | Registered artifact name or explicit caller declaration |
+
+The existing `sdv_ratings_weekly` source remains enrolled with its original
+receipt protocol. Shared Python publication code handles staging and operation
+outcomes, while each source retains its explicit column, type and key contract.
+The legacy flat-file merge path retains its existing behavior.
+
+The crosswalk files have no season column. Their receipts distinguish
+`registered_artifact_name` from `caller_declared` season assignment; they do not
+claim that the file independently proved its season. Local artifacts record no
+filesystem path or provider URL in the receipt or load ledger. The operator
+must supply the complete artifact for the declared source and season.
+
+Nullable ESPN IDs remain nullable, and team rows with all provider IDs absent
+retain the parser's canonical `norm_key#None` key when it is unique. Repeated
+normalized team names with distinct source IDs remain distinct. Game rematches
+retain their date discriminator, including postseason dates in the next
+calendar year. FPI preserves regular/postseason keys, week zero, nullable
+metrics, typed booleans and timezone-aware source timestamps.
+
+## Batch execution and publication
+
+```bash
+python scripts/load_flat_files.py --require-receipts --season 2025 \
+  --source sdv_fpi_weekly --source sdv_team_xwalk --source sdv_game_xwalk \
+  --dry-run
+```
+
+Each selected source and season gets a separate operation, staging table and
+publication transaction. A failed source reports its error and run/generation
+IDs; the remaining selected sources still run, and the command exits nonzero
+if any source did not publish. Interruptions propagate. Duplicate source
+selections, unenrolled sources and `--due` are rejected. `--file` remains
+restricted to one explicitly selected source and season. Dry runs remain
+offline and show the season evidence and declared SQL descendants, where known.
+
+Migration 072 adds the private `warehouse_source_batch` namespace for the three
+new sources. The existing publisher role receives only its bounded lifecycle
+RPCs. Source selection resolves against a fixed allowlist; callers cannot
+choose arbitrary target relations. Migration 071 and its ratings RPCs retain
+their original protocol. Consumer grants remain unchanged.
+
+The publisher replaces only the selected season, including removal of keys
+absent from a correction, and commits target rows, the success receipt, current
+generation, legacy hash-ledger observation and terminal operation outcome
+together. Raw and staged validation reject dropped rows, lossy conversions,
+duplicate keys, schema drift and invalid evidence. Genuine dlt metadata remains
+in private staging. An unchanged hash remains eligible for parser corrections.
+
+Known failures preserve the previous current generation. Uncertain commits
+retain evidence and are not retried or relabeled as definite failures. Legacy
+row writes invalidate affected season pointers; truncation and relevant DDL
+invalidate that source's pointers. Missing or altered guards block publication.
+
+PostgreSQL does not fire DDL event triggers for changes to event triggers
+themselves ([PostgreSQL 17 behavior](https://www.postgresql.org/docs/17/event-trigger-definition.html)).
+Disabling a shared event trigger therefore does not immediately clear existing
+pointers, but the publisher checks both shared guards and refuses new
+publication while either is unavailable. Privileged maintenance that bypasses
+guards must invalidate affected pointers before restoring the guards.
+
+Complete coverage means the validated contents of the selected artifact. It
+does not establish provider-wide team/game coverage, completed seasons or
+prospective model eligibility. This batch does not refresh descendants or
+activate public source freshness; crossvalidation still needs complete coverage
+of all its other inputs before generation enforcement can cover that mart.
+
+## Verification
+
+- 214 focused Python tests passed across the batch adapter, existing ratings
+  adapter, CLI, source plans, legacy multi-file loading and SDV parsers.
+- 76 bootstrap, migration, bootstrap CLI and existing ratings SQL tests passed
+  against disposable PostgreSQL 17, including real dlt staging.
+- 67 new source SQL tests passed on disposable PostgreSQL 17, including all
+  three real local Parquet/dlt adapters, source and season isolation, correction
+  removals, rollback, replay, concurrent CAS, actual caller roles, conditional
+  trigger and rewrite-rule rejection, and compatibility with ratings and Elo.
+- Independent SQL and Python/CLI reviews found no remaining material issues.
+- Ruff and formatting checks passed for the affected Python implementation,
+  CLI and unit tests. The three-source CLI dry run also passed offline.
+
+Fixtures use local files and disposable PostgreSQL; no production publication
+or provider request was made. Production lock duration, memory at the maximum
+row cap and managed-platform privilege parity remain unmeasured.

--- a/docs/warehouse-operations.md
+++ b/docs/warehouse-operations.md
@@ -96,6 +96,13 @@ advance the current pointer. It does not refresh the crossvalidation mart or
 extend the public freshness RPC. See the
 [source contract and recovery limits](plans/2026-09-09-step7-sdv-ratings-publication.md).
 
+Migration 072 extends this opt-in mode to `sdv_fpi_weekly`, `sdv_team_xwalk` and
+`sdv_game_xwalk`. Repeat `--source` to select several enrolled sources for one
+explicit season. Each commits independently; a source failure reports receipt
+IDs, permits the remaining sources to run and makes the overall exit nonzero.
+Crosswalk local files use a caller-declared season because they have no in-file
+season field. See the [batch scope and verification](plans/2026-09-09-step7-sdv-source-batch.md).
+
 ## Plays partition rollover (F08)
 
 `run_plays_pipeline()` performs catalog preflight before constructing the source

--- a/scripts/load_flat_files.py
+++ b/scripts/load_flat_files.py
@@ -78,7 +78,7 @@ from datetime import UTC, date, datetime
 import dlt
 import httpx
 
-from src.pipelines.config.source_publication_assets import SDV_RATINGS_PUBLICATION
+from src.pipelines.config.source_publication_assets import SOURCE_PUBLICATION_ASSETS
 from src.pipelines.sources.flat_files import (
     LOAD_SEASON_MONTHS,
     REGISTRY,
@@ -478,8 +478,8 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--require-receipts",
         action="store_true",
-        help="Atomically publish one sdv_ratings_weekly season with a generation receipt; "
-        "requires --source sdv_ratings_weekly and an explicit --season",
+        help="Publish each selected enrolled source/season atomically with a generation receipt; "
+        "requires explicit --source selections and --season",
     )
     parser.add_argument(
         "--dry-run",
@@ -531,43 +531,60 @@ def main(argv: list[str] | None = None) -> int:
         parser.error("--file requires exactly one --source")
 
     if args.require_receipts:
-        contract = SDV_RATINGS_PUBLICATION
-        if args.source != [contract.source_name] or args.due:
-            parser.error("--require-receipts supports exactly --source sdv_ratings_weekly")
+        if not args.source or args.due:
+            parser.error("--require-receipts requires explicit --source selections without --due")
+        if len(args.source) != len(set(args.source)):
+            parser.error("--require-receipts requires unique --source selections")
+        unsupported = set(args.source) - SOURCE_PUBLICATION_ASSETS.keys()
+        if unsupported:
+            parser.error(
+                "--require-receipts supports only: " + ", ".join(SOURCE_PUBLICATION_ASSETS)
+            )
+        contracts = [SOURCE_PUBLICATION_ASSETS[name] for name in args.source]
         try:
-            coverage_key = contract.coverage_key(args.season)
+            coverage_key = contracts[0].coverage_key(args.season)
         except ValueError as exc:
             parser.error(str(exc))
         if args.dry_run:
             from src.pipelines.utils.refresh_plan import REFRESH_GRAPH
 
-            descendants = REFRESH_GRAPH.plan(changed=[contract.asset_key]).views
-            print(f"[DRY RUN] receipt publication: {contract.asset_key}/{coverage_key}")
-            print("  Stage and validate the complete file, then replace only the selected season.")
-            print("  Reparse unchanged bytes; no legacy hash skip or older-season fallback.")
-            fetch_target = _fetch_target_display(
-                REGISTRY[contract.source_name], args.file, args.season
-            )
-            print(f"  Fetch: {fetch_target}")
-            print(f"  Declared descendants (not refreshed): {', '.join(descendants)}")
+            for contract in contracts:
+                print(f"[DRY RUN] receipt publication: {contract.asset_key}/{coverage_key}")
+                print("  Stage and validate the complete file, then replace only this season.")
+                print("  Reparse unchanged bytes; no legacy hash skip or older-season fallback.")
+                fetch_target = _fetch_target_display(
+                    REGISTRY[contract.source_name], args.file, args.season
+                )
+                print(f"  Fetch: {fetch_target}")
+                origin = "local_file" if args.file else "registered_url"
+                print(f"  Season basis: {contract.season_basis(origin)}")
+                if contract.asset_key in REFRESH_GRAPH.dependencies:
+                    descendants = REFRESH_GRAPH.plan(changed=[contract.asset_key]).views
+                    print(f"  Declared descendants (not refreshed): {', '.join(descendants)}")
+                else:
+                    print("  Descendants: source is not registered in the SQL refresh graph.")
+            print("  Each source/season has a separate operation and publication transaction.")
             print("  Live generation and schema validation is not run during --dry-run.")
             return 0
 
-        from src.pipelines.utils.sdv_ratings_publication import run_sdv_ratings_publication
+        from src.pipelines.utils.flat_file_publication import run_source_publication
 
-        result = run_sdv_ratings_publication(
-            REGISTRY[contract.source_name], file_path=args.file, season=args.season
-        )
-        print(_gate_line(result))
-        if result["status"] != "loaded":
-            print(
-                f"Receipt publication {result['status']}: "
-                f"{result.get('error') or 'No error detail was returned'}; "
-                f"run_id={result.get('run_id') or 'unavailable'}; "
-                f"generation_id={result.get('generation_id') or 'unavailable'}",
-                file=sys.stderr,
+        exit_code = 0
+        for contract in contracts:
+            result = run_source_publication(
+                REGISTRY[contract.source_name], file_path=args.file, season=args.season
             )
-        return 0 if result["status"] == "loaded" else 1
+            print(_gate_line(result))
+            if result["status"] != "loaded":
+                exit_code = 1
+                print(
+                    f"Receipt publication {result['status']}: "
+                    f"{result.get('error') or 'No error detail was returned'}; "
+                    f"run_id={result.get('run_id') or 'unavailable'}; "
+                    f"generation_id={result.get('generation_id') or 'unavailable'}",
+                    file=sys.stderr,
+                )
+        return exit_code
 
     if args.file is not None and args.season is None:
         spec = REGISTRY[args.source[0]]

--- a/src/pipelines/config/source_publication_assets.py
+++ b/src/pipelines/config/source_publication_assets.py
@@ -30,6 +30,16 @@ class SourcePublicationAsset:
             raise ValueError("receipt publication requires an explicit season from 1869 to 2200")
         return f"season:{season}"
 
+    def season_basis(self, artifact_origin: str) -> str:
+        """Describe the evidence used to assign rows to the selected season."""
+        if artifact_origin not in {"registered_url", "local_file"}:
+            raise ValueError("artifact origin must be registered_url or local_file")
+        if self.source_name in {"sdv_fpi_weekly", "sdv_ratings_weekly"}:
+            return "artifact_field"
+        if artifact_origin == "registered_url":
+            return "registered_artifact_name"
+        return "caller_declared"
+
 
 SDV_RATINGS_PUBLICATION = SourcePublicationAsset(
     source_name="sdv_ratings_weekly",
@@ -64,6 +74,141 @@ SDV_RATINGS_PUBLICATION = SourcePublicationAsset(
     primary_key=("season", "through_week", "team_id"),
 )
 
+SDV_FPI_PUBLICATION = SourcePublicationAsset(
+    source_name="sdv_fpi_weekly",
+    asset_key="ratings.espn_fpi_weekly",
+    coverage_grain="season",
+    correction_policy="replace_selected_season_from_complete_file",
+    expected_no_data_policy="never; missing file is deferred, empty file is invalid",
+    watermark_rule="artifact_sha256",
+    provider="sportsdataverse_public_file",
+    admission_policy="not_cfbd; bounded flat-file fetch retries",
+    cadence="weekly",
+    parser_contract="sdv-fpi-v1",
+    protocol="sdv-season-file-v1",
+    columns=(
+        "season",
+        "season_type",
+        "week",
+        "team_id",
+        "last_updated",
+        "run_date_time_key",
+        "snapshot_out_of_sequence",
+        "fpi",
+        "fpirank",
+        "projectedw",
+        "projectedl",
+        "projectedt",
+        "projectedwpctrank",
+        "probwinout",
+        "probwinconf",
+        "sosremainingrank",
+        "accomplishment",
+        "accomplishmentrank",
+        "adjwins",
+        "adjlosses",
+        "adjwinpctrank",
+        "gamecontrol",
+        "gamecontrolrank",
+        "adjavgingamewp",
+        "adjavgingamewprank",
+        "avgingamewp",
+        "avgingamewprank",
+        "avgsosrank",
+        "topsosrank",
+        "epaoffense",
+        "epadefense",
+        "epaspecialteams",
+        "probwindiv",
+        "probmakeplayoffs",
+        "probmaketitlegame",
+        "numwins",
+        "numlosses",
+        "numties",
+        "probwintitle",
+        "rankchange7days",
+        "prob6wins",
+        "rank",
+        "offefficiency",
+        "offefficiencyrank",
+        "defefficiency",
+        "defefficiencyrank",
+        "stefficiency",
+        "stefficiencyrank",
+        "totefficiency",
+        "totefficiencyrank",
+        "snapshot_is_contemporaneous",
+    ),
+    primary_key=("season", "season_type", "week", "team_id"),
+)
+
+SDV_TEAM_XWALK_PUBLICATION = SourcePublicationAsset(
+    source_name="sdv_team_xwalk",
+    asset_key="ref.team_id_xwalk",
+    coverage_grain="season",
+    correction_policy="replace_selected_season_from_complete_file",
+    expected_no_data_policy="never; missing file is deferred, empty file is invalid",
+    watermark_rule="artifact_sha256",
+    provider="sportsdataverse_public_file",
+    admission_policy="not_cfbd; bounded flat-file fetch retries",
+    cadence="weekly",
+    parser_contract="sdv-team-xwalk-v1",
+    protocol="sdv-season-file-v1",
+    columns=(
+        "season",
+        "norm_key",
+        "xwalk_key",
+        "espn_team_id",
+        "espn_team",
+        "espn_abbreviation",
+        "fox_team_id",
+        "fox_team",
+        "fox_abbreviation",
+        "yahoo_team_id",
+        "yahoo_team",
+        "yahoo_abbreviation",
+        "matched_sources",
+    ),
+    primary_key=("season", "xwalk_key"),
+)
+
+SDV_GAME_XWALK_PUBLICATION = SourcePublicationAsset(
+    source_name="sdv_game_xwalk",
+    asset_key="ref.game_id_xwalk",
+    coverage_grain="season",
+    correction_policy="replace_selected_season_from_complete_file",
+    expected_no_data_policy="never; missing file is deferred, empty file is invalid",
+    watermark_rule="artifact_sha256",
+    provider="sportsdataverse_public_file",
+    admission_policy="not_cfbd; bounded flat-file fetch retries",
+    cadence="weekly",
+    parser_contract="sdv-game-xwalk-v1",
+    protocol="sdv-season-file-v1",
+    columns=(
+        "season",
+        "matchup_key",
+        "yahoo_date",
+        "espn_game_id",
+        "fox_game_id",
+        "yahoo_game_id",
+        "yahoo_global_game_id",
+        "home_team",
+        "away_team",
+        "espn_date",
+        "fox_date",
+        "matched_sources",
+    ),
+    primary_key=("season", "matchup_key", "yahoo_date"),
+)
+
 SOURCE_PUBLICATION_ASSETS = MappingProxyType(
-    {SDV_RATINGS_PUBLICATION.source_name: SDV_RATINGS_PUBLICATION}
+    {
+        asset.source_name: asset
+        for asset in (
+            SDV_RATINGS_PUBLICATION,
+            SDV_FPI_PUBLICATION,
+            SDV_TEAM_XWALK_PUBLICATION,
+            SDV_GAME_XWALK_PUBLICATION,
+        )
+    }
 )

--- a/src/pipelines/utils/flat_file_publication.py
+++ b/src/pipelines/utils/flat_file_publication.py
@@ -1,0 +1,936 @@
+"""Receipt-backed publication for enrolled SportsDataverse season files.
+
+Each run normalizes one complete file into an isolated dlt staging table.  A
+bounded owner-rights RPC then replaces exactly the selected season and commits
+the load ledger, receipt, and generation pointer in the same transaction.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import logging
+import math
+import os
+import tempfile
+import time
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, replace
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any
+
+import dlt
+import httpx
+import psycopg2
+import pyarrow.parquet
+from dlt.destinations import postgres
+from psycopg2 import sql
+from psycopg2.extras import Json
+
+from src.pipelines.config.source_publication_assets import (
+    SDV_FPI_PUBLICATION,
+    SDV_GAME_XWALK_PUBLICATION,
+    SDV_TEAM_XWALK_PUBLICATION,
+    SOURCE_PUBLICATION_ASSETS,
+    SourcePublicationAsset,
+)
+from src.pipelines.sources.flat_files import (
+    REGISTRY,
+    FlatFileSpec,
+    ParseContext,
+    build_flat_file_source,
+    resolve_fetch_url,
+    resolve_parser,
+)
+from src.pipelines.utils.file_fetcher import fetch_file
+from src.pipelines.utils.load_ledger import get_db_url
+
+logger = logging.getLogger(__name__)
+
+STAGE_SCHEMA = "warehouse_source_stage"
+MAX_SOURCE_ROWS = 100_000
+ERROR_MESSAGE_LIMIT = 500
+_ROLE = "warehouse_source_publisher"
+_SUPPORTED_SOURCES = frozenset(
+    {
+        SDV_FPI_PUBLICATION.source_name,
+        SDV_TEAM_XWALK_PUBLICATION.source_name,
+        SDV_GAME_XWALK_PUBLICATION.source_name,
+    }
+)
+_EXPECTED_PLAN_KEYS = frozenset(
+    {
+        "protocol",
+        "source_name",
+        "asset_key",
+        "coverage_key",
+        "season",
+        "expected_generation_id",
+        "parser_contract",
+    }
+)
+_STAGE_SYSTEM_COLUMNS = ("_dlt_id", "_dlt_load_id")
+
+_FPI_INTS = frozenset({"season", "season_type", "week", "team_id", "run_date_time_key"})
+_FPI_BOOLS = frozenset({"snapshot_out_of_sequence", "snapshot_is_contemporaneous"})
+_FPI_TIMESTAMPS = frozenset({"last_updated"})
+_FPI_DOUBLES = frozenset(SDV_FPI_PUBLICATION.columns) - _FPI_INTS - _FPI_BOOLS - _FPI_TIMESTAMPS
+_TEAM_INTS = frozenset({"season", "espn_team_id"})
+_TEAM_TEXT = frozenset(SDV_TEAM_XWALK_PUBLICATION.columns) - _TEAM_INTS
+_GAME_INTS = frozenset({"season", "espn_game_id"})
+_GAME_DATES = frozenset({"yahoo_date", "espn_date", "fox_date"})
+_GAME_TEXT = frozenset(SDV_GAME_XWALK_PUBLICATION.columns) - _GAME_INTS - _GAME_DATES
+_RAW_COLUMNS = {
+    "sdv_fpi_weekly": frozenset(SDV_FPI_PUBLICATION.columns),
+    "sdv_team_xwalk": frozenset(SDV_TEAM_XWALK_PUBLICATION.columns) - {"season", "xwalk_key"},
+    "sdv_game_xwalk": frozenset(SDV_GAME_XWALK_PUBLICATION.columns) - {"season"},
+}
+
+_PARSER_REFS = {
+    "sdv_fpi_weekly": "sportsdataverse.parse_fpi_weekly",
+    "sdv_team_xwalk": "sportsdataverse.parse_team_xwalk",
+    "sdv_game_xwalk": "sportsdataverse.parse_game_xwalk",
+}
+_TARGETS = {
+    "sdv_fpi_weekly": ("ratings", "espn_fpi_weekly"),
+    "sdv_team_xwalk": ("ref", "team_id_xwalk"),
+    "sdv_game_xwalk": ("ref", "game_id_xwalk"),
+}
+
+
+class SourcePublicationError(RuntimeError):
+    """A known pre-commit publication failure."""
+
+
+class UncertainCommitError(RuntimeError):
+    """The client cannot determine whether a mutating RPC committed."""
+
+
+class PostCommitError(RuntimeError):
+    """A non-transactional error occurred after a confirmed RPC commit."""
+
+
+@dataclass(frozen=True)
+class _StageResult:
+    table: str
+    rows: list[dict[str, Any]]
+    evidence: dict[str, Any]
+
+
+@dataclass
+class _MutationState:
+    start_pending: bool = False
+    started: bool = False
+    publish_pending: bool = False
+    published: bool = False
+    failure_pending: bool = False
+    failure_recorded: bool = False
+
+    def set_pending(self, phase: str) -> None:
+        setattr(self, f"{phase}_pending", True)
+
+    def set_committed(self, phase: str) -> None:
+        committed = {"start": "started", "publish": "published", "failure": "failure_recorded"}
+        setattr(self, committed[phase], True)
+        setattr(self, f"{phase}_pending", False)
+
+
+@dataclass
+class _RunContext:
+    stage_table: str | None = None
+    terminal_confirmed: bool = False
+    source_sha: str | None = None
+
+
+@dataclass(frozen=True)
+class _LifecycleHooks:
+    source_name: str
+    new_id: Callable[[], Any]
+    preflight: Callable[[FlatFileSpec, int], None]
+    get_db_url: Callable[[], str]
+    get_plan: Callable[[str, int], dict[str, Any]]
+    start_run: Callable[[str, str, dict[str, Any], _MutationState], None]
+    work: Callable[
+        [
+            str,
+            FlatFileSpec,
+            str | None,
+            int,
+            str,
+            str,
+            _MutationState,
+            _RunContext,
+        ],
+        tuple[str, int],
+    ]
+    fail_run: Callable[[str, str, str, str, _MutationState], None]
+    drop_stage: Callable[[str, str], None]
+    known_error_text: Callable[[BaseException, str, str], str]
+
+
+def _asset_for(spec: FlatFileSpec, season: int) -> SourcePublicationAsset:
+    if spec.name not in _SUPPORTED_SOURCES:
+        raise ValueError(f"{spec.name} is not enrolled in generic source publication")
+    canonical = REGISTRY[spec.name]
+    if spec is not canonical:
+        raise ValueError("receipt publication requires the canonical registry spec")
+    asset = SOURCE_PUBLICATION_ASSETS[spec.name]
+    schema, table = _TARGETS[spec.name]
+    if (
+        spec.schema != schema
+        or spec.table != table
+        or spec.parser != _PARSER_REFS[spec.name]
+        or tuple(spec.primary_key) != asset.primary_key
+        or spec.write_disposition != "merge"
+        or spec.kind != "dlt"
+    ):
+        raise ValueError(f"{spec.name} registry contract does not match the publisher")
+    asset.coverage_key(season)
+    return asset
+
+
+def _base_result(source_name: str, run_id: str, generation_id: str) -> dict[str, Any]:
+    return {
+        "source": source_name,
+        "status": "failed",
+        "rows": 0,
+        "sha": None,
+        "duration_s": 0.0,
+        "error": None,
+        "unmapped": None,
+        "gaps": None,
+        "run_id": run_id,
+        "generation_id": generation_id,
+    }
+
+
+def _validated_plan(value: Any, asset: SourcePublicationAsset, season: int) -> dict[str, Any]:
+    if not isinstance(value, dict) or frozenset(value) != _EXPECTED_PLAN_KEYS:
+        raise SourcePublicationError("publisher returned an invalid source plan")
+    expected = {
+        "protocol": asset.protocol,
+        "source_name": asset.source_name,
+        "asset_key": asset.asset_key,
+        "coverage_key": asset.coverage_key(season),
+        "season": season,
+        "parser_contract": asset.parser_contract,
+    }
+    if any(value.get(key) != expected_value for key, expected_value in expected.items()):
+        raise SourcePublicationError("publisher returned a mismatched source plan")
+    generation = value["expected_generation_id"]
+    if generation is not None:
+        try:
+            if str(uuid.UUID(str(generation))) != str(generation):
+                raise ValueError
+        except (TypeError, ValueError, AttributeError) as error:
+            raise SourcePublicationError(
+                "publisher plan has an invalid expected generation"
+            ) from error
+    return value
+
+
+def _connect(dsn: str):
+    return psycopg2.connect(dsn, connect_timeout=10)
+
+
+def _execute_rpc(
+    connector: Callable[[str], Any],
+    dsn: str,
+    statement: str,
+    args: tuple[Any, ...],
+    *,
+    mutating: bool,
+    state: _MutationState | None = None,
+    phase: str | None = None,
+) -> tuple[Any, ...] | None:
+    if mutating != (state is not None and phase in {"start", "publish", "failure"}):
+        raise ValueError("mutating RPCs require an explicit mutation phase and state")
+    conn = connector(dsn)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(sql.SQL("SET LOCAL ROLE {}").format(sql.Identifier(_ROLE)))
+            cur.execute("SET LOCAL statement_timeout = '60s'")
+            cur.execute(statement, args)
+            row = cur.fetchone() if cur.description else None
+    except BaseException:
+        try:
+            conn.rollback()
+        except Exception:
+            pass
+        try:
+            conn.close()
+        except Exception:
+            pass
+        raise
+    if mutating:
+        assert state is not None and phase is not None
+        state.set_pending(phase)
+    try:
+        conn.commit()
+    except BaseException as error:
+        try:
+            conn.close()
+        except Exception:
+            pass
+        if mutating:
+            raise UncertainCommitError(
+                "source publication RPC commit outcome is uncertain"
+            ) from error
+        raise
+    if mutating:
+        state.set_committed(phase)
+    try:
+        conn.close()
+    except BaseException as error:
+        if mutating:
+            if isinstance(error, Exception):
+                logger.warning(
+                    "Source publication RPC committed but connection close failed; "
+                    "phase=%s error_type=%s",
+                    phase,
+                    type(error).__name__,
+                )
+            else:
+                raise PostCommitError(
+                    "source publication RPC committed before close was interrupted"
+                ) from error
+        else:
+            raise
+    return row
+
+
+def _rpc(
+    dsn: str,
+    statement: str,
+    args: tuple[Any, ...],
+    *,
+    mutating: bool,
+    state: _MutationState | None = None,
+    phase: str | None = None,
+) -> tuple[Any, ...] | None:
+    return _execute_rpc(
+        _connect,
+        dsn,
+        statement,
+        args,
+        mutating=mutating,
+        state=state,
+        phase=phase,
+    )
+
+
+def _get_plan(dsn: str, asset: SourcePublicationAsset, season: int) -> dict[str, Any]:
+    row = _rpc(
+        dsn,
+        "SELECT warehouse_source_batch.get_source_plan(%s,%s)",
+        (asset.source_name, season),
+        mutating=False,
+    )
+    if row is None:
+        raise SourcePublicationError("publisher returned no source plan")
+    return _validated_plan(row[0], asset, season)
+
+
+def _start_run(dsn: str, run_id: str, plan: dict[str, Any], state: _MutationState) -> None:
+    row = _rpc(
+        dsn,
+        "SELECT warehouse_source_batch.start_source_load(%s,%s)",
+        (run_id, Json(plan)),
+        mutating=True,
+        state=state,
+        phase="start",
+    )
+    if row is None or str(row[0]) != run_id:
+        raise UncertainCommitError("publisher committed an unrecognized operation result")
+
+
+def _json_default(value: Any) -> str:
+    if isinstance(value, (date, datetime)):
+        return value.isoformat()
+    raise TypeError(f"{type(value).__name__} is not JSON serializable")
+
+
+def _json_dumps(value: Any) -> str:
+    return json.dumps(value, default=_json_default, allow_nan=False)
+
+
+def _publish(
+    dsn: str,
+    run_id: str,
+    generation_id: str,
+    sha256: str,
+    stage: _StageResult,
+    state: _MutationState,
+) -> tuple[str, bool, int]:
+    row = _rpc(
+        dsn,
+        "SELECT * FROM warehouse_source_batch.publish_source_load(%s,%s,%s,%s,%s)",
+        (
+            run_id,
+            generation_id,
+            sha256,
+            Json(stage.rows, dumps=_json_dumps),
+            Json(stage.evidence),
+        ),
+        mutating=True,
+        state=state,
+        phase="publish",
+    )
+    if row is None or len(row) != 3:
+        raise UncertainCommitError("publisher committed an unrecognized publication result")
+    returned_generation, replayed, published_rows = row
+    if (
+        str(returned_generation) != generation_id
+        or type(replayed) is not bool
+        or type(published_rows) is not int
+        or published_rows != len(stage.rows)
+    ):
+        raise UncertainCommitError("publisher committed a mismatched publication result")
+    return str(returned_generation), replayed, published_rows
+
+
+def _fail_run(
+    dsn: str,
+    run_id: str,
+    generation_id: str,
+    outcome: str,
+    state: _MutationState,
+) -> None:
+    row = _rpc(
+        dsn,
+        "SELECT warehouse_source_batch.fail_source_load(%s,%s,%s)",
+        (run_id, generation_id, outcome),
+        mutating=True,
+        state=state,
+        phase="failure",
+    )
+    if row is None or str(row[0]) != generation_id:
+        raise SourcePublicationError("publisher returned a mismatched failure generation id")
+
+
+def _is_lossless_bigint(value: Any) -> bool:
+    return value is None or type(value) is int and -(1 << 63) <= value < (1 << 63)
+
+
+def _raw_row_count(raw: bytes, asset: SourcePublicationAsset, season: int) -> int:
+    try:
+        parquet_file = pyarrow.parquet.ParquetFile(io.BytesIO(raw))
+        names = parquet_file.schema_arrow.names
+        if len(names) != len(set(names)) or frozenset(names) != _RAW_COLUMNS[asset.source_name]:
+            raise SourcePublicationError(
+                f"{asset.source_name} raw columns violate the parser contract"
+            )
+        row_count = parquet_file.metadata.num_rows
+        if row_count > MAX_SOURCE_ROWS:
+            raise SourcePublicationError(f"{asset.source_name} exceeds {MAX_SOURCE_ROWS} rows")
+        integer_columns, _, boolean_columns, _, _, _ = _type_sets(asset)
+        raw_integer_columns = sorted(integer_columns.intersection(names))
+        raw_boolean_columns = sorted(boolean_columns.intersection(names))
+        checked_columns = [*raw_integer_columns, *raw_boolean_columns]
+        for batch in parquet_file.iter_batches(batch_size=4_096, columns=checked_columns):
+            values_by_name = batch.to_pydict()
+            for column in raw_integer_columns:
+                if any(not _is_lossless_bigint(value) for value in values_by_name[column]):
+                    raise SourcePublicationError(
+                        f"{asset.source_name} raw column {column} has a non-integer value"
+                    )
+            for column in raw_boolean_columns:
+                if any(
+                    value is not None and type(value) is not bool
+                    for value in values_by_name[column]
+                ):
+                    raise SourcePublicationError(
+                        f"{asset.source_name} raw column {column} has a non-boolean value"
+                    )
+            if asset is SDV_FPI_PUBLICATION and any(
+                value is not None and value != season for value in values_by_name["season"]
+            ):
+                raise SourcePublicationError(
+                    "sdv_fpi_weekly raw season does not match requested season"
+                )
+    except Exception as error:
+        if isinstance(error, SourcePublicationError):
+            raise
+        raise SourcePublicationError(
+            f"{asset.source_name} is not a readable parquet file"
+        ) from error
+    return row_count
+
+
+def _type_sets(asset: SourcePublicationAsset) -> tuple[set[str] | frozenset[str], ...]:
+    if asset is SDV_FPI_PUBLICATION:
+        return _FPI_INTS, _FPI_DOUBLES, _FPI_BOOLS, _FPI_TIMESTAMPS, frozenset(), frozenset()
+    if asset is SDV_TEAM_XWALK_PUBLICATION:
+        return _TEAM_INTS, frozenset(), frozenset(), frozenset(), frozenset(), _TEAM_TEXT
+    return _GAME_INTS, frozenset(), frozenset(), frozenset(), _GAME_DATES, _GAME_TEXT
+
+
+def _validate_scalar(asset: SourcePublicationAsset, column: str, value: Any) -> None:
+    if value is None:
+        return
+    ints, doubles, bools, timestamps, dates, texts = _type_sets(asset)
+    if column in ints and type(value) is not int:
+        raise SourcePublicationError(f"{asset.source_name} column {column} is not an integer")
+    if column in doubles and (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(float(value))
+    ):
+        raise SourcePublicationError(f"{asset.source_name} column {column} is not finite")
+    if column in bools and type(value) is not bool:
+        raise SourcePublicationError(f"{asset.source_name} column {column} is not boolean")
+    if column in timestamps and not isinstance(value, datetime):
+        raise SourcePublicationError(f"{asset.source_name} column {column} is not a timestamp")
+    if column in timestamps and value.tzinfo is None:
+        raise SourcePublicationError(f"{asset.source_name} column {column} is not timezone-aware")
+    if column in dates and type(value) is not date:
+        raise SourcePublicationError(f"{asset.source_name} column {column} is not a date")
+    if column in texts and type(value) is not str:
+        raise SourcePublicationError(f"{asset.source_name} column {column} is not text")
+
+
+def _validate_parsed_rows(
+    rows: list[dict[str, Any]], raw_count: int, asset: SourcePublicationAsset, season: int
+) -> None:
+    if raw_count == 0 or not rows:
+        raise SourcePublicationError(f"{asset.source_name} season file must be nonempty")
+    if raw_count > MAX_SOURCE_ROWS or len(rows) > MAX_SOURCE_ROWS:
+        raise SourcePublicationError(f"{asset.source_name} exceeds {MAX_SOURCE_ROWS} rows")
+    if len(rows) != raw_count:
+        raise SourcePublicationError(f"{asset.source_name} parser dropped or added source rows")
+
+    expected_columns = frozenset(asset.columns)
+    keys: set[tuple[Any, ...]] = set()
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict) or frozenset(row) != expected_columns:
+            raise SourcePublicationError(
+                f"{asset.source_name} row {index} does not match the "
+                f"{len(asset.columns)}-column parser contract"
+            )
+        if row["season"] != season:
+            raise SourcePublicationError(
+                f"{asset.source_name} row season does not match requested season"
+            )
+        key = tuple(row[column] for column in asset.primary_key)
+        if any(value is None for value in key):
+            raise SourcePublicationError(f"{asset.source_name} contains a null primary-key value")
+        if key in keys:
+            raise SourcePublicationError(f"{asset.source_name} contains a duplicate primary key")
+        keys.add(key)
+        for column, value in row.items():
+            _validate_scalar(asset, column, value)
+
+        if asset is SDV_FPI_PUBLICATION:
+            if row["season_type"] not in {2, 3}:
+                raise SourcePublicationError("sdv_fpi_weekly season_type must be 2 or 3")
+            if row["week"] < 0:
+                raise SourcePublicationError("sdv_fpi_weekly week must be nonnegative")
+            if row["team_id"] <= 0:
+                raise SourcePublicationError("sdv_fpi_weekly team_id must be positive")
+
+        if asset is SDV_TEAM_XWALK_PUBLICATION:
+            tiebreak = row["espn_team_id"]
+            if tiebreak is None:
+                tiebreak = row["fox_team_id"]
+            if tiebreak is None:
+                tiebreak = row["yahoo_team_id"]
+            if row["xwalk_key"] != f"{row['norm_key']}#{tiebreak}":
+                raise SourcePublicationError("sdv_team_xwalk contains an invalid derived xwalk_key")
+
+
+def _column_hints(asset: SourcePublicationAsset) -> list[dict[str, Any]]:
+    ints, doubles, bools, timestamps, dates, _ = _type_sets(asset)
+    hints = []
+    for name in asset.columns:
+        data_type = (
+            "bigint"
+            if name in ints
+            else "double"
+            if name in doubles
+            else "bool"
+            if name in bools
+            else "timestamp"
+            if name in timestamps
+            else "date"
+            if name in dates
+            else "text"
+        )
+        required = set(asset.primary_key)
+        if asset is SDV_TEAM_XWALK_PUBLICATION:
+            required.add("norm_key")
+        hints.append({"name": name, "data_type": data_type, "nullable": name not in required})
+    return hints
+
+
+def _require_stage_schema(dsn: str) -> None:
+    conn = _connect(dsn)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT
+                    stage.nspowner = routines.nspowner,
+                    pg_catalog.has_schema_privilege(current_user, stage.oid, 'USAGE,CREATE'),
+                    NOT EXISTS (
+                        SELECT 1 FROM pg_catalog.aclexplode(stage.nspacl) acl
+                        WHERE acl.grantee NOT IN (
+                            stage.nspowner,
+                            (SELECT oid FROM pg_catalog.pg_roles WHERE rolname = current_user)
+                        )
+                    ),
+                    pg_catalog.to_regnamespace('warehouse_source_stage_staging') IS NULL
+                FROM pg_catalog.pg_namespace stage
+                JOIN pg_catalog.pg_namespace routines
+                  ON routines.nspname = 'warehouse_source_batch'
+                WHERE stage.nspname = %s
+                """,
+                (STAGE_SCHEMA,),
+            )
+            row = cur.fetchone()
+        conn.rollback()
+    finally:
+        conn.close()
+    if row is None or row != (True, True, True, True):
+        raise SourcePublicationError("managed warehouse_source_stage boundary is unavailable")
+
+
+def _read_stage(
+    dsn: str,
+    table: str,
+    expected_rows: int,
+    asset: SourcePublicationAsset,
+    artifact_origin: str,
+    season_basis: str,
+) -> _StageResult:
+    conn = _connect(dsn)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT a.attname
+                FROM pg_catalog.pg_attribute a
+                WHERE a.attrelid = pg_catalog.to_regclass(%s)
+                  AND a.attnum > 0 AND NOT a.attisdropped
+                ORDER BY a.attnum
+                """,
+                (f"{STAGE_SCHEMA}.{table}",),
+            )
+            stage_columns = {name for (name,) in cur.fetchall()}
+            expected_columns = frozenset((*asset.columns, *_STAGE_SYSTEM_COLUMNS))
+            if stage_columns != expected_columns:
+                raise SourcePublicationError(
+                    "normalized staging columns violate the parser contract"
+                )
+            selected = [sql.Identifier(name) for name in (*asset.columns, *_STAGE_SYSTEM_COLUMNS)]
+            order = [sql.Identifier(name) for name in asset.primary_key]
+            cur.execute(
+                sql.SQL("SELECT {} FROM {}.{} ORDER BY {}").format(
+                    sql.SQL(",").join(selected),
+                    sql.Identifier(STAGE_SCHEMA),
+                    sql.Identifier(table),
+                    sql.SQL(",").join(order),
+                )
+            )
+            names = [description.name for description in cur.description]
+            rows = [dict(zip(names, values, strict=True)) for values in cur.fetchall()]
+            if len(rows) != expected_rows:
+                raise SourcePublicationError(
+                    "dlt staging row count does not match parsed source rows"
+                )
+            load_ids = sorted({row["_dlt_load_id"] for row in rows})
+            if not load_ids or any(not isinstance(value, str) or not value for value in load_ids):
+                raise SourcePublicationError("dlt staging rows do not carry actual load ids")
+            if any(not isinstance(row["_dlt_id"], str) or not row["_dlt_id"] for row in rows):
+                raise SourcePublicationError("dlt staging rows do not carry actual row ids")
+            cur.execute(
+                sql.SQL(
+                    "SELECT load_id FROM {}._dlt_loads "
+                    "WHERE load_id = ANY(%s) AND status = 0 ORDER BY load_id"
+                ).format(sql.Identifier(STAGE_SCHEMA)),
+                (load_ids,),
+            )
+            if [load_id for (load_id,) in cur.fetchall()] != load_ids:
+                raise SourcePublicationError("dlt staging load evidence is incomplete")
+        conn.rollback()
+    finally:
+        conn.close()
+    return _StageResult(
+        table=table,
+        rows=rows,
+        evidence={
+            "stage_schema": STAGE_SCHEMA,
+            "parser_contract": asset.parser_contract,
+            "dlt_load_ids": load_ids,
+            "source_rows": len(rows),
+            "artifact_origin": artifact_origin,
+            "season_basis": season_basis,
+        },
+    )
+
+
+def _stage_table_name(source_name: str, run_id: str) -> str:
+    short_name = source_name.removeprefix("sdv_").removesuffix("_weekly")
+    return f"sdv_{short_name}_{uuid.UUID(run_id).hex}"
+
+
+def _stage_rows(
+    dsn: str,
+    spec: FlatFileSpec,
+    asset: SourcePublicationAsset,
+    raw: bytes,
+    ctx: ParseContext,
+    run_id: str,
+    expected_rows: int,
+    artifact_origin: str,
+    season_basis: str,
+) -> _StageResult:
+    _require_stage_schema(dsn)
+    table = _stage_table_name(asset.source_name, run_id)
+    stage_spec = replace(spec, table=table, write_disposition="append")
+    source = build_flat_file_source(stage_spec, raw, ctx, None)
+    source.resources[table].apply_hints(
+        columns=_column_hints(asset),
+        schema_contract={"tables": "evolve", "columns": "freeze", "data_type": "freeze"},
+    )
+    run_hex = uuid.UUID(run_id).hex
+    with tempfile.TemporaryDirectory(prefix="sdv-source-dlt-") as pipelines_dir:
+        pipeline = dlt.pipeline(
+            pipeline_name=f"sdv_source_publication_{run_hex}",
+            pipelines_dir=pipelines_dir,
+            destination=postgres(credentials=dsn),
+            dataset_name=STAGE_SCHEMA,
+        )
+        load_info = pipeline.run(source)
+        load_info.raise_on_failed_jobs()
+        normalized_count = pipeline.last_trace.last_normalize_info.row_counts.get(table, 0)
+    if normalized_count != expected_rows:
+        raise SourcePublicationError("dlt normalized row count does not match parsed source rows")
+    return _read_stage(dsn, table, expected_rows, asset, artifact_origin, season_basis)
+
+
+def _drop_stage_table(dsn: str, table: str) -> None:
+    conn = _connect(dsn)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                sql.SQL("DROP TABLE IF EXISTS {}.{}").format(
+                    sql.Identifier(STAGE_SCHEMA), sql.Identifier(table)
+                )
+            )
+        conn.commit()
+    except BaseException:
+        try:
+            conn.rollback()
+        except Exception:
+            pass
+        raise
+    finally:
+        conn.close()
+
+
+def _known_error_text(
+    error: BaseException, source_name: str, run_id: str, generation_id: str
+) -> str:
+    if isinstance(error, SourcePublicationError):
+        detail = str(error)
+    elif isinstance(error, httpx.HTTPStatusError) and error.response.status_code == 404:
+        detail = f"{source_name} season file is not published"
+    else:
+        detail = f"{source_name} source publication failed"
+    return f"{detail}; run_id={run_id}; generation_id={generation_id}"[:ERROR_MESSAGE_LIMIT]
+
+
+def _generic_work(
+    dsn: str,
+    spec: FlatFileSpec,
+    file_path: str | None,
+    season: int,
+    run_id: str,
+    generation_id: str,
+    state: _MutationState,
+    context: _RunContext,
+) -> tuple[str, int]:
+    asset = SOURCE_PUBLICATION_ASSETS[spec.name]
+    if file_path is not None:
+        local_path = Path(file_path)
+        if "://" in file_path or not local_path.is_file():
+            raise SourcePublicationError("receipt file override must be an existing local file")
+        target = file_path
+        artifact_origin = "local_file"
+    else:
+        target = resolve_fetch_url(spec, season)
+        artifact_origin = "registered_url"
+    if not target:
+        raise SourcePublicationError(f"{asset.source_name} has no fetch target")
+    fetched = fetch_file(target)
+    if fetched.sha256 != hashlib.sha256(fetched.content).hexdigest():
+        raise SourcePublicationError("fetched source SHA-256 does not match its bytes")
+    context.source_sha = fetched.sha256
+    season_basis = asset.season_basis(artifact_origin)
+    ctx = ParseContext(
+        source=spec.name,
+        snapshot_date=date.today(),
+        season=season,
+        source_url=fetched.source_url,
+        file_name=os.path.basename(fetched.source_url),
+    )
+    raw_count = _raw_row_count(fetched.content, asset, season)
+    parsed_rows = list(resolve_parser(spec.parser)(fetched.content, ctx))
+    _validate_parsed_rows(parsed_rows, raw_count, asset, season)
+    context.stage_table = _stage_table_name(asset.source_name, run_id)
+    stage = _stage_rows(
+        dsn,
+        spec,
+        asset,
+        fetched.content,
+        ctx,
+        run_id,
+        len(parsed_rows),
+        artifact_origin,
+        season_basis,
+    )
+    if stage.table != context.stage_table:
+        raise SourcePublicationError("dlt returned a mismatched staging table")
+    _, _, published_rows = _publish(dsn, run_id, generation_id, fetched.sha256, stage, state)
+    return fetched.sha256, published_rows
+
+
+def _run_publication_lifecycle(
+    spec: FlatFileSpec,
+    *,
+    file_path: str | None,
+    season: int,
+    hooks: _LifecycleHooks,
+) -> dict[str, Any]:
+    """Run shared start/work/terminal-failure/cleanup transaction semantics."""
+    started_at = time.monotonic()
+    run_id = str(hooks.new_id())
+    generation_id = str(hooks.new_id())
+    result = _base_result(hooks.source_name, run_id, generation_id)
+    state = _MutationState()
+    context = _RunContext()
+    dsn = ""
+    try:
+        hooks.preflight(spec, season)
+        dsn = hooks.get_db_url()
+        plan = hooks.get_plan(dsn, season)
+        hooks.start_run(dsn, run_id, plan, state)
+        sha256, published_rows = hooks.work(
+            dsn,
+            spec,
+            file_path,
+            season,
+            run_id,
+            generation_id,
+            state,
+            context,
+        )
+        context.terminal_confirmed = True
+        result.update(status="loaded", rows=published_rows, sha=sha256)
+        return result
+    except UncertainCommitError as error:
+        context.terminal_confirmed = state.published
+        result["error"] = (f"{error}; run_id={run_id}; generation_id={generation_id}")[
+            :ERROR_MESSAGE_LIMIT
+        ]
+        if isinstance(error.__cause__, (KeyboardInterrupt, SystemExit)):
+            raise error.__cause__
+        logger.error(result["error"])
+        return result
+    except BaseException as error:
+        if isinstance(error, (KeyboardInterrupt, SystemExit)):
+            interrupt = error
+        elif isinstance(error.__cause__, (KeyboardInterrupt, SystemExit)):
+            interrupt = error.__cause__
+        else:
+            interrupt = None
+        deferred = isinstance(error, httpx.HTTPStatusError) and error.response.status_code == 404
+        blocked = isinstance(error, psycopg2.Error) and error.pgcode in {"40001", "55000"}
+        outcome = "deferred" if deferred else "blocked" if blocked else "failed"
+        result["status"] = "not_published" if deferred else outcome
+        result["error"] = hooks.known_error_text(error, run_id, generation_id)
+        if state.published:
+            context.terminal_confirmed = True
+        elif state.started and not state.publish_pending:
+            try:
+                hooks.fail_run(dsn, run_id, generation_id, outcome, state)
+                context.terminal_confirmed = True
+            except (UncertainCommitError, PostCommitError) as failure_error:
+                context.terminal_confirmed = state.failure_recorded
+                logger.error(
+                    "Source failure receipt was not confirmed; source=%s "
+                    "run_id=%s generation_id=%s",
+                    hooks.source_name,
+                    run_id,
+                    generation_id,
+                )
+                if isinstance(failure_error.__cause__, (KeyboardInterrupt, SystemExit)):
+                    raise failure_error.__cause__
+            except Exception:
+                context.terminal_confirmed = state.failure_recorded
+                logger.error(
+                    "Source failure receipt was not confirmed; source=%s "
+                    "run_id=%s generation_id=%s",
+                    hooks.source_name,
+                    run_id,
+                    generation_id,
+                )
+        if interrupt is not None:
+            raise interrupt
+        return result
+    finally:
+        if (
+            context.stage_table is not None
+            and dsn
+            and (context.terminal_confirmed or state.published or state.failure_recorded)
+        ):
+            try:
+                hooks.drop_stage(dsn, context.stage_table)
+            except Exception:
+                logger.warning(
+                    "Could not drop terminal stage table %s; run_id=%s",
+                    context.stage_table,
+                    run_id,
+                )
+        result["duration_s"] = time.monotonic() - started_at
+        if context.source_sha is not None:
+            result["sha"] = context.source_sha
+
+
+def run_source_publication(
+    spec: FlatFileSpec,
+    *,
+    file_path: str | None = None,
+    season: int,
+) -> dict[str, Any]:
+    """Publish one complete enrolled SportsDataverse season file."""
+    if spec.name == "sdv_ratings_weekly":
+        from src.pipelines.utils.sdv_ratings_publication import (
+            run_sdv_ratings_publication,
+        )
+
+        return run_sdv_ratings_publication(spec, file_path=file_path, season=season)
+
+    hooks = _LifecycleHooks(
+        source_name=spec.name,
+        new_id=uuid.uuid4,
+        preflight=lambda selected_spec, selected_season: _asset_for(selected_spec, selected_season),
+        get_db_url=get_db_url,
+        get_plan=lambda dsn, selected_season: _get_plan(
+            dsn, SOURCE_PUBLICATION_ASSETS[spec.name], selected_season
+        ),
+        start_run=_start_run,
+        work=_generic_work,
+        fail_run=_fail_run,
+        drop_stage=_drop_stage_table,
+        known_error_text=lambda error, run_id, generation_id: _known_error_text(
+            error, spec.name, run_id, generation_id
+        ),
+    )
+    return _run_publication_lifecycle(spec, file_path=file_path, season=season, hooks=hooks)
+
+
+__all__ = ["run_source_publication"]

--- a/src/pipelines/utils/flat_file_publication.py
+++ b/src/pipelines/utils/flat_file_publication.py
@@ -415,6 +415,18 @@ def _is_lossless_bigint(value: Any) -> bool:
     return value is None or type(value) is int and -(1 << 63) <= value < (1 << 63)
 
 
+def _is_lossless_double(value: Any) -> bool:
+    if value is None:
+        return True
+    if type(value) not in (int, float):
+        return False
+    try:
+        converted = float(value)
+    except OverflowError:
+        return False
+    return math.isfinite(converted) and converted == value
+
+
 def _raw_row_count(raw: bytes, asset: SourcePublicationAsset, season: int) -> int:
     try:
         parquet_file = pyarrow.parquet.ParquetFile(io.BytesIO(raw))
@@ -426,16 +438,22 @@ def _raw_row_count(raw: bytes, asset: SourcePublicationAsset, season: int) -> in
         row_count = parquet_file.metadata.num_rows
         if row_count > MAX_SOURCE_ROWS:
             raise SourcePublicationError(f"{asset.source_name} exceeds {MAX_SOURCE_ROWS} rows")
-        integer_columns, _, boolean_columns, _, _, _ = _type_sets(asset)
+        integer_columns, double_columns, boolean_columns, _, _, _ = _type_sets(asset)
         raw_integer_columns = sorted(integer_columns.intersection(names))
+        raw_double_columns = sorted(double_columns.intersection(names))
         raw_boolean_columns = sorted(boolean_columns.intersection(names))
-        checked_columns = [*raw_integer_columns, *raw_boolean_columns]
+        checked_columns = [*raw_integer_columns, *raw_double_columns, *raw_boolean_columns]
         for batch in parquet_file.iter_batches(batch_size=4_096, columns=checked_columns):
             values_by_name = batch.to_pydict()
             for column in raw_integer_columns:
                 if any(not _is_lossless_bigint(value) for value in values_by_name[column]):
                     raise SourcePublicationError(
                         f"{asset.source_name} raw column {column} has a non-integer value"
+                    )
+            for column in raw_double_columns:
+                if any(not _is_lossless_double(value) for value in values_by_name[column]):
+                    raise SourcePublicationError(
+                        f"{asset.source_name} raw column {column} is not a lossless finite number"
                     )
             for column in raw_boolean_columns:
                 if any(

--- a/src/pipelines/utils/sdv_ratings_publication.py
+++ b/src/pipelines/utils/sdv_ratings_publication.py
@@ -14,7 +14,6 @@ import logging
 import math
 import os
 import tempfile
-import time
 import uuid
 from dataclasses import dataclass, replace
 from datetime import date
@@ -39,6 +38,18 @@ from src.pipelines.sources.flat_files import (
     resolve_parser,
 )
 from src.pipelines.utils.file_fetcher import fetch_file
+from src.pipelines.utils.flat_file_publication import (
+    PostCommitError as PostCommitError,
+)
+from src.pipelines.utils.flat_file_publication import (
+    SourcePublicationError,
+    UncertainCommitError,
+    _execute_rpc,
+    _LifecycleHooks,
+    _MutationState,
+    _run_publication_lifecycle,
+    _RunContext,
+)
 from src.pipelines.utils.load_ledger import get_db_url
 
 logger = logging.getLogger(__name__)
@@ -65,59 +76,11 @@ _STAGE_SYSTEM_COLUMNS = ("_dlt_id", "_dlt_load_id")
 _EXPECTED_STAGE_COLUMNS = frozenset((*SDV_RATINGS_PUBLICATION.columns, *_STAGE_SYSTEM_COLUMNS))
 
 
-class SourcePublicationError(RuntimeError):
-    """A known pre-commit publication failure."""
-
-
-class UncertainCommitError(RuntimeError):
-    """The client cannot determine whether a mutating RPC committed."""
-
-
-class PostCommitError(RuntimeError):
-    """A non-transactional error occurred after a confirmed RPC commit."""
-
-
 @dataclass(frozen=True)
 class _StageResult:
     table: str
     rows: list[dict[str, Any]]
     evidence: dict[str, Any]
-
-
-@dataclass
-class _MutationState:
-    start_pending: bool = False
-    started: bool = False
-    publish_pending: bool = False
-    published: bool = False
-    failure_pending: bool = False
-    failure_recorded: bool = False
-
-    def set_pending(self, phase: str) -> None:
-        setattr(self, f"{phase}_pending", True)
-
-    def set_committed(self, phase: str) -> None:
-        committed = {"start": "started", "publish": "published", "failure": "failure_recorded"}
-        setattr(self, committed[phase], True)
-        # Keep the conservative pending state until the confirmed state is set.
-        # An asynchronous interrupt between these assignments can therefore
-        # never make a successful commit look safe to relabel as failed.
-        setattr(self, f"{phase}_pending", False)
-
-
-def _base_result(run_id: str, generation_id: str) -> dict[str, Any]:
-    return {
-        "source": SDV_RATINGS_PUBLICATION.source_name,
-        "status": "failed",
-        "rows": 0,
-        "sha": None,
-        "duration_s": 0.0,
-        "error": None,
-        "unmapped": None,
-        "gaps": None,
-        "run_id": run_id,
-        "generation_id": generation_id,
-    }
 
 
 def _validate_supported_spec(spec: FlatFileSpec, season: int) -> None:
@@ -175,61 +138,15 @@ def _rpc(
     state: _MutationState | None = None,
     phase: str | None = None,
 ) -> tuple[Any, ...] | None:
-    if mutating != (state is not None and phase in {"start", "publish", "failure"}):
-        raise ValueError("mutating RPCs require an explicit mutation phase and state")
-    conn = _connect(dsn)
-    try:
-        with conn.cursor() as cur:
-            cur.execute(sql.SQL("SET LOCAL ROLE {}").format(sql.Identifier(_ROLE)))
-            cur.execute("SET LOCAL statement_timeout = '60s'")
-            cur.execute(statement, args)
-            row = cur.fetchone() if cur.description else None
-    except BaseException:
-        try:
-            conn.rollback()
-        except Exception:
-            pass
-        try:
-            conn.close()
-        except Exception:
-            pass
-        raise
-
-    if mutating:
-        assert state is not None and phase is not None
-        state.set_pending(phase)
-    try:
-        conn.commit()
-    except BaseException as error:
-        try:
-            conn.close()
-        except Exception:
-            pass
-        if mutating:
-            raise UncertainCommitError(
-                "source publication RPC commit outcome is uncertain"
-            ) from error
-        raise
-    if mutating:
-        state.set_committed(phase)
-    try:
-        conn.close()
-    except BaseException as error:
-        if mutating:
-            if isinstance(error, Exception):
-                logger.warning(
-                    "Source publication RPC committed but connection close failed; "
-                    "phase=%s error_type=%s",
-                    phase,
-                    type(error).__name__,
-                )
-            else:
-                raise PostCommitError(
-                    "source publication RPC committed before close was interrupted"
-                ) from error
-        else:
-            raise
-    return row
+    return _execute_rpc(
+        _connect,
+        dsn,
+        statement,
+        args,
+        mutating=mutating,
+        state=state,
+        phase=phase,
+    )
 
 
 def _get_plan(dsn: str, season: int) -> dict[str, Any]:
@@ -583,6 +500,60 @@ def _known_error_text(error: BaseException, run_id: str, generation_id: str) -> 
     return f"{detail}; run_id={run_id}; generation_id={generation_id}"[:ERROR_MESSAGE_LIMIT]
 
 
+def _ratings_work(
+    dsn: str,
+    spec: FlatFileSpec,
+    file_path: str | None,
+    season: int,
+    run_id: str,
+    generation_id: str,
+    state: _MutationState,
+    context: _RunContext,
+) -> tuple[str, int]:
+    if file_path is not None:
+        local_path = Path(file_path)
+        if "://" in file_path or not local_path.is_file():
+            raise SourcePublicationError("receipt file override must be an existing local file")
+        target = file_path
+        artifact_origin = "local_file"
+    else:
+        target = resolve_fetch_url(spec, season)
+        artifact_origin = "registered_url"
+    if not target:
+        raise SourcePublicationError("sdv_ratings_weekly has no fetch target")
+    fetched = fetch_file(target)
+    if fetched.sha256 != hashlib.sha256(fetched.content).hexdigest():
+        raise SourcePublicationError("fetched SDV ratings SHA-256 does not match its bytes")
+    context.source_sha = fetched.sha256
+    ctx = ParseContext(
+        source=spec.name,
+        snapshot_date=date.today(),
+        season=season,
+        source_url=fetched.source_url,
+        file_name=os.path.basename(fetched.source_url),
+    )
+    raw_count = _raw_row_count(fetched.content)
+    if raw_count > MAX_SOURCE_ROWS:
+        raise SourcePublicationError(f"sdv_ratings_weekly exceeds {MAX_SOURCE_ROWS} rows")
+    parser = resolve_parser(spec.parser)
+    parsed_rows = list(parser(fetched.content, ctx))
+    _validate_parsed_rows(parsed_rows, raw_count, season)
+    context.stage_table = _stage_table_name(run_id)
+    stage = _stage_rows(
+        dsn,
+        spec,
+        fetched.content,
+        ctx,
+        run_id,
+        len(parsed_rows),
+        artifact_origin,
+    )
+    if stage.table != context.stage_table:
+        raise SourcePublicationError("dlt returned a mismatched staging table")
+    _, _, published_rows = _publish(dsn, run_id, generation_id, fetched.sha256, stage, state)
+    return fetched.sha256, published_rows
+
+
 def run_sdv_ratings_publication(
     spec: FlatFileSpec,
     *,
@@ -590,145 +561,19 @@ def run_sdv_ratings_publication(
     season: int,
 ) -> dict[str, Any]:
     """Publish one complete SDV ratings season through the bounded SQL RPCs."""
-
-    started_at = time.monotonic()
-    run_id = str(uuid.uuid4())
-    generation_id = str(uuid.uuid4())
-    result = _base_result(run_id, generation_id)
-    stage_table: str | None = None
-    state = _MutationState()
-    terminal_confirmed = False
-
-    try:
-        _validate_supported_spec(spec, season)
-        dsn = get_db_url()
-        plan = _get_plan(dsn, season)
-        _start_run(dsn, run_id, plan, state)
-
-        if file_path is not None:
-            local_path = Path(file_path)
-            if "://" in file_path or not local_path.is_file():
-                raise SourcePublicationError("receipt file override must be an existing local file")
-            target = file_path
-            artifact_origin = "local_file"
-        else:
-            target = resolve_fetch_url(spec, season)
-            artifact_origin = "registered_url"
-        if not target:
-            raise SourcePublicationError("sdv_ratings_weekly has no fetch target")
-        fetched = fetch_file(target)
-        if fetched.sha256 != hashlib.sha256(fetched.content).hexdigest():
-            raise SourcePublicationError("fetched SDV ratings SHA-256 does not match its bytes")
-        result["sha"] = fetched.sha256
-        ctx = ParseContext(
-            source=spec.name,
-            snapshot_date=date.today(),
-            season=season,
-            source_url=fetched.source_url,
-            file_name=os.path.basename(fetched.source_url),
-        )
-        raw_count = _raw_row_count(fetched.content)
-        if raw_count > MAX_SOURCE_ROWS:
-            raise SourcePublicationError(f"sdv_ratings_weekly exceeds {MAX_SOURCE_ROWS} rows")
-        parser = resolve_parser(spec.parser)
-        parsed_rows = list(parser(fetched.content, ctx))
-        _validate_parsed_rows(parsed_rows, raw_count, season)
-
-        # Set before dlt starts so a known stage failure or interrupt can clean
-        # up a table created before pipeline.run returned to us.
-        stage_table = _stage_table_name(run_id)
-        stage = _stage_rows(
-            dsn,
-            spec,
-            fetched.content,
-            ctx,
-            run_id,
-            len(parsed_rows),
-            artifact_origin,
-        )
-        if stage.table != stage_table:
-            raise SourcePublicationError("dlt returned a mismatched staging table")
-        _, _, published_rows = _publish(dsn, run_id, generation_id, fetched.sha256, stage, state)
-        terminal_confirmed = True
-        result.update(status="loaded", rows=published_rows)
-        return result
-    except UncertainCommitError as error:
-        # Never retry or write a contradictory failure after an uncertain commit.
-        terminal_confirmed = state.published
-        logger.error(
-            "SDV ratings commit/result is uncertain; run_id=%s generation_id=%s",
-            run_id,
-            generation_id,
-        )
-        if isinstance(error.__cause__, (KeyboardInterrupt, SystemExit)):
-            raise error.__cause__
-        result["error"] = (f"{error}; run_id={run_id}; generation_id={generation_id}")[
-            :ERROR_MESSAGE_LIMIT
-        ]
-        logger.error(result["error"])
-        return result
-    except BaseException as error:
-        interrupt = (
-            error
-            if isinstance(error, (KeyboardInterrupt, SystemExit))
-            else error.__cause__
-            if isinstance(error.__cause__, (KeyboardInterrupt, SystemExit))
-            else None
-        )
-        deferred = isinstance(error, httpx.HTTPStatusError) and error.response.status_code == 404
-        blocked = isinstance(error, psycopg2.Error) and error.pgcode in {"40001", "55000"}
-        outcome = "deferred" if deferred else "blocked" if blocked else "failed"
-        result["status"] = "not_published" if deferred else outcome
-        result["error"] = _known_error_text(error, run_id, generation_id)
-        if state.published:
-            # The publish commit is authoritative even if connection close or
-            # local response handling was interrupted afterward.
-            terminal_confirmed = True
-        elif state.started and not state.publish_pending:
-            try:
-                _fail_run(dsn, run_id, generation_id, outcome, state)
-                terminal_confirmed = True
-            except UncertainCommitError as failure_error:
-                logger.error(
-                    "SDV ratings failure commit outcome is uncertain; run_id=%s generation_id=%s",
-                    run_id,
-                    generation_id,
-                )
-                if isinstance(failure_error.__cause__, (KeyboardInterrupt, SystemExit)):
-                    raise failure_error.__cause__
-            except PostCommitError as failure_error:
-                terminal_confirmed = state.failure_recorded
-                logger.error(
-                    "SDV ratings failure committed before connection close failed; "
-                    "run_id=%s generation_id=%s",
-                    run_id,
-                    generation_id,
-                )
-                if isinstance(failure_error.__cause__, (KeyboardInterrupt, SystemExit)):
-                    raise failure_error.__cause__
-            except Exception:
-                terminal_confirmed = state.failure_recorded
-                logger.error(
-                    "SDV ratings failure receipt was not confirmed; run_id=%s generation_id=%s",
-                    run_id,
-                    generation_id,
-                )
-        if interrupt is not None:
-            raise interrupt
-        return result
-    finally:
-        if stage_table is not None and (
-            terminal_confirmed or state.published or state.failure_recorded
-        ):
-            try:
-                _drop_stage_table(dsn, stage_table)
-            except Exception:
-                logger.warning(
-                    "Could not drop terminal SDV ratings stage table %s; run_id=%s",
-                    stage_table,
-                    run_id,
-                )
-        result["duration_s"] = time.monotonic() - started_at
+    hooks = _LifecycleHooks(
+        source_name=SDV_RATINGS_PUBLICATION.source_name,
+        new_id=uuid.uuid4,
+        preflight=_validate_supported_spec,
+        get_db_url=get_db_url,
+        get_plan=_get_plan,
+        start_run=_start_run,
+        work=_ratings_work,
+        fail_run=_fail_run,
+        drop_stage=_drop_stage_table,
+        known_error_text=_known_error_text,
+    )
+    return _run_publication_lifecycle(spec, file_path=file_path, season=season, hooks=hooks)
 
 
 __all__ = ["run_sdv_ratings_publication"]

--- a/src/schemas/migrations/072_sdv_source_batch_publication.sql
+++ b/src/schemas/migrations/072_sdv_source_batch_publication.sql
@@ -1,0 +1,1565 @@
+-- F14/F28 source publication: extend the opt-in SDV season protocol to the
+-- remaining three sportsdataverse season files.  Migration 071's dedicated
+-- ratings.sdv_ratings_weekly entrypoints remain unchanged.
+
+ALTER TABLE meta.asset_publication_locks
+    DROP CONSTRAINT IF EXISTS asset_publication_locks_asset_key_check;
+ALTER TABLE meta.asset_publication_locks
+    ADD CONSTRAINT asset_publication_locks_asset_key_check CHECK (asset_key IN (
+        'analytics.house_elo_game',
+        'marts.house_elo_game',
+        'ratings.sdv_ratings_weekly',
+        'ratings.espn_fpi_weekly',
+        'ref.team_id_xwalk',
+        'ref.game_id_xwalk'
+    ));
+
+ALTER TABLE meta.asset_receipts
+    DROP CONSTRAINT IF EXISTS asset_receipts_coverage_key_check;
+ALTER TABLE meta.asset_receipts
+    ADD CONSTRAINT asset_receipts_coverage_key_check CHECK (
+        (asset_key IN ('analytics.house_elo_game', 'marts.house_elo_game')
+            AND coverage_key = 'source-wide')
+        OR
+        (asset_key IN (
+                'ratings.sdv_ratings_weekly', 'ratings.espn_fpi_weekly',
+                'ref.team_id_xwalk', 'ref.game_id_xwalk'
+            )
+            AND coverage_key ~
+                '^season:(18(69|[7-9][0-9])|19[0-9]{2}|20[0-9]{2}|21[0-9]{2}|2200)$')
+    );
+
+ALTER TABLE meta.asset_current_generations
+    DROP CONSTRAINT IF EXISTS asset_current_generations_coverage_key_check;
+ALTER TABLE meta.asset_current_generations
+    ADD CONSTRAINT asset_current_generations_coverage_key_check CHECK (
+        (asset_key IN ('analytics.house_elo_game', 'marts.house_elo_game')
+            AND coverage_key = 'source-wide')
+        OR
+        (asset_key IN (
+                'ratings.sdv_ratings_weekly', 'ratings.espn_fpi_weekly',
+                'ref.team_id_xwalk', 'ref.game_id_xwalk'
+            )
+            AND coverage_key ~
+                '^season:(18(69|[7-9][0-9])|19[0-9]{2}|20[0-9]{2}|21[0-9]{2}|2200)$')
+    );
+
+ALTER TABLE meta.asset_receipt_inputs
+    DROP CONSTRAINT IF EXISTS asset_receipt_inputs_input_coverage_key_check;
+ALTER TABLE meta.asset_receipt_inputs
+    ADD CONSTRAINT asset_receipt_inputs_input_coverage_key_check CHECK (
+        (input_asset_key IN ('analytics.house_elo_game', 'marts.house_elo_game')
+            AND input_coverage_key = 'source-wide')
+        OR
+        (input_asset_key IN (
+                'ratings.sdv_ratings_weekly', 'ratings.espn_fpi_weekly',
+                'ref.team_id_xwalk', 'ref.game_id_xwalk'
+            )
+            AND input_coverage_key ~
+                '^season:(18(69|[7-9][0-9])|19[0-9]{2}|20[0-9]{2}|21[0-9]{2}|2200)$')
+    );
+
+-- Keep the new protocol in its own routines-only namespace so neither the
+-- original publication nor migration 071 routine whitelist changes.
+DO $namespace$
+DECLARE ns record;
+BEGIN
+    SELECT oid, nspowner, nspacl INTO ns FROM pg_catalog.pg_namespace
+    WHERE nspname = 'warehouse_source_batch';
+    IF NOT FOUND THEN
+        CREATE SCHEMA warehouse_source_batch;
+    ELSIF ns.nspowner <> (SELECT oid FROM pg_catalog.pg_roles WHERE rolname = current_user)
+        OR EXISTS (SELECT 1 FROM pg_catalog.aclexplode(ns.nspacl) a
+            WHERE a.grantee <> ns.nspowner AND a.privilege_type = 'CREATE')
+        OR EXISTS (SELECT 1 FROM pg_catalog.pg_type WHERE typnamespace = ns.oid)
+        OR EXISTS (
+            SELECT 1 FROM pg_catalog.pg_proc p WHERE p.pronamespace = ns.oid
+              AND (p.proowner <> ns.nspowner OR p.prokind <> 'f'
+                OR p.provariadic <> 0 OR p.pronargdefaults <> 0
+                OR NOT COALESCE(p.oid = ANY(ARRAY[
+                    pg_catalog.to_regprocedure(
+                        'warehouse_source_batch.invalidate_row_pointer()'),
+                    pg_catalog.to_regprocedure(
+                        'warehouse_source_batch.invalidate_truncate_pointer()'),
+                    pg_catalog.to_regprocedure(
+                        'warehouse_source_batch.invalidate_ddl()'),
+                    pg_catalog.to_regprocedure(
+                        'warehouse_source_batch.invalidate_drop()'),
+                    pg_catalog.to_regprocedure(
+                        'warehouse_source_batch.get_source_plan(text,bigint)'),
+                    pg_catalog.to_regprocedure(
+                        'warehouse_source_batch.require_source_load(uuid)'),
+                    pg_catalog.to_regprocedure(
+                        'warehouse_source_batch.start_source_load(uuid,jsonb)'),
+                    pg_catalog.to_regprocedure(
+                        'warehouse_source_batch.publish_source_load(uuid,uuid,text,jsonb,jsonb)'),
+                    pg_catalog.to_regprocedure(
+                        'warehouse_source_batch.fail_source_load(uuid,uuid,text)')
+                ]::oid[]), false))
+        ) THEN
+        RAISE EXCEPTION
+            'warehouse_source_batch must be a trusted migration-owned routines namespace';
+    END IF;
+END
+$namespace$;
+
+DO $dependencies$
+DECLARE stage_ns record; ledger_oid oid := pg_catalog.to_regclass('meta.flat_file_loads');
+BEGIN
+    SELECT oid, nspowner, nspacl INTO stage_ns FROM pg_catalog.pg_namespace
+    WHERE nspname = 'warehouse_source_stage';
+    IF NOT FOUND
+        OR stage_ns.nspowner <>
+            (SELECT oid FROM pg_catalog.pg_roles WHERE rolname = current_user)
+        OR EXISTS (SELECT 1 FROM pg_catalog.aclexplode(stage_ns.nspacl) a
+            WHERE a.grantee <> stage_ns.nspowner) THEN
+        RAISE EXCEPTION 'warehouse_source_stage is not the trusted private staging namespace';
+    END IF;
+    IF ledger_oid IS NULL OR NOT EXISTS (
+        SELECT 1 FROM pg_catalog.pg_class c
+        WHERE c.oid = ledger_oid AND c.relkind = 'r'
+          AND c.relowner = (SELECT oid FROM pg_catalog.pg_roles WHERE rolname = current_user)
+    ) OR EXISTS (SELECT 1 FROM pg_catalog.pg_inherits i
+        WHERE i.inhrelid = ledger_oid OR i.inhparent = ledger_oid)
+      OR EXISTS (SELECT 1 FROM pg_catalog.pg_trigger t
+        WHERE t.tgrelid = ledger_oid AND NOT t.tgisinternal) THEN
+        RAISE EXCEPTION 'meta.flat_file_loads is not a trusted migration-owned ordinary table';
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_roles r
+        WHERE r.rolname = 'warehouse_source_publisher'
+          AND NOT r.rolcanlogin AND NOT r.rolinherit AND NOT r.rolsuper
+          AND NOT r.rolcreatedb AND NOT r.rolcreaterole AND NOT r.rolreplication
+          AND NOT r.rolbypassrls
+          AND NOT EXISTS (SELECT 1 FROM pg_catalog.pg_auth_members m
+              WHERE m.member = r.oid OR m.roleid = r.oid)) THEN
+        RAISE EXCEPTION
+            'warehouse_source_publisher must be a bounded membership-free NOLOGIN role';
+    END IF;
+END
+$dependencies$;
+
+-- Register exact relation identities.  Replacing a target is allowed only
+-- after its DDL guard has removed every current pointer.
+DO $assets$
+DECLARE
+    target record;
+    current_oid oid;
+    existing meta.asset_publication_locks%ROWTYPE;
+BEGIN
+    FOR target IN SELECT * FROM (VALUES
+        ('ratings.espn_fpi_weekly', 'ratings', 'espn_fpi_weekly'),
+        ('ref.team_id_xwalk', 'ref', 'team_id_xwalk'),
+        ('ref.game_id_xwalk', 'ref', 'game_id_xwalk')
+    ) AS t(asset_key, relation_schema, relation_name)
+    LOOP
+        current_oid := pg_catalog.to_regclass(pg_catalog.format(
+            '%I.%I', target.relation_schema, target.relation_name));
+        IF current_oid IS NULL OR NOT EXISTS (
+            SELECT 1 FROM pg_catalog.pg_class c
+            WHERE c.oid = current_oid AND c.relkind = 'r'
+              AND c.relowner = (SELECT oid FROM pg_catalog.pg_roles
+                  WHERE rolname = current_user)
+              AND NOT c.relrowsecurity AND NOT c.relforcerowsecurity
+              AND NOT c.relhasrules
+        ) OR EXISTS (SELECT 1 FROM pg_catalog.pg_inherits i
+            WHERE i.inhrelid = current_oid OR i.inhparent = current_oid)
+          OR EXISTS (
+            SELECT 1 FROM pg_catalog.pg_trigger tr
+            WHERE tr.tgrelid = current_oid AND NOT tr.tgisinternal
+              AND NOT (
+                tr.tgname = 'invalidate_sdv_source_batch_row_pointer'
+                AND tr.tgtype = 31
+                AND tr.tgqual IS NULL AND tr.tgnargs = 0
+                AND pg_catalog.octet_length(tr.tgargs) = 0
+                AND tr.tgattr::text = '' AND tr.tgconstraint = 0
+                AND NOT tr.tgdeferrable AND NOT tr.tginitdeferred
+                AND tr.tgparentid = 0
+                AND tr.tgfoid = pg_catalog.to_regprocedure(
+                    'warehouse_source_batch.invalidate_row_pointer()')
+                OR tr.tgname = 'invalidate_sdv_source_batch_truncate_pointer'
+                AND tr.tgtype = 34
+                AND tr.tgqual IS NULL AND tr.tgnargs = 0
+                AND pg_catalog.octet_length(tr.tgargs) = 0
+                AND tr.tgattr::text = '' AND tr.tgconstraint = 0
+                AND NOT tr.tgdeferrable AND NOT tr.tginitdeferred
+                AND tr.tgparentid = 0
+                AND tr.tgfoid = pg_catalog.to_regprocedure(
+                    'warehouse_source_batch.invalidate_truncate_pointer()')
+              )
+          ) THEN
+            RAISE EXCEPTION '% must be a trusted migration-owned ordinary table',
+                target.asset_key;
+        END IF;
+
+        SELECT * INTO existing FROM meta.asset_publication_locks l
+        WHERE l.asset_key = target.asset_key;
+        IF NOT FOUND THEN
+            INSERT INTO meta.asset_publication_locks(
+                asset_key, relation_schema, relation_name, relation_oid, relation_kind
+            ) VALUES (target.asset_key, target.relation_schema, target.relation_name,
+                current_oid, 'r'::"char");
+        ELSIF existing.relation_schema IS DISTINCT FROM target.relation_schema
+            OR existing.relation_name IS DISTINCT FROM target.relation_name
+            OR existing.relation_oid IS DISTINCT FROM current_oid
+            OR existing.relation_kind IS DISTINCT FROM 'r'::"char" THEN
+            IF EXISTS (SELECT 1 FROM meta.asset_current_generations p
+                WHERE p.asset_key = target.asset_key) THEN
+                RAISE EXCEPTION 'cannot adopt replacement % while a current pointer exists',
+                    target.asset_key;
+            END IF;
+            UPDATE meta.asset_publication_locks
+            SET relation_schema = target.relation_schema,
+                relation_name = target.relation_name,
+                relation_oid = current_oid,
+                relation_kind = 'r'::"char"
+            WHERE asset_key = target.asset_key;
+        END IF;
+    END LOOP;
+END
+$assets$;
+
+CREATE OR REPLACE FUNCTION warehouse_source_batch.invalidate_row_pointer()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $function$
+DECLARE asset text;
+BEGIN
+    asset := CASE TG_TABLE_SCHEMA || '.' || TG_TABLE_NAME
+        WHEN 'ratings.espn_fpi_weekly' THEN 'ratings.espn_fpi_weekly'
+        WHEN 'ref.team_id_xwalk' THEN 'ref.team_id_xwalk'
+        WHEN 'ref.game_id_xwalk' THEN 'ref.game_id_xwalk'
+        ELSE NULL END;
+    IF asset IS NULL THEN
+        RAISE EXCEPTION 'source invalidation trigger is attached to an untrusted target';
+    END IF;
+    DELETE FROM meta.asset_current_generations p
+    WHERE p.asset_key = asset
+      AND p.coverage_key IN (
+          CASE WHEN TG_OP IN ('UPDATE', 'DELETE') THEN 'season:' || OLD.season::text END,
+          CASE WHEN TG_OP IN ('UPDATE', 'INSERT') THEN 'season:' || NEW.season::text END
+      );
+    IF TG_OP = 'DELETE' THEN RETURN OLD; END IF;
+    RETURN NEW;
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION warehouse_source_batch.invalidate_truncate_pointer()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $function$
+DECLARE asset text;
+BEGIN
+    asset := CASE TG_TABLE_SCHEMA || '.' || TG_TABLE_NAME
+        WHEN 'ratings.espn_fpi_weekly' THEN 'ratings.espn_fpi_weekly'
+        WHEN 'ref.team_id_xwalk' THEN 'ref.team_id_xwalk'
+        WHEN 'ref.game_id_xwalk' THEN 'ref.game_id_xwalk'
+        ELSE NULL END;
+    IF asset IS NULL THEN
+        RAISE EXCEPTION 'source invalidation trigger is attached to an untrusted target';
+    END IF;
+    DELETE FROM meta.asset_current_generations p WHERE p.asset_key = asset;
+    RETURN NULL;
+END
+$function$;
+
+DROP TRIGGER IF EXISTS invalidate_sdv_source_batch_row_pointer
+    ON ratings.espn_fpi_weekly;
+CREATE TRIGGER invalidate_sdv_source_batch_row_pointer
+    BEFORE INSERT OR UPDATE OR DELETE ON ratings.espn_fpi_weekly
+    FOR EACH ROW EXECUTE FUNCTION warehouse_source_batch.invalidate_row_pointer();
+DROP TRIGGER IF EXISTS invalidate_sdv_source_batch_truncate_pointer
+    ON ratings.espn_fpi_weekly;
+CREATE TRIGGER invalidate_sdv_source_batch_truncate_pointer
+    BEFORE TRUNCATE ON ratings.espn_fpi_weekly
+    FOR EACH STATEMENT EXECUTE FUNCTION warehouse_source_batch.invalidate_truncate_pointer();
+
+DROP TRIGGER IF EXISTS invalidate_sdv_source_batch_row_pointer ON ref.team_id_xwalk;
+CREATE TRIGGER invalidate_sdv_source_batch_row_pointer
+    BEFORE INSERT OR UPDATE OR DELETE ON ref.team_id_xwalk
+    FOR EACH ROW EXECUTE FUNCTION warehouse_source_batch.invalidate_row_pointer();
+DROP TRIGGER IF EXISTS invalidate_sdv_source_batch_truncate_pointer ON ref.team_id_xwalk;
+CREATE TRIGGER invalidate_sdv_source_batch_truncate_pointer
+    BEFORE TRUNCATE ON ref.team_id_xwalk
+    FOR EACH STATEMENT EXECUTE FUNCTION warehouse_source_batch.invalidate_truncate_pointer();
+
+DROP TRIGGER IF EXISTS invalidate_sdv_source_batch_row_pointer ON ref.game_id_xwalk;
+CREATE TRIGGER invalidate_sdv_source_batch_row_pointer
+    BEFORE INSERT OR UPDATE OR DELETE ON ref.game_id_xwalk
+    FOR EACH ROW EXECUTE FUNCTION warehouse_source_batch.invalidate_row_pointer();
+DROP TRIGGER IF EXISTS invalidate_sdv_source_batch_truncate_pointer ON ref.game_id_xwalk;
+CREATE TRIGGER invalidate_sdv_source_batch_truncate_pointer
+    BEFORE TRUNCATE ON ref.game_id_xwalk
+    FOR EACH STATEMENT EXECUTE FUNCTION warehouse_source_batch.invalidate_truncate_pointer();
+
+CREATE OR REPLACE FUNCTION warehouse_source_batch.invalidate_ddl()
+RETURNS event_trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $function$
+DECLARE command record; target record; invalidate_all boolean := false; changed boolean;
+BEGIN
+    FOR command IN SELECT * FROM pg_catalog.pg_event_trigger_ddl_commands() LOOP
+        IF command.object_identity LIKE 'warehouse_source_batch.%'
+            OR command.object_identity IN (
+                'warehouse_source_batch_invalidate_ddl',
+                'warehouse_source_batch_invalidate_drop') THEN
+            invalidate_all := true;
+        END IF;
+        FOR target IN SELECT * FROM (VALUES
+            ('ratings.espn_fpi_weekly', 'ratings', 'espn_fpi_weekly'),
+            ('ref.team_id_xwalk', 'ref', 'team_id_xwalk'),
+            ('ref.game_id_xwalk', 'ref', 'game_id_xwalk')
+        ) AS t(asset_key, relation_schema, relation_name)
+        LOOP
+            changed := EXISTS (
+                SELECT 1 FROM meta.asset_publication_locks l
+                WHERE l.asset_key = target.asset_key
+                  AND (command.objid = l.relation_oid OR command.objid =
+                    pg_catalog.to_regclass(pg_catalog.format('%I.%I',
+                        target.relation_schema, target.relation_name)))
+            ) OR EXISTS (
+                SELECT 1 FROM pg_catalog.pg_trigger tr
+                JOIN meta.asset_publication_locks l ON l.relation_oid = tr.tgrelid
+                WHERE l.asset_key = target.asset_key AND tr.oid = command.objid
+            ) OR EXISTS (
+                SELECT 1 FROM pg_catalog.pg_index ix
+                JOIN meta.asset_publication_locks l ON l.relation_oid = ix.indrelid
+                WHERE l.asset_key = target.asset_key AND ix.indexrelid = command.objid
+            ) OR EXISTS (
+                SELECT 1 FROM pg_catalog.pg_constraint con
+                JOIN meta.asset_publication_locks l ON l.relation_oid = con.conrelid
+                WHERE l.asset_key = target.asset_key AND con.oid = command.objid
+            ) OR EXISTS (
+                SELECT 1 FROM pg_catalog.pg_rewrite rw
+                JOIN meta.asset_publication_locks l ON l.relation_oid = rw.ev_class
+                WHERE l.asset_key = target.asset_key AND rw.oid = command.objid
+            ) OR EXISTS (
+                SELECT 1 FROM pg_catalog.pg_inherits i
+                WHERE i.inhrelid = pg_catalog.to_regclass(pg_catalog.format('%I.%I',
+                        target.relation_schema, target.relation_name))
+                   OR i.inhparent = pg_catalog.to_regclass(pg_catalog.format('%I.%I',
+                        target.relation_schema, target.relation_name))
+            ) OR EXISTS (
+                SELECT 1 FROM meta.asset_publication_locks l
+                WHERE l.asset_key = target.asset_key
+                  AND l.relation_oid IS DISTINCT FROM pg_catalog.to_regclass(
+                    pg_catalog.format('%I.%I', target.relation_schema,
+                        target.relation_name))
+            );
+            IF changed THEN
+                DELETE FROM meta.asset_current_generations p
+                WHERE p.asset_key = target.asset_key;
+            END IF;
+        END LOOP;
+    END LOOP;
+    IF invalidate_all THEN
+        DELETE FROM meta.asset_current_generations p
+        WHERE p.asset_key IN (
+            'ratings.espn_fpi_weekly', 'ref.team_id_xwalk', 'ref.game_id_xwalk');
+    END IF;
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION warehouse_source_batch.invalidate_drop()
+RETURNS event_trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $function$
+DECLARE dropped record; target record; invalidate_all boolean := false; changed boolean;
+BEGIN
+    FOR dropped IN SELECT * FROM pg_catalog.pg_event_trigger_dropped_objects() LOOP
+        IF dropped.object_identity LIKE 'warehouse_source_batch.%'
+            OR dropped.object_identity IN (
+                'warehouse_source_batch_invalidate_ddl',
+                'warehouse_source_batch_invalidate_drop') THEN
+            invalidate_all := true;
+        END IF;
+        FOR target IN SELECT * FROM (VALUES
+            ('ratings.espn_fpi_weekly', 'ratings', 'espn_fpi_weekly'),
+            ('ref.team_id_xwalk', 'ref', 'team_id_xwalk'),
+            ('ref.game_id_xwalk', 'ref', 'game_id_xwalk')
+        ) AS t(asset_key, relation_schema, relation_name)
+        LOOP
+            changed := EXISTS (
+                SELECT 1 FROM meta.asset_publication_locks l
+                WHERE l.asset_key = target.asset_key
+                  AND (dropped.objid = l.relation_oid OR
+                    (dropped.address_names[1] = target.relation_schema
+                        AND dropped.address_names[2] = target.relation_name))
+            ) OR (
+                dropped.object_type = 'trigger'
+                AND target.relation_schema = ANY(dropped.address_names)
+                AND target.relation_name = ANY(dropped.address_names)
+            ) OR EXISTS (
+                SELECT 1 FROM meta.asset_publication_locks l
+                WHERE l.asset_key = target.asset_key
+                  AND l.relation_oid IS DISTINCT FROM pg_catalog.to_regclass(
+                    pg_catalog.format('%I.%I', target.relation_schema,
+                        target.relation_name))
+            );
+            IF changed THEN
+                DELETE FROM meta.asset_current_generations p
+                WHERE p.asset_key = target.asset_key;
+            END IF;
+        END LOOP;
+    END LOOP;
+    IF invalidate_all THEN
+        DELETE FROM meta.asset_current_generations p
+        WHERE p.asset_key IN (
+            'ratings.espn_fpi_weekly', 'ref.team_id_xwalk', 'ref.game_id_xwalk');
+    END IF;
+END
+$function$;
+
+DROP EVENT TRIGGER IF EXISTS warehouse_source_batch_invalidate_ddl;
+CREATE EVENT TRIGGER warehouse_source_batch_invalidate_ddl ON ddl_command_end
+    EXECUTE FUNCTION warehouse_source_batch.invalidate_ddl();
+DROP EVENT TRIGGER IF EXISTS warehouse_source_batch_invalidate_drop;
+CREATE EVENT TRIGGER warehouse_source_batch_invalidate_drop ON sql_drop
+    EXECUTE FUNCTION warehouse_source_batch.invalidate_drop();
+
+CREATE OR REPLACE FUNCTION warehouse_source_batch.get_source_plan(
+    p_source_name text, p_season bigint
+)
+RETURNS jsonb LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = '' AS $function$
+DECLARE asset text; parser text; coverage text; current_generation uuid;
+BEGIN
+    IF p_season IS NULL OR p_season < 1869 OR p_season > 2200 THEN
+        RAISE EXCEPTION 'SDV source season must be between 1869 and 2200'
+            USING ERRCODE = '22023';
+    END IF;
+    SELECT CASE p_source_name
+        WHEN 'sdv_fpi_weekly' THEN 'ratings.espn_fpi_weekly'
+        WHEN 'sdv_team_xwalk' THEN 'ref.team_id_xwalk'
+        WHEN 'sdv_game_xwalk' THEN 'ref.game_id_xwalk'
+        END,
+        CASE p_source_name
+        WHEN 'sdv_fpi_weekly' THEN 'sdv-fpi-v1'
+        WHEN 'sdv_team_xwalk' THEN 'sdv-team-xwalk-v1'
+        WHEN 'sdv_game_xwalk' THEN 'sdv-game-xwalk-v1'
+        END
+    INTO asset, parser;
+    IF asset IS NULL THEN
+        RAISE EXCEPTION 'source is not enrolled in the SDV season protocol'
+            USING ERRCODE = '22023';
+    END IF;
+    coverage := 'season:' || p_season::text;
+    SELECT p.generation_id INTO current_generation
+    FROM meta.asset_current_generations p
+    WHERE p.asset_key = asset AND p.coverage_key = coverage;
+    RETURN pg_catalog.jsonb_build_object(
+        'protocol', 'sdv-season-file-v1',
+        'source_name', p_source_name,
+        'asset_key', asset,
+        'coverage_key', coverage,
+        'season', p_season,
+        'expected_generation_id', current_generation,
+        'parser_contract', parser
+    );
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION warehouse_source_batch.require_source_load(p_run_id uuid)
+RETURNS meta.operation_runs LANGUAGE plpgsql SET search_path = '' AS $function$
+DECLARE
+    run_row meta.operation_runs%ROWTYPE;
+    source_name text;
+    asset text;
+    parser text;
+    season_value bigint;
+    expected_generation uuid;
+    expected jsonb;
+BEGIN
+    IF p_run_id IS NULL THEN
+        RAISE EXCEPTION 'operation run ID is required' USING ERRCODE = '22023';
+    END IF;
+    SELECT * INTO run_row FROM meta.operation_runs r
+    WHERE r.operation_run_id = p_run_id FOR UPDATE;
+    IF NOT FOUND OR run_row.recorded_by <> session_user
+        OR run_row.operation_kind <> 'load' OR run_row.initiator <> 'load_flat_files'
+        OR run_row.code_revision IS NOT NULL THEN
+        RAISE EXCEPTION 'operation does not belong to this source publisher'
+            USING ERRCODE = '22023';
+    END IF;
+    BEGIN
+        source_name := run_row.requested_scope->>'source_name';
+        season_value := (run_row.requested_scope->>'season')::bigint;
+        expected_generation := CASE
+            WHEN run_row.requested_scope->>'expected_generation_id' IS NULL THEN NULL::uuid
+            ELSE (run_row.requested_scope->>'expected_generation_id')::uuid END;
+    EXCEPTION WHEN OTHERS THEN
+        RAISE EXCEPTION 'stored source publication scope is invalid'
+            USING ERRCODE = '22023';
+    END;
+    SELECT CASE source_name
+        WHEN 'sdv_fpi_weekly' THEN 'ratings.espn_fpi_weekly'
+        WHEN 'sdv_team_xwalk' THEN 'ref.team_id_xwalk'
+        WHEN 'sdv_game_xwalk' THEN 'ref.game_id_xwalk' END,
+        CASE source_name
+        WHEN 'sdv_fpi_weekly' THEN 'sdv-fpi-v1'
+        WHEN 'sdv_team_xwalk' THEN 'sdv-team-xwalk-v1'
+        WHEN 'sdv_game_xwalk' THEN 'sdv-game-xwalk-v1' END
+    INTO asset, parser;
+    expected := pg_catalog.jsonb_build_object(
+        'protocol', 'sdv-season-file-v1', 'source_name', source_name,
+        'asset_key', asset, 'coverage_key', 'season:' || season_value::text,
+        'season', season_value, 'expected_generation_id', expected_generation,
+        'parser_contract', parser
+    );
+    IF source_name IS NULL OR asset IS NULL OR parser IS NULL
+        OR season_value < 1869 OR season_value > 2200
+        OR run_row.requested_scope IS DISTINCT FROM expected
+        OR run_row.plan_digest IS DISTINCT FROM pg_catalog.md5(expected::text) THEN
+        RAISE EXCEPTION 'stored source publication scope is invalid'
+            USING ERRCODE = '22023';
+    END IF;
+    RETURN run_row;
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION warehouse_source_batch.start_source_load(
+    p_run_id uuid, p_plan jsonb
+)
+RETURNS uuid LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $function$
+DECLARE source_name text; season_value bigint; current_plan jsonb;
+BEGIN
+    IF p_run_id IS NULL OR p_plan IS NULL OR pg_catalog.jsonb_typeof(p_plan) <> 'object' THEN
+        RAISE EXCEPTION 'source publication start context is invalid'
+            USING ERRCODE = '22023';
+    END IF;
+    BEGIN
+        source_name := p_plan->>'source_name';
+        season_value := (p_plan->>'season')::bigint;
+    EXCEPTION WHEN OTHERS THEN
+        RAISE EXCEPTION 'source publication plan is invalid' USING ERRCODE = '22023';
+    END;
+    current_plan := warehouse_source_batch.get_source_plan(source_name, season_value);
+    IF p_plan IS DISTINCT FROM current_plan THEN
+        RAISE EXCEPTION 'source publication plan is stale or invalid'
+            USING ERRCODE = '40001';
+    END IF;
+    PERFORM warehouse_quota.start_operation_run(
+        p_run_id, 'load', 'load_flat_files', p_plan, pg_catalog.md5(p_plan::text), NULL
+    );
+    PERFORM warehouse_source_batch.require_source_load(p_run_id);
+    RETURN p_run_id;
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION warehouse_source_batch.publish_source_load(
+    p_run_id uuid,
+    p_generation_id uuid,
+    p_source_sha256 text,
+    p_rows jsonb,
+    p_dlt_evidence jsonb
+)
+RETURNS TABLE (generation_id uuid, replayed boolean, published_rows bigint)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $function$
+DECLARE
+    run_row meta.operation_runs%ROWTYPE;
+    existing meta.asset_receipts%ROWTYPE;
+    source_name text;
+    asset text;
+    parser text;
+    season_basis text;
+    season_value bigint;
+    coverage_value text;
+    expected_generation uuid;
+    actual_generation uuid;
+    request_digest_value text;
+    row_count_value bigint;
+    previous_rows bigint;
+    inserted_rows bigint;
+    deleted_rows bigint;
+    changed_rows bigint;
+    publication_time timestamptz;
+    actual_load_ids jsonb;
+    catalog_shape jsonb;
+    expected_catalog jsonb;
+    expected_keys text[];
+    ledger_inserted integer;
+    ledger_source_url text;
+BEGIN
+    IF p_run_id IS NULL OR p_generation_id IS NULL
+        OR p_source_sha256 IS NULL OR p_source_sha256 !~ '^[0-9a-f]{64}$'
+        OR p_rows IS NULL OR pg_catalog.jsonb_typeof(p_rows) <> 'array'
+        OR p_dlt_evidence IS NULL OR pg_catalog.jsonb_typeof(p_dlt_evidence) <> 'object' THEN
+        RAISE EXCEPTION 'source publication input is invalid' USING ERRCODE = '22023';
+    END IF;
+    IF pg_catalog.octet_length(p_rows::text) > 134217728 THEN
+        RAISE EXCEPTION 'source publication payload exceeds 128 MiB'
+            USING ERRCODE = '54000';
+    END IF;
+
+    run_row := warehouse_source_batch.require_source_load(p_run_id);
+    source_name := run_row.requested_scope->>'source_name';
+    asset := run_row.requested_scope->>'asset_key';
+    parser := run_row.requested_scope->>'parser_contract';
+    season_value := (run_row.requested_scope->>'season')::bigint;
+    coverage_value := run_row.requested_scope->>'coverage_key';
+    expected_generation := (run_row.requested_scope->>'expected_generation_id')::uuid;
+    season_basis := CASE source_name
+        WHEN 'sdv_fpi_weekly' THEN 'artifact_field'
+        WHEN 'sdv_team_xwalk' THEN CASE p_dlt_evidence->>'artifact_origin'
+            WHEN 'registered_url' THEN 'registered_artifact_name'
+            WHEN 'local_file' THEN 'caller_declared' END
+        WHEN 'sdv_game_xwalk' THEN CASE p_dlt_evidence->>'artifact_origin'
+            WHEN 'registered_url' THEN 'registered_artifact_name'
+            WHEN 'local_file' THEN 'caller_declared' END
+        END;
+    request_digest_value := pg_catalog.md5(pg_catalog.jsonb_build_object(
+        'run_id', p_run_id, 'generation_id', p_generation_id,
+        'source_sha256', p_source_sha256, 'plan', run_row.requested_scope,
+        'rows', p_rows, 'dlt_evidence', p_dlt_evidence
+    )::text);
+
+    SELECT * INTO existing FROM meta.asset_receipts r
+    WHERE r.generation_id = p_generation_id;
+    IF FOUND THEN
+        IF existing.operation_run_id <> p_run_id
+            OR existing.asset_key <> asset
+            OR existing.coverage_key <> coverage_value
+            OR existing.outcome <> 'succeeded'
+            OR existing.source_watermark <> p_source_sha256
+            OR existing.request_digest <> request_digest_value
+            OR run_row.outcome <> 'succeeded' THEN
+            RAISE EXCEPTION
+                'generation ID already has different source publication context'
+                USING ERRCODE = '22023';
+        END IF;
+        RETURN QUERY SELECT p_generation_id, true,
+            (existing.row_delta->>'published_rows')::bigint;
+        RETURN;
+    END IF;
+    IF run_row.outcome <> 'running' THEN
+        RAISE EXCEPTION 'source publication operation is terminal' USING ERRCODE = '22023';
+    END IF;
+
+    SELECT count(*) INTO row_count_value FROM pg_catalog.jsonb_array_elements(p_rows);
+    IF row_count_value < 1 OR row_count_value > 100000 THEN
+        RAISE EXCEPTION 'source publication requires between 1 and 100000 rows'
+            USING ERRCODE = '22023';
+    END IF;
+
+    expected_keys := CASE source_name
+        WHEN 'sdv_fpi_weekly' THEN ARRAY[
+            '_dlt_id','_dlt_load_id','accomplishment','accomplishmentrank',
+            'adjavgingamewp','adjavgingamewprank','adjlosses','adjwinpctrank',
+            'adjwins','avgingamewp','avgingamewprank','avgsosrank','defefficiency',
+            'defefficiencyrank','epadefense','epaoffense','epaspecialteams','fpi',
+            'fpirank','gamecontrol','gamecontrolrank','last_updated','numlosses',
+            'numties','numwins','offefficiency','offefficiencyrank','prob6wins',
+            'probmakeplayoffs','probmaketitlegame','probwinconf','probwindiv',
+            'probwinout','probwintitle','projectedl','projectedt','projectedw',
+            'projectedwpctrank','rank','rankchange7days','run_date_time_key','season',
+            'season_type','snapshot_is_contemporaneous','snapshot_out_of_sequence',
+            'sosremainingrank','stefficiency','stefficiencyrank','team_id','topsosrank',
+            'totefficiency','totefficiencyrank','week'
+        ]::text[]
+        WHEN 'sdv_team_xwalk' THEN ARRAY[
+            '_dlt_id','_dlt_load_id','espn_abbreviation','espn_team','espn_team_id',
+            'fox_abbreviation','fox_team','fox_team_id','matched_sources','norm_key',
+            'season','xwalk_key','yahoo_abbreviation','yahoo_team','yahoo_team_id'
+        ]::text[]
+        WHEN 'sdv_game_xwalk' THEN ARRAY[
+            '_dlt_id','_dlt_load_id','away_team','espn_date','espn_game_id','fox_date',
+            'fox_game_id','home_team','matched_sources','matchup_key','season','yahoo_date',
+            'yahoo_game_id','yahoo_global_game_id'
+        ]::text[] END;
+    IF EXISTS (
+        SELECT 1 FROM pg_catalog.jsonb_array_elements(p_rows) item
+        WHERE pg_catalog.jsonb_typeof(item) <> 'object'
+           OR ARRAY(SELECT k FROM pg_catalog.jsonb_object_keys(item) k
+                    ORDER BY k COLLATE "C") IS DISTINCT FROM expected_keys
+    ) THEN
+        RAISE EXCEPTION 'source publication rows have unexpected or missing fields'
+            USING ERRCODE = '22023';
+    END IF;
+
+    -- Validate the raw JSON shape before typed conversion.  PostgreSQL's
+    -- bigint JSON conversion can round fractional numerics, so every integer
+    -- is required to have an integral canonical representation first.
+    IF EXISTS (
+        SELECT 1 FROM pg_catalog.jsonb_array_elements(p_rows) item
+        WHERE pg_catalog.jsonb_typeof(item->'season') <> 'number'
+           OR item->>'season' !~ '^-?(0|[1-9][0-9]*)$'
+           OR pg_catalog.jsonb_typeof(item->'_dlt_id') <> 'string'
+           OR pg_catalog.jsonb_typeof(item->'_dlt_load_id') <> 'string'
+           OR item->>'_dlt_id' = '' OR item->>'_dlt_load_id' = ''
+           OR pg_catalog.length(item->>'_dlt_id') > 256
+           OR pg_catalog.length(item->>'_dlt_load_id') > 256
+    ) THEN
+        RAISE EXCEPTION 'source publication row types are invalid' USING ERRCODE = '22023';
+    END IF;
+
+    IF source_name = 'sdv_fpi_weekly' THEN
+        IF EXISTS (
+            SELECT 1 FROM pg_catalog.jsonb_array_elements(p_rows) item
+            WHERE pg_catalog.jsonb_typeof(item->'season_type') <> 'number'
+               OR item->>'season_type' !~ '^-?(0|[1-9][0-9]*)$'
+               OR pg_catalog.jsonb_typeof(item->'week') <> 'number'
+               OR item->>'week' !~ '^-?(0|[1-9][0-9]*)$'
+               OR pg_catalog.jsonb_typeof(item->'team_id') <> 'number'
+               OR item->>'team_id' !~ '^-?(0|[1-9][0-9]*)$'
+               OR (pg_catalog.jsonb_typeof(item->'run_date_time_key') = 'number'
+                   AND item->>'run_date_time_key' !~ '^-?(0|[1-9][0-9]*)$')
+               OR pg_catalog.jsonb_typeof(item->'run_date_time_key')
+                    NOT IN ('number','null')
+               OR (pg_catalog.jsonb_typeof(item->'last_updated') = 'string'
+                   AND item->>'last_updated' !~
+                    '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}(:[0-9]{2}(\.[0-9]{1,6})?)?(Z|[+-][0-9]{2}:[0-9]{2})$')
+               OR pg_catalog.jsonb_typeof(item->'last_updated') NOT IN ('string','null')
+               OR pg_catalog.jsonb_typeof(item->'snapshot_out_of_sequence')
+                    NOT IN ('boolean','null')
+               OR pg_catalog.jsonb_typeof(item->'snapshot_is_contemporaneous')
+                    NOT IN ('boolean','null')
+               OR EXISTS (
+                    SELECT 1 FROM pg_catalog.jsonb_each(item) field
+                    WHERE field.key = ANY(ARRAY[
+                        'fpi','fpirank','projectedw','projectedl','projectedt',
+                        'projectedwpctrank','probwinout','probwinconf',
+                        'sosremainingrank','accomplishment','accomplishmentrank',
+                        'adjwins','adjlosses','adjwinpctrank','gamecontrol',
+                        'gamecontrolrank','adjavgingamewp','adjavgingamewprank',
+                        'avgingamewp','avgingamewprank','avgsosrank','topsosrank',
+                        'epaoffense','epadefense','epaspecialteams','probwindiv',
+                        'probmakeplayoffs','probmaketitlegame','numwins','numlosses',
+                        'numties','probwintitle','rankchange7days','prob6wins','rank',
+                        'offefficiency','offefficiencyrank','defefficiency',
+                        'defefficiencyrank','stefficiency','stefficiencyrank',
+                        'totefficiency','totefficiencyrank']::text[])
+                      AND pg_catalog.jsonb_typeof(field.value) NOT IN ('number','null')
+               )
+        ) THEN
+            RAISE EXCEPTION 'FPI source publication row types are invalid'
+                USING ERRCODE = '22023';
+        END IF;
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM pg_catalog.jsonb_to_recordset(p_rows) AS r(
+                    season bigint, season_type bigint, week bigint, team_id bigint,
+                    last_updated timestamptz, run_date_time_key bigint,
+                    snapshot_out_of_sequence boolean, fpi double precision,
+                    fpirank double precision, projectedw double precision,
+                    projectedl double precision, projectedt double precision,
+                    projectedwpctrank double precision, probwinout double precision,
+                    probwinconf double precision, sosremainingrank double precision,
+                    accomplishment double precision, accomplishmentrank double precision,
+                    adjwins double precision, adjlosses double precision,
+                    adjwinpctrank double precision, gamecontrol double precision,
+                    gamecontrolrank double precision, adjavgingamewp double precision,
+                    adjavgingamewprank double precision, avgingamewp double precision,
+                    avgingamewprank double precision, avgsosrank double precision,
+                    topsosrank double precision, epaoffense double precision,
+                    epadefense double precision, epaspecialteams double precision,
+                    probwindiv double precision, probmakeplayoffs double precision,
+                    probmaketitlegame double precision, numwins double precision,
+                    numlosses double precision, numties double precision,
+                    probwintitle double precision, rankchange7days double precision,
+                    prob6wins double precision, rank double precision,
+                    offefficiency double precision, offefficiencyrank double precision,
+                    defefficiency double precision, defefficiencyrank double precision,
+                    stefficiency double precision, stefficiencyrank double precision,
+                    totefficiency double precision, totefficiencyrank double precision,
+                    snapshot_is_contemporaneous boolean, _dlt_load_id text, _dlt_id text
+                )
+                WHERE r.season IS DISTINCT FROM season_value
+                   OR r.season_type NOT IN (2,3) OR r.week < 0 OR r.team_id <= 0
+                   OR (r.last_updated IS NOT NULL AND NOT pg_catalog.isfinite(r.last_updated))
+                   OR 'NaN' = ANY(ARRAY[
+                        r.fpi::text,r.fpirank::text,r.projectedw::text,r.projectedl::text,
+                        r.projectedt::text,r.projectedwpctrank::text,r.probwinout::text,
+                        r.probwinconf::text,r.sosremainingrank::text,r.accomplishment::text,
+                        r.accomplishmentrank::text,r.adjwins::text,r.adjlosses::text,
+                        r.adjwinpctrank::text,r.gamecontrol::text,r.gamecontrolrank::text,
+                        r.adjavgingamewp::text,r.adjavgingamewprank::text,
+                        r.avgingamewp::text,r.avgingamewprank::text,r.avgsosrank::text,
+                        r.topsosrank::text,r.epaoffense::text,r.epadefense::text,
+                        r.epaspecialteams::text,r.probwindiv::text,r.probmakeplayoffs::text,
+                        r.probmaketitlegame::text,r.numwins::text,r.numlosses::text,
+                        r.numties::text,r.probwintitle::text,r.rankchange7days::text,
+                        r.prob6wins::text,r.rank::text,r.offefficiency::text,
+                        r.offefficiencyrank::text,r.defefficiency::text,
+                        r.defefficiencyrank::text,r.stefficiency::text,
+                        r.stefficiencyrank::text,r.totefficiency::text,
+                        r.totefficiencyrank::text]::text[])
+                   OR 'Infinity' = ANY(ARRAY[
+                        r.fpi::text,r.fpirank::text,r.projectedw::text,r.projectedl::text,
+                        r.projectedt::text,r.projectedwpctrank::text,r.probwinout::text,
+                        r.probwinconf::text,r.sosremainingrank::text,r.accomplishment::text,
+                        r.accomplishmentrank::text,r.adjwins::text,r.adjlosses::text,
+                        r.adjwinpctrank::text,r.gamecontrol::text,r.gamecontrolrank::text,
+                        r.adjavgingamewp::text,r.adjavgingamewprank::text,
+                        r.avgingamewp::text,r.avgingamewprank::text,r.avgsosrank::text,
+                        r.topsosrank::text,r.epaoffense::text,r.epadefense::text,
+                        r.epaspecialteams::text,r.probwindiv::text,r.probmakeplayoffs::text,
+                        r.probmaketitlegame::text,r.numwins::text,r.numlosses::text,
+                        r.numties::text,r.probwintitle::text,r.rankchange7days::text,
+                        r.prob6wins::text,r.rank::text,r.offefficiency::text,
+                        r.offefficiencyrank::text,r.defefficiency::text,
+                        r.defefficiencyrank::text,r.stefficiency::text,
+                        r.stefficiencyrank::text,r.totefficiency::text,
+                        r.totefficiencyrank::text]::text[])
+                   OR '-Infinity' = ANY(ARRAY[
+                        r.fpi::text,r.fpirank::text,r.projectedw::text,r.projectedl::text,
+                        r.projectedt::text,r.projectedwpctrank::text,r.probwinout::text,
+                        r.probwinconf::text,r.sosremainingrank::text,r.accomplishment::text,
+                        r.accomplishmentrank::text,r.adjwins::text,r.adjlosses::text,
+                        r.adjwinpctrank::text,r.gamecontrol::text,r.gamecontrolrank::text,
+                        r.adjavgingamewp::text,r.adjavgingamewprank::text,
+                        r.avgingamewp::text,r.avgingamewprank::text,r.avgsosrank::text,
+                        r.topsosrank::text,r.epaoffense::text,r.epadefense::text,
+                        r.epaspecialteams::text,r.probwindiv::text,r.probmakeplayoffs::text,
+                        r.probmaketitlegame::text,r.numwins::text,r.numlosses::text,
+                        r.numties::text,r.probwintitle::text,r.rankchange7days::text,
+                        r.prob6wins::text,r.rank::text,r.offefficiency::text,
+                        r.offefficiencyrank::text,r.defefficiency::text,
+                        r.defefficiencyrank::text,r.stefficiency::text,
+                        r.stefficiencyrank::text,r.totefficiency::text,
+                        r.totefficiencyrank::text]::text[])
+            ) THEN
+                RAISE EXCEPTION 'FPI source publication contains an invalid value'
+                    USING ERRCODE = '22023';
+            END IF;
+        EXCEPTION WHEN invalid_text_representation OR numeric_value_out_of_range
+            OR datetime_field_overflow THEN
+            RAISE EXCEPTION 'FPI source publication contains an invalid typed value'
+                USING ERRCODE = '22023';
+        END;
+    ELSIF source_name = 'sdv_team_xwalk' THEN
+        IF EXISTS (
+            SELECT 1 FROM pg_catalog.jsonb_array_elements(p_rows) item
+            WHERE pg_catalog.jsonb_typeof(item->'norm_key') <> 'string'
+               OR pg_catalog.jsonb_typeof(item->'xwalk_key') <> 'string'
+               OR (pg_catalog.jsonb_typeof(item->'espn_team_id') = 'number'
+                   AND item->>'espn_team_id' !~ '^-?(0|[1-9][0-9]*)$')
+               OR pg_catalog.jsonb_typeof(item->'espn_team_id') NOT IN ('number','null')
+               OR EXISTS (
+                    SELECT 1 FROM pg_catalog.jsonb_each(item) field
+                    WHERE field.key = ANY(ARRAY[
+                        'espn_team','espn_abbreviation','fox_team_id','fox_team',
+                        'fox_abbreviation','yahoo_team_id','yahoo_team',
+                        'yahoo_abbreviation','matched_sources']::text[])
+                      AND pg_catalog.jsonb_typeof(field.value) NOT IN ('string','null')
+               )
+        ) THEN
+            RAISE EXCEPTION 'team crosswalk source publication row types are invalid'
+                USING ERRCODE = '22023';
+        END IF;
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM pg_catalog.jsonb_to_recordset(p_rows) AS r(
+                    season bigint, norm_key text, xwalk_key text, espn_team_id bigint,
+                    espn_team text, espn_abbreviation text, fox_team_id text,
+                    fox_team text, fox_abbreviation text, yahoo_team_id text,
+                    yahoo_team text, yahoo_abbreviation text, matched_sources text,
+                    _dlt_load_id text, _dlt_id text
+                )
+                WHERE r.season IS DISTINCT FROM season_value
+                   OR pg_catalog.btrim(r.norm_key) = ''
+                   OR pg_catalog.btrim(r.xwalk_key) = ''
+                   OR (r.espn_team_id IS NOT NULL AND r.espn_team_id <= 0)
+                   OR r.xwalk_key IS DISTINCT FROM r.norm_key || '#' ||
+                        COALESCE(r.espn_team_id::text, r.fox_team_id,
+                            r.yahoo_team_id, 'None')
+            ) THEN
+                RAISE EXCEPTION 'team crosswalk publication contains an invalid key or ID'
+                    USING ERRCODE = '22023';
+            END IF;
+        EXCEPTION WHEN invalid_text_representation OR numeric_value_out_of_range THEN
+            RAISE EXCEPTION 'team crosswalk publication contains an invalid typed value'
+                USING ERRCODE = '22023';
+        END;
+    ELSIF source_name = 'sdv_game_xwalk' THEN
+        IF EXISTS (
+            SELECT 1 FROM pg_catalog.jsonb_array_elements(p_rows) item
+            WHERE pg_catalog.jsonb_typeof(item->'matchup_key') <> 'string'
+               OR pg_catalog.jsonb_typeof(item->'yahoo_date') <> 'string'
+               OR item->>'yahoo_date' !~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'
+               OR (pg_catalog.jsonb_typeof(item->'espn_game_id') = 'number'
+                   AND item->>'espn_game_id' !~ '^-?(0|[1-9][0-9]*)$')
+               OR pg_catalog.jsonb_typeof(item->'espn_game_id') NOT IN ('number','null')
+               OR (pg_catalog.jsonb_typeof(item->'espn_date') = 'string'
+                   AND item->>'espn_date' !~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}$')
+               OR pg_catalog.jsonb_typeof(item->'espn_date') NOT IN ('string','null')
+               OR (pg_catalog.jsonb_typeof(item->'fox_date') = 'string'
+                   AND item->>'fox_date' !~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}$')
+               OR pg_catalog.jsonb_typeof(item->'fox_date') NOT IN ('string','null')
+               OR EXISTS (
+                    SELECT 1 FROM pg_catalog.jsonb_each(item) field
+                    WHERE field.key = ANY(ARRAY[
+                        'fox_game_id','yahoo_game_id','yahoo_global_game_id',
+                        'home_team','away_team','matched_sources']::text[])
+                      AND pg_catalog.jsonb_typeof(field.value) NOT IN ('string','null')
+               )
+        ) THEN
+            RAISE EXCEPTION 'game crosswalk source publication row types are invalid'
+                USING ERRCODE = '22023';
+        END IF;
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM pg_catalog.jsonb_to_recordset(p_rows) AS r(
+                    season bigint, matchup_key text, yahoo_date date,
+                    espn_game_id bigint, fox_game_id text, yahoo_game_id text,
+                    yahoo_global_game_id text, home_team text, away_team text,
+                    espn_date date, fox_date date, matched_sources text,
+                    _dlt_load_id text, _dlt_id text
+                )
+                WHERE r.season IS DISTINCT FROM season_value
+                   OR pg_catalog.btrim(r.matchup_key) = ''
+                   OR (r.espn_game_id IS NOT NULL AND r.espn_game_id <= 0)
+            ) THEN
+                RAISE EXCEPTION 'game crosswalk publication contains an invalid key or ID'
+                    USING ERRCODE = '22023';
+            END IF;
+        EXCEPTION WHEN invalid_text_representation OR numeric_value_out_of_range
+            OR datetime_field_overflow THEN
+            RAISE EXCEPTION 'game crosswalk publication contains an invalid typed value'
+                USING ERRCODE = '22023';
+        END;
+    END IF;
+
+    -- Check both the target grain and dlt's global row identity.
+    IF source_name = 'sdv_fpi_weekly' THEN
+        IF EXISTS (SELECT 1 FROM pg_catalog.jsonb_to_recordset(p_rows) AS r(
+                season bigint, season_type bigint, week bigint, team_id bigint)
+            GROUP BY season, season_type, week, team_id HAVING count(*) > 1) THEN
+            RAISE EXCEPTION 'source publication payload contains duplicate keys'
+                USING ERRCODE = '22023';
+        END IF;
+    ELSIF source_name = 'sdv_team_xwalk' THEN
+        IF EXISTS (SELECT 1 FROM pg_catalog.jsonb_to_recordset(p_rows) AS r(
+                season bigint, xwalk_key text)
+            GROUP BY season, xwalk_key HAVING count(*) > 1) THEN
+            RAISE EXCEPTION 'source publication payload contains duplicate keys'
+                USING ERRCODE = '22023';
+        END IF;
+    ELSE
+        IF EXISTS (SELECT 1 FROM pg_catalog.jsonb_to_recordset(p_rows) AS r(
+                season bigint, matchup_key text, yahoo_date date)
+            GROUP BY season, matchup_key, yahoo_date HAVING count(*) > 1) THEN
+            RAISE EXCEPTION 'source publication payload contains duplicate keys'
+                USING ERRCODE = '22023';
+        END IF;
+    END IF;
+    IF EXISTS (SELECT 1 FROM pg_catalog.jsonb_to_recordset(p_rows) AS r(_dlt_id text)
+        GROUP BY _dlt_id HAVING count(*) > 1) THEN
+        RAISE EXCEPTION 'source publication payload contains duplicate dlt identities'
+            USING ERRCODE = '22023';
+    END IF;
+
+    SELECT pg_catalog.jsonb_agg(v ORDER BY v COLLATE "C") INTO actual_load_ids
+    FROM (SELECT DISTINCT item->>'_dlt_load_id' AS v
+        FROM pg_catalog.jsonb_array_elements(p_rows) item) ids;
+    IF ARRAY(SELECT k FROM pg_catalog.jsonb_object_keys(p_dlt_evidence) k
+            ORDER BY k COLLATE "C")
+            IS DISTINCT FROM ARRAY[
+                'artifact_origin','dlt_load_ids','parser_contract','season_basis',
+                'source_rows','stage_schema'
+            ]::text[]
+        OR pg_catalog.jsonb_typeof(p_dlt_evidence->'artifact_origin') <> 'string'
+        OR p_dlt_evidence->>'artifact_origin' NOT IN ('registered_url','local_file')
+        OR pg_catalog.jsonb_typeof(p_dlt_evidence->'season_basis') <> 'string'
+        OR p_dlt_evidence->>'season_basis' IS DISTINCT FROM season_basis
+        OR p_dlt_evidence->>'stage_schema' IS DISTINCT FROM 'warehouse_source_stage'
+        OR p_dlt_evidence->>'parser_contract' IS DISTINCT FROM parser
+        OR pg_catalog.jsonb_typeof(p_dlt_evidence->'dlt_load_ids') <> 'array'
+        OR p_dlt_evidence->'dlt_load_ids' IS DISTINCT FROM actual_load_ids
+        OR pg_catalog.jsonb_typeof(p_dlt_evidence->'source_rows') <> 'number'
+        OR p_dlt_evidence->>'source_rows' !~ '^(0|[1-9][0-9]*)$'
+        OR (p_dlt_evidence->>'source_rows')::numeric <> row_count_value::numeric THEN
+        RAISE EXCEPTION 'dlt evidence does not match the normalized payload'
+            USING ERRCODE = '22023';
+    END IF;
+
+    IF pg_catalog.current_setting('transaction_isolation') <> 'read committed'
+        OR pg_catalog.current_setting('session_replication_role') <> 'origin'
+        OR COALESCE(pg_catalog.current_setting('event_triggers', true), 'on') <> 'on' THEN
+        RAISE EXCEPTION 'source publication requires READ COMMITTED and active guards'
+            USING ERRCODE = '25001';
+    END IF;
+
+    IF source_name = 'sdv_fpi_weekly' THEN
+        LOCK TABLE ratings.espn_fpi_weekly IN EXCLUSIVE MODE;
+    ELSIF source_name = 'sdv_team_xwalk' THEN
+        LOCK TABLE ref.team_id_xwalk IN EXCLUSIVE MODE;
+    ELSE
+        LOCK TABLE ref.game_id_xwalk IN EXCLUSIVE MODE;
+    END IF;
+    PERFORM 1 FROM meta.asset_publication_locks l
+    WHERE l.asset_key = asset FOR UPDATE;
+
+    SELECT pg_catalog.jsonb_agg(pg_catalog.jsonb_build_object(
+        'name', a.attname, 'type', pg_catalog.format_type(a.atttypid, a.atttypmod),
+        'not_null', a.attnotnull) ORDER BY a.attnum)
+    INTO catalog_shape
+    FROM pg_catalog.pg_attribute a
+    WHERE a.attrelid = pg_catalog.to_regclass(asset)
+      AND a.attnum > 0 AND NOT a.attisdropped;
+
+    expected_catalog := CASE source_name
+        WHEN 'sdv_fpi_weekly' THEN '[
+            {"name":"season","type":"bigint","not_null":true},
+            {"name":"season_type","type":"bigint","not_null":true},
+            {"name":"week","type":"bigint","not_null":true},
+            {"name":"team_id","type":"bigint","not_null":true},
+            {"name":"last_updated","type":"timestamp with time zone","not_null":false},
+            {"name":"run_date_time_key","type":"bigint","not_null":false},
+            {"name":"snapshot_out_of_sequence","type":"boolean","not_null":false},
+            {"name":"fpi","type":"double precision","not_null":false},
+            {"name":"fpirank","type":"double precision","not_null":false},
+            {"name":"projectedw","type":"double precision","not_null":false},
+            {"name":"projectedl","type":"double precision","not_null":false},
+            {"name":"projectedt","type":"double precision","not_null":false},
+            {"name":"projectedwpctrank","type":"double precision","not_null":false},
+            {"name":"probwinout","type":"double precision","not_null":false},
+            {"name":"probwinconf","type":"double precision","not_null":false},
+            {"name":"sosremainingrank","type":"double precision","not_null":false},
+            {"name":"accomplishment","type":"double precision","not_null":false},
+            {"name":"accomplishmentrank","type":"double precision","not_null":false},
+            {"name":"adjwins","type":"double precision","not_null":false},
+            {"name":"adjlosses","type":"double precision","not_null":false},
+            {"name":"adjwinpctrank","type":"double precision","not_null":false},
+            {"name":"gamecontrol","type":"double precision","not_null":false},
+            {"name":"gamecontrolrank","type":"double precision","not_null":false},
+            {"name":"adjavgingamewp","type":"double precision","not_null":false},
+            {"name":"adjavgingamewprank","type":"double precision","not_null":false},
+            {"name":"avgingamewp","type":"double precision","not_null":false},
+            {"name":"avgingamewprank","type":"double precision","not_null":false},
+            {"name":"avgsosrank","type":"double precision","not_null":false},
+            {"name":"topsosrank","type":"double precision","not_null":false},
+            {"name":"epaoffense","type":"double precision","not_null":false},
+            {"name":"epadefense","type":"double precision","not_null":false},
+            {"name":"epaspecialteams","type":"double precision","not_null":false},
+            {"name":"probwindiv","type":"double precision","not_null":false},
+            {"name":"probmakeplayoffs","type":"double precision","not_null":false},
+            {"name":"probmaketitlegame","type":"double precision","not_null":false},
+            {"name":"numwins","type":"double precision","not_null":false},
+            {"name":"numlosses","type":"double precision","not_null":false},
+            {"name":"numties","type":"double precision","not_null":false},
+            {"name":"probwintitle","type":"double precision","not_null":false},
+            {"name":"rankchange7days","type":"double precision","not_null":false},
+            {"name":"prob6wins","type":"double precision","not_null":false},
+            {"name":"rank","type":"double precision","not_null":false},
+            {"name":"offefficiency","type":"double precision","not_null":false},
+            {"name":"offefficiencyrank","type":"double precision","not_null":false},
+            {"name":"defefficiency","type":"double precision","not_null":false},
+            {"name":"defefficiencyrank","type":"double precision","not_null":false},
+            {"name":"stefficiency","type":"double precision","not_null":false},
+            {"name":"stefficiencyrank","type":"double precision","not_null":false},
+            {"name":"totefficiency","type":"double precision","not_null":false},
+            {"name":"totefficiencyrank","type":"double precision","not_null":false},
+            {"name":"snapshot_is_contemporaneous","type":"boolean","not_null":false},
+            {"name":"loaded_at","type":"timestamp with time zone","not_null":true},
+            {"name":"_dlt_load_id","type":"character varying","not_null":true},
+            {"name":"_dlt_id","type":"character varying","not_null":true}
+        ]'::jsonb
+        WHEN 'sdv_team_xwalk' THEN '[
+            {"name":"season","type":"bigint","not_null":true},
+            {"name":"norm_key","type":"text","not_null":true},
+            {"name":"xwalk_key","type":"text","not_null":true},
+            {"name":"espn_team_id","type":"bigint","not_null":false},
+            {"name":"espn_team","type":"text","not_null":false},
+            {"name":"espn_abbreviation","type":"text","not_null":false},
+            {"name":"fox_team_id","type":"text","not_null":false},
+            {"name":"fox_team","type":"text","not_null":false},
+            {"name":"fox_abbreviation","type":"text","not_null":false},
+            {"name":"yahoo_team_id","type":"text","not_null":false},
+            {"name":"yahoo_team","type":"text","not_null":false},
+            {"name":"yahoo_abbreviation","type":"text","not_null":false},
+            {"name":"matched_sources","type":"text","not_null":false},
+            {"name":"loaded_at","type":"timestamp with time zone","not_null":true},
+            {"name":"_dlt_load_id","type":"character varying","not_null":true},
+            {"name":"_dlt_id","type":"character varying","not_null":true}
+        ]'::jsonb
+        WHEN 'sdv_game_xwalk' THEN '[
+            {"name":"season","type":"bigint","not_null":true},
+            {"name":"matchup_key","type":"text","not_null":true},
+            {"name":"yahoo_date","type":"date","not_null":true},
+            {"name":"espn_game_id","type":"bigint","not_null":false},
+            {"name":"fox_game_id","type":"text","not_null":false},
+            {"name":"yahoo_game_id","type":"text","not_null":false},
+            {"name":"yahoo_global_game_id","type":"text","not_null":false},
+            {"name":"home_team","type":"text","not_null":false},
+            {"name":"away_team","type":"text","not_null":false},
+            {"name":"espn_date","type":"date","not_null":false},
+            {"name":"fox_date","type":"date","not_null":false},
+            {"name":"matched_sources","type":"text","not_null":false},
+            {"name":"loaded_at","type":"timestamp with time zone","not_null":true},
+            {"name":"_dlt_load_id","type":"character varying","not_null":true},
+            {"name":"_dlt_id","type":"character varying","not_null":true}
+        ]'::jsonb END;
+
+    IF catalog_shape IS DISTINCT FROM expected_catalog
+        OR NOT EXISTS (
+            SELECT 1 FROM pg_catalog.pg_class c
+            WHERE c.oid = pg_catalog.to_regclass(asset) AND c.relkind = 'r'
+              AND c.relowner = (SELECT oid FROM pg_catalog.pg_roles
+                  WHERE rolname = current_user)
+              AND NOT c.relrowsecurity AND NOT c.relforcerowsecurity
+              AND NOT c.relhasrules
+        ) OR EXISTS (SELECT 1 FROM pg_catalog.pg_inherits i
+            WHERE i.inhrelid = pg_catalog.to_regclass(asset)
+               OR i.inhparent = pg_catalog.to_regclass(asset))
+        OR NOT EXISTS (SELECT 1 FROM pg_catalog.pg_constraint c
+            WHERE c.conrelid = pg_catalog.to_regclass(asset) AND c.contype = 'u'
+              AND pg_catalog.pg_get_constraintdef(c.oid) = 'UNIQUE (_dlt_id)')
+        OR NOT EXISTS (SELECT 1 FROM pg_catalog.pg_constraint c
+            WHERE c.conrelid = pg_catalog.to_regclass(asset) AND c.contype = 'p'
+              AND pg_catalog.pg_get_constraintdef(c.oid) = CASE source_name
+                  WHEN 'sdv_fpi_weekly' THEN
+                      'PRIMARY KEY (season, season_type, week, team_id)'
+                  WHEN 'sdv_team_xwalk' THEN 'PRIMARY KEY (season, xwalk_key)'
+                  WHEN 'sdv_game_xwalk' THEN
+                      'PRIMARY KEY (season, matchup_key, yahoo_date)' END) THEN
+        RAISE EXCEPTION '% catalog differs from the reviewed contract', asset
+            USING ERRCODE = '55000';
+    END IF;
+    IF (SELECT l.relation_oid FROM meta.asset_publication_locks l
+            WHERE l.asset_key = asset) IS DISTINCT FROM pg_catalog.to_regclass(asset)
+        OR NOT EXISTS (SELECT 1 FROM pg_catalog.pg_trigger t
+            WHERE t.tgrelid = pg_catalog.to_regclass(asset)
+              AND t.tgname = 'invalidate_sdv_source_batch_row_pointer'
+              AND t.tgtype = 31 AND t.tgenabled IN ('O','A') AND NOT t.tgisinternal
+              AND t.tgqual IS NULL AND t.tgnargs = 0
+              AND pg_catalog.octet_length(t.tgargs) = 0
+              AND t.tgattr::text = '' AND t.tgconstraint = 0
+              AND NOT t.tgdeferrable AND NOT t.tginitdeferred AND t.tgparentid = 0
+              AND t.tgfoid = pg_catalog.to_regprocedure(
+                  'warehouse_source_batch.invalidate_row_pointer()'))
+        OR NOT EXISTS (SELECT 1 FROM pg_catalog.pg_trigger t
+            WHERE t.tgrelid = pg_catalog.to_regclass(asset)
+              AND t.tgname = 'invalidate_sdv_source_batch_truncate_pointer'
+              AND t.tgtype = 34 AND t.tgenabled IN ('O','A') AND NOT t.tgisinternal
+              AND t.tgqual IS NULL AND t.tgnargs = 0
+              AND pg_catalog.octet_length(t.tgargs) = 0
+              AND t.tgattr::text = '' AND t.tgconstraint = 0
+              AND NOT t.tgdeferrable AND NOT t.tginitdeferred AND t.tgparentid = 0
+              AND t.tgfoid = pg_catalog.to_regprocedure(
+                  'warehouse_source_batch.invalidate_truncate_pointer()'))
+        OR EXISTS (SELECT 1 FROM pg_catalog.pg_trigger t
+            WHERE t.tgrelid = pg_catalog.to_regclass(asset) AND NOT t.tgisinternal
+              AND t.tgname NOT IN (
+                  'invalidate_sdv_source_batch_row_pointer',
+                  'invalidate_sdv_source_batch_truncate_pointer'))
+        OR NOT EXISTS (SELECT 1 FROM pg_catalog.pg_event_trigger e
+            WHERE e.evtname = 'warehouse_source_batch_invalidate_ddl'
+              AND e.evtevent = 'ddl_command_end' AND e.evtenabled IN ('O','A')
+              AND e.evttags IS NULL
+              AND e.evtfoid = pg_catalog.to_regprocedure(
+                  'warehouse_source_batch.invalidate_ddl()'))
+        OR NOT EXISTS (SELECT 1 FROM pg_catalog.pg_event_trigger e
+            WHERE e.evtname = 'warehouse_source_batch_invalidate_drop'
+              AND e.evtevent = 'sql_drop' AND e.evtenabled IN ('O','A')
+              AND e.evttags IS NULL
+              AND e.evtfoid = pg_catalog.to_regprocedure(
+                  'warehouse_source_batch.invalidate_drop()')) THEN
+        RAISE EXCEPTION 'source publication guards or asset identity are invalid'
+            USING ERRCODE = '55000';
+    END IF;
+
+    SELECT p.generation_id INTO actual_generation
+    FROM meta.asset_current_generations p
+    WHERE p.asset_key = asset AND p.coverage_key = coverage_value FOR UPDATE;
+    IF actual_generation IS DISTINCT FROM expected_generation THEN
+        RAISE EXCEPTION 'source generation changed; replan required' USING ERRCODE = '40001';
+    END IF;
+
+    LOCK TABLE meta.flat_file_loads IN ROW EXCLUSIVE MODE;
+    IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_class c
+        WHERE c.oid = 'meta.flat_file_loads'::pg_catalog.regclass
+          AND c.relkind = 'r'
+          AND c.relowner = (SELECT oid FROM pg_catalog.pg_roles
+              WHERE rolname = current_user)
+          AND NOT c.relrowsecurity AND NOT c.relforcerowsecurity)
+        OR EXISTS (SELECT 1 FROM pg_catalog.pg_inherits i
+            WHERE i.inhrelid = 'meta.flat_file_loads'::pg_catalog.regclass
+               OR i.inhparent = 'meta.flat_file_loads'::pg_catalog.regclass)
+        OR EXISTS (SELECT 1 FROM pg_catalog.pg_trigger t
+            WHERE t.tgrelid = 'meta.flat_file_loads'::pg_catalog.regclass
+              AND NOT t.tgisinternal) THEN
+        RAISE EXCEPTION 'meta.flat_file_loads is not a trusted publication ledger'
+            USING ERRCODE = '55000';
+    END IF;
+
+    publication_time := pg_catalog.clock_timestamp();
+    IF source_name = 'sdv_fpi_weekly' THEN
+        SELECT count(*) INTO previous_rows FROM ratings.espn_fpi_weekly old
+        WHERE old.season = season_value;
+        WITH incoming AS (
+            SELECT * FROM pg_catalog.jsonb_populate_recordset(
+                NULL::ratings.espn_fpi_weekly, p_rows)
+        )
+        SELECT
+            count(*) FILTER (WHERE old.season IS NULL),
+            count(*) FILTER (WHERE new.season IS NULL),
+            count(*) FILTER (
+                WHERE old.season IS NOT NULL AND new.season IS NOT NULL
+                  AND (pg_catalog.to_jsonb(old) -
+                        ARRAY['loaded_at','_dlt_load_id','_dlt_id']::text[])
+                      IS DISTINCT FROM
+                      (pg_catalog.to_jsonb(new) -
+                        ARRAY['loaded_at','_dlt_load_id','_dlt_id']::text[]))
+        INTO inserted_rows, deleted_rows, changed_rows
+        FROM ratings.espn_fpi_weekly old
+        FULL JOIN incoming new USING (season, season_type, week, team_id)
+        WHERE COALESCE(old.season, new.season) = season_value;
+
+        DELETE FROM ratings.espn_fpi_weekly WHERE season = season_value;
+        INSERT INTO ratings.espn_fpi_weekly
+        SELECT r.* FROM pg_catalog.jsonb_populate_recordset(
+            NULL::ratings.espn_fpi_weekly,
+            (SELECT pg_catalog.jsonb_agg(item || pg_catalog.jsonb_build_object(
+                    'loaded_at', publication_time))
+             FROM pg_catalog.jsonb_array_elements(p_rows) item)
+        ) r;
+        IF (SELECT count(*) FROM ratings.espn_fpi_weekly
+                WHERE season = season_value) <> row_count_value THEN
+            RAISE EXCEPTION 'published season differs from the normalized FPI file';
+        END IF;
+    ELSIF source_name = 'sdv_team_xwalk' THEN
+        SELECT count(*) INTO previous_rows FROM ref.team_id_xwalk old
+        WHERE old.season = season_value;
+        WITH incoming AS (
+            SELECT * FROM pg_catalog.jsonb_populate_recordset(
+                NULL::ref.team_id_xwalk, p_rows)
+        )
+        SELECT
+            count(*) FILTER (WHERE old.season IS NULL),
+            count(*) FILTER (WHERE new.season IS NULL),
+            count(*) FILTER (
+                WHERE old.season IS NOT NULL AND new.season IS NOT NULL
+                  AND (pg_catalog.to_jsonb(old) -
+                        ARRAY['loaded_at','_dlt_load_id','_dlt_id']::text[])
+                      IS DISTINCT FROM
+                      (pg_catalog.to_jsonb(new) -
+                        ARRAY['loaded_at','_dlt_load_id','_dlt_id']::text[]))
+        INTO inserted_rows, deleted_rows, changed_rows
+        FROM ref.team_id_xwalk old
+        FULL JOIN incoming new USING (season, xwalk_key)
+        WHERE COALESCE(old.season, new.season) = season_value;
+
+        DELETE FROM ref.team_id_xwalk WHERE season = season_value;
+        INSERT INTO ref.team_id_xwalk
+        SELECT r.* FROM pg_catalog.jsonb_populate_recordset(
+            NULL::ref.team_id_xwalk,
+            (SELECT pg_catalog.jsonb_agg(item || pg_catalog.jsonb_build_object(
+                    'loaded_at', publication_time))
+             FROM pg_catalog.jsonb_array_elements(p_rows) item)
+        ) r;
+        IF (SELECT count(*) FROM ref.team_id_xwalk
+                WHERE season = season_value) <> row_count_value THEN
+            RAISE EXCEPTION 'published season differs from the normalized team crosswalk file';
+        END IF;
+    ELSE
+        SELECT count(*) INTO previous_rows FROM ref.game_id_xwalk old
+        WHERE old.season = season_value;
+        WITH incoming AS (
+            SELECT * FROM pg_catalog.jsonb_populate_recordset(
+                NULL::ref.game_id_xwalk, p_rows)
+        )
+        SELECT
+            count(*) FILTER (WHERE old.season IS NULL),
+            count(*) FILTER (WHERE new.season IS NULL),
+            count(*) FILTER (
+                WHERE old.season IS NOT NULL AND new.season IS NOT NULL
+                  AND (pg_catalog.to_jsonb(old) -
+                        ARRAY['loaded_at','_dlt_load_id','_dlt_id']::text[])
+                      IS DISTINCT FROM
+                      (pg_catalog.to_jsonb(new) -
+                        ARRAY['loaded_at','_dlt_load_id','_dlt_id']::text[]))
+        INTO inserted_rows, deleted_rows, changed_rows
+        FROM ref.game_id_xwalk old
+        FULL JOIN incoming new USING (season, matchup_key, yahoo_date)
+        WHERE COALESCE(old.season, new.season) = season_value;
+
+        DELETE FROM ref.game_id_xwalk WHERE season = season_value;
+        INSERT INTO ref.game_id_xwalk
+        SELECT r.* FROM pg_catalog.jsonb_populate_recordset(
+            NULL::ref.game_id_xwalk,
+            (SELECT pg_catalog.jsonb_agg(item || pg_catalog.jsonb_build_object(
+                    'loaded_at', publication_time))
+             FROM pg_catalog.jsonb_array_elements(p_rows) item)
+        ) r;
+        IF (SELECT count(*) FROM ref.game_id_xwalk
+                WHERE season = season_value) <> row_count_value THEN
+            RAISE EXCEPTION 'published season differs from the normalized game crosswalk file';
+        END IF;
+    END IF;
+
+    INSERT INTO meta.asset_receipts(
+        generation_id, operation_run_id, asset_key, coverage_key, outcome, coverage,
+        source_watermark, input_observations, row_delta, request_digest, published_at
+    ) VALUES (
+        p_generation_id, p_run_id, asset, coverage_value, 'succeeded',
+        pg_catalog.jsonb_build_object(
+            'complete', true, 'scope', 'season', 'season', season_value,
+            'mode', 'full_file_for_season', 'source_rows', row_count_value,
+            'published_rows', row_count_value),
+        p_source_sha256, pg_catalog.jsonb_build_object(
+            'publisher', 'load_flat_files', 'protocol', 'sdv-season-file-v1',
+            'source_name', source_name, 'parser_contract', parser,
+            'stage_schema', 'warehouse_source_stage',
+            'artifact_origin', p_dlt_evidence->>'artifact_origin',
+            'season_basis', season_basis, 'dlt_load_ids', actual_load_ids),
+        pg_catalog.jsonb_build_object(
+            'previous_rows', previous_rows, 'published_rows', row_count_value,
+            'inserted_rows', inserted_rows, 'deleted_rows', deleted_rows,
+            'changed_rows', changed_rows),
+        request_digest_value, publication_time
+    );
+    INSERT INTO meta.asset_current_generations(asset_key, coverage_key, generation_id)
+    VALUES (asset, coverage_value, p_generation_id)
+    ON CONFLICT (asset_key, coverage_key) DO UPDATE
+        SET generation_id = EXCLUDED.generation_id;
+
+    ledger_source_url := CASE
+        WHEN p_dlt_evidence->>'artifact_origin' = 'local_file' THEN NULL
+        WHEN source_name = 'sdv_fpi_weekly' THEN
+            'https://github.com/sportsdataverse/sportsdataverse-data/releases/download/'
+            || 'cfb_fpi_weekly/cfb_fpi_weekly_' || season_value::text || '.parquet'
+        WHEN source_name = 'sdv_team_xwalk' THEN
+            'https://github.com/sportsdataverse/sportsdataverse-data/releases/download/'
+            || 'cfb_crosswalk/cfb_teams_crosswalk_' || season_value::text || '.parquet'
+        WHEN source_name = 'sdv_game_xwalk' THEN
+            'https://github.com/sportsdataverse/sportsdataverse-data/releases/download/'
+            || 'cfb_crosswalk/cfb_schedule_crosswalk_' || season_value::text || '.parquet'
+        END;
+    INSERT INTO meta.flat_file_loads(
+        source, file_sha256, source_url, row_count, status, error
+    ) VALUES (source_name || ':' || season_value::text, p_source_sha256,
+        ledger_source_url, row_count_value::integer, 'loaded', NULL)
+    ON CONFLICT (source, file_sha256) WHERE status = 'loaded' DO NOTHING;
+    GET DIAGNOSTICS ledger_inserted = ROW_COUNT;
+    IF ledger_inserted = 0 THEN
+        INSERT INTO meta.flat_file_loads(
+            source, file_sha256, source_url, row_count, status, error
+        ) VALUES (source_name || ':' || season_value::text, p_source_sha256,
+            ledger_source_url, row_count_value::integer, 'skipped', NULL);
+    END IF;
+
+    PERFORM warehouse_quota.finish_operation_run(p_run_id, 'succeeded', NULL);
+    RETURN QUERY SELECT p_generation_id, false, row_count_value;
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION warehouse_source_batch.fail_source_load(
+    p_run_id uuid, p_generation_id uuid, p_outcome text
+)
+RETURNS uuid LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $function$
+DECLARE
+    run_row meta.operation_runs%ROWTYPE;
+    existing meta.asset_receipts%ROWTYPE;
+    source_name text;
+    asset text;
+    parser text;
+    season_value bigint;
+    coverage_value text;
+    operation_outcome text;
+    digest text;
+BEGIN
+    IF p_generation_id IS NULL OR p_outcome IS NULL
+        OR p_outcome NOT IN ('failed','deferred','blocked') THEN
+        RAISE EXCEPTION 'invalid source publication failure outcome'
+            USING ERRCODE = '22023';
+    END IF;
+    run_row := warehouse_source_batch.require_source_load(p_run_id);
+    source_name := run_row.requested_scope->>'source_name';
+    asset := run_row.requested_scope->>'asset_key';
+    parser := run_row.requested_scope->>'parser_contract';
+    season_value := (run_row.requested_scope->>'season')::bigint;
+    coverage_value := run_row.requested_scope->>'coverage_key';
+    operation_outcome := CASE WHEN p_outcome = 'deferred' THEN 'blocked' ELSE p_outcome END;
+    digest := pg_catalog.md5(pg_catalog.jsonb_build_object(
+        'run_id', p_run_id, 'generation_id', p_generation_id,
+        'plan', run_row.requested_scope, 'outcome', p_outcome,
+        'error_category', 'source_publication_failed')::text);
+
+    SELECT * INTO existing FROM meta.asset_receipts r
+    WHERE r.generation_id = p_generation_id;
+    IF FOUND THEN
+        IF existing.operation_run_id <> p_run_id OR existing.asset_key <> asset
+            OR existing.coverage_key <> coverage_value OR existing.outcome <> p_outcome
+            OR existing.request_digest <> digest
+            OR existing.error_summary <> 'source_publication_failed'
+            OR run_row.outcome <> operation_outcome THEN
+            RAISE EXCEPTION 'generation ID already has different source failure context'
+                USING ERRCODE = '22023';
+        END IF;
+        RETURN p_generation_id;
+    END IF;
+    IF run_row.outcome <> 'running' THEN
+        RAISE EXCEPTION 'source publication operation is terminal' USING ERRCODE = '22023';
+    END IF;
+
+    INSERT INTO meta.asset_receipts(
+        generation_id, operation_run_id, asset_key, coverage_key, outcome,
+        coverage, input_observations, request_digest, error_summary
+    ) VALUES (
+        p_generation_id, p_run_id, asset, coverage_value, p_outcome,
+        pg_catalog.jsonb_build_object(
+            'complete', false, 'scope', 'season', 'season', season_value,
+            'mode', 'full_file_for_season'),
+        pg_catalog.jsonb_build_object(
+            'publisher', 'load_flat_files', 'protocol', 'sdv-season-file-v1',
+            'source_name', source_name, 'parser_contract', parser),
+        digest, 'source_publication_failed'
+    );
+    PERFORM warehouse_quota.finish_operation_run(
+        p_run_id, operation_outcome, 'source_publication_failed');
+    RETURN p_generation_id;
+END
+$function$;
+
+-- Scrub host defaults before exposing exactly the four public entrypoints.
+DO $acl$
+DECLARE item record; recipient text;
+BEGIN
+    FOR item IN
+        SELECT 'SCHEMA' AS kind, pg_catalog.format('%I', n.nspname) AS name, a.grantee
+        FROM pg_catalog.pg_namespace n
+        CROSS JOIN LATERAL pg_catalog.aclexplode(n.nspacl) a
+        WHERE n.nspname = 'warehouse_source_batch' AND a.grantee <> n.nspowner
+        UNION
+        SELECT 'FUNCTION', p.oid::pg_catalog.regprocedure::text, a.grantee
+        FROM pg_catalog.pg_proc p JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+        CROSS JOIN LATERAL pg_catalog.aclexplode(
+            COALESCE(p.proacl, pg_catalog.acldefault('f', p.proowner))) a
+        WHERE n.nspname = 'warehouse_source_batch' AND a.grantee <> p.proowner
+    LOOP
+        recipient := CASE WHEN item.grantee = 0 THEN 'PUBLIC'
+            ELSE pg_catalog.quote_ident(pg_catalog.pg_get_userbyid(item.grantee)) END;
+        EXECUTE pg_catalog.format(
+            'REVOKE ALL ON %s %s FROM %s', item.kind, item.name, recipient);
+    END LOOP;
+END
+$acl$;
+
+-- Host default privileges may grant PUBLIC execution to newly created routines.
+-- Make the post-creation boundary explicit in addition to scrubbing every
+-- catalog-visible direct grantee above.
+REVOKE ALL ON ALL FUNCTIONS IN SCHEMA warehouse_source_batch FROM PUBLIC;
+
+REVOKE ALL ON ratings.espn_fpi_weekly, ref.team_id_xwalk, ref.game_id_xwalk,
+    meta.asset_publication_locks, meta.asset_receipts,
+    meta.asset_current_generations, meta.asset_receipt_inputs,
+    meta.operation_runs, meta.flat_file_loads
+FROM warehouse_source_publisher;
+REVOKE CREATE ON SCHEMA warehouse_source_batch, warehouse_source
+FROM warehouse_source_publisher;
+REVOKE USAGE ON SCHEMA warehouse_source_stage, warehouse_quota,
+    warehouse_publication, warehouse_refresh
+FROM warehouse_source_publisher;
+REVOKE EXECUTE ON ALL FUNCTIONS IN SCHEMA warehouse_quota,
+    warehouse_publication, warehouse_refresh
+FROM warehouse_source_publisher;
+
+GRANT USAGE ON SCHEMA warehouse_source, warehouse_source_batch
+TO warehouse_source_publisher;
+GRANT EXECUTE ON FUNCTION
+    warehouse_source.get_sdv_ratings_plan(bigint),
+    warehouse_source.start_sdv_ratings_load(uuid,jsonb),
+    warehouse_source.publish_sdv_ratings_load(uuid,uuid,text,jsonb,jsonb),
+    warehouse_source.fail_sdv_ratings_load(uuid,uuid,text),
+    warehouse_source_batch.get_source_plan(text,bigint),
+    warehouse_source_batch.start_source_load(uuid,jsonb),
+    warehouse_source_batch.publish_source_load(uuid,uuid,text,jsonb,jsonb),
+    warehouse_source_batch.fail_source_load(uuid,uuid,text)
+TO warehouse_source_publisher;
+
+DO $boundary$
+DECLARE relation_name text;
+BEGIN
+    FOREACH relation_name IN ARRAY ARRAY[
+        'ratings.sdv_ratings_weekly','ratings.espn_fpi_weekly',
+        'ref.team_id_xwalk','ref.game_id_xwalk',
+        'meta.asset_publication_locks','meta.asset_receipts',
+        'meta.asset_current_generations','meta.asset_receipt_inputs',
+        'meta.operation_runs','meta.flat_file_loads'
+    ] LOOP
+        IF pg_catalog.current_setting('server_version_num')::integer >= 170000 THEN
+            IF pg_catalog.has_table_privilege(
+                    'warehouse_source_publisher', relation_name, 'MAINTAIN') THEN
+                RAISE EXCEPTION 'warehouse_source_publisher has unsafe maintenance access to %',
+                    relation_name;
+            END IF;
+        END IF;
+        IF (SELECT c.relowner FROM pg_catalog.pg_class c
+                WHERE c.oid = pg_catalog.to_regclass(relation_name)) =
+                (SELECT oid FROM pg_catalog.pg_roles
+                    WHERE rolname = 'warehouse_source_publisher')
+            OR pg_catalog.has_table_privilege(
+                'warehouse_source_publisher', relation_name,
+                'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER') THEN
+            RAISE EXCEPTION 'warehouse_source_publisher has unsafe direct access to %',
+                relation_name;
+        END IF;
+    END LOOP;
+    IF pg_catalog.has_schema_privilege(
+            'warehouse_source_publisher','warehouse_source_batch','CREATE')
+        OR pg_catalog.has_schema_privilege(
+            'warehouse_source_publisher','warehouse_source','CREATE')
+        OR NOT pg_catalog.has_schema_privilege(
+            'warehouse_source_publisher','warehouse_source_batch','USAGE')
+        OR NOT pg_catalog.has_schema_privilege(
+            'warehouse_source_publisher','warehouse_source','USAGE')
+        OR pg_catalog.has_schema_privilege(
+            'warehouse_source_publisher','warehouse_source_stage','USAGE,CREATE')
+        OR EXISTS (
+            SELECT 1 FROM pg_catalog.pg_proc p
+            JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+            WHERE n.nspname IN (
+                    'warehouse_quota','warehouse_publication','warehouse_refresh')
+              AND pg_catalog.has_function_privilege(
+                  'warehouse_source_publisher', p.oid, 'EXECUTE'))
+        OR NOT pg_catalog.has_function_privilege(
+            'warehouse_source_publisher',
+            'warehouse_source_batch.get_source_plan(text,bigint)', 'EXECUTE')
+        OR NOT pg_catalog.has_function_privilege(
+            'warehouse_source_publisher',
+            'warehouse_source_batch.start_source_load(uuid,jsonb)', 'EXECUTE')
+        OR NOT pg_catalog.has_function_privilege(
+            'warehouse_source_publisher',
+            'warehouse_source_batch.publish_source_load(uuid,uuid,text,jsonb,jsonb)',
+            'EXECUTE')
+        OR NOT pg_catalog.has_function_privilege(
+            'warehouse_source_publisher',
+            'warehouse_source_batch.fail_source_load(uuid,uuid,text)', 'EXECUTE')
+        OR NOT pg_catalog.has_function_privilege(
+            'warehouse_source_publisher',
+            'warehouse_source.get_sdv_ratings_plan(bigint)', 'EXECUTE')
+        OR NOT pg_catalog.has_function_privilege(
+            'warehouse_source_publisher',
+            'warehouse_source.start_sdv_ratings_load(uuid,jsonb)', 'EXECUTE')
+        OR NOT pg_catalog.has_function_privilege(
+            'warehouse_source_publisher',
+            'warehouse_source.publish_sdv_ratings_load(uuid,uuid,text,jsonb,jsonb)',
+            'EXECUTE')
+        OR NOT pg_catalog.has_function_privilege(
+            'warehouse_source_publisher',
+            'warehouse_source.fail_sdv_ratings_load(uuid,uuid,text)', 'EXECUTE')
+        OR EXISTS (
+            SELECT 1 FROM pg_catalog.pg_proc p
+            JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+            WHERE n.nspname = 'warehouse_source_batch'
+              AND p.oid <> ALL(ARRAY[
+                  'warehouse_source_batch.get_source_plan(text,bigint)'::pg_catalog.regprocedure,
+                  'warehouse_source_batch.start_source_load(uuid,jsonb)'::pg_catalog.regprocedure,
+                  'warehouse_source_batch.publish_source_load(uuid,uuid,text,jsonb,jsonb)'::pg_catalog.regprocedure,
+                  'warehouse_source_batch.fail_source_load(uuid,uuid,text)'::pg_catalog.regprocedure
+              ]::oid[])
+              AND pg_catalog.has_function_privilege(
+                  'warehouse_source_publisher', p.oid, 'EXECUTE'))
+        OR EXISTS (
+            SELECT 1 FROM pg_catalog.pg_proc p
+            JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+            WHERE n.nspname = 'warehouse_source'
+              AND p.oid <> ALL(ARRAY[
+                  'warehouse_source.get_sdv_ratings_plan(bigint)'::pg_catalog.regprocedure,
+                  'warehouse_source.start_sdv_ratings_load(uuid,jsonb)'::pg_catalog.regprocedure,
+                  'warehouse_source.publish_sdv_ratings_load(uuid,uuid,text,jsonb,jsonb)'::pg_catalog.regprocedure,
+                  'warehouse_source.fail_sdv_ratings_load(uuid,uuid,text)'::pg_catalog.regprocedure
+              ]::oid[])
+              AND pg_catalog.has_function_privilege(
+                  'warehouse_source_publisher', p.oid, 'EXECUTE')) THEN
+        RAISE EXCEPTION 'warehouse_source_publisher has unrelated or internal access';
+    END IF;
+END
+$boundary$;
+
+COMMENT ON SCHEMA warehouse_source_batch IS
+    'Private fixed-allowlist publication RPCs for the three remaining SDV season files.';
+COMMENT ON FUNCTION warehouse_source_batch.get_source_plan(text,bigint) IS
+    'Returns the exact current-generation CAS plan for one enrolled SDV source season.';
+COMMENT ON FUNCTION warehouse_source_batch.publish_source_load(uuid,uuid,text,jsonb,jsonb) IS
+    'Atomically replaces one complete nonempty season for a fixed enrolled SDV source.';

--- a/src/schemas/production-manifest.json
+++ b/src/schemas/production-manifest.json
@@ -34,6 +34,11 @@
       "id": "warehouse.source.071",
       "path": "src/schemas/migrations/071_sdv_ratings_publication.sql",
       "kind": "immutable"
+    },
+    {
+      "id": "warehouse.source.072",
+      "path": "src/schemas/migrations/072_sdv_source_batch_publication.sql",
+      "kind": "immutable"
     }
   ],
   "version": 1

--- a/src/schemas/warehouse-manifest.json
+++ b/src/schemas/warehouse-manifest.json
@@ -60,6 +60,11 @@
       "id": "warehouse.source.071",
       "path": "src/schemas/migrations/071_sdv_ratings_publication.sql",
       "kind": "immutable"
+    },
+    {
+      "id": "warehouse.source.072",
+      "path": "src/schemas/migrations/072_sdv_source_batch_publication.sql",
+      "kind": "immutable"
     }
   ]
 }

--- a/tests/test_flat_file_publication.py
+++ b/tests/test_flat_file_publication.py
@@ -1,0 +1,438 @@
+"""Unit coverage for generic receipt-backed flat-file publication."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import uuid
+from dataclasses import replace
+from datetime import UTC, date, datetime
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from src.pipelines.config.source_publication_assets import (
+    SDV_FPI_PUBLICATION,
+    SDV_GAME_XWALK_PUBLICATION,
+    SDV_RATINGS_PUBLICATION,
+    SDV_TEAM_XWALK_PUBLICATION,
+    SOURCE_PUBLICATION_ASSETS,
+)
+from src.pipelines.sources.flat_files import REGISTRY
+from src.pipelines.utils import flat_file_publication as publication
+from src.pipelines.utils.file_fetcher import FetchedFile
+
+RUN_ID = "11111111-1111-4111-8111-111111111111"
+GENERATION_ID = "22222222-2222-4222-8222-222222222222"
+
+
+def fpi_row(**overrides):
+    row = {column: None for column in SDV_FPI_PUBLICATION.columns}
+    row.update(
+        season=2025,
+        season_type=2,
+        week=0,
+        team_id=333,
+        last_updated=datetime(2025, 8, 1, tzinfo=UTC),
+        run_date_time_key=20250801000000,
+        snapshot_out_of_sequence=False,
+        fpi=1.25,
+        snapshot_is_contemporaneous=True,
+    )
+    row.update(overrides)
+    return row
+
+
+def team_row(**overrides):
+    row = {
+        "season": 2025,
+        "norm_key": "example owls",
+        "xwalk_key": "example owls#None",
+        "espn_team_id": None,
+        "espn_team": None,
+        "espn_abbreviation": None,
+        "fox_team_id": None,
+        "fox_team": None,
+        "fox_abbreviation": None,
+        "yahoo_team_id": None,
+        "yahoo_team": None,
+        "yahoo_abbreviation": None,
+        "matched_sources": "fox",
+    }
+    row.update(overrides)
+    return row
+
+
+def game_row(**overrides):
+    row = {
+        "season": 2025,
+        "matchup_key": "away|home",
+        "yahoo_date": date(2025, 9, 1),
+        "espn_game_id": None,
+        "fox_game_id": None,
+        "yahoo_game_id": "123",
+        "yahoo_global_game_id": "global-123",
+        "home_team": "Home Owls",
+        "away_team": "Away Bears",
+        "espn_date": None,
+        "fox_date": None,
+        "matched_sources": "yahoo",
+    }
+    row.update(overrides)
+    return row
+
+
+def plan(asset, season=2025):
+    return {
+        "protocol": "sdv-season-file-v1",
+        "source_name": asset.source_name,
+        "asset_key": asset.asset_key,
+        "coverage_key": f"season:{season}",
+        "season": season,
+        "expected_generation_id": None,
+        "parser_contract": asset.parser_contract,
+    }
+
+
+def install_ids(monkeypatch):
+    values = iter((uuid.UUID(RUN_ID), uuid.UUID(GENERATION_ID)))
+    monkeypatch.setattr(publication.uuid, "uuid4", lambda: next(values))
+
+
+def test_assets_enroll_all_sources_with_stable_season_evidence():
+    assert tuple(SOURCE_PUBLICATION_ASSETS) == (
+        "sdv_ratings_weekly",
+        "sdv_fpi_weekly",
+        "sdv_team_xwalk",
+        "sdv_game_xwalk",
+    )
+    assert SDV_RATINGS_PUBLICATION.season_basis("local_file") == "artifact_field"
+    assert SDV_FPI_PUBLICATION.season_basis("registered_url") == "artifact_field"
+    assert SDV_TEAM_XWALK_PUBLICATION.season_basis("registered_url") == ("registered_artifact_name")
+    assert SDV_GAME_XWALK_PUBLICATION.season_basis("local_file") == "caller_declared"
+    with pytest.raises(ValueError, match="artifact origin"):
+        SDV_FPI_PUBLICATION.season_basis("unknown")
+
+
+@pytest.mark.parametrize(
+    "source,asset",
+    [
+        ("sdv_fpi_weekly", SDV_FPI_PUBLICATION),
+        ("sdv_team_xwalk", SDV_TEAM_XWALK_PUBLICATION),
+        ("sdv_game_xwalk", SDV_GAME_XWALK_PUBLICATION),
+    ],
+)
+def test_only_exact_canonical_specs_are_accepted(source, asset):
+    assert publication._asset_for(REGISTRY[source], 2025) is asset
+    with pytest.raises(ValueError, match="canonical"):
+        publication._asset_for(replace(REGISTRY[source]), 2025)
+
+
+@pytest.mark.parametrize(
+    "spec,season",
+    [
+        (replace(REGISTRY["sdv_fpi_weekly"]), 2025),
+        (REGISTRY["sdv_game_xwalk"], 2201),
+        (REGISTRY["massey"], 2025),
+    ],
+)
+def test_run_returns_failed_result_when_generic_preflight_rejects(monkeypatch, spec, season):
+    install_ids(monkeypatch)
+    monkeypatch.setattr(
+        publication,
+        "get_db_url",
+        lambda: pytest.fail("preflight must run before database configuration"),
+    )
+    result = publication.run_source_publication(spec, season=season)
+    assert result["source"] == spec.name
+    assert result["status"] == "failed"
+    assert result["run_id"] == RUN_ID
+    assert result["generation_id"] == GENERATION_ID
+
+
+def test_plan_requires_exact_source_protocol_and_generation():
+    expected = plan(SDV_FPI_PUBLICATION)
+    assert publication._validated_plan(expected, SDV_FPI_PUBLICATION, 2025) == expected
+    with pytest.raises(publication.SourcePublicationError, match="invalid source plan"):
+        publication._validated_plan({**expected, "extra": True}, SDV_FPI_PUBLICATION, 2025)
+    with pytest.raises(publication.SourcePublicationError, match="mismatched"):
+        publication._validated_plan(
+            {**expected, "source_name": "sdv_game_xwalk"}, SDV_FPI_PUBLICATION, 2025
+        )
+    with pytest.raises(publication.SourcePublicationError, match="invalid expected"):
+        publication._validated_plan(
+            {**expected, "expected_generation_id": "bad"}, SDV_FPI_PUBLICATION, 2025
+        )
+
+
+def test_team_rows_preserve_all_null_provider_ids_and_verify_derived_key():
+    publication._validate_parsed_rows([team_row()], 1, SDV_TEAM_XWALK_PUBLICATION, 2025)
+    publication._validate_parsed_rows(
+        [team_row(fox_team_id="fox-1", xwalk_key="example owls#fox-1")],
+        1,
+        SDV_TEAM_XWALK_PUBLICATION,
+        2025,
+    )
+    with pytest.raises(publication.SourcePublicationError, match="derived xwalk_key"):
+        publication._validate_parsed_rows(
+            [team_row(xwalk_key="wrong")], 1, SDV_TEAM_XWALK_PUBLICATION, 2025
+        )
+
+
+@pytest.mark.parametrize(
+    "row,message",
+    [
+        (fpi_row(last_updated=datetime(2025, 8, 1)), "timezone-aware"),
+        (fpi_row(season_type=1), "season_type"),
+        (fpi_row(week=-1), "nonnegative"),
+        (fpi_row(team_id=0), "positive"),
+    ],
+)
+def test_fpi_domain_and_timezone_validation(row, message):
+    with pytest.raises(publication.SourcePublicationError, match=message):
+        publication._validate_parsed_rows([row], 1, SDV_FPI_PUBLICATION, 2025)
+
+
+def _parquet_bytes(row):
+    buffer = io.BytesIO()
+    pq.write_table(pa.Table.from_pylist([row]), buffer)
+    return buffer.getvalue()
+
+
+@pytest.mark.parametrize("added_column", ["season", "xwalk_key"])
+def test_team_raw_schema_rejects_conflicting_parser_derived_columns(added_column):
+    raw_row = team_row()
+    raw_row.pop("season")
+    raw_row.pop("xwalk_key")
+    raw_row[added_column] = 2024 if added_column == "season" else "upstream#key"
+    with pytest.raises(publication.SourcePublicationError, match="raw columns"):
+        publication._raw_row_count(_parquet_bytes(raw_row), SDV_TEAM_XWALK_PUBLICATION, 2025)
+
+
+def test_raw_schema_rejects_duplicate_column_names(monkeypatch):
+    class Schema:
+        names = [*SDV_GAME_XWALK_PUBLICATION.columns[1:], "matchup_key"]
+
+    class Parquet:
+        schema_arrow = Schema()
+
+    monkeypatch.setattr(publication.pyarrow.parquet, "ParquetFile", lambda stream: Parquet())
+    with pytest.raises(publication.SourcePublicationError, match="raw columns"):
+        publication._raw_row_count(b"unused", SDV_GAME_XWALK_PUBLICATION, 2025)
+
+
+@pytest.mark.parametrize(
+    "column,value,message",
+    [
+        ("season_type", 2.5, "non-integer"),
+        ("snapshot_out_of_sequence", "false", "non-boolean"),
+    ],
+)
+def test_fpi_raw_values_are_checked_before_lossy_parser_coercion(column, value, message):
+    raw = fpi_row()
+    raw["last_updated"] = "2025-08-01T00:00:00Z"
+    raw[column] = value
+    with pytest.raises(publication.SourcePublicationError, match=message):
+        publication._raw_row_count(_parquet_bytes(raw), SDV_FPI_PUBLICATION, 2025)
+
+
+def test_fpi_raw_season_must_match_selected_season():
+    raw = fpi_row(season=2024)
+    raw["last_updated"] = "2024-08-01T00:00:00Z"
+    with pytest.raises(publication.SourcePublicationError, match="raw season"):
+        publication._raw_row_count(_parquet_bytes(raw), SDV_FPI_PUBLICATION, 2025)
+
+
+@pytest.mark.parametrize(
+    "rows,count,asset,message",
+    [
+        ([], 0, SDV_FPI_PUBLICATION, "nonempty"),
+        ([fpi_row()], 2, SDV_FPI_PUBLICATION, "dropped or added"),
+        ([fpi_row(season=2024)], 1, SDV_FPI_PUBLICATION, "requested season"),
+        ([fpi_row(team_id=None)], 1, SDV_FPI_PUBLICATION, "null primary-key"),
+        ([fpi_row(), fpi_row()], 2, SDV_FPI_PUBLICATION, "duplicate primary key"),
+        ([fpi_row(fpi=float("nan"))], 1, SDV_FPI_PUBLICATION, "not finite"),
+        ([fpi_row(season_type=2.5)], 1, SDV_FPI_PUBLICATION, "not an integer"),
+        ([game_row(yahoo_date="2025-09-01")], 1, SDV_GAME_XWALK_PUBLICATION, "not a date"),
+    ],
+)
+def test_snapshot_validation_rejects_incomplete_or_unsafe_rows(rows, count, asset, message):
+    with pytest.raises(publication.SourcePublicationError, match=message):
+        publication._validate_parsed_rows(rows, count, asset, 2025)
+
+
+def test_snapshot_contract_rejects_missing_and_extra_columns():
+    missing = game_row()
+    missing.pop("fox_date")
+    with pytest.raises(publication.SourcePublicationError, match="12-column"):
+        publication._validate_parsed_rows([missing], 1, SDV_GAME_XWALK_PUBLICATION, 2025)
+    with pytest.raises(publication.SourcePublicationError, match="12-column"):
+        publication._validate_parsed_rows(
+            [game_row(unexpected=True)], 1, SDV_GAME_XWALK_PUBLICATION, 2025
+        )
+
+
+def test_explicit_hints_cover_each_business_column_and_nullable_ids():
+    fpi = {hint["name"]: hint for hint in publication._column_hints(SDV_FPI_PUBLICATION)}
+    team = {hint["name"]: hint for hint in publication._column_hints(SDV_TEAM_XWALK_PUBLICATION)}
+    game = {hint["name"]: hint for hint in publication._column_hints(SDV_GAME_XWALK_PUBLICATION)}
+    assert (len(fpi), len(team), len(game)) == (51, 13, 12)
+    assert fpi["last_updated"]["data_type"] == "timestamp"
+    assert fpi["snapshot_is_contemporaneous"]["data_type"] == "bool"
+    assert team["espn_team_id"] == {
+        "name": "espn_team_id",
+        "data_type": "bigint",
+        "nullable": True,
+    }
+    assert team["norm_key"]["nullable"] is False
+    assert game["yahoo_date"]["data_type"] == "date"
+    assert game["espn_game_id"]["nullable"] is True
+
+
+def test_json_encoding_preserves_dates_timestamps_and_booleans():
+    encoded = publication._json_dumps(
+        {
+            "date": date(2025, 9, 1),
+            "timestamp": datetime(2025, 9, 1, tzinfo=UTC),
+            "flag": False,
+        }
+    )
+    assert '"date": "2025-09-01"' in encoded
+    assert '"timestamp": "2025-09-01T00:00:00+00:00"' in encoded
+    assert '"flag": false' in encoded
+
+
+@pytest.mark.parametrize(
+    "source,row,origin,basis",
+    [
+        ("sdv_fpi_weekly", fpi_row(), "local_file", "artifact_field"),
+        ("sdv_team_xwalk", team_row(), "local_file", "caller_declared"),
+        (
+            "sdv_game_xwalk",
+            game_row(),
+            "registered_url",
+            "registered_artifact_name",
+        ),
+    ],
+)
+def test_success_lifecycle_stages_evidence_and_cleans_up(
+    monkeypatch, tmp_path, source, row, origin, basis
+):
+    install_ids(monkeypatch)
+    raw = b"parquet fixture"
+    sha = hashlib.sha256(raw).hexdigest()
+    path = tmp_path / f"{source}.parquet"
+    path.write_bytes(raw)
+    events = []
+    monkeypatch.setattr(publication, "get_db_url", lambda: "postgres://fixture")
+    monkeypatch.setattr(publication, "_get_plan", lambda dsn, asset, season: plan(asset))
+
+    def start(dsn, run_id, selected_plan, state):
+        state.started = True
+        events.append(("start", selected_plan["source_name"]))
+
+    monkeypatch.setattr(publication, "_start_run", start)
+    source_url = str(path) if origin == "local_file" else f"https://example/{source}_2025.parquet"
+    monkeypatch.setattr(
+        publication,
+        "fetch_file",
+        lambda target: FetchedFile(content=raw, sha256=sha, source_url=source_url),
+    )
+    monkeypatch.setattr(publication, "_raw_row_count", lambda raw, asset, season: 1)
+    monkeypatch.setattr(publication, "resolve_parser", lambda ref: lambda raw, ctx: [row])
+
+    def stage(dsn, spec, asset, raw, ctx, run_id, count, artifact_origin, season_basis):
+        events.append(("stage", artifact_origin, season_basis))
+        return publication._StageResult(
+            table=publication._stage_table_name(source, run_id),
+            rows=[{**row, "_dlt_id": "row", "_dlt_load_id": "load"}],
+            evidence={
+                "stage_schema": publication.STAGE_SCHEMA,
+                "parser_contract": asset.parser_contract,
+                "dlt_load_ids": ["load"],
+                "source_rows": 1,
+                "artifact_origin": artifact_origin,
+                "season_basis": season_basis,
+            },
+        )
+
+    monkeypatch.setattr(publication, "_stage_rows", stage)
+
+    def publish(dsn, run_id, generation_id, fetched_sha, staged, state):
+        events.append(("publish", staged.evidence))
+        return generation_id, False, 1
+
+    monkeypatch.setattr(publication, "_publish", publish)
+    monkeypatch.setattr(
+        publication,
+        "_drop_stage_table",
+        lambda dsn, table: events.append(("drop", table)),
+    )
+
+    result = publication.run_source_publication(
+        REGISTRY[source],
+        file_path=str(path) if origin == "local_file" else None,
+        season=2025,
+    )
+
+    assert result["status"] == "loaded"
+    assert result["source"] == source
+    assert result["rows"] == 1
+    assert result["sha"] == sha
+    assert result["run_id"] == RUN_ID
+    assert result["generation_id"] == GENERATION_ID
+    assert [event[0] for event in events] == ["start", "stage", "publish", "drop"]
+    assert events[1] == ("stage", origin, basis)
+    assert events[2][1]["season_basis"] == basis
+
+
+def test_generic_entrypoint_delegates_legacy_ratings(monkeypatch):
+    expected = {"source": "sdv_ratings_weekly", "status": "loaded"}
+    from src.pipelines.utils import sdv_ratings_publication
+
+    monkeypatch.setattr(
+        sdv_ratings_publication,
+        "run_sdv_ratings_publication",
+        lambda spec, file_path, season: expected,
+    )
+    assert (
+        publication.run_source_publication(
+            REGISTRY["sdv_ratings_weekly"], file_path=None, season=2025
+        )
+        is expected
+    )
+
+
+def test_failure_after_start_records_failed_generation(monkeypatch, tmp_path):
+    install_ids(monkeypatch)
+    path = tmp_path / "team.parquet"
+    path.write_bytes(b"bad")
+    failures = []
+    monkeypatch.setattr(publication, "get_db_url", lambda: "postgres://fixture")
+    monkeypatch.setattr(
+        publication,
+        "_get_plan",
+        lambda dsn, asset, season: plan(SDV_TEAM_XWALK_PUBLICATION),
+    )
+
+    def start(dsn, run_id, selected_plan, state):
+        state.started = True
+
+    monkeypatch.setattr(publication, "_start_run", start)
+    monkeypatch.setattr(
+        publication,
+        "fetch_file",
+        lambda target: FetchedFile(content=b"bad", sha256="0" * 64, source_url=str(path)),
+    )
+    monkeypatch.setattr(
+        publication,
+        "_fail_run",
+        lambda dsn, run_id, generation_id, outcome, state: failures.append(outcome),
+    )
+    result = publication.run_source_publication(
+        REGISTRY["sdv_team_xwalk"], file_path=str(path), season=2025
+    )
+    assert result["status"] == "failed"
+    assert "SHA-256" in result["error"]
+    assert failures == ["failed"]

--- a/tests/test_flat_file_publication.py
+++ b/tests/test_flat_file_publication.py
@@ -237,6 +237,66 @@ def test_fpi_raw_values_are_checked_before_lossy_parser_coercion(column, value, 
         publication._raw_row_count(_parquet_bytes(raw), SDV_FPI_PUBLICATION, 2025)
 
 
+@pytest.mark.parametrize("column", ["fpi", "projectedt", "totefficiencyrank"])
+@pytest.mark.parametrize("value", [True, "1.25", float("nan"), float("inf"), 2**53 + 1])
+def test_fpi_raw_metrics_reject_type_drift_and_lossy_values(column, value):
+    raw = fpi_row(**{column: value})
+    with pytest.raises(publication.SourcePublicationError, match=f"raw column {column}"):
+        publication._raw_row_count(_parquet_bytes(raw), SDV_FPI_PUBLICATION, 2025)
+
+
+@pytest.mark.parametrize("value", [None, 0, 2**53, -1.25, 0.0, 1.25])
+def test_fpi_raw_metrics_accept_null_and_lossless_finite_numbers(value):
+    raw = fpi_row(fpi=value)
+    assert publication._raw_row_count(_parquet_bytes(raw), SDV_FPI_PUBLICATION, 2025) == 1
+
+
+@pytest.mark.parametrize("value", [True, "1.25"])
+def test_bad_raw_fpi_metric_fails_before_parser_staging_or_publication(
+    monkeypatch, tmp_path, value
+):
+    install_ids(monkeypatch)
+    raw = _parquet_bytes(fpi_row(fpi=value))
+    sha = hashlib.sha256(raw).hexdigest()
+    path = tmp_path / "fpi.parquet"
+    path.write_bytes(raw)
+    failures = []
+    reached = []
+    monkeypatch.setattr(publication, "get_db_url", lambda: "postgres://fixture")
+    monkeypatch.setattr(publication, "_get_plan", lambda dsn, asset, season: plan(asset))
+
+    def start(dsn, run_id, selected_plan, state):
+        state.started = True
+
+    def forbidden(*args, **kwargs):
+        reached.append("parser_or_publication")
+        raise AssertionError("invalid raw metrics must not reach the parser or publication")
+
+    monkeypatch.setattr(publication, "_start_run", start)
+    monkeypatch.setattr(
+        publication,
+        "fetch_file",
+        lambda target: FetchedFile(content=raw, sha256=sha, source_url=str(path)),
+    )
+    for name in ("resolve_parser", "_stage_rows", "_publish"):
+        monkeypatch.setattr(publication, name, forbidden)
+    monkeypatch.setattr(
+        publication,
+        "_fail_run",
+        lambda dsn, run_id, generation_id, outcome, state: failures.append(outcome),
+    )
+
+    result = publication.run_source_publication(
+        REGISTRY["sdv_fpi_weekly"], file_path=str(path), season=2025
+    )
+
+    assert result["status"] == "failed"
+    assert "raw column fpi" in result["error"]
+    assert result["sha"] == sha
+    assert failures == ["failed"]
+    assert reached == []
+
+
 def test_fpi_raw_season_must_match_selected_season():
     raw = fpi_row(season=2024)
     raw["last_updated"] = "2024-08-01T00:00:00Z"

--- a/tests/test_flat_file_publication_sql.py
+++ b/tests/test_flat_file_publication_sql.py
@@ -1,0 +1,1417 @@
+"""Executed publication checks for the three season-file SDV sources."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from datetime import date, datetime
+from pathlib import Path
+
+import psycopg2
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from psycopg2 import sql
+from psycopg2.extensions import parse_dsn
+
+from tests.test_asset_freshness_sql import freshness_db as _freshness_db  # noqa: F401
+from tests.test_asset_publication_sql import publication_args as elo_publication_args
+from tests.test_asset_publication_sql import publication_db as _publication_db  # noqa: F401
+from tests.test_asset_publication_sql import publish as publish_elo
+from tests.test_generation_refresh_sql import generation_db as _generation_db  # noqa: F401
+from tests.test_sdv_ratings_publication_sql import SOURCE_OBJECTS as SDV_RATINGS_OBJECTS
+from tests.test_sdv_ratings_publication_sql import publication_args as ratings_publication_args
+from tests.test_sdv_ratings_publication_sql import publish as publish_ratings
+from tests.test_warehouse_migrations_sql import query
+from tests.test_warehouse_migrations_sql import warehouse_db as _warehouse_db  # noqa: F401
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATION_071 = ROOT / "src/schemas/migrations/071_sdv_ratings_publication.sql"
+MIGRATION_072 = ROOT / "src/schemas/migrations/072_sdv_source_batch_publication.sql"
+PROTOCOL = "sdv-season-file-v1"
+
+SOURCES = {
+    "sdv_fpi_weekly": {
+        "asset": "ratings.espn_fpi_weekly",
+        "parser": "sdv-fpi-v1",
+        "season_basis": "artifact_field",
+        "url": (
+            "https://github.com/sportsdataverse/sportsdataverse-data/releases/download/"
+            "cfb_fpi_weekly/cfb_fpi_weekly_{season}.parquet"
+        ),
+    },
+    "sdv_team_xwalk": {
+        "asset": "ref.team_id_xwalk",
+        "parser": "sdv-team-xwalk-v1",
+        "season_basis": "registered_artifact_name",
+        "url": (
+            "https://github.com/sportsdataverse/sportsdataverse-data/releases/download/"
+            "cfb_crosswalk/cfb_teams_crosswalk_{season}.parquet"
+        ),
+    },
+    "sdv_game_xwalk": {
+        "asset": "ref.game_id_xwalk",
+        "parser": "sdv-game-xwalk-v1",
+        "season_basis": "registered_artifact_name",
+        "url": (
+            "https://github.com/sportsdataverse/sportsdataverse-data/releases/download/"
+            "cfb_crosswalk/cfb_schedule_crosswalk_{season}.parquet"
+        ),
+    },
+}
+
+FPI_DOUBLES = (
+    "fpi",
+    "fpirank",
+    "projectedw",
+    "projectedl",
+    "projectedt",
+    "projectedwpctrank",
+    "probwinout",
+    "probwinconf",
+    "sosremainingrank",
+    "accomplishment",
+    "accomplishmentrank",
+    "adjwins",
+    "adjlosses",
+    "adjwinpctrank",
+    "gamecontrol",
+    "gamecontrolrank",
+    "adjavgingamewp",
+    "adjavgingamewprank",
+    "avgingamewp",
+    "avgingamewprank",
+    "avgsosrank",
+    "topsosrank",
+    "epaoffense",
+    "epadefense",
+    "epaspecialteams",
+    "probwindiv",
+    "probmakeplayoffs",
+    "probmaketitlegame",
+    "numwins",
+    "numlosses",
+    "numties",
+    "probwintitle",
+    "rankchange7days",
+    "prob6wins",
+    "rank",
+    "offefficiency",
+    "offefficiencyrank",
+    "defefficiency",
+    "defefficiencyrank",
+    "stefficiency",
+    "stefficiencyrank",
+    "totefficiency",
+    "totefficiencyrank",
+)
+
+SOURCE_OBJECTS = """
+CREATE SCHEMA ref;
+CREATE TABLE ref.team_id_xwalk (
+    season bigint NOT NULL,
+    norm_key text NOT NULL,
+    xwalk_key text NOT NULL,
+    espn_team_id bigint,
+    espn_team text,
+    espn_abbreviation text,
+    fox_team_id text,
+    fox_team text,
+    fox_abbreviation text,
+    yahoo_team_id text,
+    yahoo_team text,
+    yahoo_abbreviation text,
+    matched_sources text,
+    loaded_at timestamptz NOT NULL DEFAULT now(),
+    _dlt_load_id varchar NOT NULL,
+    _dlt_id varchar NOT NULL,
+    PRIMARY KEY (season, xwalk_key),
+    UNIQUE (_dlt_id)
+);
+CREATE INDEX idx_team_id_xwalk_norm_key ON ref.team_id_xwalk(season, norm_key);
+CREATE INDEX idx_team_id_xwalk_espn ON ref.team_id_xwalk(espn_team_id)
+    WHERE espn_team_id IS NOT NULL;
+
+CREATE TABLE ref.game_id_xwalk (
+    season bigint NOT NULL,
+    matchup_key text NOT NULL,
+    yahoo_date date NOT NULL,
+    espn_game_id bigint,
+    fox_game_id text,
+    yahoo_game_id text,
+    yahoo_global_game_id text,
+    home_team text,
+    away_team text,
+    espn_date date,
+    fox_date date,
+    matched_sources text,
+    loaded_at timestamptz NOT NULL DEFAULT now(),
+    _dlt_load_id varchar NOT NULL,
+    _dlt_id varchar NOT NULL,
+    PRIMARY KEY (season, matchup_key, yahoo_date),
+    UNIQUE (_dlt_id)
+);
+CREATE INDEX idx_game_id_xwalk_espn ON ref.game_id_xwalk(espn_game_id)
+    WHERE espn_game_id IS NOT NULL;
+CREATE INDEX idx_game_id_xwalk_yahoo ON ref.game_id_xwalk(yahoo_game_id);
+
+CREATE TABLE ratings.espn_fpi_weekly (
+    season bigint NOT NULL,
+    season_type bigint NOT NULL,
+    week bigint NOT NULL,
+    team_id bigint NOT NULL,
+    last_updated timestamptz,
+    run_date_time_key bigint,
+    snapshot_out_of_sequence boolean,
+    fpi double precision,
+    fpirank double precision,
+    projectedw double precision,
+    projectedl double precision,
+    projectedt double precision,
+    projectedwpctrank double precision,
+    probwinout double precision,
+    probwinconf double precision,
+    sosremainingrank double precision,
+    accomplishment double precision,
+    accomplishmentrank double precision,
+    adjwins double precision,
+    adjlosses double precision,
+    adjwinpctrank double precision,
+    gamecontrol double precision,
+    gamecontrolrank double precision,
+    adjavgingamewp double precision,
+    adjavgingamewprank double precision,
+    avgingamewp double precision,
+    avgingamewprank double precision,
+    avgsosrank double precision,
+    topsosrank double precision,
+    epaoffense double precision,
+    epadefense double precision,
+    epaspecialteams double precision,
+    probwindiv double precision,
+    probmakeplayoffs double precision,
+    probmaketitlegame double precision,
+    numwins double precision,
+    numlosses double precision,
+    numties double precision,
+    probwintitle double precision,
+    rankchange7days double precision,
+    prob6wins double precision,
+    rank double precision,
+    offefficiency double precision,
+    offefficiencyrank double precision,
+    defefficiency double precision,
+    defefficiencyrank double precision,
+    stefficiency double precision,
+    stefficiencyrank double precision,
+    totefficiency double precision,
+    totefficiencyrank double precision,
+    snapshot_is_contemporaneous boolean,
+    loaded_at timestamptz NOT NULL DEFAULT now(),
+    _dlt_load_id varchar NOT NULL,
+    _dlt_id varchar NOT NULL,
+    PRIMARY KEY (season, season_type, week, team_id),
+    UNIQUE (_dlt_id)
+);
+CREATE INDEX idx_espn_fpi_weekly_season_week
+    ON ratings.espn_fpi_weekly(season, week);
+
+REVOKE ALL ON ref.team_id_xwalk, ref.game_id_xwalk,
+    ratings.espn_fpi_weekly
+FROM anon, authenticated, analyst_ro, publication_bystander;
+REVOKE ALL ON SCHEMA ref, ratings
+FROM anon, authenticated, analyst_ro, publication_bystander;
+GRANT USAGE ON SCHEMA ref, ratings TO anon, authenticated, analyst_ro;
+GRANT SELECT ON ref.team_id_xwalk, ref.game_id_xwalk,
+    ratings.espn_fpi_weekly TO anon, authenticated, analyst_ro;
+"""
+
+PUBLISH_SQL = """
+SELECT * FROM warehouse_source_batch.publish_source_load(
+    %s, %s, %s, %s::jsonb, %s::jsonb
+)
+"""
+
+
+@pytest.fixture
+def batch_db(request):
+    conn, target = request.getfixturevalue("_generation_db")
+    query(conn, SDV_RATINGS_OBJECTS)
+    query(conn, SOURCE_OBJECTS)
+    query(conn, MIGRATION_071.read_text())
+    query(conn, MIGRATION_072.read_text())
+    query(conn, MIGRATION_072.read_text())
+    return conn, target
+
+
+def source_query(conn, statement, values=None, *, commit=True):
+    with conn.cursor() as cur:
+        cur.execute("SET LOCAL ROLE warehouse_source_publisher")
+        cur.execute(statement, values)
+        result = cur.fetchall() if cur.description else None
+    if commit:
+        conn.commit()
+    return result
+
+
+def plan(conn, source, season=2025):
+    return source_query(
+        conn,
+        "SELECT warehouse_source_batch.get_source_plan(%s,%s)",
+        (source, season),
+    )[0][0]
+
+
+def start_load(conn, load_plan, run_id=None):
+    run_id = str(run_id or uuid.uuid4())
+    result = source_query(
+        conn,
+        "SELECT warehouse_source_batch.start_source_load(%s,%s::jsonb)",
+        (run_id, json.dumps(load_plan)),
+    )[0][0]
+    assert str(result) == run_id
+    return run_id
+
+
+def fpi_row(season=2025, team_id=333, *, week=0, season_type=2, suffix="a"):
+    row = {name: None for name in FPI_DOUBLES}
+    row.update(
+        season=season,
+        season_type=season_type,
+        week=week,
+        team_id=team_id,
+        last_updated="2025-08-20T12:30:00+00:00",
+        run_date_time_key=20250820123000,
+        snapshot_out_of_sequence=False,
+        snapshot_is_contemporaneous=True,
+        fpi=18.25,
+        fpirank=float(team_id),
+        _dlt_load_id=f"fpi-load-{season}-{suffix}",
+        _dlt_id=f"fpi-row-{season}-{season_type}-{week}-{team_id}-{suffix}",
+    )
+    return row
+
+
+def team_row(
+    season=2025,
+    norm_key="alpha wolves",
+    *,
+    espn_team_id=101,
+    fox_team_id="fox-101",
+    yahoo_team_id="yahoo-101",
+    suffix="a",
+):
+    first_id = next(
+        (value for value in (espn_team_id, fox_team_id, yahoo_team_id) if value is not None),
+        None,
+    )
+    return {
+        "season": season,
+        "norm_key": norm_key,
+        "xwalk_key": f"{norm_key}#{first_id}",
+        "espn_team_id": espn_team_id,
+        "espn_team": None,
+        "espn_abbreviation": None,
+        "fox_team_id": fox_team_id,
+        "fox_team": None,
+        "fox_abbreviation": None,
+        "yahoo_team_id": yahoo_team_id,
+        "yahoo_team": None,
+        "yahoo_abbreviation": None,
+        "matched_sources": None,
+        "_dlt_load_id": f"team-load-{season}-{suffix}",
+        "_dlt_id": f"team-row-{season}-{suffix}",
+    }
+
+
+def game_row(season=2025, matchup_key="alpha|beta", *, day=None, suffix="a"):
+    day = day or f"{season}-08-30"
+    return {
+        "season": season,
+        "matchup_key": matchup_key,
+        "yahoo_date": day,
+        "espn_game_id": None,
+        "fox_game_id": None,
+        "yahoo_game_id": f"yahoo-{suffix}",
+        "yahoo_global_game_id": None,
+        "home_team": "Beta Bears",
+        "away_team": "Alpha Wolves",
+        "espn_date": None,
+        "fox_date": None,
+        "matched_sources": "yahoo",
+        "_dlt_load_id": f"game-load-{season}-{suffix}",
+        "_dlt_id": f"game-row-{season}-{suffix}",
+    }
+
+
+def rows_for(source, season=2025, *, suffix="a"):
+    if source == "sdv_fpi_weekly":
+        return [fpi_row(season, suffix=suffix), fpi_row(season, 2483, week=1, suffix=suffix)]
+    if source == "sdv_team_xwalk":
+        return [
+            team_row(season, suffix=f"{suffix}-1"),
+            team_row(
+                season,
+                "null ids school",
+                espn_team_id=None,
+                fox_team_id=None,
+                yahoo_team_id=None,
+                suffix=f"{suffix}-2",
+            ),
+        ]
+    return [
+        game_row(season, suffix=f"{suffix}-1"),
+        game_row(season, "alpha|beta", day=f"{season}-12-06", suffix=f"{suffix}-2"),
+    ]
+
+
+def evidence(source, rows, *, artifact_origin="registered_url"):
+    basis = (
+        "artifact_field"
+        if source == "sdv_fpi_weekly"
+        else (
+            "registered_artifact_name" if artifact_origin == "registered_url" else "caller_declared"
+        )
+    )
+    return {
+        "artifact_origin": artifact_origin,
+        "stage_schema": "warehouse_source_stage",
+        "parser_contract": SOURCES[source]["parser"],
+        "dlt_load_ids": sorted({row["_dlt_load_id"] for row in rows}),
+        "source_rows": len(rows),
+        "season_basis": basis,
+    }
+
+
+def publication_args(
+    conn,
+    source,
+    *,
+    season=2025,
+    rows=None,
+    generation_id=None,
+    sha=None,
+    load_plan=None,
+    artifact_origin="registered_url",
+):
+    rows = rows if rows is not None else rows_for(source, season)
+    load_plan = load_plan or plan(conn, source, season)
+    return (
+        start_load(conn, load_plan),
+        str(generation_id or uuid.uuid4()),
+        sha or ("a" * 64),
+        json.dumps(rows),
+        json.dumps(evidence(source, rows, artifact_origin=artifact_origin)),
+    )
+
+
+def publish(conn, args, *, commit=True):
+    return source_query(conn, PUBLISH_SQL, args, commit=commit)[0]
+
+
+def current(conn, *, asset=None, season=None):
+    clauses = []
+    values = []
+    if asset is not None:
+        clauses.append("asset_key=%s")
+        values.append(asset)
+    if season is not None:
+        clauses.append("coverage_key=%s")
+        values.append(f"season:{season}")
+    where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
+    return query(
+        conn,
+        "SELECT asset_key,coverage_key,generation_id::text "
+        f"FROM meta.asset_current_generations{where} ORDER BY asset_key,coverage_key",
+        tuple(values) or None,
+    )
+
+
+def denied(conn, role, statement):
+    try:
+        with conn.cursor() as cur:
+            cur.execute(sql.SQL("SET LOCAL ROLE {}").format(sql.Identifier(role)))
+            with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+                cur.execute(statement)
+    finally:
+        conn.rollback()
+
+
+@pytest.mark.parametrize("source", SOURCES)
+def test_plan_is_exact_source_and_season_contract(source, batch_db):
+    conn, _ = batch_db
+    assert plan(conn, source) == {
+        "protocol": PROTOCOL,
+        "source_name": source,
+        "asset_key": SOURCES[source]["asset"],
+        "coverage_key": "season:2025",
+        "season": 2025,
+        "expected_generation_id": None,
+        "parser_contract": SOURCES[source]["parser"],
+    }
+    assert query(
+        conn,
+        "SELECT count(*) FROM meta.asset_freshness_policies WHERE asset_key=%s",
+        (SOURCES[source]["asset"],),
+    ) == [(0,)]
+
+
+@pytest.mark.parametrize(
+    "source,season",
+    [
+        ("sdv_ratings_weekly", 2025),
+        ("unknown", 2025),
+        ("sdv_fpi_weekly", 1868),
+        ("sdv_fpi_weekly", 2201),
+    ],
+)
+def test_plan_rejects_unregistered_source_and_out_of_range_season(source, season, batch_db):
+    conn, _ = batch_db
+    with pytest.raises(psycopg2.Error):
+        plan(conn, source, season)
+    conn.rollback()
+
+
+@pytest.mark.parametrize("source", SOURCES)
+def test_publish_preserves_source_specific_types_nulls_and_grain(source, batch_db):
+    conn, _ = batch_db
+    rows = rows_for(source)
+    args = publication_args(conn, source, rows=rows, artifact_origin="local_file")
+    assert publish(conn, args) == (args[1], False, 2)
+    asset = SOURCES[source]["asset"]
+    assert current(conn, asset=asset, season=2025) == [(asset, "season:2025", args[1])]
+
+    if source == "sdv_fpi_weekly":
+        result = query(
+            conn,
+            """
+            SELECT season,season_type,week,team_id,last_updated,
+                   snapshot_out_of_sequence,snapshot_is_contemporaneous,
+                   projectedt,fpi
+            FROM ratings.espn_fpi_weekly ORDER BY week,team_id
+            """,
+        )
+        assert result[0][:4] == (2025, 2, 0, 333)
+        assert isinstance(result[0][4], datetime) and result[0][4].tzinfo is not None
+        assert result[0][5:] == (False, True, None, 18.25)
+    elif source == "sdv_team_xwalk":
+        assert query(
+            conn,
+            """
+            SELECT norm_key,xwalk_key,espn_team_id,fox_team_id,yahoo_team_id
+            FROM ref.team_id_xwalk ORDER BY norm_key
+            """,
+        ) == [
+            ("alpha wolves", "alpha wolves#101", 101, "fox-101", "yahoo-101"),
+            ("null ids school", "null ids school#None", None, None, None),
+        ]
+    else:
+        assert query(
+            conn,
+            """
+            SELECT matchup_key,yahoo_date,espn_game_id,espn_date,fox_date
+            FROM ref.game_id_xwalk ORDER BY yahoo_date
+            """,
+        ) == [
+            ("alpha|beta", date(2025, 8, 30), None, None, None),
+            ("alpha|beta", date(2025, 12, 6), None, None, None),
+        ]
+
+    receipt = query(
+        conn,
+        """
+        SELECT coverage,input_observations,source_watermark
+        FROM meta.asset_receipts WHERE generation_id=%s
+        """,
+        (args[1],),
+    )[0]
+    assert receipt[0] == {
+        "complete": True,
+        "scope": "season",
+        "season": 2025,
+        "mode": "full_file_for_season",
+        "source_rows": 2,
+        "published_rows": 2,
+    }
+    assert receipt[1]["protocol"] == PROTOCOL
+    assert receipt[1]["parser_contract"] == SOURCES[source]["parser"]
+    assert receipt[1]["artifact_origin"] == "local_file"
+    assert (
+        receipt[1]["season_basis"]
+        == evidence(source, rows, artifact_origin="local_file")["season_basis"]
+    )
+    assert receipt[2] == args[2]
+    assert query(
+        conn,
+        "SELECT source_url,status,row_count FROM meta.flat_file_loads",
+    ) == [(None, "loaded", 2)]
+
+
+def test_team_all_null_provider_id_key_is_valid_and_collides_only_on_full_key(batch_db):
+    conn, _ = batch_db
+    rows = [
+        team_row(
+            norm_key="same school",
+            espn_team_id=None,
+            fox_team_id=None,
+            yahoo_team_id=None,
+            suffix="none",
+        ),
+        team_row(norm_key="same school", espn_team_id=777, suffix="espn"),
+    ]
+    args = publication_args(conn, "sdv_team_xwalk", rows=rows)
+    assert publish(conn, args) == (args[1], False, 2)
+    assert query(
+        conn,
+        "SELECT xwalk_key,espn_team_id FROM ref.team_id_xwalk ORDER BY xwalk_key",
+    ) == [("same school#777", 777), ("same school#None", None)]
+
+    duplicate = rows + [dict(rows[0], _dlt_id="another-row-id")]
+    bad = publication_args(
+        conn,
+        "sdv_team_xwalk",
+        rows=duplicate,
+        sha="b" * 64,
+    )
+    with pytest.raises(psycopg2.Error):
+        publish(conn, bad)
+    conn.rollback()
+    assert current(conn, asset=SOURCES["sdv_team_xwalk"]["asset"], season=2025) == [
+        (SOURCES["sdv_team_xwalk"]["asset"], "season:2025", args[1])
+    ]
+
+
+def test_correction_removes_stale_rows_and_preserves_other_source_seasons(batch_db):
+    conn, _ = batch_db
+    generations = {}
+    digest_chars = iter("abcdef")
+    for source in SOURCES:
+        for season in (2024, 2025):
+            args = publication_args(
+                conn,
+                source,
+                season=season,
+                rows=rows_for(source, season, suffix="initial"),
+                sha=next(digest_chars) * 64,
+            )
+            publish(conn, args)
+            generations[(source, season)] = args[1]
+
+    corrected = [team_row(2025, norm_key="replacement", suffix="corrected")]
+    corrected_args = publication_args(
+        conn,
+        "sdv_team_xwalk",
+        rows=corrected,
+        sha="1" * 64,
+    )
+    assert publish(conn, corrected_args) == (corrected_args[1], False, 1)
+
+    assert query(
+        conn,
+        "SELECT season,norm_key FROM ref.team_id_xwalk ORDER BY season,norm_key",
+    ) == [
+        (2024, "alpha wolves"),
+        (2024, "null ids school"),
+        (2025, "replacement"),
+    ]
+    assert query(
+        conn,
+        "SELECT season,count(*) FROM ratings.espn_fpi_weekly GROUP BY season ORDER BY season",
+    ) == [(2024, 2), (2025, 2)]
+    assert query(
+        conn,
+        "SELECT season,count(*) FROM ref.game_id_xwalk GROUP BY season ORDER BY season",
+    ) == [(2024, 2), (2025, 2)]
+    assert current(conn, asset=SOURCES["sdv_team_xwalk"]["asset"]) == [
+        (SOURCES["sdv_team_xwalk"]["asset"], "season:2024", generations[("sdv_team_xwalk", 2024)]),
+        (SOURCES["sdv_team_xwalk"]["asset"], "season:2025", corrected_args[1]),
+    ]
+    assert query(
+        conn,
+        "SELECT row_delta FROM meta.asset_receipts WHERE generation_id=%s",
+        (corrected_args[1],),
+    ) == [
+        (
+            {
+                "previous_rows": 2,
+                "published_rows": 1,
+                "inserted_rows": 1,
+                "deleted_rows": 2,
+                "changed_rows": 0,
+            },
+        )
+    ]
+
+
+def test_registered_url_ledger_and_season_basis_are_source_specific(batch_db):
+    conn, _ = batch_db
+    for index, source in enumerate(SOURCES, start=1):
+        args = publication_args(conn, source, sha=str(index) * 64)
+        publish(conn, args)
+    assert query(
+        conn,
+        """
+        SELECT source,source_url FROM meta.flat_file_loads ORDER BY source
+        """,
+    ) == sorted(
+        [
+            (
+                f"{source}:2025",
+                SOURCES[source]["url"].format(season=2025),
+            )
+            for source in SOURCES
+        ]
+    )
+    assert query(
+        conn,
+        """
+        SELECT asset_key,input_observations->>'season_basis'
+        FROM meta.asset_receipts
+        WHERE asset_key = ANY(%s) ORDER BY asset_key
+        """,
+        ([details["asset"] for details in SOURCES.values()],),
+    ) == sorted([(details["asset"], details["season_basis"]) for details in SOURCES.values()])
+
+
+@pytest.mark.parametrize(
+    "source,malformation",
+    [
+        ("sdv_fpi_weekly", "empty"),
+        ("sdv_fpi_weekly", "extra"),
+        ("sdv_fpi_weekly", "missing"),
+        ("sdv_fpi_weekly", "wrong_season"),
+        ("sdv_fpi_weekly", "duplicate_pk"),
+        ("sdv_fpi_weekly", "duplicate_dlt"),
+        ("sdv_fpi_weekly", "negative_week"),
+        ("sdv_fpi_weekly", "string_bool"),
+        ("sdv_fpi_weekly", "naive_timestamp"),
+        ("sdv_fpi_weekly", "nonfinite"),
+        ("sdv_team_xwalk", "wrong_xwalk_key"),
+        ("sdv_team_xwalk", "blank_key"),
+        ("sdv_game_xwalk", "bad_date"),
+        ("sdv_game_xwalk", "blank_key"),
+    ],
+)
+def test_malformed_rows_fail_before_data_receipt_pointer_or_ledger(source, malformation, batch_db):
+    conn, _ = batch_db
+    rows = rows_for(source)
+    if malformation == "empty":
+        rows = []
+    elif malformation == "extra":
+        rows[0]["unexpected"] = 1
+    elif malformation == "missing":
+        del rows[0]["projectedt"]
+    elif malformation == "wrong_season":
+        rows[0]["season"] = 2024
+    elif malformation == "duplicate_pk":
+        rows.append(dict(rows[0], _dlt_id="distinct-dlt-id"))
+    elif malformation == "duplicate_dlt":
+        rows[1]["_dlt_id"] = rows[0]["_dlt_id"]
+    elif malformation == "negative_week":
+        rows[0]["week"] = -1
+    elif malformation == "string_bool":
+        rows[0]["snapshot_is_contemporaneous"] = "false"
+    elif malformation == "naive_timestamp":
+        rows[0]["last_updated"] = "2025-08-20T12:30:00"
+    elif malformation == "nonfinite":
+        rows[0]["fpi"] = "Infinity"
+    elif malformation == "wrong_xwalk_key":
+        rows[0]["xwalk_key"] = "forged"
+    elif malformation == "bad_date":
+        rows[0]["yahoo_date"] = "2025-02-30"
+    else:
+        key = "norm_key" if source == "sdv_team_xwalk" else "matchup_key"
+        rows[0][key] = " "
+        if source == "sdv_team_xwalk":
+            rows[0]["xwalk_key"] = " #101"
+
+    args = publication_args(conn, source, rows=rows)
+    if malformation == "nonfinite":
+        args = (
+            *args[:3],
+            args[3].replace('"fpi": "Infinity"', '"fpi": 1e10000'),
+            args[4],
+        )
+    with pytest.raises(psycopg2.Error):
+        publish(conn, args)
+    conn.rollback()
+    assert query(conn, f"SELECT count(*) FROM {SOURCES[source]['asset']}") == [(0,)]
+    assert current(conn, asset=SOURCES[source]["asset"]) == []
+    assert query(
+        conn,
+        "SELECT count(*) FROM meta.asset_receipts WHERE asset_key=%s",
+        (SOURCES[source]["asset"],),
+    ) == [(0,)]
+    assert query(conn, "SELECT count(*) FROM meta.flat_file_loads") == [(0,)]
+
+
+@pytest.mark.parametrize(
+    "source,evidence_error",
+    [
+        ("sdv_fpi_weekly", "extra"),
+        ("sdv_fpi_weekly", "missing"),
+        ("sdv_fpi_weekly", "stage_schema"),
+        ("sdv_fpi_weekly", "parser"),
+        ("sdv_fpi_weekly", "source_rows"),
+        ("sdv_fpi_weekly", "dlt_load_ids"),
+        ("sdv_fpi_weekly", "season_basis"),
+        ("sdv_team_xwalk", "season_basis"),
+        ("sdv_game_xwalk", "season_basis"),
+    ],
+)
+def test_staged_evidence_must_be_exact_and_match_rows(source, evidence_error, batch_db):
+    conn, _ = batch_db
+    args = list(publication_args(conn, source))
+    proof = json.loads(args[4])
+    if evidence_error == "extra":
+        proof["unexpected"] = True
+    elif evidence_error == "missing":
+        del proof["artifact_origin"]
+    elif evidence_error == "stage_schema":
+        proof["stage_schema"] = "public"
+    elif evidence_error == "parser":
+        proof["parser_contract"] = "wrong-v1"
+    elif evidence_error == "source_rows":
+        proof["source_rows"] += 1
+    elif evidence_error == "dlt_load_ids":
+        proof["dlt_load_ids"] = ["forged"]
+    else:
+        proof["season_basis"] = (
+            "caller_declared" if source == "sdv_fpi_weekly" else "artifact_field"
+        )
+    args[4] = json.dumps(proof)
+
+    with pytest.raises(psycopg2.Error, match="evidence|season|stage|parser|row|dlt"):
+        publish(conn, tuple(args))
+    conn.rollback()
+    assert query(conn, f"SELECT count(*) FROM {SOURCES[source]['asset']}") == [(0,)]
+    assert current(conn, asset=SOURCES[source]["asset"]) == []
+    assert query(conn, "SELECT count(*) FROM meta.flat_file_loads") == [(0,)]
+
+
+def test_start_rejects_forged_or_noncanonical_plan(batch_db):
+    conn, _ = batch_db
+    good = plan(conn, "sdv_fpi_weekly")
+    for mutation in (
+        {"source_name": "sdv_team_xwalk"},
+        {"asset_key": "ref.team_id_xwalk"},
+        {"coverage_key": "season:2024"},
+        {"parser_contract": "wrong"},
+        {"unexpected": True},
+    ):
+        forged = dict(good)
+        forged.update(mutation)
+        with pytest.raises(psycopg2.Error):
+            start_load(conn, forged)
+        conn.rollback()
+    assert query(conn, "SELECT count(*) FROM meta.operation_runs") == [(0,)]
+
+
+@pytest.mark.parametrize("source", SOURCES)
+def test_rollback_is_atomic_for_rows_receipt_pointer_and_ledger(source, batch_db):
+    conn, target = batch_db
+    original = publication_args(conn, source, sha="a" * 64)
+    publish(conn, original)
+    replacement_rows = rows_for(source, suffix="rollback")
+    replacement_rows.pop()
+    replacement = publication_args(
+        conn,
+        source,
+        rows=replacement_rows,
+        sha="b" * 64,
+    )
+    observer = psycopg2.connect(target)
+    try:
+        assert publish(conn, replacement, commit=False) == (replacement[1], False, 1)
+        assert current(observer, asset=SOURCES[source]["asset"], season=2025) == [
+            (SOURCES[source]["asset"], "season:2025", original[1])
+        ]
+        conn.rollback()
+        assert current(observer, asset=SOURCES[source]["asset"], season=2025) == [
+            (SOURCES[source]["asset"], "season:2025", original[1])
+        ]
+        assert query(
+            observer,
+            "SELECT count(*) FROM meta.asset_receipts WHERE generation_id=%s",
+            (replacement[1],),
+        ) == [(0,)]
+        assert query(
+            observer,
+            "SELECT count(*) FROM meta.flat_file_loads WHERE file_sha256=%s",
+            (replacement[2],),
+        ) == [(0,)]
+        assert query(observer, f"SELECT count(*) FROM {SOURCES[source]['asset']}") == [(2,)]
+    finally:
+        observer.close()
+
+
+@pytest.mark.parametrize("source", SOURCES)
+def test_replay_and_same_hash_new_generation_have_distinct_semantics(source, batch_db):
+    conn, _ = batch_db
+    first = publication_args(conn, source, sha="a" * 64)
+    assert publish(conn, first) == (first[1], False, 2)
+    second = publication_args(
+        conn,
+        source,
+        rows=rows_for(source, suffix="new"),
+        sha="a" * 64,
+    )
+    assert publish(conn, second) == (second[1], False, 2)
+    assert query(
+        conn,
+        "SELECT status FROM meta.flat_file_loads ORDER BY id",
+    ) == [("loaded",), ("skipped",)]
+
+    assert publish(conn, first) == (first[1], True, 2)
+    assert current(conn, asset=SOURCES[source]["asset"], season=2025) == [
+        (SOURCES[source]["asset"], "season:2025", second[1])
+    ]
+    assert query(
+        conn,
+        "SELECT count(*) FROM meta.asset_receipts WHERE asset_key=%s",
+        (SOURCES[source]["asset"],),
+    ) == [(2,)]
+
+
+@pytest.mark.parametrize("source", SOURCES)
+def test_compare_and_swap_allows_one_concurrent_winner(source, batch_db):
+    conn, target = batch_db
+    expected = plan(conn, source)
+    args = [
+        publication_args(
+            conn,
+            source,
+            load_plan=expected,
+            rows=rows_for(source, suffix=suffix),
+            sha=char * 64,
+        )
+        for suffix, char in (("one", "a"), ("two", "b"))
+    ]
+
+    def contender(call_args):
+        other = psycopg2.connect(target)
+        try:
+            try:
+                return "ok", source_query(other, PUBLISH_SQL, call_args)[0]
+            except psycopg2.Error as exc:
+                other.rollback()
+                return "error", str(exc)
+        finally:
+            other.close()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(contender, args))
+    assert sorted(status for status, _ in results) == ["error", "ok"]
+    assert "changed" in next(detail for status, detail in results if status == "error").lower()
+    winner = next(detail for status, detail in results if status == "ok")
+    assert current(conn, asset=SOURCES[source]["asset"], season=2025) == [
+        (SOURCES[source]["asset"], "season:2025", str(winner[0]))
+    ]
+    assert query(
+        conn,
+        "SELECT count(*) FROM meta.asset_receipts WHERE asset_key=%s",
+        (SOURCES[source]["asset"],),
+    ) == [(1,)]
+    assert query(conn, "SELECT count(*) FROM meta.flat_file_loads") == [(1,)]
+
+
+@pytest.mark.parametrize("source", SOURCES)
+@pytest.mark.parametrize("outcome", ["failed", "deferred"])
+def test_failure_finishes_run_without_rows_ledger_or_pointer(source, outcome, batch_db):
+    conn, _ = batch_db
+    good = publication_args(conn, source, sha="a" * 64)
+    publish(conn, good)
+    before = current(conn, asset=SOURCES[source]["asset"], season=2025)
+
+    run_id = start_load(conn, plan(conn, source))
+    generation_id = str(uuid.uuid4())
+    result = source_query(
+        conn,
+        "SELECT warehouse_source_batch.fail_source_load(%s,%s,%s)",
+        (run_id, generation_id, outcome),
+    )[0][0]
+    assert str(result) == generation_id
+    assert current(conn, asset=SOURCES[source]["asset"], season=2025) == before
+    assert query(
+        conn,
+        """
+        SELECT r.outcome,r.published_at,r.coverage->>'complete',r.error_summary,
+               o.outcome
+        FROM meta.asset_receipts r
+        JOIN meta.operation_runs o USING(operation_run_id)
+        WHERE r.generation_id=%s
+        """,
+        (generation_id,),
+    ) == [
+        (
+            outcome,
+            None,
+            "false",
+            "source_publication_failed",
+            "blocked" if outcome == "deferred" else outcome,
+        )
+    ]
+    assert query(conn, "SELECT count(*) FROM meta.flat_file_loads") == [(1,)]
+
+
+def test_publisher_has_only_four_new_rpcs_and_no_relation_or_stage_access(batch_db):
+    conn, _ = batch_db
+    assert query(
+        conn,
+        """
+        SELECT rolcanlogin,rolinherit,rolsuper,rolcreatedb,rolcreaterole,
+               rolreplication,rolbypassrls
+        FROM pg_roles WHERE rolname='warehouse_source_publisher'
+        """,
+    ) == [(False, False, False, False, False, False, False)]
+
+    signatures = (
+        "warehouse_source_batch.get_source_plan(text,bigint)",
+        "warehouse_source_batch.start_source_load(uuid,jsonb)",
+        "warehouse_source_batch.publish_source_load(uuid,uuid,text,jsonb,jsonb)",
+        "warehouse_source_batch.fail_source_load(uuid,uuid,text)",
+    )
+    for signature in signatures:
+        privilege = query(
+            conn,
+            "SELECT has_function_privilege('warehouse_source_publisher',%s,'EXECUTE'),"
+            "has_function_privilege('anon',%s,'EXECUTE')",
+            (signature, signature),
+        )
+        assert privilege == [(True, False)], signature
+    assert query(
+        conn,
+        """
+        SELECT count(*)
+        FROM pg_proc p
+        JOIN pg_namespace n ON n.oid=p.pronamespace
+        WHERE n.nspname='warehouse_source_batch'
+          AND has_function_privilege('warehouse_source_publisher',p.oid,'EXECUTE')
+        """,
+    ) == [(4,)]
+
+    for role in ("anon", "authenticated", "analyst_ro", "publication_bystander"):
+        denied(
+            conn,
+            role,
+            "SELECT warehouse_source_batch.get_source_plan('sdv_fpi_weekly',2025)",
+        )
+        assert query(
+            conn,
+            "SELECT has_schema_privilege(%s,'warehouse_source_batch','USAGE'),"
+            "has_schema_privilege(%s,'warehouse_source_stage','USAGE,CREATE')",
+            (role, role),
+        ) == [(False, False)]
+
+    for relation in (
+        "ratings.espn_fpi_weekly",
+        "ref.team_id_xwalk",
+        "ref.game_id_xwalk",
+        "meta.flat_file_loads",
+        "meta.asset_receipts",
+        "meta.asset_current_generations",
+        "meta.operation_runs",
+    ):
+        assert query(
+            conn,
+            "SELECT has_table_privilege('warehouse_source_publisher',%s,"
+            "'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')",
+            (relation,),
+        ) == [(False,)]
+    denied(
+        conn,
+        "warehouse_source_publisher",
+        "UPDATE ratings.espn_fpi_weekly SET fpi=0",
+    )
+    denied(conn, "warehouse_source_publisher", "SELECT * FROM meta.asset_receipts")
+
+    for role in ("anon", "authenticated"):
+        for relation in (details["asset"] for details in SOURCES.values()):
+            privileges = query(
+                conn,
+                "SELECT has_table_privilege(%s,%s,'SELECT'),"
+                "has_table_privilege(%s,%s,'INSERT'),"
+                "has_table_privilege(%s,%s,'UPDATE'),"
+                "has_table_privilege(%s,%s,'DELETE'),"
+                "has_table_privilege(%s,%s,'TRUNCATE')",
+                (role, relation, role, relation, role, relation, role, relation, role, relation),
+            )
+            assert privileges == [(True, False, False, False, False)], (
+                role,
+                relation,
+                privileges,
+            )
+
+    # Migration 071 remains callable through its original bounded RPC.
+    assert (
+        source_query(
+            conn,
+            "SELECT warehouse_source.get_sdv_ratings_plan(2025)",
+        )[0][0]["protocol"]
+        == "sdv-ratings-season-v1"
+    )
+
+
+@pytest.mark.parametrize("source", SOURCES)
+def test_direct_row_mutation_invalidates_only_affected_source_season(source, batch_db):
+    conn, _ = batch_db
+    other_source = next(candidate for candidate in SOURCES if candidate != source)
+    source_generations = {}
+    for season, char in ((2024, "a"), (2025, "b")):
+        args = publication_args(
+            conn,
+            source,
+            season=season,
+            rows=rows_for(source, season),
+            sha=char * 64,
+        )
+        publish(conn, args)
+        source_generations[season] = args[1]
+    other = publication_args(conn, other_source, sha="c" * 64)
+    publish(conn, other)
+
+    table = SOURCES[source]["asset"]
+    query(conn, f"UPDATE {table} SET loaded_at=loaded_at WHERE season=2025")
+    assert current(conn, asset=table) == [(table, "season:2024", source_generations[2024])]
+    assert current(conn, asset=SOURCES[other_source]["asset"], season=2025) == [
+        (SOURCES[other_source]["asset"], "season:2025", other[1])
+    ]
+
+    query(conn, f"TRUNCATE {table}")
+    assert current(conn, asset=table) == []
+    assert current(conn, asset=SOURCES[other_source]["asset"], season=2025) == [
+        (SOURCES[other_source]["asset"], "season:2025", other[1])
+    ]
+
+
+@pytest.mark.parametrize(
+    "source,statement",
+    [
+        (
+            "sdv_fpi_weekly",
+            "ALTER TABLE ratings.espn_fpi_weekly RENAME TO espn_fpi_weekly_moved",
+        ),
+        ("sdv_team_xwalk", "DROP TABLE ref.team_id_xwalk"),
+        (
+            "sdv_game_xwalk",
+            "DROP TRIGGER invalidate_sdv_source_batch_row_pointer ON ref.game_id_xwalk",
+        ),
+    ],
+)
+def test_new_target_ddl_does_not_block_old_sdv_or_elo_publication(source, statement, batch_db):
+    conn, _ = batch_db
+    new_args = {}
+    for candidate, char in zip(SOURCES, "123", strict=True):
+        args = publication_args(conn, candidate, sha=char * 64)
+        publish(conn, args)
+        new_args[candidate] = args
+    old_args = ratings_publication_args(conn, sha="b" * 64)
+    publish_ratings(conn, old_args)
+    elo_args = elo_publication_args(conn)
+    publish_elo(conn, elo_args)
+
+    query(conn, statement)
+    assert current(conn, asset=SOURCES[source]["asset"]) == []
+    for candidate in SOURCES:
+        if candidate != source:
+            assert current(conn, asset=SOURCES[candidate]["asset"], season=2025) == [
+                (
+                    SOURCES[candidate]["asset"],
+                    "season:2025",
+                    new_args[candidate][1],
+                )
+            ]
+    assert current(conn, asset="ratings.sdv_ratings_weekly", season=2025) == [
+        ("ratings.sdv_ratings_weekly", "season:2025", old_args[1])
+    ]
+    assert {
+        row[0]
+        for row in current(conn)
+        if row[0] in {"analytics.house_elo_game", "marts.house_elo_game"}
+    } == {"analytics.house_elo_game", "marts.house_elo_game"}
+
+    sibling = next(candidate for candidate in SOURCES if candidate != source)
+    sibling_args = publication_args(
+        conn,
+        sibling,
+        rows=rows_for(sibling, suffix="after-ddl"),
+        sha="d" * 64,
+    )
+    assert publish(conn, sibling_args) == (sibling_args[1], False, 2)
+    corrected_old = ratings_publication_args(
+        conn,
+        rows=None,
+        sha="c" * 64,
+    )
+    assert publish_ratings(conn, corrected_old) == (corrected_old[1], False, 2)
+    next_elo = elo_publication_args(conn)
+    assert publish_elo(conn, next_elo)[:3] == (next_elo[1], next_elo[2], False)
+
+
+def test_inherited_target_child_invalidates_and_blocks_publication(batch_db):
+    conn, _ = batch_db
+    first = publication_args(conn, "sdv_team_xwalk")
+    publish(conn, first)
+    query(
+        conn,
+        "CREATE TABLE ref.team_id_xwalk_child () INHERITS (ref.team_id_xwalk)",
+    )
+    query(
+        conn,
+        """
+        INSERT INTO ref.team_id_xwalk_child(
+            season,norm_key,xwalk_key,_dlt_load_id,_dlt_id
+        ) VALUES (2025,'child','child#None','child-load','child-row')
+        """,
+    )
+    assert current(conn, asset=SOURCES["sdv_team_xwalk"]["asset"]) == []
+
+    retry = publication_args(
+        conn,
+        "sdv_team_xwalk",
+        rows=rows_for("sdv_team_xwalk", suffix="retry"),
+        sha="b" * 64,
+    )
+    with pytest.raises(psycopg2.Error, match="catalog|contract|inherit"):
+        publish(conn, retry)
+    conn.rollback()
+    assert current(conn, asset=SOURCES["sdv_team_xwalk"]["asset"]) == []
+
+
+@pytest.mark.parametrize(
+    "statement",
+    [
+        """
+        DROP TRIGGER invalidate_sdv_source_batch_row_pointer
+            ON ratings.espn_fpi_weekly;
+        CREATE TRIGGER invalidate_sdv_source_batch_row_pointer
+            BEFORE INSERT OR UPDATE OR DELETE ON ratings.espn_fpi_weekly
+            FOR EACH ROW WHEN (false)
+            EXECUTE FUNCTION warehouse_source_batch.invalidate_row_pointer()
+        """,
+        """
+        CREATE RULE suppress_source_insert AS
+            ON INSERT TO ratings.espn_fpi_weekly
+            DO INSTEAD NOTHING
+        """,
+    ],
+)
+def test_altered_target_guard_or_rewrite_rule_fails_closed_without_sibling_loss(
+    statement, batch_db
+):
+    conn, _ = batch_db
+    original = {}
+    for source, char in zip(SOURCES, "123", strict=True):
+        args = publication_args(conn, source, sha=char * 64)
+        publish(conn, args)
+        original[source] = args[1]
+
+    query(conn, statement)
+    assert current(conn, asset=SOURCES["sdv_fpi_weekly"]["asset"]) == []
+    for sibling in ("sdv_team_xwalk", "sdv_game_xwalk"):
+        assert current(conn, asset=SOURCES[sibling]["asset"], season=2025) == [
+            (SOURCES[sibling]["asset"], "season:2025", original[sibling])
+        ]
+
+    retry = publication_args(
+        conn,
+        "sdv_fpi_weekly",
+        rows=rows_for("sdv_fpi_weekly", suffix="untrusted-topology"),
+        sha="4" * 64,
+    )
+    with pytest.raises(psycopg2.Error, match="catalog|contract|guard|trigger|rule"):
+        publish(conn, retry)
+    conn.rollback()
+    for sibling in ("sdv_team_xwalk", "sdv_game_xwalk"):
+        assert current(conn, asset=SOURCES[sibling]["asset"], season=2025) == [
+            (SOURCES[sibling]["asset"], "season:2025", original[sibling])
+        ]
+
+
+def test_shared_function_ddl_invalidates_all_three_source_pointers(batch_db):
+    conn, _ = batch_db
+    for source, char in zip(SOURCES, "123", strict=True):
+        publish(conn, publication_args(conn, source, sha=char * 64))
+    assert (
+        len(
+            [
+                row
+                for row in current(conn)
+                if row[0] in {details["asset"] for details in SOURCES.values()}
+            ]
+        )
+        == 3
+    )
+
+    query(
+        conn,
+        "ALTER FUNCTION warehouse_source_batch.invalidate_row_pointer() "
+        "RENAME TO invalidate_row_pointer_changed",
+    )
+    assert all(current(conn, asset=details["asset"]) == [] for details in SOURCES.values())
+
+
+def test_disabled_event_guard_blocks_all_three_publishers(batch_db):
+    conn, _ = batch_db
+    original = {}
+    for source, char in zip(SOURCES, "123", strict=True):
+        args = publication_args(conn, source, sha=char * 64)
+        publish(conn, args)
+        original[source] = args[1]
+
+    # PostgreSQL excludes commands targeting event triggers from
+    # ddl_command_start/end. Runtime catalog checks must therefore fail closed.
+    query(conn, "ALTER EVENT TRIGGER warehouse_source_batch_invalidate_drop DISABLE")
+    for source, char in zip(SOURCES, "456", strict=True):
+        retry = publication_args(
+            conn,
+            source,
+            rows=rows_for(source, suffix="disabled-guard"),
+            sha=char * 64,
+        )
+        with pytest.raises(psycopg2.Error, match="catalog|contract|guard"):
+            publish(conn, retry)
+        conn.rollback()
+        assert current(conn, asset=SOURCES[source]["asset"], season=2025) == [
+            (SOURCES[source]["asset"], "season:2025", original[source])
+        ]
+
+
+@pytest.mark.parametrize(
+    "source,fixture_name",
+    [
+        ("sdv_fpi_weekly", "sdv_fpi_weekly_sample.parquet"),
+        ("sdv_team_xwalk", "sdv_team_xwalk_sample.parquet"),
+        ("sdv_game_xwalk", "sdv_game_xwalk_sample.parquet"),
+    ],
+)
+def test_real_adapter_stages_local_parquet_and_publishes_exact_types(
+    source, fixture_name, batch_db, monkeypatch, tmp_path
+):
+    from src.pipelines.sources.flat_files import REGISTRY
+    from src.pipelines.utils import flat_file_publication as adapter
+
+    conn, target = batch_db
+    schema = pq.read_schema(ROOT / "tests/fixtures/flatfiles" / fixture_name)
+    raw_row = {name: None for name in schema.names}
+    if source == "sdv_fpi_weekly":
+        raw_row.update(
+            season=2025,
+            season_type=2,
+            week=0,
+            team_id=333,
+            last_updated="2025-08-20T12:30:00Z",
+            run_date_time_key=20250820123000,
+            snapshot_out_of_sequence=False,
+            snapshot_is_contemporaneous=True,
+            fpi=18.25,
+        )
+    elif source == "sdv_team_xwalk":
+        raw_row.update(norm_key="all null providers")
+    else:
+        raw_row.update(
+            matchup_key="alpha wolves|beta bears",
+            yahoo_date="2026-01-02",
+            home_team="Beta Bears",
+            away_team="Alpha Wolves",
+        )
+    local_file = tmp_path / f"{source}.parquet"
+    pq.write_table(pa.Table.from_pylist([raw_row], schema=schema), local_file)
+    dsn = parse_dsn(target)
+    target_url = (
+        f"postgresql://{dsn['user']}:{dsn['password']}@{dsn['host']}:{dsn['port']}/{dsn['dbname']}"
+    )
+    monkeypatch.setattr(adapter, "get_db_url", lambda: target_url)
+
+    result = adapter.run_source_publication(
+        REGISTRY[source],
+        file_path=str(local_file),
+        season=2025,
+    )
+    assert result["error"] is None
+    assert result["status"] == "loaded"
+    assert result["rows"] == 1
+
+    if source == "sdv_fpi_weekly":
+        row = query(
+            conn,
+            """
+            SELECT season,season_type,week,team_id,last_updated,
+                   snapshot_out_of_sequence,snapshot_is_contemporaneous,
+                   projectedt,fpi,_dlt_load_id,_dlt_id
+            FROM ratings.espn_fpi_weekly
+            """,
+        )[0]
+        assert row[:4] == (2025, 2, 0, 333)
+        assert isinstance(row[4], datetime) and row[4].tzinfo is not None
+        assert row[5:9] == (False, True, None, 18.25)
+    elif source == "sdv_team_xwalk":
+        row = query(
+            conn,
+            """
+            SELECT season,norm_key,xwalk_key,espn_team_id,fox_team_id,
+                   yahoo_team_id,_dlt_load_id,_dlt_id
+            FROM ref.team_id_xwalk
+            """,
+        )[0]
+        assert row[:6] == (
+            2025,
+            "all null providers",
+            "all null providers#None",
+            None,
+            None,
+            None,
+        )
+    else:
+        row = query(
+            conn,
+            """
+            SELECT season,matchup_key,yahoo_date,espn_game_id,espn_date,
+                   fox_date,_dlt_load_id,_dlt_id
+            FROM ref.game_id_xwalk
+            """,
+        )[0]
+        assert row[:6] == (
+            2025,
+            "alpha wolves|beta bears",
+            date(2026, 1, 2),
+            None,
+            None,
+            None,
+        )
+    assert all(isinstance(value, str) and value for value in row[-2:])
+
+    receipt = query(
+        conn,
+        """
+        SELECT generation_id::text,input_observations,source_watermark
+        FROM meta.asset_receipts WHERE asset_key=%s
+        """,
+        (SOURCES[source]["asset"],),
+    )[0]
+    assert receipt[0] == result["generation_id"]
+    assert receipt[1]["artifact_origin"] == "local_file"
+    assert receipt[1]["season_basis"] == (
+        "artifact_field" if source == "sdv_fpi_weekly" else "caller_declared"
+    )
+    assert receipt[1]["dlt_load_ids"] == [row[-2]]
+    assert receipt[2] == result["sha"]
+    assert query(
+        conn,
+        "SELECT count(*) FROM warehouse_source_stage._dlt_loads WHERE load_id=%s",
+        (row[-2],),
+    ) == [(1,)]
+    stage_name = adapter._stage_table_name(source, result["run_id"])
+    assert query(
+        conn,
+        """
+        SELECT pg_catalog.to_regclass(%s),
+               pg_catalog.to_regnamespace('warehouse_source_stage_staging')
+        """,
+        (f"warehouse_source_stage.{stage_name}",),
+    ) == [(None, None)]
+    assert query(
+        conn,
+        "SELECT source_url,status,row_count FROM meta.flat_file_loads",
+    ) == [(None, "loaded", 1)]

--- a/tests/test_sdv_ratings_publication.py
+++ b/tests/test_sdv_ratings_publication.py
@@ -176,6 +176,22 @@ def test_only_canonical_registry_spec_is_supported():
         publication._validate_supported_spec(REGISTRY["sdv_ratings_weekly"], 2201)
 
 
+def test_run_preserves_failed_result_contract_for_invalid_spec(monkeypatch):
+    install_ids(monkeypatch)
+    monkeypatch.setattr(
+        publication,
+        "get_db_url",
+        lambda: pytest.fail("preflight must run before database configuration"),
+    )
+    result = publication.run_sdv_ratings_publication(
+        replace(REGISTRY["sdv_ratings_weekly"]), season=2025
+    )
+    assert result["status"] == "failed"
+    assert "source publication failed" in result["error"]
+    assert result["run_id"] == RUN_ID
+    assert result["generation_id"] == GENERATION_ID
+
+
 def test_plan_requires_exact_protocol_and_keys():
     assert publication._validated_plan(plan(), 2025) == plan()
     with pytest.raises(publication.SourcePublicationError, match="invalid.*plan"):
@@ -533,7 +549,7 @@ def test_cas_readiness_error_records_blocked(monkeypatch, tmp_path):
 
 def test_known_stage_failure_records_failure_and_drops_run_table(monkeypatch, tmp_path):
     events = []
-    path, _ = install_success_fakes(monkeypatch, tmp_path, events)
+    path, sha = install_success_fakes(monkeypatch, tmp_path, events)
     failures = []
     monkeypatch.setattr(
         publication,
@@ -551,6 +567,7 @@ def test_known_stage_failure_records_failure_and_drops_run_table(monkeypatch, tm
     )
 
     assert result["status"] == "failed"
+    assert result["sha"] == sha
     assert failures == ["failed"]
     assert events[-1] == ("drop", publication._stage_table_name(RUN_ID))
 

--- a/tests/test_source_publication_plan.py
+++ b/tests/test_source_publication_plan.py
@@ -13,11 +13,18 @@ from src.pipelines.config.source_publication_assets import (
 from src.pipelines.sources.flat_files import REGISTRY
 from src.pipelines.utils.refresh_plan import REFRESH_GRAPH
 
+ENROLLED_SOURCES = (
+    "sdv_ratings_weekly",
+    "sdv_fpi_weekly",
+    "sdv_team_xwalk",
+    "sdv_game_xwalk",
+)
+
 
 def test_source_contract_matches_loader_and_declared_dependencies():
     contract = SDV_RATINGS_PUBLICATION
     spec = REGISTRY[contract.source_name]
-    assert set(SOURCE_PUBLICATION_ASSETS) == {spec.name}
+    assert set(SOURCE_PUBLICATION_ASSETS) == set(ENROLLED_SOURCES)
     assert contract.asset_key == f"{spec.schema}.{spec.table}"
     assert contract.primary_key == spec.primary_key
     assert contract.cadence == spec.cadence
@@ -25,6 +32,19 @@ def test_source_contract_matches_loader_and_declared_dependencies():
     assert set(contract.primary_key) <= set(contract.columns)
     assert contract.coverage_key(2025) == "season:2025"
     assert REFRESH_GRAPH.plan(changed=[contract.asset_key]).views == ("marts.epa_crossvalidation",)
+
+
+@pytest.mark.parametrize("name", ENROLLED_SOURCES)
+def test_enrolled_sources_preserve_registry_identity_and_scope(name):
+    contract = SOURCE_PUBLICATION_ASSETS[name]
+    spec = REGISTRY[name]
+    assert contract.source_name == name
+    assert contract.asset_key == f"{spec.schema}.{spec.table}"
+    assert contract.primary_key == spec.primary_key
+    assert contract.cadence == spec.cadence
+    assert len(contract.columns) == len(set(contract.columns))
+    assert set(contract.primary_key) <= set(contract.columns)
+    assert contract.coverage_key(2025) == "season:2025"
 
 
 @pytest.mark.parametrize("season", [None, True, "2025", 2025.0, 1868, 2201])
@@ -41,7 +61,18 @@ def test_invalid_source_coverage_is_rejected(season):
         ["--source", "massey", "--season", "2025"],
         ["--source", "sdv_ratings_weekly"],
         ["--source", "sdv_ratings_weekly", "--season", "2201"],
-        ["--source", "sdv_ratings_weekly", "--source", "sdv_fpi_weekly", "--season", "2025"],
+        ["--source", "sdv_ratings_weekly", "--source", "massey", "--season", "2025"],
+        ["--source", "sdv_ratings_weekly", "--source", "sdv_ratings_weekly", "--season", "2025"],
+        [
+            "--source",
+            "sdv_ratings_weekly",
+            "--source",
+            "sdv_fpi_weekly",
+            "--season",
+            "2025",
+            "--file",
+            "fixture.parquet",
+        ],
     ],
 )
 def test_receipt_cli_rejects_unsupported_plans_before_work(monkeypatch, args):
@@ -103,8 +134,8 @@ def test_receipt_cli_routes_exact_scope_and_fails_closed(monkeypatch, capsys, st
 
     monkeypatch.setitem(
         sys.modules,
-        "src.pipelines.utils.sdv_ratings_publication",
-        SimpleNamespace(run_sdv_ratings_publication=adapter),
+        "src.pipelines.utils.flat_file_publication",
+        SimpleNamespace(run_source_publication=adapter),
     )
     assert (
         load_flat_files.main(
@@ -132,3 +163,85 @@ def test_receipt_cli_routes_exact_scope_and_fails_closed(monkeypatch, capsys, st
         assert status in output.err
     else:
         assert output.err == ""
+
+
+def test_batch_dry_run_labels_source_season_provenance_without_querying(monkeypatch, capsys):
+    def forbidden(*_args, **_kwargs):
+        pytest.fail("batch dry-run must not invoke publication or fetch")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "src.pipelines.utils.flat_file_publication",
+        SimpleNamespace(run_source_publication=forbidden),
+    )
+    monkeypatch.setattr(load_flat_files, "fetch_file", forbidden)
+    monkeypatch.setattr(load_flat_files, "last_checked", forbidden)
+    args = ["--require-receipts", "--season", "2025", "--dry-run"]
+    for name in ENROLLED_SOURCES:
+        args.extend(["--source", name])
+
+    assert load_flat_files.main(args) == 0
+    output = capsys.readouterr().out
+    for contract in SOURCE_PUBLICATION_ASSETS.values():
+        assert f"{contract.asset_key}/season:2025" in output
+    assert output.count("Season basis: artifact_field") == 2
+    assert output.count("Season basis: registered_artifact_name") == 2
+    assert "not registered in the SQL refresh graph" in output
+    assert "separate operation and publication transaction" in output
+
+
+def test_crosswalk_local_dry_run_labels_caller_declared_season(capsys):
+    assert (
+        load_flat_files.main(
+            [
+                "--require-receipts",
+                "--source",
+                "sdv_team_xwalk",
+                "--season",
+                "2025",
+                "--file",
+                "arbitrary-name.parquet",
+                "--dry-run",
+            ]
+        )
+        == 0
+    )
+    assert "Season basis: caller_declared" in capsys.readouterr().out
+
+
+def test_batch_reports_each_result_and_continues_after_source_failure(monkeypatch, capsys):
+    names = ("sdv_fpi_weekly", "sdv_team_xwalk", "sdv_game_xwalk")
+    calls = []
+
+    def adapter(spec, **kwargs):
+        calls.append((spec.name, kwargs))
+        failed = spec.name == "sdv_team_xwalk"
+        return {
+            "source": spec.name,
+            "status": "failed" if failed else "loaded",
+            "rows": 0 if failed else 2,
+            "sha": None,
+            "duration_s": 0.1,
+            "error": "invalid crosswalk" if failed else None,
+            "run_id": f"run-{spec.name}",
+            "generation_id": f"generation-{spec.name}",
+        }
+
+    monkeypatch.setitem(
+        sys.modules,
+        "src.pipelines.utils.flat_file_publication",
+        SimpleNamespace(run_source_publication=adapter),
+    )
+    args = ["--require-receipts", "--season", "2025"]
+    for name in names:
+        args.extend(["--source", name])
+
+    assert load_flat_files.main(args) == 1
+    assert calls == [(name, {"file_path": None, "season": 2025}) for name in names]
+    output = capsys.readouterr()
+    for name in names:
+        assert name in output.out
+    assert "invalid crosswalk" in output.err
+    assert "run-sdv_team_xwalk" in output.err
+    assert "generation-sdv_team_xwalk" in output.err
+    assert "run-sdv_game_xwalk" not in output.err

--- a/tests/test_warehouse_bootstrap_sql.py
+++ b/tests/test_warehouse_bootstrap_sql.py
@@ -389,7 +389,7 @@ def test_managed_warehouse_catalog_data_and_access(
         _insert_representative_rows(conn)
         before_upgrade = _fixture_snapshot(conn)
         upgrade = apply_manifest(conn, manifest, mode="upgrade")
-        assert len(upgrade.pending) == 8
+        assert len(upgrade.pending) == 9
         assert [step.id for step in upgrade.pending] == [
             migration.id for migration in manifest.migrations[4:]
         ]


### PR DESCRIPTION
Extend opt-in receipt publication to `sdv_fpi_weekly`, `sdv_team_xwalk`, and `sdv_game_xwalk`. A corrected season file now replaces that source's entire selected season and commits its receipt, current generation, load-ledger observation, and operation outcome atomically. Selecting several enrolled sources runs independent publications and continues after a source failure, with a nonzero overall exit.

The new sources share the Python transaction lifecycle with SDV ratings while retaining explicit parser, type, key, and provenance contracts. Migration 072 exposes four bounded RPCs in a private namespace, preserves consumer grants and the existing ratings/Elo protocols, and rejects stale plans or altered publication guards. Crosswalk receipts distinguish a season assigned by the registered artifact name from one declared by a local-file caller.

Validation: 214 focused Python/CLI/parser tests, 67 new executed PostgreSQL 17 publication tests with all three real local Parquet-to-dlt adapters, and 76 bootstrap and existing publication regressions passed. Ruff and formatting passed; independent SQL and Python/CLI reviews found no remaining material issues. Details are recorded in `docs/plans/2026-09-09-step7-sdv-source-batch.md`.

Production rollout, runtime membership, scheduling, downstream refreshes, and public source freshness remain separate. Production lock duration and maximum-size payload memory are unmeasured. PostgreSQL does not emit DDL events for event-trigger changes; publication refuses disabled shared guards, and privileged guard-bypass maintenance requires explicit pointer invalidation before restoration.




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends receipt-backed season publication from SDV ratings to FPI, team crosswalk, and game crosswalk sources. It adds source-specific parser, schema, key, type, and season-evidence contracts; transactional persistence for published rows, receipts, generation pointers, ledger observations, and outcomes; and independent multi-source CLI publication.

<h3>Confidence Score: 5/5</h3>

Safe to merge; no blocking issues remain.

No new findings or outstanding previous findings remain.

<sub>Reviews (2): Last reviewed commit: ["Validate raw FPI metrics before numeric ..."](https://github.com/rstover-fo/cfb-database/commit/87551fdecf14a0c55e90503fadf5d9422d2863f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62256205)</sub>

<!-- /greptile_comment -->