### PR TITLE
Report SDV season publication freshness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - run: ./scripts/setup_dev.sh
       - name: Managed bootstrap and upgrade integration
-        run: .venv/bin/python -m pytest tests/test_warehouse_migrations_sql.py tests/test_warehouse_bootstrap_sql.py tests/test_adopt_warehouse_catalog_sql.py tests/test_f06_verification_transactions_sql.py tests/test_mart_release_sql.py tests/test_play_partitions.py tests/test_play_indexes_sql.py tests/test_operational_quota_sql.py tests/test_operational_quota_lifecycle_sql.py tests/test_cfbd_transport_admission_sql.py tests/test_asset_publication_sql.py tests/test_asset_freshness_sql.py tests/test_generation_refresh_sql.py tests/test_sdv_ratings_publication_sql.py tests/test_flat_file_publication_sql.py -q --tb=short
+        run: .venv/bin/python -m pytest tests/test_warehouse_migrations_sql.py tests/test_warehouse_bootstrap_sql.py tests/test_adopt_warehouse_catalog_sql.py tests/test_f06_verification_transactions_sql.py tests/test_mart_release_sql.py tests/test_play_partitions.py tests/test_play_indexes_sql.py tests/test_operational_quota_sql.py tests/test_operational_quota_lifecycle_sql.py tests/test_cfbd_transport_admission_sql.py tests/test_asset_publication_sql.py tests/test_asset_freshness_sql.py tests/test_generation_refresh_sql.py tests/test_sdv_ratings_publication_sql.py tests/test_flat_file_publication_sql.py tests/test_source_freshness_sql.py -q --tb=short
         env:
           F06_TEST_DB_URL: postgresql://postgres:f06-disposable-ci@127.0.0.1:5432/postgres
           F06_REQUIRE_DB: "1"

--- a/docs/SCHEMA_CONTRACT.md
+++ b/docs/SCHEMA_CONTRACT.md
@@ -15,6 +15,14 @@ Last updated: 2026-09-09
 
 ## Recent Contract Changes
 
+- **2026-09-09 — SDV season receipt freshness (prepared, not deployed).**
+  Migration `073_sdv_source_freshness.sql` adds
+  `public.get_source_freshness(p_season bigint)` for exactly the four enrolled
+  SDV sources. It reports current publication evidence, statement-time age,
+  explicit per-season freshness policy and separate failure diagnostics.
+  Existing house Elo and legacy freshness RPCs remain compatible. See the
+  [SDV freshness contract](plans/2026-09-09-step7-sdv-source-freshness.md).
+
 - **2026-09-09 — F19 receipt freshness (prepared, not deployed).**
   Migration `069_receipt_backed_freshness.sql` adds the separate
   `public.get_asset_freshness()` RPC for the two controlled house Elo assets.
@@ -1122,6 +1130,7 @@ Server-side functions callable via `supabase.rpc()`.
 | `get_conference_head_to_head` | `public` | `(p_conf1, p_conf2, p_season_start?, p_season_end?)` | Conference vs conference head-to-head records by season. Flips results to match caller's conference order. |
 | `get_data_freshness` | `public` | `()` | Legacy six-column maintenance heuristic for 24 tracked tables; vacuum/analyze activity does not prove publication freshness. Existing cfb-app/MCP contract preserved. |
 | `get_asset_freshness` | `public` | `()` | **Prepared, not deployed.** Query-time publication evidence for the two source-wide house Elo assets; see the contract below. |
+| `get_source_freshness` | `public` | `(p_season bigint)` | **Prepared, not deployed.** Exactly four SDV source/season rows with current publication evidence, nullable freshness policy and separate failure diagnostics. |
 | `run_analyst_query` | `public` | `(query_sql text)` | Guarded free-form read-only SQL for the cfb-app MCP `run_sql` tool (added 2026-07-22). Single SELECT/WITH statement only; executes as the `analyst_ro` role (SELECT on `api` schema only, read-only transaction); rows hard-capped at 200; returns a `jsonb` array. Timeout is enforced by the calling role's Supabase statement_timeout, not in-function. Defined in `src/schemas/public/012_run_analyst_query.sql`. |
 
 ### Receipt freshness compatibility (prepared, not deployed)
@@ -1147,6 +1156,26 @@ The private `meta.asset_freshness_policies` table stores optional positive
 publication intervals. Neither runtime policy configuration nor workflow
 activation is part of applying the prepared code. See the
 [implementation and rollout limits](plans/2026-09-09-f19-receipt-freshness.md).
+
+### SDV season freshness (prepared, not deployed)
+
+`public.get_source_freshness(p_season bigint)` requires an explicit season from
+1869 through 2200. It returns exactly one row for each of
+`sdv_ratings_weekly`, `sdv_fpi_weekly`, `sdv_team_xwalk` and `sdv_game_xwalk`,
+including missing receipt histories. This owner-rights RPC grants EXECUTE to
+`anon` and `authenticated` and exposes only its 21 typed scalar fields; private
+ledger/policy tables, raw JSON and arbitrary errors remain inaccessible.
+
+Current publication states distinguish `unrecorded`, `unpublished`, `invalid`
+and `current`. Only exact complete successful season receipts populate current
+generation, age, row counts and provenance. Missing policy leaves stale status
+NULL; no threshold is inferred from fetching cadence. Latest receipt outcome
+and historical failure diagnostics are independent of current publication.
+Crosswalk season evidence remains registered-name or caller-declared.
+
+The private policy table permits the four SDV season scopes alongside the
+existing two Elo source-wide scopes. Existing Elo policy values and RPC
+contracts are preserved. See the [complete output contract and verifier rules](plans/2026-09-09-step7-sdv-source-freshness.md).
 
 ### Reference Tables (Direct Access Allowed)
 

--- a/docs/plans/2026-09-08-f14-f19-operational-records.md
+++ b/docs/plans/2026-09-08-f14-f19-operational-records.md
@@ -367,11 +367,13 @@ Delivery progress (2026-09-09): steps 1–6 have merged through PR #142 with
 bounded opt-in adapters. The first step-7 slice merged in PR #143 is
 [SDV ratings season publication](2026-09-09-step7-sdv-ratings-publication.md):
 explicit source coverage metadata and staged dlt output published atomically
-for one season. Remaining sources, crossvalidation generation closure, public
-source freshness, and production activation remain separate work. The next
+for one season. The
 [three-source SDV batch](2026-09-09-step7-sdv-source-batch.md) extends season
 publication to weekly FPI and the team/game crosswalks using shared plumbing
-and independent source outcomes.
+and independent source outcomes and merged in PR #144. The next bounded slice
+adds [SDV season freshness and verification](2026-09-09-step7-sdv-source-freshness.md)
+while retaining both existing public freshness contracts. Crossvalidation
+generation enforcement still requires receipts for its remaining inputs.
 
 Steps 2 and 4 share database primitives but should remain separate PRs so
 quota-safety review is not coupled to a broad freshness API change. Step 3 can

--- a/docs/plans/2026-09-09-step7-sdv-source-freshness.md
+++ b/docs/plans/2026-09-09-step7-sdv-source-freshness.md
@@ -1,0 +1,101 @@
+# Step 7: SDV season publication freshness
+
+Status: implemented and independently reviewed after the four source publishers
+merged in PRs #143 and #144. Production migration, policy configuration and workflow
+activation remain separate rollout steps.
+
+## Additive API
+
+Migration 073 adds `public.get_source_freshness(p_season bigint)`. An explicit
+season from 1869 through 2200 returns exactly four rows, ordered as SDV ratings,
+weekly FPI, team crosswalk and game crosswalk. Missing receipts do not remove
+rows. NULL and out-of-range seasons are errors.
+
+The existing `get_asset_freshness()` two-row house Elo contract and the legacy
+six-column `get_data_freshness()` contract remain unchanged. No current app or
+MCP consumer is redirected. Consumers can adopt the new RPC separately after
+deployment; generated client types live in the downstream repositories.
+
+The new RPC uses owner rights with an empty search path and grants only its
+bounded read result to `anon` and `authenticated`. Private receipts, operation
+records, policy tables and staging data remain private. The response contains
+typed scalar columns; raw JSON, file paths, URLs, operation scopes and arbitrary
+error strings are excluded.
+
+| Fields | Meaning |
+|---|---|
+| `source_name`, `asset_key`, `season`, `coverage_key` | Fixed source identity and exact `season:YYYY` scope. |
+| `generation_id`, `published_at`, `current_outcome`, `is_complete` | Exact valid current successful season receipt, or NULL when no valid current publication exists. |
+| `source_rows`, `published_rows` | Equal nonempty artifact and published counts from the current receipt. |
+| `age_seconds`, `expected_refresh_interval`, `is_stale` | Publication age computed at statement time, explicit per-season policy and nullable stale result. |
+| `publication_state` | `unrecorded`, `unpublished`, `invalid` or `current`. |
+| `artifact_origin`, `season_basis` | Allowlisted provenance: registered URL or local file, with in-file, registered-name or caller-declared season evidence. |
+| `latest_outcome`, `latest_recorded_at` | Latest receipt diagnostic, independent of the currently readable generation. |
+| `last_failure_outcome`, `last_failure_at`, `last_failure_category` | Latest failed/partial/deferred/blocked receipt, retained after recovery; only an allowlisted category is exposed. |
+
+## Evidence and policy
+
+`unrecorded` means there is no pointer or receipt history. `unpublished` means
+history exists but the current pointer is absent, including invalidation after
+a legacy write. `invalid` means a pointer exists but its receipt cannot prove
+the required successful, complete source/season publication. No historical
+success is substituted for a missing or invalid pointer.
+
+Current evidence must match the selected source, parser protocol, season and
+complete-file scope, carry valid provenance, and have equal nonempty artifact
+and publication counts. Publication timestamps must be finite and no later
+than the current statement. Migration 071 ratings receipts predate `season_basis`;
+the API derives their `artifact_field` basis from that reviewed protocol.
+Migration 072 receipts carry their basis explicitly. Neither complete-file
+coverage nor publication age proves provider-wide coverage, finished seasons
+or availability before a prediction.
+
+The existing private `meta.asset_freshness_policies` table gains exact SDV
+season scopes while preserving both Elo `source-wide` scopes and their policy
+values. No SDV policies or thresholds are seeded. Missing or NULL intervals
+produce NULL `is_stale`; fetch cadence does not silently become an SLA.
+Publication age advances between SQL statements without a materialized-view
+refresh, and `ANALYZE` cannot renew it.
+
+A later unsuccessful attempt does not hide an older valid current publication.
+The response reports both independently. A subsequent successful publication
+becomes the latest outcome while preserving the historical failure diagnostic.
+Latest-outcome diagnostics accept the full receipt outcome enum, including
+`expected_no_data`; current SDV evidence requires `succeeded`. Failure categories
+are limited to `source_publication_failed` or NULL.
+This RPC reads recorded publication evidence; it does not reread source files,
+verify every target row or enforce downstream generation dependencies. The
+trusted-administrator guard-bypass limits of the publication protocol still
+apply.
+
+## Verifier behavior
+
+`verify_load.py` checks the new RPC for the requested season after the existing
+Elo receipt check. Missing migration or unrecorded optional publishers warn,
+including in strict mode. Receipt history with no current publication warns
+normally and fails in strict mode. Invalid identity, grain or current evidence
+always fails. Query, permission and transport errors propagate.
+
+A declared stale publication fails in season or strict mode, otherwise warns.
+Unknown policy always warns. A valid current publication inside its declared
+interval can pass this publication check. A latest unsuccessful attempt emits
+a separate warning; an older historical failure does not keep a recovered
+publication in warning status forever.
+
+## Verification
+
+- 125 verifier and manifest unit tests passed, including optional missing
+  evidence, strict grading, malformed contracts and separate failure diagnostics.
+- 38 new SQL tests passed on disposable PostgreSQL 17, including exact types
+  and grain, actual public caller roles, private-data exclusions, malformed and
+  future-dated evidence, policy isolation, aging, compatibility and migration
+  reapplication. The real verifier passed across publication, failure and
+  recovery using database-serialized responses.
+- 154 existing bootstrap, upgrade, freshness, generation and SDV publication
+  SQL regressions passed on a separate disposable PostgreSQL 17 fixture.
+- 3 legacy MCP freshness tests and affected Python lint/format checks passed.
+- Independent SQL and Python review found no remaining material issues.
+
+No production migration, policy activation or provider request was performed.
+Production query latency and costs at representative receipt-history volume
+remain unmeasured.

--- a/docs/warehouse-operations.md
+++ b/docs/warehouse-operations.md
@@ -73,6 +73,14 @@ the six-column `get_data_freshness()` consumer RPC remain compatible.
 See the [evidence meanings and rollout limits](plans/2026-09-09-f19-receipt-freshness.md)
 before interpreting either surface as a source-freshness guarantee.
 
+Migration 073 adds `public.get_source_freshness(p_season bigint)` and an additive
+SDV check in `verify_load.py`. It reports all four enrolled sources for the
+requested season, including absent or invalid current evidence and separate
+latest-failure diagnostics. Publication intervals are explicitly configured per
+source/season; missing thresholds remain unknown. The verifier warns for
+unrecorded optional sources or undeclared policy, and fails malformed evidence.
+See the [SDV response contract, strict-mode grading and rollout limits](plans/2026-09-09-step7-sdv-source-freshness.md).
+
 ## Generation-enforced refresh (prepared)
 
 After migration 070 and a separately authorized role/cadence rollout, use

--- a/scripts/verify_load.py
+++ b/scripts/verify_load.py
@@ -22,11 +22,13 @@ Checks:
        off-season and FAILs in-season (or with --strict)
     6. Optional house Elo receipts: publication age and exact recorded inputs;
        unknown cadence/upstream closure WARN, broken required inputs FAIL
-    7. ratings.massey_composite has a recent, full-coverage snapshot for the
+    7. Optional season-scoped SDV source receipts: exact complete publication
+       evidence and owner-declared age policy for the selected season
+    8. ratings.massey_composite has a recent, full-coverage snapshot for the
        season (in-season only; WARNs if migration 041 isn't applied yet)
-    8. meta.flat_file_loads has a recent successful 'availability' load
+    9. meta.flat_file_loads has a recent successful 'availability' load
        (in-season only; never FAILs -- external conference sites are flaky)
-    9. no unexpected dlt VARIANT (__v_double) twin has appeared on a
+    10. no unexpected dlt VARIANT (__v_double) twin has appeared on a
        charting source table since the mart(s) reading it were authored
        (KTD7 tripwire; see src/pipelines/utils/variant_twins.py) -- FAILs
        naming the column, since it means a metric is silently reading NULL
@@ -40,6 +42,7 @@ already have rows for the upcoming season).
 
 import argparse
 import logging
+import math
 import sys
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
@@ -610,6 +613,234 @@ def check_receipt_freshness(cur, in_season: bool, strict: bool, report: Report) 
         report.record(status, "receipt_freshness", "; ".join(details))
 
 
+SOURCE_FRESHNESS_IDENTITIES = (
+    ("sdv_ratings_weekly", "ratings.sdv_ratings_weekly"),
+    ("sdv_fpi_weekly", "ratings.espn_fpi_weekly"),
+    ("sdv_team_xwalk", "ref.team_id_xwalk"),
+    ("sdv_game_xwalk", "ref.game_id_xwalk"),
+)
+SOURCE_FRESHNESS_FIELDS = frozenset(
+    {
+        "source_name",
+        "asset_key",
+        "season",
+        "coverage_key",
+        "generation_id",
+        "published_at",
+        "age_seconds",
+        "expected_refresh_interval",
+        "is_stale",
+        "publication_state",
+        "current_outcome",
+        "is_complete",
+        "source_rows",
+        "published_rows",
+        "artifact_origin",
+        "season_basis",
+        "latest_outcome",
+        "latest_recorded_at",
+        "last_failure_outcome",
+        "last_failure_at",
+        "last_failure_category",
+    }
+)
+_SOURCE_CURRENT_FIELDS = (
+    "generation_id",
+    "published_at",
+    "age_seconds",
+    "is_stale",
+    "current_outcome",
+    "is_complete",
+    "source_rows",
+    "published_rows",
+    "artifact_origin",
+    "season_basis",
+)
+_SOURCE_PUBLICATION_STATES = {"unrecorded", "unpublished", "invalid", "current"}
+_SOURCE_TERMINAL_OUTCOMES = {
+    "succeeded",
+    "expected_no_data",
+    *NONCURRENT_RECEIPT_OUTCOMES,
+}
+
+
+def _nonempty_string(value) -> bool:
+    return type(value) is str and bool(value)
+
+
+def _source_row_contract_error(row: dict, source_name: str) -> str | None:
+    """Return why a typed source-freshness row is internally inconsistent."""
+    state = row["publication_state"]
+    if state not in _SOURCE_PUBLICATION_STATES:
+        return "unknown publication state"
+
+    interval = row["expected_refresh_interval"]
+    if interval is not None and not _nonempty_string(interval):
+        return "invalid refresh interval"
+    if row["is_stale"] is not None and type(row["is_stale"]) is not bool:
+        return "invalid staleness value"
+
+    latest_outcome = row["latest_outcome"]
+    latest_at = row["latest_recorded_at"]
+    if state == "unrecorded":
+        if latest_outcome is not None or latest_at is not None:
+            return "unrecorded source has receipt history"
+    elif latest_outcome not in _SOURCE_TERMINAL_OUTCOMES or not _nonempty_string(latest_at):
+        return "receipt history is malformed"
+
+    failure_outcome = row["last_failure_outcome"]
+    failure_at = row["last_failure_at"]
+    failure_category = row["last_failure_category"]
+    if state == "unrecorded" and any(
+        value is not None for value in (failure_outcome, failure_at, failure_category)
+    ):
+        return "unrecorded source has receipt history"
+    if failure_outcome is None:
+        if failure_at is not None or failure_category is not None:
+            return "failure history is malformed"
+    elif (
+        failure_outcome not in NONCURRENT_RECEIPT_OUTCOMES
+        or not _nonempty_string(failure_at)
+        or failure_category not in {None, "source_publication_failed"}
+    ):
+        return "failure history is malformed"
+
+    if state != "current":
+        if any(row[field] is not None for field in _SOURCE_CURRENT_FIELDS):
+            return "non-current source exposes current publication evidence"
+        return None
+
+    if (
+        not _nonempty_string(row["generation_id"])
+        or not _nonempty_string(row["published_at"])
+        or row["current_outcome"] != "succeeded"
+        or row["is_complete"] is not True
+        or type(row["source_rows"]) is not int
+        or type(row["published_rows"]) is not int
+        or not 1 <= row["source_rows"] <= 100_000
+        or row["published_rows"] != row["source_rows"]
+        or row["artifact_origin"] not in {"registered_url", "local_file"}
+    ):
+        return "invalid current publication evidence"
+    age = row["age_seconds"]
+    if (
+        isinstance(age, bool)
+        or not isinstance(age, (int, float))
+        or not math.isfinite(age)
+        or age < 0
+    ):
+        return "invalid publication age"
+
+    if source_name in {"sdv_ratings_weekly", "sdv_fpi_weekly"}:
+        expected_basis = "artifact_field"
+    elif row["artifact_origin"] == "registered_url":
+        expected_basis = "registered_artifact_name"
+    else:
+        expected_basis = "caller_declared"
+    if row["season_basis"] != expected_basis:
+        return "invalid season evidence"
+    return None
+
+
+def check_source_freshness(cur, season: int, in_season: bool, strict: bool, report: Report) -> None:
+    """Inspect optional complete-file publication evidence for one SDV season."""
+    cur.execute("SELECT to_regprocedure('public.get_source_freshness(bigint)')")
+    if cur.fetchone()[0] is None:
+        report.record(
+            WARN,
+            "source_freshness",
+            "season source freshness migration is not installed",
+        )
+        return
+
+    cur.execute(
+        "SELECT to_jsonb(f) FROM public.get_source_freshness(%s) f",
+        (season,),
+    )
+    rows = [item[0] for item in cur.fetchall()]
+    if any(type(row) is not dict or frozenset(row) != SOURCE_FRESHNESS_FIELDS for row in rows):
+        report.record(FAIL, "source_freshness", "source freshness row shape is invalid")
+        return
+
+    coverage_key = f"season:{season}"
+    expected = {
+        (source_name, asset_key, season, coverage_key)
+        for source_name, asset_key in SOURCE_FRESHNESS_IDENTITIES
+    }
+    identities = [
+        (row["source_name"], row["asset_key"], row["season"], row["coverage_key"]) for row in rows
+    ]
+    identities_are_typed = all(
+        _nonempty_string(source_name)
+        and _nonempty_string(asset_key)
+        and type(row_season) is int
+        and _nonempty_string(row_coverage)
+        for source_name, asset_key, row_season, row_coverage in identities
+    )
+    if not identities_are_typed or len(identities) != len(expected) or set(identities) != expected:
+        report.record(
+            FAIL,
+            "source_freshness",
+            f"expected exactly four SDV source assets for {coverage_key}",
+        )
+        return
+
+    by_source = {row["source_name"]: row for row in rows}
+    for source_name, asset_key in SOURCE_FRESHNESS_IDENTITIES:
+        row = by_source[source_name]
+        contract_error = _source_row_contract_error(row, source_name)
+        if contract_error is not None:
+            report.record(
+                FAIL,
+                "source_freshness",
+                f"{asset_key}/{coverage_key}: {contract_error}",
+            )
+            continue
+
+        latest_outcome = row["latest_outcome"]
+        if latest_outcome in NONCURRENT_RECEIPT_OUTCOMES:
+            report.record(
+                WARN,
+                "source_receipt_attempt",
+                f"{asset_key}/{coverage_key}: latest attempt {latest_outcome}; "
+                "this does not replace current publication evidence",
+            )
+
+        state = row["publication_state"]
+        if state == "unrecorded":
+            report.record(
+                WARN,
+                "source_freshness",
+                f"{asset_key}/{coverage_key}: optional publisher has no receipts",
+            )
+            continue
+        if state == "unpublished":
+            report.record(
+                FAIL if strict else WARN,
+                "source_freshness",
+                f"{asset_key}/{coverage_key}: receipt history exists but no valid "
+                "current publication",
+            )
+            continue
+        if state == "invalid":
+            report.record(
+                FAIL,
+                "source_freshness",
+                f"{asset_key}/{coverage_key}: current publication pointer is invalid",
+            )
+            continue
+
+        status = PASS
+        details = [f"{asset_key}/{coverage_key}: current succeeded complete publication"]
+        if row["is_stale"] is True:
+            status = FAIL if in_season or strict else WARN
+            details.append("age exceeds declared publication interval")
+        elif row["is_stale"] is None or row["expected_refresh_interval"] is None:
+            status = WARN
+            details.append("publication age policy is undeclared or unknown")
+        report.record(status, "source_freshness", "; ".join(details))
+
+
 def verify(season: int, strict: bool) -> int:
     """Run all checks. Returns the number of failures."""
     from datetime import datetime
@@ -632,6 +863,7 @@ def verify(season: int, strict: bool) -> int:
             check_backtest_freshness(cur, report)
             check_freshness(cur, in_season, strict, report)
             check_receipt_freshness(cur, in_season, strict, report)
+            check_source_freshness(cur, season, in_season, strict, report)
             check_variant_twins(cur, report)
             check_massey_composite(cur, season, report)
             check_availability_archive(cur, season, report)

--- a/src/schemas/migrations/073_sdv_source_freshness.sql
+++ b/src/schemas/migrations/073_sdv_source_freshness.sql
@@ -1,0 +1,289 @@
+-- F19 additive SDV season-source freshness. Managed forward migration after 072.
+-- This is a query-time compatibility surface over publication receipts; it
+-- declares no source cadence and does not change get_asset_freshness().
+
+DO $policy_preflight$
+DECLARE policy_oid oid := pg_catalog.to_regclass('meta.asset_freshness_policies');
+BEGIN
+    IF policy_oid IS NULL OR NOT EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_class c
+        WHERE c.oid = policy_oid
+            AND c.relkind = 'r'
+            AND c.relowner = (
+                SELECT r.oid FROM pg_catalog.pg_roles r WHERE r.rolname = current_user)
+            AND c.relrowsecurity
+            AND NOT c.relforcerowsecurity
+            AND NOT c.relhasrules
+    ) OR EXISTS (
+        SELECT 1 FROM pg_catalog.pg_inherits i
+        WHERE i.inhrelid = policy_oid OR i.inhparent = policy_oid
+    ) THEN
+        RAISE EXCEPTION
+            'asset freshness policy must be a trusted migration-owned private table';
+    END IF;
+END
+$policy_preflight$;
+
+ALTER TABLE meta.asset_freshness_policies
+    DROP CONSTRAINT IF EXISTS asset_freshness_policies_asset_key_check;
+ALTER TABLE meta.asset_freshness_policies
+    ADD CONSTRAINT asset_freshness_policies_asset_key_check CHECK (asset_key IN (
+        'analytics.house_elo_game',
+        'marts.house_elo_game',
+        'ratings.sdv_ratings_weekly',
+        'ratings.espn_fpi_weekly',
+        'ref.team_id_xwalk',
+        'ref.game_id_xwalk'
+    ));
+
+ALTER TABLE meta.asset_freshness_policies
+    DROP CONSTRAINT IF EXISTS asset_freshness_policies_coverage_key_check;
+ALTER TABLE meta.asset_freshness_policies
+    ADD CONSTRAINT asset_freshness_policies_coverage_key_check CHECK (
+        (asset_key IN ('analytics.house_elo_game', 'marts.house_elo_game')
+            AND coverage_key = 'source-wide')
+        OR
+        (asset_key IN (
+                'ratings.sdv_ratings_weekly', 'ratings.espn_fpi_weekly',
+                'ref.team_id_xwalk', 'ref.game_id_xwalk'
+            )
+            AND coverage_key ~
+                '^season:(18(69|[7-9][0-9])|19[0-9]{2}|20[0-9]{2}|21[0-9]{2}|2200)$')
+    );
+
+CREATE OR REPLACE FUNCTION public.get_source_freshness(p_season bigint)
+RETURNS TABLE (
+    source_name text,
+    asset_key text,
+    season bigint,
+    coverage_key text,
+    generation_id uuid,
+    published_at timestamptz,
+    age_seconds numeric,
+    expected_refresh_interval interval,
+    is_stale boolean,
+    publication_state text,
+    current_outcome text,
+    is_complete boolean,
+    source_rows bigint,
+    published_rows bigint,
+    artifact_origin text,
+    season_basis text,
+    latest_outcome text,
+    latest_recorded_at timestamptz,
+    last_failure_outcome text,
+    last_failure_at timestamptz,
+    last_failure_category text
+)
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = ''
+AS $function$
+BEGIN
+    IF p_season IS NULL OR p_season < 1869 OR p_season > 2200 THEN
+        RAISE EXCEPTION 'SDV source season must be between 1869 and 2200'
+            USING ERRCODE = '22023';
+    END IF;
+
+    RETURN QUERY
+    WITH sources(source_order, source_name, asset_key, expected_protocol,
+            expected_parser) AS (
+        VALUES
+            (1, 'sdv_ratings_weekly'::text, 'ratings.sdv_ratings_weekly'::text,
+                'sdv-ratings-season-v1'::text, 'sdv-ratings-v1'::text),
+            (2, 'sdv_fpi_weekly'::text, 'ratings.espn_fpi_weekly'::text,
+                'sdv-season-file-v1'::text, 'sdv-fpi-v1'::text),
+            (3, 'sdv_team_xwalk'::text, 'ref.team_id_xwalk'::text,
+                'sdv-season-file-v1'::text, 'sdv-team-xwalk-v1'::text),
+            (4, 'sdv_game_xwalk'::text, 'ref.game_id_xwalk'::text,
+                'sdv-season-file-v1'::text, 'sdv-game-xwalk-v1'::text)
+    ), requested AS (
+        SELECT s.*, p_season AS season, 'season:' || p_season::text AS coverage_key
+        FROM sources s
+    ), receipt_evidence AS (
+        SELECT a.*, pointer.generation_id AS pointer_generation_id,
+            receipt.generation_id AS receipt_generation_id,
+            receipt.outcome AS receipt_outcome,
+            receipt.coverage,
+            receipt.input_observations,
+            receipt.row_delta,
+            receipt.published_at AS receipt_published_at,
+            policy.expected_refresh_interval,
+            latest.outcome AS latest_outcome,
+            latest.recorded_at AS latest_recorded_at,
+            failure.outcome AS last_failure_outcome,
+            failure.recorded_at AS last_failure_at,
+            CASE WHEN failure.error_summary = 'source_publication_failed'
+                THEN 'source_publication_failed'::text ELSE NULL::text
+                END AS last_failure_category
+        FROM requested a
+        LEFT JOIN meta.asset_current_generations pointer
+            ON pointer.asset_key = a.asset_key
+            AND pointer.coverage_key = a.coverage_key
+        LEFT JOIN meta.asset_receipts receipt
+            ON receipt.asset_key = pointer.asset_key
+            AND receipt.coverage_key = pointer.coverage_key
+            AND receipt.generation_id = pointer.generation_id
+        LEFT JOIN meta.asset_freshness_policies policy
+            ON policy.asset_key = a.asset_key
+            AND policy.coverage_key = a.coverage_key
+        LEFT JOIN LATERAL (
+            SELECT r.outcome, r.recorded_at
+            FROM meta.asset_receipts r
+            WHERE r.asset_key = a.asset_key
+                AND r.coverage_key = a.coverage_key
+            ORDER BY r.recorded_at DESC, r.generation_id DESC
+            LIMIT 1
+        ) latest ON true
+        LEFT JOIN LATERAL (
+            SELECT r.outcome, r.recorded_at, r.error_summary
+            FROM meta.asset_receipts r
+            WHERE r.asset_key = a.asset_key
+                AND r.coverage_key = a.coverage_key
+                AND r.outcome IN ('failed', 'partial', 'deferred', 'blocked')
+            ORDER BY r.recorded_at DESC, r.generation_id DESC
+            LIMIT 1
+        ) failure ON true
+    ), normalized AS (
+        SELECT e.*,
+            CASE
+                WHEN pg_catalog.jsonb_typeof(e.coverage->'season') = 'number'
+                    AND e.coverage->>'season' ~ '^(0|[1-9][0-9]*)$'
+                THEN (e.coverage->>'season')::numeric
+                END AS evidence_season,
+            CASE
+                WHEN pg_catalog.jsonb_typeof(e.coverage->'source_rows') = 'number'
+                    AND e.coverage->>'source_rows' ~ '^[1-9][0-9]{0,5}$'
+                THEN (e.coverage->>'source_rows')::numeric
+                END AS evidence_source_rows,
+            CASE
+                WHEN pg_catalog.jsonb_typeof(e.coverage->'published_rows') = 'number'
+                    AND e.coverage->>'published_rows' ~ '^[1-9][0-9]{0,5}$'
+                THEN (e.coverage->>'published_rows')::numeric
+                END AS evidence_published_rows,
+            CASE
+                WHEN pg_catalog.jsonb_typeof(e.row_delta->'published_rows') = 'number'
+                    AND e.row_delta->>'published_rows' ~ '^[1-9][0-9]{0,5}$'
+                THEN (e.row_delta->>'published_rows')::numeric
+                END AS delta_published_rows
+        FROM receipt_evidence e
+    ), checked AS (
+        SELECT e.*,
+            e.receipt_generation_id IS NOT NULL
+            AND e.receipt_outcome = 'succeeded'
+            AND e.receipt_published_at IS NOT NULL
+            AND pg_catalog.isfinite(e.receipt_published_at)
+            AND e.receipt_published_at <= pg_catalog.statement_timestamp()
+            AND pg_catalog.jsonb_typeof(e.coverage) = 'object'
+            AND pg_catalog.jsonb_typeof(e.coverage->'complete') = 'boolean'
+            AND e.coverage->'complete' = 'true'::jsonb
+            AND pg_catalog.jsonb_typeof(e.coverage->'scope') = 'string'
+            AND e.coverage->>'scope' = 'season'
+            AND pg_catalog.jsonb_typeof(e.coverage->'mode') = 'string'
+            AND e.coverage->>'mode' = 'full_file_for_season'
+            AND e.evidence_season = e.season
+            AND e.evidence_source_rows BETWEEN 1 AND 100000
+            AND e.evidence_published_rows = e.evidence_source_rows
+            AND pg_catalog.jsonb_typeof(e.row_delta) = 'object'
+            AND e.delta_published_rows = e.evidence_published_rows
+            AND pg_catalog.jsonb_typeof(e.input_observations) = 'object'
+            AND pg_catalog.jsonb_typeof(e.input_observations->'publisher') = 'string'
+            AND e.input_observations->>'publisher' = 'load_flat_files'
+            AND pg_catalog.jsonb_typeof(e.input_observations->'protocol') = 'string'
+            AND e.input_observations->>'protocol' = e.expected_protocol
+            AND pg_catalog.jsonb_typeof(e.input_observations->'parser_contract') = 'string'
+            AND e.input_observations->>'parser_contract' = e.expected_parser
+            AND pg_catalog.jsonb_typeof(e.input_observations->'stage_schema') = 'string'
+            AND e.input_observations->>'stage_schema' = 'warehouse_source_stage'
+            AND pg_catalog.jsonb_typeof(e.input_observations->'artifact_origin') = 'string'
+            AND e.input_observations->>'artifact_origin' IN ('registered_url', 'local_file')
+            AND (
+                e.source_name = 'sdv_ratings_weekly'
+                OR (
+                    pg_catalog.jsonb_typeof(
+                        e.input_observations->'source_name') = 'string'
+                    AND e.input_observations->>'source_name' = e.source_name
+                    AND pg_catalog.jsonb_typeof(
+                        e.input_observations->'season_basis') = 'string'
+                    AND e.input_observations->>'season_basis' = CASE
+                        WHEN e.source_name = 'sdv_fpi_weekly'
+                            THEN 'artifact_field'
+                        WHEN e.input_observations->>'artifact_origin' = 'registered_url'
+                            THEN 'registered_artifact_name'
+                        ELSE 'caller_declared'
+                    END
+                )
+            ) AS current_is_valid
+        FROM normalized e
+    )
+    SELECT c.source_name, c.asset_key, c.season, c.coverage_key,
+        CASE WHEN c.current_is_valid THEN c.receipt_generation_id END AS generation_id,
+        CASE WHEN c.current_is_valid THEN c.receipt_published_at END AS published_at,
+        CASE WHEN c.current_is_valid THEN
+            EXTRACT(EPOCH FROM (
+                pg_catalog.statement_timestamp() - c.receipt_published_at))
+            END AS age_seconds,
+        c.expected_refresh_interval,
+        CASE WHEN c.current_is_valid AND c.expected_refresh_interval IS NOT NULL
+            THEN pg_catalog.statement_timestamp() - c.receipt_published_at
+                > c.expected_refresh_interval
+            ELSE NULL::boolean END AS is_stale,
+        CASE WHEN c.current_is_valid THEN 'current'::text
+            WHEN c.pointer_generation_id IS NOT NULL THEN 'invalid'::text
+            WHEN c.latest_outcome IS NOT NULL THEN 'unpublished'::text
+            ELSE 'unrecorded'::text END AS publication_state,
+        CASE WHEN c.current_is_valid THEN c.receipt_outcome END AS current_outcome,
+        CASE WHEN c.current_is_valid THEN true ELSE NULL::boolean END AS is_complete,
+        CASE WHEN c.current_is_valid
+            THEN c.evidence_source_rows::bigint END AS source_rows,
+        CASE WHEN c.current_is_valid
+            THEN c.evidence_published_rows::bigint END AS published_rows,
+        CASE WHEN c.current_is_valid
+            THEN c.input_observations->>'artifact_origin' END AS artifact_origin,
+        CASE WHEN c.current_is_valid THEN
+            CASE WHEN c.source_name = 'sdv_ratings_weekly' THEN 'artifact_field'::text
+                ELSE c.input_observations->>'season_basis' END
+            END AS season_basis,
+        c.latest_outcome, c.latest_recorded_at,
+        c.last_failure_outcome, c.last_failure_at, c.last_failure_category
+    FROM checked c
+    ORDER BY c.source_order;
+END
+$function$;
+
+COMMENT ON FUNCTION public.get_source_freshness(bigint) IS
+'Safe query-time publication evidence for four fixed SDV season sources. Missing cadence and unusable evidence produce unknown staleness; season provenance is allowlisted.';
+
+-- Remove inherited default grants and expose only this bounded owner-rights RPC.
+DO $access$
+DECLARE
+    rpc record;
+    acl_entry record;
+    owner_id oid;
+    recipient text;
+BEGIN
+    SELECT oid INTO owner_id FROM pg_catalog.pg_roles WHERE rolname = current_user;
+    SELECT p.oid, p.proowner, p.proacl INTO rpc
+    FROM pg_catalog.pg_proc p
+    WHERE p.oid = 'public.get_source_freshness(bigint)'::regprocedure;
+    IF NOT FOUND OR rpc.proowner <> owner_id THEN
+        RAISE EXCEPTION 'source freshness RPC must be migration-owned';
+    END IF;
+
+    FOR acl_entry IN
+        SELECT DISTINCT a.grantee
+        FROM pg_catalog.aclexplode(
+            COALESCE(rpc.proacl, pg_catalog.acldefault('f', rpc.proowner))) a
+        WHERE a.grantee <> owner_id
+    LOOP
+        recipient := CASE WHEN acl_entry.grantee = 0 THEN 'PUBLIC'
+            ELSE pg_catalog.quote_ident(
+                pg_catalog.pg_get_userbyid(acl_entry.grantee)) END;
+        EXECUTE pg_catalog.format(
+            'REVOKE ALL ON FUNCTION public.get_source_freshness(bigint) FROM %s',
+            recipient);
+    END LOOP;
+END
+$access$;
+
+GRANT USAGE ON SCHEMA public TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_source_freshness(bigint) TO anon, authenticated;

--- a/src/schemas/production-manifest.json
+++ b/src/schemas/production-manifest.json
@@ -39,6 +39,11 @@
       "id": "warehouse.source.072",
       "path": "src/schemas/migrations/072_sdv_source_batch_publication.sql",
       "kind": "immutable"
+    },
+    {
+      "id": "warehouse.f19.073",
+      "path": "src/schemas/migrations/073_sdv_source_freshness.sql",
+      "kind": "immutable"
     }
   ],
   "version": 1

--- a/src/schemas/warehouse-manifest.json
+++ b/src/schemas/warehouse-manifest.json
@@ -65,6 +65,11 @@
       "id": "warehouse.source.072",
       "path": "src/schemas/migrations/072_sdv_source_batch_publication.sql",
       "kind": "immutable"
+    },
+    {
+      "id": "warehouse.f19.073",
+      "path": "src/schemas/migrations/073_sdv_source_freshness.sql",
+      "kind": "immutable"
     }
   ]
 }

--- a/tests/test_source_freshness_sql.py
+++ b/tests/test_source_freshness_sql.py
@@ -1,0 +1,719 @@
+"""Executed receipt freshness checks for the four SDV season sources."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+
+import psycopg2
+import pytest
+from psycopg2 import sql
+
+from tests.test_asset_freshness_sql import freshness_db as _freshness_db  # noqa: F401
+from tests.test_asset_publication_sql import publication_db as _publication_db  # noqa: F401
+from tests.test_flat_file_publication_sql import (
+    SOURCES as BATCH_SOURCES,
+)
+from tests.test_flat_file_publication_sql import batch_db as _batch_db  # noqa: F401
+from tests.test_flat_file_publication_sql import (
+    plan as batch_plan,
+)
+from tests.test_flat_file_publication_sql import (
+    publication_args as batch_publication_args,
+)
+from tests.test_flat_file_publication_sql import (
+    publish as publish_batch,
+)
+from tests.test_flat_file_publication_sql import (
+    source_query as batch_query,
+)
+from tests.test_flat_file_publication_sql import (
+    start_load as start_batch_load,
+)
+from tests.test_generation_refresh_sql import generation_db as _generation_db  # noqa: F401
+from tests.test_sdv_ratings_publication_sql import (
+    ASSET as RATINGS_ASSET,
+)
+from tests.test_sdv_ratings_publication_sql import (
+    plan as ratings_plan,
+)
+from tests.test_sdv_ratings_publication_sql import (
+    publication_args as ratings_publication_args,
+)
+from tests.test_sdv_ratings_publication_sql import (
+    publish as publish_ratings,
+)
+from tests.test_sdv_ratings_publication_sql import (
+    source_query as ratings_query,
+)
+from tests.test_sdv_ratings_publication_sql import (
+    start_load as start_ratings_load,
+)
+from tests.test_warehouse_migrations_sql import query
+from tests.test_warehouse_migrations_sql import warehouse_db as _warehouse_db  # noqa: F401
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATION = ROOT / "src/schemas/migrations/073_sdv_source_freshness.sql"
+
+SOURCE_ASSETS = {
+    "sdv_ratings_weekly": RATINGS_ASSET,
+    **{source: config["asset"] for source, config in BATCH_SOURCES.items()},
+}
+SOURCE_ORDER = tuple(SOURCE_ASSETS)
+EXPECTED_COLUMNS = (
+    "source_name",
+    "asset_key",
+    "season",
+    "coverage_key",
+    "generation_id",
+    "published_at",
+    "age_seconds",
+    "expected_refresh_interval",
+    "is_stale",
+    "publication_state",
+    "current_outcome",
+    "is_complete",
+    "source_rows",
+    "published_rows",
+    "artifact_origin",
+    "season_basis",
+    "latest_outcome",
+    "latest_recorded_at",
+    "last_failure_outcome",
+    "last_failure_at",
+    "last_failure_category",
+)
+EXPECTED_TYPE_OIDS = (
+    25,  # text
+    25,
+    20,  # bigint
+    25,
+    2950,  # uuid
+    1184,  # timestamptz
+    1700,  # numeric
+    1186,  # interval
+    16,  # boolean
+    25,
+    25,
+    16,
+    20,
+    20,
+    25,
+    25,
+    25,
+    1184,
+    25,
+    1184,
+    25,
+)
+CURRENT_EVIDENCE_COLUMNS = (
+    "generation_id",
+    "published_at",
+    "age_seconds",
+    "current_outcome",
+    "is_complete",
+    "source_rows",
+    "published_rows",
+    "artifact_origin",
+    "season_basis",
+)
+PRIVATE_TABLES = (
+    "asset_publication_locks",
+    "asset_receipts",
+    "asset_current_generations",
+    "asset_receipt_inputs",
+    "asset_freshness_policies",
+    "operation_runs",
+)
+
+
+@pytest.fixture
+def source_freshness_db(request):
+    conn, target = request.getfixturevalue("_batch_db")
+    query(conn, MIGRATION.read_text())
+    return conn, target
+
+
+def source_rows(conn, season=2025, *, role="anon"):
+    with conn.cursor() as cur:
+        cur.execute(sql.SQL("SET LOCAL ROLE {}").format(sql.Identifier(role)))
+        cur.execute("SELECT * FROM public.get_source_freshness(%s)", (season,))
+        columns = tuple(column.name for column in cur.description)
+        type_oids = tuple(column.type_code for column in cur.description)
+        result = [dict(zip(columns, row, strict=True)) for row in cur.fetchall()]
+    conn.commit()
+    return result, columns, type_oids
+
+
+def rows_by_source(conn, season=2025, *, role="anon"):
+    result, _, _ = source_rows(conn, season, role=role)
+    return {row["source_name"]: row for row in result}
+
+
+def denied(conn, role, statement):
+    try:
+        with conn.cursor() as cur:
+            cur.execute(sql.SQL("SET LOCAL ROLE {}").format(sql.Identifier(role)))
+            try:
+                cur.execute(statement)
+            except psycopg2.errors.InsufficientPrivilege:
+                return
+            pytest.fail(f"{role} unexpectedly executed: {statement}")
+    finally:
+        conn.rollback()
+
+
+def publish_source(conn, source, *, season=2025, suffix="a", artifact_origin="registered_url"):
+    if source == "sdv_ratings_weekly":
+        args = ratings_publication_args(
+            conn,
+            season=season,
+            sha=(f"{season:04x}{suffix}" * 16)[:64],
+            artifact_origin=artifact_origin,
+        )
+        publish_ratings(conn, args)
+    else:
+        args = batch_publication_args(
+            conn,
+            source,
+            season=season,
+            sha=(f"{season:04x}{suffix}" * 16)[:64],
+            artifact_origin=artifact_origin,
+        )
+        publish_batch(conn, args)
+    return args
+
+
+def record_failure(conn, source, *, season=2025, outcome="failed"):
+    generation_id = str(uuid.uuid4())
+    if source == "sdv_ratings_weekly":
+        run_id = start_ratings_load(conn, ratings_plan(conn, season))
+        ratings_query(
+            conn,
+            "SELECT warehouse_source.fail_sdv_ratings_load(%s,%s,%s)",
+            (run_id, generation_id, outcome),
+        )
+    else:
+        run_id = start_batch_load(conn, batch_plan(conn, source, season))
+        batch_query(
+            conn,
+            "SELECT warehouse_source_batch.fail_source_load(%s,%s,%s)",
+            (run_id, generation_id, outcome),
+        )
+    return generation_id
+
+
+def test_rpc_has_exact_typed_four_row_missing_contract(source_freshness_db):
+    conn, _ = source_freshness_db
+    for role in ("anon", "authenticated"):
+        result, columns, type_oids = source_rows(conn, role=role)
+        assert columns == EXPECTED_COLUMNS
+        assert type_oids == EXPECTED_TYPE_OIDS
+        assert [row["source_name"] for row in result] == list(SOURCE_ORDER)
+        assert [row["asset_key"] for row in result] == list(SOURCE_ASSETS.values())
+        for row in result:
+            assert row["season"] == 2025
+            assert row["coverage_key"] == "season:2025"
+            assert row["publication_state"] == "unrecorded"
+            assert row["expected_refresh_interval"] is None
+            assert all(
+                row[column] is None
+                for column in EXPECTED_COLUMNS[4:]
+                if column not in {"publication_state"}
+            )
+
+
+@pytest.mark.parametrize("season", [1869, 2200])
+def test_rpc_accepts_exact_season_boundaries(source_freshness_db, season):
+    conn, _ = source_freshness_db
+    result = rows_by_source(conn, season)
+    assert tuple(result) == SOURCE_ORDER
+    assert {(row["season"], row["coverage_key"]) for row in result.values()} == {
+        (season, f"season:{season}")
+    }
+
+
+@pytest.mark.parametrize("season", [None, 1868, 2201])
+def test_rpc_rejects_null_and_out_of_range_seasons(source_freshness_db, season):
+    conn, _ = source_freshness_db
+    with pytest.raises(psycopg2.errors.InvalidParameterValue):
+        query(conn, "SELECT * FROM public.get_source_freshness(%s)", (season,))
+    conn.rollback()
+
+
+@pytest.mark.parametrize("source", SOURCE_ORDER)
+def test_each_publisher_yields_allowlisted_current_evidence_only_for_its_season(
+    source_freshness_db, source
+):
+    conn, _ = source_freshness_db
+    args = publish_source(conn, source)
+
+    current = rows_by_source(conn)
+    row = current[source]
+    assert str(row["generation_id"]) == args[1]
+    assert row["publication_state"] == "current"
+    assert row["current_outcome"] == "succeeded"
+    assert row["is_complete"] is True
+    assert row["source_rows"] == 2
+    assert row["published_rows"] == 2
+    assert row["artifact_origin"] == "registered_url"
+    assert row["season_basis"] == (
+        "artifact_field"
+        if source in {"sdv_ratings_weekly", "sdv_fpi_weekly"}
+        else "registered_artifact_name"
+    )
+    assert row["published_at"] is not None
+    assert row["age_seconds"] >= 0
+    assert row["expected_refresh_interval"] is None
+    assert row["is_stale"] is None
+    assert row["latest_outcome"] == "succeeded"
+    assert row["latest_recorded_at"] is not None
+    assert row["last_failure_outcome"] is None
+    for other_source in set(SOURCE_ORDER) - {source}:
+        assert current[other_source]["publication_state"] == "unrecorded"
+    assert all(
+        other["publication_state"] == "unrecorded" for other in rows_by_source(conn, 2024).values()
+    )
+
+
+def test_source_and_season_publications_remain_isolated(source_freshness_db):
+    conn, _ = source_freshness_db
+    first = publish_source(conn, "sdv_ratings_weekly", season=2024, suffix="b")
+    second = publish_source(conn, "sdv_team_xwalk", season=2025, suffix="c")
+
+    rows_2024 = rows_by_source(conn, 2024)
+    rows_2025 = rows_by_source(conn, 2025)
+    assert str(rows_2024["sdv_ratings_weekly"]["generation_id"]) == first[1]
+    assert rows_2024["sdv_team_xwalk"]["publication_state"] == "unrecorded"
+    assert str(rows_2025["sdv_team_xwalk"]["generation_id"]) == second[1]
+    assert rows_2025["sdv_ratings_weekly"]["publication_state"] == "unrecorded"
+
+
+@pytest.mark.parametrize("source", ["sdv_team_xwalk", "sdv_game_xwalk"])
+def test_local_crosswalk_publication_exposes_only_caller_declared_basis(
+    source_freshness_db, source
+):
+    conn, _ = source_freshness_db
+    publish_source(conn, source, artifact_origin="local_file")
+    row = rows_by_source(conn)[source]
+    assert row["publication_state"] == "current"
+    assert row["artifact_origin"] == "local_file"
+    assert row["season_basis"] == "caller_declared"
+
+
+@pytest.mark.parametrize("source", SOURCE_ORDER)
+def test_latest_failure_preserves_older_current_proof(source_freshness_db, source):
+    conn, _ = source_freshness_db
+    published = publish_source(conn, source)
+    failed_generation = record_failure(conn, source)
+
+    row = rows_by_source(conn)[source]
+    assert str(row["generation_id"]) == published[1]
+    assert str(row["generation_id"]) != failed_generation
+    assert row["publication_state"] == "current"
+    assert row["current_outcome"] == "succeeded"
+    assert row["latest_outcome"] == "failed"
+    assert row["last_failure_outcome"] == "failed"
+    assert row["last_failure_at"] == row["latest_recorded_at"]
+    assert row["last_failure_category"] == "source_publication_failed"
+
+
+def test_missing_pointer_is_unpublished_and_cannot_resurrect_history(source_freshness_db):
+    conn, _ = source_freshness_db
+    published = publish_source(conn, "sdv_ratings_weekly")
+    query(
+        conn,
+        "DELETE FROM meta.asset_current_generations "
+        "WHERE asset_key=%s AND coverage_key='season:2025'",
+        (RATINGS_ASSET,),
+    )
+
+    row = rows_by_source(conn)["sdv_ratings_weekly"]
+    assert row["publication_state"] == "unpublished"
+    assert row["latest_outcome"] == "succeeded"
+    assert row["latest_recorded_at"] is not None
+    assert all(row[column] is None for column in CURRENT_EVIDENCE_COLUMNS)
+    assert query(
+        conn,
+        "SELECT count(*) FROM meta.asset_receipts WHERE generation_id=%s",
+        (published[1],),
+    ) == [(1,)]
+
+
+@pytest.mark.parametrize(
+    ("broken_field", "broken_expression", "broken_value", "private_marker"),
+    [
+        (
+            "coverage",
+            "jsonb_set(coverage,'{season}',%s::jsonb)",
+            json.dumps("private-season-marker"),
+            "private-season-marker",
+        ),
+        (
+            "coverage",
+            "jsonb_set(coverage,'{source_rows}',%s::jsonb)",
+            json.dumps("private-source-rows-marker"),
+            "private-source-rows-marker",
+        ),
+        (
+            "coverage",
+            "jsonb_set(coverage,'{published_rows}',%s::jsonb)",
+            "1.5",
+            None,
+        ),
+        (
+            "input_observations",
+            "%s::jsonb",
+            json.dumps({"artifact_origin": "/private/secret.parquet"}),
+            "/private/secret.parquet",
+        ),
+        (
+            "row_delta",
+            "jsonb_set(row_delta,'{published_rows}',%s::jsonb)",
+            json.dumps("private-delta-marker"),
+            "private-delta-marker",
+        ),
+        ("published_at", "%s::timestamptz", "infinity", None),
+        ("published_at", "%s::timestamptz", "2201-01-01T00:00:00Z", None),
+        ("outcome", "%s::text", "expected_no_data", None),
+    ],
+)
+def test_unusable_pointer_is_invalid_and_exposes_no_current_fields(
+    source_freshness_db,
+    broken_field,
+    broken_expression,
+    broken_value,
+    private_marker,
+):
+    conn, _ = source_freshness_db
+    published = publish_source(conn, "sdv_ratings_weekly")
+    invalid_generation = str(uuid.uuid4())
+    replacement = {
+        "outcome": "outcome",
+        "coverage": "coverage",
+        "input_observations": "input_observations",
+        "row_delta": "row_delta",
+        "published_at": "published_at",
+    }
+    replacement[broken_field] = broken_expression
+    query(
+        conn,
+        f"""
+        INSERT INTO meta.asset_receipts (
+            generation_id, operation_run_id, asset_key, coverage_key, outcome,
+            coverage, source_watermark, input_observations, row_delta,
+            request_digest, published_at
+        )
+        SELECT %s, operation_run_id, asset_key, coverage_key,
+            {replacement["outcome"]},
+            {replacement["coverage"]}, source_watermark,
+            {replacement["input_observations"]}, {replacement["row_delta"]},
+            request_digest, {replacement["published_at"]}
+        FROM meta.asset_receipts WHERE generation_id=%s
+        """,
+        (invalid_generation, broken_value, published[1]),
+    )
+    query(
+        conn,
+        "ALTER TABLE meta.asset_current_generations "
+        "DISABLE TRIGGER guard_asset_current_generation; "
+        "UPDATE meta.asset_current_generations SET generation_id=%s "
+        "WHERE asset_key=%s AND coverage_key='season:2025'; "
+        "ALTER TABLE meta.asset_current_generations ENABLE TRIGGER guard_asset_current_generation",
+        (invalid_generation, RATINGS_ASSET),
+    )
+
+    row = rows_by_source(conn)["sdv_ratings_weekly"]
+    assert row["publication_state"] == "invalid"
+    assert row["latest_outcome"] == (broken_value if broken_field == "outcome" else "succeeded")
+    assert all(row[column] is None for column in CURRENT_EVIDENCE_COLUMNS)
+    serialized = json.dumps(row, default=str)
+    assert invalid_generation not in serialized
+    if private_marker is not None:
+        assert private_marker not in serialized
+
+
+def test_age_advances_at_query_time_and_analyze_cannot_refresh_proof(source_freshness_db):
+    conn, _ = source_freshness_db
+    published = publish_source(conn, "sdv_fpi_weekly")
+    asset = SOURCE_ASSETS["sdv_fpi_weekly"]
+    query(
+        conn,
+        "INSERT INTO meta.asset_freshness_policies "
+        "(asset_key,coverage_key,expected_refresh_interval) VALUES (%s,%s,'0.3 seconds')",
+        (asset, "season:2025"),
+    )
+
+    with conn.cursor() as cur:
+        cur.execute("SET LOCAL ROLE anon")
+        cur.execute(
+            "SELECT generation_id,age_seconds FROM public.get_source_freshness(2025) "
+            "WHERE source_name='sdv_fpi_weekly'"
+        )
+        before = cur.fetchone()
+        cur.execute("SELECT pg_sleep(0.35)")
+        cur.execute(
+            "SELECT generation_id,age_seconds,is_stale "
+            "FROM public.get_source_freshness(2025) WHERE source_name='sdv_fpi_weekly'"
+        )
+        after = cur.fetchone()
+    conn.commit()
+    assert str(before[0]) == published[1] == str(after[0])
+    assert after[1] - before[1] >= 0.3
+    assert after[2] is True
+
+    query(conn, "ANALYZE ratings.espn_fpi_weekly")
+    analyzed = rows_by_source(conn)["sdv_fpi_weekly"]
+    assert str(analyzed["generation_id"]) == published[1]
+    assert analyzed["is_stale"] is True
+    query(
+        conn,
+        "UPDATE meta.asset_freshness_policies SET expected_refresh_interval='100 years' "
+        "WHERE asset_key=%s AND coverage_key='season:2025'",
+        (asset,),
+    )
+    assert rows_by_source(conn)["sdv_fpi_weekly"]["is_stale"] is False
+
+
+def test_null_cadence_remains_unknown_for_current_publication(source_freshness_db):
+    conn, _ = source_freshness_db
+    publish_source(conn, "sdv_game_xwalk")
+    asset = SOURCE_ASSETS["sdv_game_xwalk"]
+    query(
+        conn,
+        "INSERT INTO meta.asset_freshness_policies(asset_key,coverage_key) VALUES (%s,%s)",
+        (asset, "season:2025"),
+    )
+    row = rows_by_source(conn)["sdv_game_xwalk"]
+    assert row["publication_state"] == "current"
+    assert row["expected_refresh_interval"] is None
+    assert row["is_stale"] is None
+
+
+@pytest.mark.parametrize(
+    ("asset", "coverage", "cadence"),
+    [
+        ("ratings.sdv_ratings_weekly", "source-wide", "1 day"),
+        ("analytics.house_elo_game", "season:2025", "1 day"),
+        ("ref.team_id_xwalk", "season:1868", "1 day"),
+        ("ref.game_id_xwalk", "season:2201", "1 day"),
+        ("ratings.espn_fpi_weekly", "season:2025", "0 seconds"),
+    ],
+)
+def test_policy_rejects_other_grains_bounds_and_nonpositive_cadence(
+    source_freshness_db, asset, coverage, cadence
+):
+    conn, _ = source_freshness_db
+    with pytest.raises(psycopg2.errors.CheckViolation):
+        query(
+            conn,
+            "INSERT INTO meta.asset_freshness_policies "
+            "(asset_key,coverage_key,expected_refresh_interval) VALUES (%s,%s,%s)",
+            (asset, coverage, cadence),
+        )
+    conn.rollback()
+
+
+def test_access_boundary_scrubs_hostile_defaults_and_private_evidence(
+    source_freshness_db,
+):
+    conn, _ = source_freshness_db
+    publish_source(conn, "sdv_team_xwalk")
+    record_failure(conn, "sdv_team_xwalk")
+
+    for role in ("anon", "authenticated"):
+        result, columns, _ = source_rows(conn, role=role)
+        assert len(result) == 4
+        assert columns == EXPECTED_COLUMNS
+    for role in (
+        "analyst_ro",
+        "publication_bystander",
+        "warehouse_publisher",
+        "warehouse_source_publisher",
+    ):
+        denied(conn, role, "SELECT * FROM public.get_source_freshness(2025)")
+    for role in (
+        "anon",
+        "authenticated",
+        "analyst_ro",
+        "publication_bystander",
+        "warehouse_publisher",
+        "warehouse_source_publisher",
+    ):
+        for table in PRIVATE_TABLES:
+            denied(conn, role, f"SELECT * FROM meta.{table}")
+        denied(
+            conn,
+            role,
+            "UPDATE meta.asset_freshness_policies SET expected_refresh_interval='1 day'",
+        )
+    assert query(
+        conn,
+        "SELECT has_table_privilege('anon','meta.flat_file_loads','SELECT'), "
+        "has_table_privilege('authenticated','meta.flat_file_loads','SELECT')",
+    ) == [(True, True)]
+
+    document = json.dumps(rows_by_source(conn), default=str)
+    for forbidden in (
+        "input_observations",
+        "error_summary",
+        "operation_run_id",
+        "source_watermark",
+        "request_digest",
+        "warehouse_source_stage",
+        "github.com/",
+        ".parquet",
+    ):
+        assert forbidden not in document
+
+
+def test_migration_reapply_preserves_policy_old_elo_rpc_and_existing_acl(request):
+    conn, _ = request.getfixturevalue("_batch_db")
+    old_definition = query(
+        conn,
+        "SELECT pg_get_functiondef('public.get_asset_freshness()'::regprocedure)",
+    )
+    old_rows = query(
+        conn,
+        "SELECT asset_key,coverage_key,expected_refresh_interval "
+        "FROM public.get_asset_freshness() ORDER BY asset_key",
+    )
+    old_acl = query(
+        conn,
+        "SELECT has_function_privilege('anon','public.get_asset_freshness()','EXECUTE'), "
+        "has_function_privilege('authenticated','public.get_asset_freshness()','EXECUTE'), "
+        "has_function_privilege('publication_bystander',"
+        "'public.get_asset_freshness()','EXECUTE')",
+    )
+    flat_file_acl = query(
+        conn,
+        "SELECT has_table_privilege('anon','meta.flat_file_loads','SELECT'), "
+        "has_table_privilege('authenticated','meta.flat_file_loads','SELECT')",
+    )
+
+    query(conn, MIGRATION.read_text())
+    query(
+        conn,
+        "INSERT INTO meta.asset_freshness_policies "
+        "(asset_key,coverage_key,expected_refresh_interval) VALUES (%s,%s,'2 days')",
+        (RATINGS_ASSET, "season:2025"),
+    )
+    query(conn, MIGRATION.read_text())
+
+    assert query(
+        conn,
+        "SELECT expected_refresh_interval::text FROM meta.asset_freshness_policies "
+        "WHERE asset_key=%s AND coverage_key='season:2025'",
+        (RATINGS_ASSET,),
+    ) == [("2 days",)]
+    assert (
+        query(
+            conn,
+            "SELECT pg_get_functiondef('public.get_asset_freshness()'::regprocedure)",
+        )
+        == old_definition
+    )
+    assert (
+        query(
+            conn,
+            "SELECT asset_key,coverage_key,expected_refresh_interval "
+            "FROM public.get_asset_freshness() ORDER BY asset_key",
+        )
+        == old_rows
+        == [
+            ("analytics.house_elo_game", "source-wide", None),
+            ("marts.house_elo_game", "source-wide", None),
+        ]
+    )
+    assert (
+        query(
+            conn,
+            "SELECT has_function_privilege('anon','public.get_asset_freshness()','EXECUTE'), "
+            "has_function_privilege('authenticated','public.get_asset_freshness()','EXECUTE'), "
+            "has_function_privilege('publication_bystander',"
+            "'public.get_asset_freshness()','EXECUTE')",
+        )
+        == old_acl
+        == [(True, True, False)]
+    )
+    assert (
+        query(
+            conn,
+            "SELECT has_table_privilege('anon','meta.flat_file_loads','SELECT'), "
+            "has_table_privilege('authenticated','meta.flat_file_loads','SELECT')",
+        )
+        == flat_file_acl
+        == [(True, True)]
+    )
+
+
+@pytest.mark.parametrize(
+    "sabotage",
+    [
+        "ALTER TABLE meta.asset_freshness_policies OWNER TO publication_bystander",
+        "ALTER TABLE meta.asset_freshness_policies DISABLE ROW LEVEL SECURITY",
+    ],
+)
+def test_migration_rejects_untrusted_private_policy_before_rpc_exposure(request, sabotage):
+    conn, _ = request.getfixturevalue("_batch_db")
+    query(conn, sabotage)
+    with pytest.raises(psycopg2.Error, match="trusted migration-owned private table"):
+        query(conn, MIGRATION.read_text())
+    conn.rollback()
+    assert query(
+        conn,
+        "SELECT to_regprocedure('public.get_source_freshness(bigint)')",
+    ) == [(None,)]
+
+
+def test_real_verifier_reports_failure_recovery_without_losing_history(source_freshness_db, capsys):
+    from scripts.verify_load import Report, check_source_freshness
+
+    conn, _ = source_freshness_db
+    for suffix, source in zip("abcd", SOURCE_ORDER, strict=True):
+        publish_source(conn, source, suffix=suffix)
+    query(
+        conn,
+        "INSERT INTO meta.asset_freshness_policies "
+        "(asset_key,coverage_key,expected_refresh_interval) "
+        "SELECT asset_key,'season:2025','100 years'::interval "
+        "FROM unnest(%s::text[]) AS asset(asset_key)",
+        (list(SOURCE_ASSETS.values()),),
+    )
+
+    def verify_as_anon():
+        report = Report()
+        with conn.cursor() as cur:
+            cur.execute("SET LOCAL ROLE anon")
+            check_source_freshness(
+                cur,
+                season=2025,
+                in_season=True,
+                strict=True,
+                report=report,
+            )
+        conn.rollback()
+        return report, capsys.readouterr().out
+
+    report, output = verify_as_anon()
+    assert report.failures == 0
+    assert output.count("[PASS] source_freshness:") == 4
+
+    record_failure(conn, "sdv_ratings_weekly")
+    report, output = verify_as_anon()
+    assert report.failures == 0
+    assert output.count("[PASS] source_freshness:") == 4
+    assert "[WARN] source_receipt_attempt:" in output
+    assert "latest attempt failed" in output
+
+    recovered = publish_source(conn, "sdv_ratings_weekly", suffix="e")
+    report, output = verify_as_anon()
+    assert report.failures == 0
+    assert output.count("[PASS] source_freshness:") == 4
+    assert "[WARN] source_receipt_attempt:" not in output
+    row = rows_by_source(conn)["sdv_ratings_weekly"]
+    assert str(row["generation_id"]) == recovered[1]
+    assert row["latest_outcome"] == "succeeded"
+    assert row["last_failure_outcome"] == "failed"
+    assert row["last_failure_category"] == "source_publication_failed"

--- a/tests/test_verify_load.py
+++ b/tests/test_verify_load.py
@@ -720,6 +720,301 @@ def test_receipt_rpc_error_propagates_instead_of_silent_pass():
         check_receipt_freshness(cur, in_season=True, strict=False, report=Report())
 
 
+SOURCE_IDENTITIES = (
+    ("sdv_ratings_weekly", "ratings.sdv_ratings_weekly"),
+    ("sdv_fpi_weekly", "ratings.espn_fpi_weekly"),
+    ("sdv_team_xwalk", "ref.team_id_xwalk"),
+    ("sdv_game_xwalk", "ref.game_id_xwalk"),
+)
+
+
+class SourceReceiptCursor:
+    def __init__(self, rows, installed=True, error=None):
+        self.rows = rows
+        self.installed = installed
+        self.error = error
+        self.queries = []
+
+    def execute(self, statement, params=None):
+        self.queries.append((statement, params))
+        if self.error and "to_jsonb" in statement:
+            raise self.error
+
+    def fetchone(self):
+        return ("get_source_freshness(bigint)" if self.installed else None,)
+
+    def fetchall(self):
+        return [(row,) for row in self.rows]
+
+
+def source_receipt_rows(season=2025, **changes):
+    rows = []
+    for source_name, asset_key in SOURCE_IDENTITIES:
+        origin = "registered_url"
+        basis = (
+            "artifact_field"
+            if source_name in {"sdv_ratings_weekly", "sdv_fpi_weekly"}
+            else "registered_artifact_name"
+        )
+        row = {
+            "source_name": source_name,
+            "asset_key": asset_key,
+            "season": season,
+            "coverage_key": f"season:{season}",
+            "generation_id": "11111111-1111-4111-8111-111111111111",
+            "published_at": "2026-09-09T00:00:00Z",
+            "age_seconds": 5.0,
+            "expected_refresh_interval": "8 days",
+            "is_stale": False,
+            "publication_state": "current",
+            "current_outcome": "succeeded",
+            "is_complete": True,
+            "source_rows": 10,
+            "published_rows": 10,
+            "artifact_origin": origin,
+            "season_basis": basis,
+            "latest_outcome": "succeeded",
+            "latest_recorded_at": "2026-09-09T00:00:00Z",
+            "last_failure_outcome": None,
+            "last_failure_at": None,
+            "last_failure_category": None,
+        }
+        row.update(changes)
+        rows.append(row)
+    return rows
+
+
+def noncurrent_source_rows(state, season=2025, **changes):
+    rows = source_receipt_rows(season)
+    for row in rows:
+        row.update(
+            publication_state=state,
+            generation_id=None,
+            published_at=None,
+            age_seconds=None,
+            is_stale=None,
+            current_outcome=None,
+            is_complete=None,
+            source_rows=None,
+            published_rows=None,
+            artifact_origin=None,
+            season_basis=None,
+        )
+        if state == "unrecorded":
+            row.update(latest_outcome=None, latest_recorded_at=None)
+        row.update(changes)
+    return rows
+
+
+def source_receipt_check(
+    rows=None, *, season=2025, installed=True, strict=False, in_season=True, error=None
+):
+    from scripts.verify_load import Report, check_source_freshness
+
+    report = Report()
+    cur = SourceReceiptCursor(
+        source_receipt_rows(season) if rows is None else rows,
+        installed=installed,
+        error=error,
+    )
+    check_source_freshness(cur, season=season, in_season=in_season, strict=strict, report=report)
+    return report, cur
+
+
+def test_source_receipt_query_is_season_scoped_and_fresh_rows_pass(capsys):
+    report, cur = source_receipt_check(season=2025)
+    assert report.failures == 0
+    assert cur.queries == [
+        ("SELECT to_regprocedure('public.get_source_freshness(bigint)')", None),
+        ("SELECT to_jsonb(f) FROM public.get_source_freshness(%s) f", (2025,)),
+    ]
+    output = capsys.readouterr().out
+    assert output.count("[PASS] source_freshness:") == 4
+
+
+def test_source_receipt_missing_rpc_warns_under_strict_without_querying(capsys):
+    report, cur = source_receipt_check(installed=False, strict=True)
+    assert report.failures == 0
+    assert len(cur.queries) == 1
+    output = capsys.readouterr().out
+    assert "[WARN] source_freshness:" in output
+    assert "[PASS]" not in output
+
+
+def test_source_receipt_scope_requires_exact_four_selected_season_rows():
+    valid = source_receipt_rows()
+    wrong_season = source_receipt_rows()
+    wrong_season[0]["season"] = 2024
+    wrong_coverage = source_receipt_rows()
+    wrong_coverage[0]["coverage_key"] = "season:2024"
+    wrong_source = source_receipt_rows()
+    wrong_source[0]["source_name"] = "unknown"
+    for rows in (
+        [],
+        valid[:3],
+        [*valid, valid[0]],
+        [valid[0], valid[0], *valid[2:]],
+        wrong_season,
+        wrong_coverage,
+        wrong_source,
+    ):
+        assert source_receipt_check(rows)[0].failures == 1
+
+
+def test_source_receipt_requires_exact_flat_rpc_shape():
+    missing = source_receipt_rows()
+    missing[0].pop("source_rows")
+    extra = source_receipt_rows()
+    extra[0]["coverage"] = {"complete": True}
+    malformed_identity = source_receipt_rows()
+    malformed_identity[0]["season"] = {"year": 2025}
+    for rows in (missing, extra, malformed_identity):
+        assert source_receipt_check(rows)[0].failures == 1
+
+
+def test_source_receipt_unrecorded_is_optional_even_under_strict(capsys):
+    report, _ = source_receipt_check(noncurrent_source_rows("unrecorded"), strict=True)
+    assert report.failures == 0
+    output = capsys.readouterr().out
+    assert output.count("optional publisher has no receipts") == 4
+    assert "[PASS]" not in output
+
+
+def test_source_receipt_unpublished_history_fails_only_when_strict(capsys):
+    rows = noncurrent_source_rows(
+        "unpublished",
+        latest_outcome="failed",
+        last_failure_outcome="failed",
+        last_failure_at="2026-09-09T00:00:00Z",
+        last_failure_category="source_publication_failed",
+    )
+    assert source_receipt_check(rows, strict=False)[0].failures == 0
+    assert source_receipt_check(rows, strict=True)[0].failures == 4
+    assert "latest attempt failed" in capsys.readouterr().out
+
+
+def test_source_receipt_invalid_pointer_always_fails():
+    rows = noncurrent_source_rows("invalid")
+    assert source_receipt_check(rows, in_season=False, strict=False)[0].failures == 4
+
+
+def test_source_receipt_current_evidence_is_exact_and_complete():
+    mutations = (
+        {"current_outcome": "failed"},
+        {"is_complete": False},
+        {"source_rows": 0, "published_rows": 0},
+        {"source_rows": 10, "published_rows": 9},
+        {"artifact_origin": "unknown"},
+        {"age_seconds": float("nan")},
+    )
+    for mutation in mutations:
+        rows = source_receipt_rows()
+        rows[0].update(mutation)
+        assert source_receipt_check(rows)[0].failures == 1
+
+
+def test_source_receipt_season_basis_matches_source_and_origin():
+    wrong_fpi = source_receipt_rows()
+    wrong_fpi[1]["season_basis"] = "caller_declared"
+    wrong_local_xwalk = source_receipt_rows()
+    wrong_local_xwalk[2].update(
+        artifact_origin="local_file", season_basis="registered_artifact_name"
+    )
+    valid_local_xwalk = source_receipt_rows()
+    valid_local_xwalk[2].update(artifact_origin="local_file", season_basis="caller_declared")
+    assert source_receipt_check(wrong_fpi)[0].failures == 1
+    assert source_receipt_check(wrong_local_xwalk)[0].failures == 1
+    assert source_receipt_check(valid_local_xwalk)[0].failures == 0
+
+
+def test_source_receipt_declared_staleness_uses_existing_severity_rule():
+    rows = source_receipt_rows(is_stale=True)
+    assert source_receipt_check(rows, in_season=True)[0].failures == 4
+    assert source_receipt_check(rows, in_season=False)[0].failures == 0
+    assert source_receipt_check(rows, in_season=False, strict=True)[0].failures == 4
+
+
+def test_source_receipt_unknown_policy_warns_and_never_claims_freshness(capsys):
+    rows = source_receipt_rows(expected_refresh_interval=None, is_stale=None)
+    report, _ = source_receipt_check(rows, strict=True)
+    assert report.failures == 0
+    output = capsys.readouterr().out
+    assert output.count("[WARN] source_freshness:") == 4
+    assert "[PASS]" not in output
+
+
+def test_source_receipt_latest_bad_attempt_does_not_replace_readable_current(capsys):
+    for outcome in ("failed", "deferred", "blocked", "partial"):
+        rows = source_receipt_rows(
+            latest_outcome=outcome,
+            last_failure_outcome=outcome,
+            last_failure_at="2026-09-09T01:00:00Z",
+            last_failure_category="source_publication_failed",
+        )
+        report, _ = source_receipt_check(rows)
+        assert report.failures == 0
+        output = capsys.readouterr().out
+        assert f"latest attempt {outcome}" in output
+        assert "current succeeded complete publication" in output
+
+
+def test_source_receipt_expected_no_data_is_diagnostic_only(capsys):
+    unpublished = noncurrent_source_rows("unpublished", latest_outcome="expected_no_data")
+    assert source_receipt_check(unpublished, strict=False)[0].failures == 0
+    assert source_receipt_check(unpublished, strict=True)[0].failures == 4
+
+    current_diagnostic = source_receipt_rows(latest_outcome="expected_no_data")
+    assert source_receipt_check(current_diagnostic)[0].failures == 0
+
+    invalid_current = source_receipt_rows(current_outcome="expected_no_data")
+    assert source_receipt_check(invalid_current)[0].failures == 4
+    output = capsys.readouterr().out
+    assert "latest attempt expected_no_data" not in output
+    assert "invalid current publication evidence" in output
+
+
+def test_source_receipt_historical_failure_after_recovery_does_not_warn(capsys):
+    rows = source_receipt_rows(
+        last_failure_outcome="failed",
+        last_failure_at="2026-09-08T00:00:00Z",
+        last_failure_category="source_publication_failed",
+    )
+    assert source_receipt_check(rows)[0].failures == 0
+    output = capsys.readouterr().out
+    assert "[WARN] source_receipt_attempt:" not in output
+    assert output.count("[PASS] source_freshness:") == 4
+
+
+def test_source_receipt_malformed_state_and_history_always_fail():
+    cases = (
+        ("publication_state", "mystery"),
+        ("latest_recorded_at", None),
+        ("last_failure_outcome", "failed"),
+        ("expected_refresh_interval", 8),
+    )
+    for field, value in cases:
+        rows = source_receipt_rows()
+        rows[0][field] = value
+        assert source_receipt_check(rows)[0].failures == 1
+
+
+def test_source_receipt_rejects_arbitrary_failure_category(capsys):
+    rows = source_receipt_rows(
+        last_failure_outcome="failed",
+        last_failure_at="2026-09-08T00:00:00Z",
+        last_failure_category="raw-secret-error",
+    )
+    assert source_receipt_check(rows)[0].failures == 4
+    assert "failure history is malformed" in capsys.readouterr().out
+
+
+def test_source_receipt_rpc_error_propagates_instead_of_silent_pass():
+    import pytest
+
+    with pytest.raises(RuntimeError, match="permission denied"):
+        source_receipt_check(error=RuntimeError("permission denied"))
+
+
 def test_verify_includes_receipt_check_after_legacy_check(monkeypatch):
     from unittest.mock import MagicMock
 
@@ -736,6 +1031,7 @@ def test_verify_includes_receipt_check_after_legacy_check(monkeypatch):
         "check_backtest_freshness",
         "check_freshness",
         "check_receipt_freshness",
+        "check_source_freshness",
         "check_variant_twins",
         "check_massey_composite",
         "check_availability_archive",

--- a/tests/test_warehouse_bootstrap_sql.py
+++ b/tests/test_warehouse_bootstrap_sql.py
@@ -389,7 +389,7 @@ def test_managed_warehouse_catalog_data_and_access(
         _insert_representative_rows(conn)
         before_upgrade = _fixture_snapshot(conn)
         upgrade = apply_manifest(conn, manifest, mode="upgrade")
-        assert len(upgrade.pending) == 9
+        assert len(upgrade.pending) == 10
         assert [step.id for step in upgrade.pending] == [
             migration.id for migration in manifest.migrations[4:]
         ]


### PR DESCRIPTION
SDV publication receipts now cover four sources, but freshness reporting and verification still cover only house Elo. Add `public.get_source_freshness(p_season bigint)` to report each SDV source's exact current season generation, completeness, publication age, provenance and separate latest-attempt/failure diagnostics. Missing cadence stays unknown; no freshness thresholds are seeded.

Add the season-scoped check to `verify_load.py`, preserve both existing freshness RPCs and their consumer access, and keep private receipt details behind the bounded owner-rights result. Register migration 073 in the bootstrap/production manifests and its executed SQL suite in CI.

Validation: 125 verifier/manifest unit tests, 38 new PostgreSQL 17 source-freshness tests, 154 existing bootstrap/publication SQL regressions, and 3 legacy MCP freshness tests passed. Executed checks cover actual anon/authenticated callers, private-data exclusions, malformed/future-dated receipts, aging, migration reapplication and a real verifier publication/failure/recovery flow. Ruff checks passed; independent SQL and Python reviews found no remaining material issues.

Production migration, policy configuration, scheduling and downstream consumer adoption remain separate rollout steps. Production query latency at representative receipt volume is unmeasured.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

## Summary
- Adds season-scoped freshness reporting for the four enrolled SDV sources and incorporates it into load verification.
- Registers migration 073 in both manifests, expands policy validation, adds focused test coverage, and documents the public contract and operational behavior.

## T-Rex validation blocked
- A disposable PostgreSQL database URL was not available, so the database-backed integration fixture could not execute. The focused static contract check completed successfully and verified source/season isolation, evidence validation, bounded output, and access-control definitions.

<h3>Confidence Score: 5/5</h3>

Safe to merge; no actionable issues were identified.

No confirmed findings remain. The focused static validation completed successfully; database-backed integration validation could not run because no disposable PostgreSQL connection was configured.

**Files Needing Attention:** None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted the focused source-and-season isolation integration test that required a database connection, but the setup stopped because F06\_TEST\_DB\_URL was not configured.
- T-Rex ran the focused source freshness fixture without a database connection, and all 38 database-dependent tests were skipped as expected.
- T-Rex authored and ran a static contract check for migration 073 and its focused fixture; all 15 checks passed across the defined coverage areas.
- T-Rex ran the requested verification, but its local artifact references were not uploaded.

<a href="https://app.greptile.com/trex/runs/23427727/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Report SDV season publication freshness"](https://github.com/rstover-fo/cfb-database/commit/a05dfa5d98f8afb7a8f4ad2fc439ef3cdc5b62a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62287222)</sub>

<!-- /greptile_comment -->