### PR TITLE
Fix PG17 creator roles and add managed production deploy actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - run: ./scripts/setup_dev.sh
       - name: Managed bootstrap and upgrade integration
-        run: .venv/bin/python -m pytest tests/test_warehouse_migrations_sql.py tests/test_warehouse_bootstrap_sql.py tests/test_adopt_warehouse_catalog_sql.py tests/test_f06_verification_transactions_sql.py tests/test_mart_release_sql.py tests/test_play_partitions.py tests/test_play_indexes_sql.py tests/test_operational_quota_sql.py tests/test_operational_quota_lifecycle_sql.py tests/test_cfbd_transport_admission_sql.py tests/test_asset_publication_sql.py tests/test_asset_freshness_sql.py tests/test_generation_refresh_sql.py tests/test_sdv_ratings_publication_sql.py tests/test_flat_file_publication_sql.py tests/test_source_freshness_sql.py -q --tb=short
+        run: .venv/bin/python -m pytest tests/test_warehouse_migrations_sql.py tests/test_warehouse_bootstrap_sql.py tests/test_adopt_warehouse_catalog_sql.py tests/test_f06_verification_transactions_sql.py tests/test_mart_release_sql.py tests/test_play_partitions.py tests/test_play_indexes_sql.py tests/test_operational_quota_sql.py tests/test_operational_quota_lifecycle_sql.py tests/test_cfbd_transport_admission_sql.py tests/test_asset_publication_sql.py tests/test_asset_freshness_sql.py tests/test_generation_refresh_sql.py tests/test_sdv_ratings_publication_sql.py tests/test_flat_file_publication_sql.py tests/test_source_freshness_sql.py tests/test_pg17_creator_membership_sql.py -q --tb=short
         env:
           F06_TEST_DB_URL: postgresql://postgres:f06-disposable-ci@127.0.0.1:5432/postgres
           F06_REQUIRE_DB: "1"

--- a/.github/workflows/deploy-schema.yml
+++ b/.github/workflows/deploy-schema.yml
@@ -28,6 +28,9 @@ on:
           - apply
           - backfill
           - compute
+          - managed_plan
+          - managed_upgrade
+          - managed_status
         default: presence_check
       mart_release:
         description: "Reviewed dependency-aware mart release manifest (apply only)"
@@ -80,7 +83,6 @@ permissions:
 env:
   PYTHON_VERSION: "3.11"
   SOURCES__CFBD__API_KEY: ${{ secrets.CFBD_API_KEY }}
-  SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
 
 jobs:
   deploy:
@@ -95,13 +97,18 @@ jobs:
           cache: pip
       - run: pip install -e ".[compute]"
       - name: Set dlt destination credentials
+        if: github.event_name == 'push' || ! startsWith(inputs.action, 'managed_')
         # dlt requires the postgres:// scheme (see .dlt/secrets.toml.example)
+        env:
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
         run: echo "DESTINATION__POSTGRES__CREDENTIALS=$(printf '%s' "$SUPABASE_DB_URL" | sed 's/^postgresql:/postgres:/')" >> "$GITHUB_ENV"
       - name: Deploy via manifest (push)
         if: github.event_name == 'push'
+        env:
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
         run: python scripts/deploy_schema.py --manifest deploy-manifest.json
-      - name: Deploy via CLI flags (workflow_dispatch)
-        if: github.event_name == 'workflow_dispatch'
+      - name: Deploy via legacy CLI flags (workflow_dispatch)
+        if: github.event_name == 'workflow_dispatch' && ! startsWith(inputs.action, 'managed_')
         # Hardening (PR #75 review finding C): route every workflow_dispatch
         # input used below through a step-level env: var (probe-endpoints.yml's
         # pattern) rather than interpolating ${{ inputs.* }} directly into the
@@ -119,6 +126,7 @@ jobs:
           SOURCES_INPUT: ${{ inputs.sources }}
           COMPUTE_SCRIPT_INPUT: ${{ inputs.compute_script }}
           COMPUTE_ARGS_INPUT: ${{ inputs.compute_args }}
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
         run: |
           set -euo pipefail
           ARGS=(--action "$ACTION_INPUT")
@@ -132,6 +140,46 @@ jobs:
           if [ -n "$COMPUTE_SCRIPT_INPUT" ]; then ARGS+=(--compute-script "$COMPUTE_SCRIPT_INPUT"); fi
           if [ -n "$COMPUTE_ARGS_INPUT" ]; then ARGS+=("--compute-args=$COMPUTE_ARGS_INPUT"); fi
           python scripts/deploy_schema.py "${ARGS[@]}"
+
+      - name: Run managed production action
+        id: managed_deploy
+        if: github.event_name == 'workflow_dispatch' && startsWith(inputs.action, 'managed_')
+        env:
+          ACTION_INPUT: ${{ inputs.action }}
+          MART_RELEASE_INPUT: ${{ inputs.mart_release }}
+          PLAN_INPUT: ${{ inputs.plan }}
+          FILES_INPUT: ${{ inputs.files }}
+          REFRESH_INPUT: ${{ inputs.refresh }}
+          BACKFILL_START_INPUT: ${{ inputs.backfill_start }}
+          BACKFILL_END_INPUT: ${{ inputs.backfill_end }}
+          SOURCES_INPUT: ${{ inputs.sources }}
+          COMPUTE_SCRIPT_INPUT: ${{ inputs.compute_script }}
+          COMPUTE_ARGS_INPUT: ${{ inputs.compute_args }}
+          # The managed runner accepts this credential name only. Keep the
+          # production secret scoped to the managed subprocess path.
+          WAREHOUSE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+        run: |
+          set -euo pipefail
+          ARGS=(--action "$ACTION_INPUT")
+          if [ -n "$MART_RELEASE_INPUT" ]; then ARGS+=(--mart-release "$MART_RELEASE_INPUT"); fi
+          if [ "$PLAN_INPUT" = "true" ]; then ARGS+=(--plan); fi
+          if [ -n "$FILES_INPUT" ]; then ARGS+=(--files "$FILES_INPUT"); fi
+          if [ "$REFRESH_INPUT" = "true" ]; then ARGS+=(--refresh); fi
+          if [ -n "$BACKFILL_START_INPUT" ]; then ARGS+=(--backfill-start "$BACKFILL_START_INPUT"); fi
+          if [ -n "$BACKFILL_END_INPUT" ]; then ARGS+=(--backfill-end "$BACKFILL_END_INPUT"); fi
+          if [ -n "$SOURCES_INPUT" ]; then ARGS+=(--sources "$SOURCES_INPUT"); fi
+          if [ -n "$COMPUTE_SCRIPT_INPUT" ]; then ARGS+=(--compute-script "$COMPUTE_SCRIPT_INPUT"); fi
+          if [ -n "$COMPUTE_ARGS_INPUT" ]; then ARGS+=("--compute-args=$COMPUTE_ARGS_INPUT"); fi
+          python scripts/deploy_schema.py "${ARGS[@]}"
+
+      - name: Observe managed status after upgrade attempt
+        # This is a read-only observation, not a retry. The status runner takes
+        # the same advisory lock as upgrade, and this step cannot erase a failed
+        # managed_deploy outcome.
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && inputs.action == 'managed_upgrade' && steps.managed_deploy.outcome != 'skipped' }}
+        env:
+          WAREHOUSE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+        run: python scripts/deploy_schema.py --action managed_status
 
       - name: Upload schema-only catalog
         if: github.event_name == 'workflow_dispatch' && inputs.compute_script == 'export_warehouse_catalog'

--- a/docs/plans/2026-09-09-production-receipts-preflight.md
+++ b/docs/plans/2026-09-09-production-receipts-preflight.md
@@ -1,0 +1,226 @@
+# Production receipts preflight — 2026-09-09
+
+**September 10 follow-up:** the role compatibility correction and managed
+production workflow actions are implemented and independently reviewed; see
+[the deployment guide](../warehouse-bootstrap.md#managed-production-workflow).
+Local checks passed: four focused non-superuser role tests, 175 migration,
+publication and freshness SQL regressions, and 140 deployment/CLI tests.
+A fresh read-only production check still found only the adopted root. No
+production upgrade or runtime activation has been performed. Exact full-chain
+execution under Supabase's event-trigger privileges remains a deployment check.
+The findings below record the original preflight and remaining rollout work.
+
+**Result: prepare a compatibility and deployment-runner change before applying
+migrations 066–073.** A PostgreSQL 17 reproduction exposed a role-membership
+guard failure under production's non-superuser migration-role model. Scheduled
+publication also needs separate data repair and writer coordination.
+
+This was a read-only production preflight, observed approximately 20:43–20:54 UTC
+against Supabase project `ibobsbwlewpqslkqbrjd` (`cfbd-database`). The reviewed
+checkout was `e626d8832173d1bb2b04fbae3c659c044b75e253` (merged PR #145).
+Production DDL, data, grants, policies, workflows and provider requests were not
+changed. A separate local PostgreSQL 17 reproduction was rolled back.
+
+## Verified production state
+
+- PostgreSQL 17.6; the connected `postgres` role has `CREATEROLE` and
+  `BYPASSRLS`, but is **not a superuser**. It can create database objects and
+  belongs to `supabase_privileged_role`. Event triggers are enabled and
+  `session_replication_role` is `origin`.
+- The managed ledger contains exactly the adopted production root,
+  `warehouse.production.catalog-adopted.20260907.288b4eaf817b`, applied
+  September 7 at 21:37:07 UTC. Its recorded SHA-256 is
+  `d621e7026d135f6e16aede646628624357cbc51c734dc3b381b4d441d8ab7dcb`.
+  There is no repeatable history. Comparing these observed rows with the local
+  production manifest using the runner's planner returned eight pending
+  migrations and no diagnostics. This was not a remote, advisory-locked plan.
+- New quota/receipt/policy relations, warehouse runtime namespaces, the four
+  bounded roles, and both new freshness RPCs are absent. No conflicting new
+  namespace was found. `btree_gist` 1.7 is available but is not installed.
+- The four SDV targets match migrations 071/072's reviewed ordered column
+  names, types, nullability, primary keys and unique dlt identifiers: ratings
+  19 columns, FPI 54, team crosswalk 16 and game crosswalk 15. Relevant source,
+  Elo and flat-file-ledger relations have the expected ownership and kinds;
+  no unexpected source triggers, inheritance or source RLS were found.
+- Executed `SET LOCAL ROLE anon` and `authenticated` checks each returned
+  24 legacy `get_data_freshness()` rows and successfully read
+  `api.game_elo_history`. Both lacked private scouting/control-schema access;
+  the managed ledger was inaccessible to them and `analyst_ro`. Direct access
+  to the raw Elo mart was denied as expected by the owner-rights API contract.
+- Nine GitHub workflows were active. No active warehouse transaction or
+  conflicting writer lock was found in the database snapshot, and inspected
+  recent writer runs had completed. This observation is not a maintenance
+  window or protection against a later job starting.
+
+The pending chain in [production-manifest.json](../../src/schemas/production-manifest.json)
+is 066 quota ledger → 067 transport admission → 068 publication receipts →
+069 Elo freshness → 070 generation refresh → 071 SDV ratings → 072 remaining
+SDV sources → 073 SDV freshness. Use this adopted-production manifest, not the
+disposable bootstrap manifest. Recompute checksums after the preparation change.
+
+## Deployment blocker and delivery gap
+
+PostgreSQL 17 automatically gives a non-superuser role creator an inbound
+membership in a new role with `ADMIN=true`, `INHERIT=false`, `SET=false`.
+Migration 071 creates `warehouse_source_publisher`; migration 072 then rejects
+**any** inbound or outbound membership in that role. The exact 072 dependency
+block failed with SQLSTATE `P0001` on an isolated PostgreSQL 17 instance using
+a non-superuser `CREATEROLE` migration role. The transaction was rolled back.
+The same assumption affects direct reapplication of 070 and 071. Earlier
+superuser fixtures did not exercise this behavior.
+
+Preparation must distinguish a narrowly validated creator administration edge
+from runtime access or role escalation, preserve the ability to grant the later
+runtime membership, and continue rejecting unrelated memberships. Blindly
+revoking the creator's administration edge can strand later activation. Add
+focused non-superuser PostgreSQL 17 regressions for role creation, guard
+reapplication, the 072 dependency check, and runtime grant/role-assumption
+behavior. Retain the full-chain superuser transaction tests. Stock PostgreSQL
+does not allow this non-superuser to create event triggers; full-chain execution
+under that identity needs a faithful Supautils equivalent or the authorized
+Supabase upgrade with rollback/status verification. At the September 9 preflight,
+the proposed fix had not yet been applied or tested.
+
+The existing Deploy Schema workflow also lacks a first-class managed upgrade
+action. Its compute allowlist does not admit `bootstrap_warehouse`, and its
+environment does not map the production secret to `WAREHOUSE_DB_URL`, the only
+credential variable accepted by that runner. The raw `run_migrations.py --file`
+path bypasses the managed ledger and commits files independently. Prepare a
+reviewed workflow action or use an authorized secure runner; do not substitute
+raw-file application or hand-written ledger inserts.
+
+Supabase documents that its privileged `postgres` role can manage event
+triggers through Supautils. The observed role and settings are consistent with
+that path, but read-only inspection does not prove execution of these exact DDL
+statements on the managed platform. No full fresh catalog fingerprint, live
+production migration, or production publication benchmark was performed.
+See [Supabase event triggers](https://supabase.com/docs/guides/database/postgres/event-triggers)
+and [PostgreSQL 17 role creation](https://www.postgresql.org/docs/17/sql-createrole.html).
+
+## Existing data and workflow issues
+
+The [September 9 daily load](https://github.com/rstover-fo/cfb-database/actions/runs/34362468024)
+completed ingestion and flat-file loading but failed its `variant_twins`
+verification check; downstream recaps were skipped. Production has 56 variant
+columns on `stats.passing_player_season`, of which 55 are outside the current
+allowlist. For 2026, 222 of 249 rows route `explosiveness` to a non-NULL twin
+while its base is NULL; 201 do so for `success_rate`. Mart 045 does not select
+those two fields or the location fields inspected. Do not infer consumer metric
+loss solely from the raw-column count. Review the full set against consumed
+fields, classify reviewed raw-only variants separately, and use a dependency-
+complete mart release only where a consumed field needs repair. Migrations
+066–073 do not fix this daily verification failure.
+
+The full Elo publisher currently has two eligible completed games without final
+scores: `401907219` (Missouri S&T–Westgate Christian, 2026 week 1) and
+`401908553` (Centenary LA–Westgate Christian, 2026 week 1). The existing reviewed
+cancelled-game exclusion accounts for the third NULL-score record. All five
+existing superseded/replacement pairs matched. Resolve the two remaining games
+from upstream evidence before full publication; do not invent scores or add
+unreviewed exclusions.
+
+Loaded SDV coverage is split across seasons:
+
+| Source | Observed season and rows |
+| --- | --- |
+| `sdv_ratings_weekly` | 2026: 1,275 |
+| `sdv_fpi_weekly` | 2025: 2,312; 2026: 138 |
+| `sdv_team_xwalk` | 2025: 828 |
+| `sdv_game_xwalk` | 2025: 1,689 |
+
+These are database observations, not proof of current provider artifact
+availability. Use explicit source/season pairs for initial publication; there
+is no common currently loaded season across all four sources. Fetch cadence
+does not define a freshness SLA. Migration 073 deliberately seeds no thresholds.
+
+## Staged rollout and acceptance
+
+1. **Preparation PR:** resolve the creator-membership guard, exercise the
+   focused non-superuser guards and actual runtime role assumptions, retain
+   full-chain transactional coverage, and add a managed
+   production plan/upgrade/status delivery path. Independently review the
+   changes. Repair the separate daily variant tripwire with consumer-aware
+   evidence so normal verification can be useful during rollout.
+2. **Authorized schema window:** quiesce warehouse writers, recheck active
+   transactions and pending checksums, and run the managed production plan.
+   From the reviewed secure workflow environment, the intended commands are:
+
+   ```sh
+   WAREHOUSE_DB_URL="$SUPABASE_DB_URL" python scripts/bootstrap_warehouse.py plan --manifest src/schemas/production-manifest.json
+   WAREHOUSE_DB_URL="$SUPABASE_DB_URL" python scripts/bootstrap_warehouse.py upgrade --manifest src/schemas/production-manifest.json
+   WAREHOUSE_DB_URL="$SUPABASE_DB_URL" python scripts/bootstrap_warehouse.py status --manifest src/schemas/production-manifest.json
+   ```
+
+   The runner applies the pending chain and ledger entries in one transaction
+   under its advisory lock. A failed upgrade must leave the pre-upgrade ledger
+   intact. Do not work around a failing guard by applying individual files.
+   The runner sets neither `lock_timeout` nor `statement_timeout`; acquired DDL
+   locks remain held until the transaction ends. Quiesce target DML and
+   administrator DDL before dispatch, monitor the backend, and do not use
+   cancellation as the normal timeout policy. If a workflow result or commit
+   acknowledgement is ambiguous, wait for its backend and locks to disappear,
+   then inspect managed `status` before retrying. A failed job alone does not
+   prove rollback. Any added database timeout policy needs separate review.
+3. **Post-schema verification:** check the eight new ledger entries and checksums
+   (nine total including adoption), extension schema, runtime-role attributes and membership
+   options. Execute the new RPCs as both `anon` and `authenticated`: Elo must
+   return two rows, SDV four rows for each of 2025 and 2026, and the legacy RPC
+   must retain its contract. Verify the six warehouse event triggers in the
+   `warehouse_publication_*`, `warehouse_source_*` and
+   `warehouse_source_batch_*` families are enabled (`O` or `A`), with existing
+   platform triggers preserved. Check private table/schema/function denial,
+   negative new-RPC calls as `analyst_ro` and a bystander without memberships,
+   and owner-rights API reads. Existing broad public default privileges make
+   effective ACL checks necessary. Missing receipts and unknown policies must
+   remain explicit; do not seed guessed intervals or globally change defaults.
+4. **SDV canary:** configure only the reviewed source-publisher runtime grant,
+   verify the selected artifact's availability, then publish one explicit
+   source/season, such as `sdv_fpi_weekly`/2026, using
+   `load_flat_files.py --source sdv_fpi_weekly --season 2026 --require-receipts`.
+   Verify target counts, dlt identifiers, receipt identity, current pointer,
+   freshness response and the actual runtime role's permissions. Measure
+   publication/lock duration. Extend to the other confirmed source/season pairs.
+   A distinct runtime login needs `ADMIN=false`, `INHERIT=false`, `SET=true`.
+   If the existing `postgres` login is reused, grant role switching with
+   explicit `INHERIT FALSE, SET TRUE` while preserving its automatic
+   administration edge. The September 10 stock PostgreSQL 17 regression found
+   a separate self-granted runtime row alongside the bootstrap-superuser
+   administration row; inspect all grantors on the actual target. The underlying
+   credential still has broad `BYPASSRLS` access. Test the actual connection's
+   role assumption. Activated memberships
+   must not be mistaken for the pre-activation creator exception on direct
+   migration reapplication; subsequent managed upgrades skip applied entries.
+   Apply this rule separately for each later activation: map
+   `warehouse_source_publisher` to the flat-file publisher connection,
+   `warehouse_publisher` to the Elo compute connection, `warehouse_refresher`
+   to the mart refresher connection, and `warehouse_ingest` to
+   `CFBD_QUOTA_DB_URL`. Resolve each login from its actual `session_user`;
+   do not assume the connections share an identity. No runtime grants precede
+   the complete 066–073 commit. Test role assumption and only the allowlisted
+   RPC permissions on each actual connection.
+5. **Sustained receipt operation:** implement explicit source/season scheduling
+   and reviewed freshness intervals. The current legacy `--due` path cannot be
+   combined with `--require-receipts`; corrected legacy writes invalidate
+   pointers. For Elo, resolve the two games, benchmark
+   `compute_house_elo.py --full --publish-receipts`, and coordinate daily,
+   backfill and historical writers/refreshes before cutover. Current incremental
+   Elo cannot publish receipts; legacy Elo DML clears the source and mart pointers, and
+   ordinary Elo mart refresh clears its pointer. Refresh APIs currently cannot
+   exclude only the protected Elo mart from all these paths. A strict refresh
+   afterward can restore evidence on success but cannot preserve the previous
+   publication if it fails. Add the needed orchestration support before relying
+   on current receipts continuously. Declare a positive Elo freshness interval
+   before enabling generation-enforced refresh.
+6. **Separate durable quota activation:** establish real provider headroom,
+   explicit finite extraction and reconciliation periods/caps, and the dedicated
+   connection that can assume `warehouse_ingest`. Set `CFBD_QUOTA_MODE=durable`,
+   `CFBD_QUOTA_DB_URL` and `CFBD_QUOTA_ACCOUNT` only for the enrolled
+   `load_season`, `backfill_refresh` and `poll_scoreboard` entrypoints. Verify
+   admission, exhaustion, failure and recovery before extending coverage to
+   other commands; their current default is legacy admission.
+
+Schema deployment and each activation are separate decisions. After a committed
+schema upgrade, disable a failing opt-in activation and preserve its receipt
+history for diagnosis; use a reviewed forward correction rather than deleting
+ledger entries or dropping receipt tables. Crossvalidation generation enforcement
+still depends on later receipts for CFBD FPI, `ref.teams`, and the two EPA marts.

--- a/docs/warehouse-bootstrap.md
+++ b/docs/warehouse-bootstrap.md
@@ -184,6 +184,108 @@ recorded in the rollout evidence, not fabricated as managed migration history.
 
 See [production rollout evidence](plans/2026-09-07-f06-production-rollout.md).
 
+## Managed production workflow
+
+The Deploy Schema workflow has three explicit `workflow_dispatch` actions:
+
+| Action | Behavior |
+| --- | --- |
+| `managed_plan` | Read-only comparison of the production manifest and ledger. |
+| `managed_upgrade` | Apply pending production entries in one managed transaction, then observe status in a separate workflow step. |
+| `managed_status` | Read-only inspection of the production ledger and pending entries. |
+
+Select a reviewed commit/ref and one action, leaving the legacy mart, file,
+refresh, backfill and compute inputs empty. Managed actions cannot be mixed
+with those options or dispatched through a pushed `deploy-manifest.json`.
+They always select `src/schemas/production-manifest.json`; there is no manifest
+override or bootstrap action in this workflow path. The workflow maps its
+existing `SUPABASE_DB_URL` secret to `WAREHOUSE_DB_URL` for the managed step.
+The bootstrap CLI's complete-URL and ambient-libpq validation still applies.
+
+On an authorized secure runner with `WAREHOUSE_DB_URL` configured, the same
+deployment driver commands are:
+
+```bash
+python scripts/deploy_schema.py --action managed_plan
+python scripts/deploy_schema.py --action managed_upgrade
+python scripts/deploy_schema.py --action managed_status
+```
+
+These actions invoke `bootstrap_warehouse.py` rather than the per-file SQL
+runner. They do not run ingestion, refresh marts, seed freshness policies or
+grant runtime memberships. Preparing or merging this path does not dispatch it.
+
+Before an upgrade, review the plan/checksums and quiesce target DML and
+administrator DDL. The managed advisory lock coordinates managed runners, not
+all existing warehouse jobs. The current runner sets neither `lock_timeout`
+nor `statement_timeout`, and DDL locks last until the transaction ends. Monitor
+the backend during the window; do not treat workflow cancellation as a normal
+timeout policy.
+
+The workflow runs an observational managed status step after an attempted
+upgrade, including an unsuccessful attempt. Status takes the same advisory lock
+before reading, so it cannot overtake a still-running managed transaction. It
+does not retry the upgrade or turn a failed upgrade step green. If a runner is
+killed or commit acknowledgement is lost, a failed job alone does not prove
+rollback. Wait for the backend/locks to disappear and run `managed_status`
+before deciding whether another upgrade is needed. A completed upgrade should
+have the reviewed checksums recorded and no pending entries. Verify actual
+consumer roles, private ACLs and enabled warehouse event triggers separately.
+
+## PostgreSQL 17 role creation and activation
+
+On PostgreSQL 17, a non-superuser with `CREATEROLE` receives an automatic
+membership in a new role with administration enabled, inheritance disabled
+and role switching disabled. The prepared 070/071 role guards and 072 dependency
+guard accept that narrow migration-owner administration edge, as well as the
+membership-free state produced by the superuser fixtures. They reject outbound
+memberships, unrelated members and activated `SET`/`INHERIT` edges. They do not
+grant runtime access as part of schema deployment.
+
+The correction changes previously prepared migration files because the
+September 10 read-only production ledger check still found only the adopted
+root, with no 066–073 executions. Once these exact bytes are applied, they are
+immutable. Recreate disposable fixtures with older applied bytes; never rewrite
+their ledger checksums to hide drift.
+
+After the complete migration chain commits, resolve each actual connection's
+`session_user` before configuring its bounded role:
+
+| Bounded role | Runtime connection |
+| --- | --- |
+| `warehouse_ingest` | Dedicated `CFBD_QUOTA_DB_URL` connection |
+| `warehouse_publisher` | House Elo compute connection |
+| `warehouse_refresher` | Generation-enforced mart refresh connection |
+| `warehouse_source_publisher` | Receipt-enabled flat-file publication connection |
+
+A distinct runtime login needs `ADMIN=false`, `INHERIT=false`, `SET=true` on
+the granted membership. If the migration-owner login is reused, grant role
+switching with explicit `INHERIT FALSE, SET TRUE` while preserving its automatic
+administration edge. The stock PostgreSQL 17 test produces two membership rows:
+the original bootstrap-superuser grant with `ADMIN=true, INHERIT=false, SET=false`,
+and a self-granted runtime edge with `ADMIN=false, INHERIT=false, SET=true`.
+Inspect all grantor rows on the actual target; do not assume one row per role
+and member. Explicitly disable membership inheritance even when the login has
+`INHERIT` enabled. Do not blindly revoke the creator edge: that may
+remove the non-superuser's ability to administer the bounded role later. A
+reused `postgres` credential still has its underlying broad `BYPASSRLS` rights.
+Exercise `SET LOCAL ROLE` and the allowlisted RPC permissions on each actual
+runtime connection before enabling its job.
+
+After activation, direct reapplication of the guarded SQL intentionally fails
+on those runtime memberships. Normal managed upgrades skip already applied
+immutable entries and do not re-run the guards. Schema deployment, each runtime
+activation, positive freshness intervals and quota capacity remain separate
+rollout decisions; see the
+[production preflight](plans/2026-09-09-production-receipts-preflight.md).
+
+Focused stock PostgreSQL 17 tests execute the non-superuser role creation,
+revalidation/dependency guards and runtime grant/role-switching paths. The full
+chain still runs in the superuser fixture. Stock PostgreSQL does not allow the
+non-superuser to create event triggers; exact full-chain non-superuser execution
+requires Supautils-equivalent privileges and remains part of the authorized
+Supabase deployment verification.
+
 ## Forward correction discovered by executed role checks
 
 The captured `public.team_season_trajectory` wrapper grants consumer access but

--- a/scripts/deploy_schema.py
+++ b/scripts/deploy_schema.py
@@ -4,8 +4,9 @@
 Reads a plan from either a JSON manifest (pushed to a `deploy/**` branch as
 `deploy-manifest.json`, the mechanism `docs/plans/2026-07-19-tier1-analytics-unlock-plan.md`
 describes) or CLI flags (workflow_dispatch, for human-triggered runs), then
-executes it by shelling out to the existing driver scripts: run_marts.py,
-run_migrations.py, refresh_marts.py, load_season.py, and check_presence.py.
+executes it by shelling out to the existing driver scripts. Managed production
+schema actions are workflow-dispatch-only and always use the repository's fixed
+production manifest.
 
 Manifest schema:
     {
@@ -32,6 +33,9 @@ Usage:
         --files src/schemas/functions/get_player_game_log.sql --refresh
     python scripts/deploy_schema.py --action backfill \\
         --backfill-start 2014 --backfill-end 2025 --sources stats,betting
+    python scripts/deploy_schema.py --action managed_plan
+    python scripts/deploy_schema.py --action managed_upgrade
+    python scripts/deploy_schema.py --action managed_status
 
 Plan-building (plan_from_manifest / plan_from_cli / validate_plan) is pure --
 no subprocesses, no DB -- so it can be unit tested directly; execute_plan is
@@ -43,6 +47,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import subprocess
 import sys
 import time
@@ -60,8 +65,15 @@ RUN_MIGRATIONS = SCRIPTS_DIR / "run_migrations.py"
 REFRESH_MARTS = SCRIPTS_DIR / "refresh_marts.py"
 LOAD_SEASON = SCRIPTS_DIR / "load_season.py"
 CHECK_PRESENCE = SCRIPTS_DIR / "check_presence.py"
+BOOTSTRAP_WAREHOUSE = SCRIPTS_DIR / "bootstrap_warehouse.py"
+PRODUCTION_MANIFEST = "src/schemas/production-manifest.json"
 
-VALID_ACTIONS = {"presence_check", "apply", "backfill", "compute"}
+MANAGED_ACTION_MODES = {
+    "managed_plan": "plan",
+    "managed_upgrade": "upgrade",
+    "managed_status": "status",
+}
+VALID_ACTIONS = {"presence_check", "apply", "backfill", "compute", *MANAGED_ACTION_MODES}
 
 # Allowlist of compute scripts the "compute" action may run (scripts/<name>.py).
 # These land in later Tier 2 + Tier 3 phases -- membership is checked, not file
@@ -162,6 +174,34 @@ def validate_plan(plan: Plan) -> None:
     """Raise ValueError if the plan is not executable. Called by both builders."""
     if plan.action not in VALID_ACTIONS:
         raise ValueError(f"invalid action {plan.action!r}; must be one of {sorted(VALID_ACTIONS)}")
+
+    if plan.action in MANAGED_ACTION_MODES:
+        conflicts = []
+        if plan.mart_release:
+            conflicts.append("mart_release")
+        if plan.plan:
+            conflicts.append("plan")
+        if plan.marts_from:
+            conflicts.append("marts_from")
+        if plan.marts_only:
+            conflicts.append("marts_only")
+        if plan.files:
+            conflicts.append("files")
+        if plan.refresh:
+            conflicts.append("refresh")
+        if plan.refresh_views:
+            conflicts.append("refresh_views")
+        if plan.backfill is not None:
+            conflicts.append("backfill")
+        if plan.strict:
+            conflicts.append("strict")
+        if plan.compute is not None:
+            conflicts.append("compute")
+        if conflicts:
+            raise ValueError(
+                f"{plan.action} uses the fixed production manifest and cannot be combined "
+                "with legacy deploy fields: " + ", ".join(conflicts)
+            )
 
     if plan.action == "backfill":
         if plan.backfill is None:
@@ -283,6 +323,11 @@ def plan_from_manifest(manifest: dict) -> Plan:
         compute=compute,
     )
     validate_plan(plan)
+    if plan.action in MANAGED_ACTION_MODES:
+        raise ValueError(
+            f"{plan.action} requires workflow_dispatch; managed production actions "
+            "cannot run from deploy-manifest.json"
+        )
     if plan.compute and plan.compute.script == "recover_season_projections":
         raise ValueError(
             "recover_season_projections requires workflow_dispatch with compute_script; "
@@ -327,6 +372,9 @@ def plan_from_cli(
             sources=sources or "",
         )
 
+    if compute_args and compute_script is None:
+        raise ValueError("--compute-args requires --compute-script")
+
     compute = None
     if compute_script is not None:
         arg_list = [a.strip() for a in compute_args.split(",") if a.strip()] if compute_args else []
@@ -354,10 +402,10 @@ def plan_from_cli(
 # --------------------------------------------------------------------------
 
 
-def run_cmd(cmd: list[str], label: str) -> int:
+def run_cmd(cmd: list[str], label: str, *, env: dict[str, str] | None = None) -> int:
     """Run a subprocess, inheriting stdout/stderr so CI logs show it live."""
     logger.info(f"--- {label}: {' '.join(cmd)} ---")
-    proc = subprocess.run(cmd)
+    proc = subprocess.run(cmd, env=env)
     logger.info(f"--- {label} exit={proc.returncode} ---")
     return proc.returncode
 
@@ -457,6 +505,36 @@ def run_compute(plan: Plan) -> int:
     return 0
 
 
+def run_managed_production(plan: Plan) -> int:
+    """Dispatch one managed action against the fixed production manifest."""
+    validate_plan(plan)
+    mode = MANAGED_ACTION_MODES[plan.action]
+
+    # bootstrap_warehouse.py intentionally accepts WAREHOUSE_DB_URL only. Keep
+    # legacy/dlt connection aliases out of its subprocess even when a caller's
+    # ambient environment contains them; the workflow supplies WAREHOUSE_DB_URL
+    # only on managed steps.
+    managed_env = os.environ.copy()
+    for variable in (
+        "SUPABASE_DB_URL",
+        "DATABASE_URL",
+        "DESTINATION__POSTGRES__CREDENTIALS",
+    ):
+        managed_env.pop(variable, None)
+
+    return run_cmd(
+        [
+            sys.executable,
+            str(BOOTSTRAP_WAREHOUSE),
+            mode,
+            "--manifest",
+            PRODUCTION_MANIFEST,
+        ],
+        f"managed production {mode}",
+        env=managed_env,
+    )
+
+
 def execute_plan(plan: Plan) -> int:
     logger.info(f"executing plan: {plan}")
     if plan.action == "presence_check":
@@ -467,6 +545,8 @@ def execute_plan(plan: Plan) -> int:
         return run_backfill(plan)
     if plan.action == "compute":
         return run_compute(plan)
+    if plan.action in MANAGED_ACTION_MODES:
+        return run_managed_production(plan)
     raise ValueError(f"unknown action: {plan.action}")  # unreachable after validate_plan
 
 
@@ -534,6 +614,33 @@ def main(argv: list[str] | None = None) -> None:
     args = parser.parse_args(argv)
 
     if args.manifest:
+        conflicting_flags = []
+        for field_name in (
+            "action",
+            "mart_release",
+            "marts_from",
+            "marts_only",
+            "files",
+            "refresh_views",
+            "backfill_start",
+            "backfill_end",
+            "sources",
+            "compute_script",
+            "compute_args",
+        ):
+            if getattr(args, field_name) is not None:
+                conflicting_flags.append("--" + field_name.replace("_", "-"))
+        for enabled, flag in (
+            (args.plan, "--plan"),
+            (args.refresh, "--refresh"),
+            (args.strict, "--strict"),
+        ):
+            if enabled:
+                conflicting_flags.append(flag)
+        if conflicting_flags:
+            parser.error(
+                "--manifest cannot be combined with CLI plan flags: " + ", ".join(conflicting_flags)
+            )
         manifest = load_manifest(args.manifest)
         plan = plan_from_manifest(manifest)
     else:

--- a/src/schemas/migrations/070_generation_enforced_refresh.sql
+++ b/src/schemas/migrations/070_generation_enforced_refresh.sql
@@ -34,11 +34,27 @@ BEGIN
     IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname='warehouse_refresher') THEN
         CREATE ROLE warehouse_refresher NOLOGIN NOINHERIT NOSUPERUSER NOCREATEDB
             NOCREATEROLE NOREPLICATION NOBYPASSRLS;
-    ELSIF EXISTS (SELECT 1 FROM pg_catalog.pg_roles r WHERE r.rolname='warehouse_refresher'
+    END IF;
+
+    -- This migration is still pending in production, so its role guard is
+    -- amended in place for PostgreSQL 17's non-superuser CREATEROLE behavior.
+    -- CREATE ROLE gives the creator an inbound ADMIN membership with neither
+    -- SET nor INHERIT.  Stock PG17 records its bootstrap superuser as grantor,
+    -- so the creator identity and the three option columns define the edge.
+    -- Retaining that exact administration edge lets the migration owner grant
+    -- a SET-only runtime membership during activation.
+    -- Every outbound, unrelated, inherited or already-activated edge remains
+    -- unsafe and makes a direct reapplication fail closed.
+    IF EXISTS (SELECT 1 FROM pg_catalog.pg_roles r WHERE r.rolname='warehouse_refresher'
         AND (r.rolcanlogin OR r.rolinherit OR r.rolsuper OR r.rolcreatedb
             OR r.rolcreaterole OR r.rolreplication OR r.rolbypassrls
-            OR EXISTS (SELECT 1 FROM pg_catalog.pg_auth_members
-                WHERE member=r.oid OR roleid=r.oid))) THEN
+            OR EXISTS (SELECT 1 FROM pg_catalog.pg_auth_members m
+                WHERE m.member=r.oid
+                    OR (m.roleid=r.oid AND NOT (
+                        m.member=(SELECT oid FROM pg_catalog.pg_roles
+                            WHERE rolname=current_user)
+                        AND m.admin_option AND NOT m.inherit_option AND NOT m.set_option
+                    ))))) THEN
         RAISE EXCEPTION 'warehouse_refresher must be a bounded NOLOGIN role';
     END IF;
 END

--- a/src/schemas/migrations/071_sdv_ratings_publication.sql
+++ b/src/schemas/migrations/071_sdv_ratings_publication.sql
@@ -186,15 +186,29 @@ BEGIN
         WHERE rolname = 'warehouse_source_publisher') THEN
         CREATE ROLE warehouse_source_publisher NOLOGIN NOINHERIT NOSUPERUSER NOCREATEDB
             NOCREATEROLE NOREPLICATION NOBYPASSRLS;
-    ELSIF EXISTS (
+    END IF;
+
+    -- This prepared migration has not been applied to production.  PostgreSQL
+    -- 17 gives a non-superuser CREATEROLE creator an inbound ADMIN membership
+    -- when CREATE ROLE succeeds.  Its catalog grantor is the bootstrap
+    -- superuser, so admit only the current migration owner as member while
+    -- SET and INHERIT are both false, retaining the authority needed to grant
+    -- a separate SET-only runtime membership after the managed migration.
+    -- Runtime activation and every other membership still fail this guard.
+    IF EXISTS (
         SELECT 1 FROM pg_catalog.pg_roles r
         WHERE r.rolname = 'warehouse_source_publisher'
           AND (r.rolcanlogin OR r.rolinherit OR r.rolsuper OR r.rolcreatedb
             OR r.rolcreaterole OR r.rolreplication OR r.rolbypassrls
             OR EXISTS (SELECT 1 FROM pg_catalog.pg_auth_members m
-                WHERE m.member = r.oid OR m.roleid = r.oid))
+                WHERE m.member = r.oid
+                   OR (m.roleid = r.oid AND NOT (
+                        m.member = (SELECT oid FROM pg_catalog.pg_roles
+                            WHERE rolname = current_user)
+                        AND m.admin_option AND NOT m.inherit_option AND NOT m.set_option
+                    ))))
     ) THEN
-        RAISE EXCEPTION 'warehouse_source_publisher must be a bounded membership-free NOLOGIN role';
+        RAISE EXCEPTION 'warehouse_source_publisher must be a bounded NOLOGIN role';
     END IF;
 END
 $role$;

--- a/src/schemas/migrations/072_sdv_source_batch_publication.sql
+++ b/src/schemas/migrations/072_sdv_source_batch_publication.sql
@@ -125,15 +125,26 @@ BEGIN
         WHERE t.tgrelid = ledger_oid AND NOT t.tgisinternal) THEN
         RAISE EXCEPTION 'meta.flat_file_loads is not a trusted migration-owned ordinary table';
     END IF;
+    -- 071 and 072 are both pending in production.  Under PostgreSQL 17 a
+    -- non-superuser CREATEROLE migration owner receives an automatic inbound
+    -- ADMIN membership in the role created by 071; stock PG17 records the
+    -- bootstrap superuser as grantor.  Accept only that exact
+    -- creator edge while SET and INHERIT remain false.  Any runtime
+    -- activation, unrelated member or outbound membership still fails closed.
     IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_roles r
         WHERE r.rolname = 'warehouse_source_publisher'
           AND NOT r.rolcanlogin AND NOT r.rolinherit AND NOT r.rolsuper
           AND NOT r.rolcreatedb AND NOT r.rolcreaterole AND NOT r.rolreplication
           AND NOT r.rolbypassrls
           AND NOT EXISTS (SELECT 1 FROM pg_catalog.pg_auth_members m
-              WHERE m.member = r.oid OR m.roleid = r.oid)) THEN
+              WHERE m.member = r.oid
+                 OR (m.roleid = r.oid AND NOT (
+                    m.member = (SELECT oid FROM pg_catalog.pg_roles
+                        WHERE rolname = current_user)
+                    AND m.admin_option AND NOT m.inherit_option AND NOT m.set_option
+                )))) THEN
         RAISE EXCEPTION
-            'warehouse_source_publisher must be a bounded membership-free NOLOGIN role';
+            'warehouse_source_publisher must be a bounded NOLOGIN role';
     END IF;
 END
 $dependencies$;

--- a/tests/test_deploy_schema.py
+++ b/tests/test_deploy_schema.py
@@ -2,12 +2,15 @@
 
 import json
 import sys
+from types import SimpleNamespace
 
 import pytest
 
 import scripts.deploy_schema as deploy_schema
 from scripts.deploy_schema import (
     COMPUTE_SCRIPTS,
+    MANAGED_ACTION_MODES,
+    PRODUCTION_MANIFEST,
     VALID_ACTIONS,
     BackfillSpec,
     ComputeSpec,
@@ -34,7 +37,21 @@ class TestValidActions:
         assert plan.compute.args == ["--execute"]
 
     def test_expected_actions(self):
-        assert VALID_ACTIONS == {"presence_check", "apply", "backfill", "compute"}
+        assert MANAGED_ACTION_MODES == {
+            "managed_plan": "plan",
+            "managed_upgrade": "upgrade",
+            "managed_status": "status",
+        }
+        assert PRODUCTION_MANIFEST == "src/schemas/production-manifest.json"
+        assert VALID_ACTIONS == {
+            "presence_check",
+            "apply",
+            "backfill",
+            "compute",
+            "managed_plan",
+            "managed_upgrade",
+            "managed_status",
+        }
 
 
 class TestComputeScripts:
@@ -311,6 +328,10 @@ class TestPlanFromCli:
         with pytest.raises(ValueError, match="compute block"):
             plan_from_cli(action="compute")
 
+    def test_compute_args_without_script_rejected(self):
+        with pytest.raises(ValueError, match="--compute-script"):
+            plan_from_cli(action="compute", compute_args="--full")
+
     def test_compute_refresh_flag_mapped(self):
         plan = plan_from_cli(action="compute", compute_script="compute_house_elo", refresh=True)
         assert plan.refresh is True
@@ -456,3 +477,166 @@ class TestMartReleasePlans:
                 "--plan",
             ]
         ]
+
+
+class TestManagedProductionActions:
+    @pytest.mark.parametrize(
+        ("action", "mode"),
+        sorted(MANAGED_ACTION_MODES.items()),
+    )
+    def test_cli_maps_explicit_managed_action(self, action, mode):
+        plan = plan_from_cli(action=action)
+
+        assert plan.action == action
+        assert MANAGED_ACTION_MODES[plan.action] == mode
+
+    @pytest.mark.parametrize("action", sorted(MANAGED_ACTION_MODES))
+    def test_push_manifest_rejects_managed_actions(self, action):
+        with pytest.raises(ValueError, match="requires workflow_dispatch"):
+            plan_from_manifest({"action": action})
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("mart_release", "release.json"),
+            ("plan", True),
+            ("marts_from", "029"),
+            ("marts_only", "011"),
+            ("files", ["src/schemas/api/example.sql"]),
+            ("refresh", True),
+            ("refresh_views", ["marts.example"]),
+            ("backfill", BackfillSpec(start=2026, end=2026, sources="stats")),
+            ("strict", True),
+            ("compute", ComputeSpec(script="compute_house_elo")),
+        ],
+    )
+    def test_managed_action_rejects_legacy_deploy_fields(self, field, value):
+        plan = Plan(action="managed_plan")
+        setattr(plan, field, value)
+
+        with pytest.raises(ValueError, match=field):
+            validate_plan(plan)
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"mart_release": "release.json"},
+            {"plan": True},
+            {"marts_from": "029"},
+            {"marts_only": "011"},
+            {"files": "src/schemas/api/example.sql"},
+            {"refresh": True},
+            {"refresh_views": "marts.example"},
+            {"backfill_start": 2026},
+            {"backfill_end": 2026},
+            {"sources": "stats"},
+            {"strict": True},
+            {"compute_script": "compute_house_elo"},
+            {"compute_args": "--full"},
+        ],
+    )
+    def test_managed_cli_rejects_each_incompatible_input(self, kwargs):
+        with pytest.raises(ValueError):
+            plan_from_cli(action="managed_status", **kwargs)
+
+    @pytest.mark.parametrize(
+        ("action", "mode"),
+        sorted(MANAGED_ACTION_MODES.items()),
+    )
+    def test_dispatches_fixed_manifest_and_managed_environment(self, monkeypatch, action, mode):
+        secret = "postgresql://deploy-user:sensitive-password@db.example:5432/postgres"
+        monkeypatch.setenv("WAREHOUSE_DB_URL", secret)
+        monkeypatch.setenv("SUPABASE_DB_URL", secret)
+        monkeypatch.setenv("DATABASE_URL", secret)
+        monkeypatch.setenv("DESTINATION__POSTGRES__CREDENTIALS", secret)
+        calls = []
+
+        def fake_run_cmd(cmd, label, *, env=None):
+            calls.append((cmd, label, env))
+            return 0
+
+        monkeypatch.setattr(deploy_schema, "run_cmd", fake_run_cmd)
+
+        assert deploy_schema.execute_plan(Plan(action=action)) == 0
+        assert len(calls) == 1
+        cmd, label, env = calls[0]
+        assert cmd == [
+            sys.executable,
+            str(deploy_schema.BOOTSTRAP_WAREHOUSE),
+            mode,
+            "--manifest",
+            PRODUCTION_MANIFEST,
+        ]
+        assert label == f"managed production {mode}"
+        assert env["WAREHOUSE_DB_URL"] == secret
+        assert "SUPABASE_DB_URL" not in env
+        assert "DATABASE_URL" not in env
+        assert "DESTINATION__POSTGRES__CREDENTIALS" not in env
+        assert secret not in " ".join(cmd)
+        assert secret not in label
+
+    def test_managed_runner_failure_is_returned_and_not_retried(self, monkeypatch):
+        calls = []
+
+        def fake_run_cmd(cmd, label, *, env=None):
+            calls.append((cmd, label, env))
+            return 23
+
+        monkeypatch.setattr(deploy_schema, "run_cmd", fake_run_cmd)
+
+        assert deploy_schema.execute_plan(Plan(action="managed_upgrade")) == 23
+        assert len(calls) == 1
+
+    def test_managed_secret_is_not_logged(self, monkeypatch, caplog):
+        secret = "postgresql://deploy-user:sensitive-password@db.example:5432/postgres"
+        caplog.set_level("INFO", logger=deploy_schema.__name__)
+        monkeypatch.setenv("WAREHOUSE_DB_URL", secret)
+        monkeypatch.setattr(
+            deploy_schema.subprocess,
+            "run",
+            lambda cmd, env=None: SimpleNamespace(returncode=1),
+        )
+
+        assert deploy_schema.execute_plan(Plan(action="managed_status")) == 1
+        assert secret not in caplog.text
+        assert "sensitive-password" not in caplog.text
+
+    def test_manifest_and_cli_flags_are_mutually_exclusive(self, capsys):
+        with pytest.raises(SystemExit) as exc_info:
+            deploy_schema.main(["--manifest", "deploy-manifest.json", "--action", "managed_status"])
+
+        assert exc_info.value.code == 2
+        assert "--manifest cannot be combined" in capsys.readouterr().err
+
+
+def test_workflow_scopes_managed_credentials_and_observes_upgrade_status():
+    workflow = (deploy_schema.REPO_ROOT / ".github/workflows/deploy-schema.yml").read_text()
+    workflow_env = workflow.split("env:\n", 1)[1].split("jobs:\n", 1)[0]
+    managed_step = workflow.split("      - name: Run managed production action\n", 1)[1].split(
+        "      - name: Observe managed status after upgrade attempt\n", 1
+    )[0]
+
+    for action in MANAGED_ACTION_MODES:
+        assert f"          - {action}\n" in workflow
+    assert "id: managed_deploy" in workflow
+    for input_name in (
+        "MART_RELEASE_INPUT",
+        "PLAN_INPUT",
+        "FILES_INPUT",
+        "REFRESH_INPUT",
+        "BACKFILL_START_INPUT",
+        "BACKFILL_END_INPUT",
+        "SOURCES_INPUT",
+        "COMPUTE_SCRIPT_INPUT",
+        "COMPUTE_ARGS_INPUT",
+    ):
+        assert input_name in managed_step
+    assert 'python scripts/deploy_schema.py "${ARGS[@]}"' in managed_step
+    assert "inputs.action == 'managed_upgrade'" in workflow
+    assert "steps.managed_deploy.outcome != 'skipped'" in workflow
+    assert "run: python scripts/deploy_schema.py --action managed_status" in workflow
+    assert "WAREHOUSE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}" in workflow
+    assert "SUPABASE_DB_URL:" not in workflow_env
+    assert "WAREHOUSE_DB_URL:" not in workflow_env
+    assert "          SUPABASE_DB_URL:" not in managed_step
+    assert "run: python scripts/deploy_schema.py --action ${{ inputs.action }}" not in workflow

--- a/tests/test_pg17_creator_membership_sql.py
+++ b/tests/test_pg17_creator_membership_sql.py
@@ -1,0 +1,369 @@
+"""PostgreSQL 17 non-superuser role-creator compatibility checks."""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import psycopg2
+import pytest
+from psycopg2 import sql
+from psycopg2.extensions import make_dsn
+
+from tests.test_warehouse_migrations_sql import query
+from tests.test_warehouse_migrations_sql import warehouse_db as _warehouse_db  # noqa: F401
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATION_070 = ROOT / "src/schemas/migrations/070_generation_enforced_refresh.sql"
+MIGRATION_071 = ROOT / "src/schemas/migrations/071_sdv_ratings_publication.sql"
+MIGRATION_072 = ROOT / "src/schemas/migrations/072_sdv_source_batch_publication.sql"
+
+
+def tagged_block(path: Path, tag: str) -> str:
+    migration = path.read_text(encoding="utf-8")
+    opening = f"DO ${tag}$"
+    closing = f"${tag}$;"
+    start = migration.index(opening)
+    end = migration.index(closing, start) + len(closing)
+    return migration[start:end]
+
+
+ROLE_070 = tagged_block(MIGRATION_070, "role")
+ROLE_071 = tagged_block(MIGRATION_071, "role")
+DEPENDENCIES_072 = tagged_block(MIGRATION_072, "dependencies")
+
+
+def for_refresher(role_name: str) -> str:
+    return ROLE_070.replace("warehouse_refresher", role_name)
+
+
+def for_publisher(block: str, role_name: str) -> str:
+    return block.replace("warehouse_source_publisher", role_name)
+
+
+def rejected(conn, statement: str) -> None:
+    with pytest.raises(psycopg2.Error, match="bounded NOLOGIN role"):
+        with conn.cursor() as cur:
+            cur.execute(statement)
+    conn.rollback()
+
+
+def role_memberships(conn, role_name: str):
+    return query(
+        conn,
+        """
+        SELECT parent.rolname, member.rolname, grantor.rolname,
+               membership.admin_option, membership.inherit_option,
+               membership.set_option
+        FROM pg_catalog.pg_auth_members membership
+        JOIN pg_catalog.pg_roles parent ON parent.oid = membership.roleid
+        JOIN pg_catalog.pg_roles member ON member.oid = membership.member
+        JOIN pg_catalog.pg_roles grantor ON grantor.oid = membership.grantor
+        WHERE parent.rolname = %s OR member.rolname = %s
+        ORDER BY parent.rolname, member.rolname, grantor.rolname
+        """,
+        (role_name, role_name),
+    )
+
+
+def bootstrap_creator_edge(
+    conn,
+    role_name: str,
+    creator_name: str,
+    *,
+    admin: bool = True,
+    inherit: bool = False,
+    set_option: bool = False,
+):
+    bootstrap_superuser = query(conn, "SELECT rolname FROM pg_catalog.pg_roles WHERE oid = 10")[0][
+        0
+    ]
+    return [
+        (
+            role_name,
+            creator_name,
+            bootstrap_superuser,
+            admin,
+            inherit,
+            set_option,
+        )
+    ]
+
+
+def set_role_identity(conn, role_name: str):
+    with conn.cursor() as cur:
+        cur.execute(sql.SQL("SET ROLE {}").format(sql.Identifier(role_name)))
+        cur.execute("SELECT current_user, session_user")
+        identity = cur.fetchone()
+        cur.execute("RESET ROLE")
+    conn.commit()
+    return identity
+
+
+@pytest.fixture
+def pg17_creator_db(request):
+    admin, target = request.getfixturevalue("_warehouse_db")
+    version = query(admin, "SELECT current_setting('server_version_num')::integer")[0][0]
+    if version < 170000 or version >= 180000:
+        pytest.fail("creator-membership regression requires stock PostgreSQL 17")
+
+    suffix = uuid.uuid4().hex[:12]
+    names = {
+        "creator": f"pg17_creator_{suffix}",
+        "refresher": f"pg17_refresh_{suffix}",
+        "publisher": f"pg17_publish_{suffix}",
+        "runtime": f"pg17_runtime_{suffix}",
+        "bystander": f"pg17_other_{suffix}",
+        "parent": f"pg17_parent_{suffix}",
+        "inherited": f"pg17_inherit_{suffix}",
+        "noadmin": f"pg17_noadmin_{suffix}",
+        "setexact": f"pg17_setexact_{suffix}",
+    }
+    creator_password = "creator-" + uuid.uuid4().hex
+    runtime_password = "runtime-" + uuid.uuid4().hex
+    database = query(admin, "SELECT current_database()")[0][0]
+
+    query(
+        admin,
+        sql.SQL(
+            "CREATE ROLE {} LOGIN INHERIT NOSUPERUSER NOCREATEDB "
+            "CREATEROLE NOREPLICATION NOBYPASSRLS PASSWORD {}"
+        ).format(sql.Identifier(names["creator"]), sql.Literal(creator_password)),
+    )
+    query(
+        admin,
+        sql.SQL("GRANT CREATE ON DATABASE {} TO {}").format(
+            sql.Identifier(database), sql.Identifier(names["creator"])
+        ),
+    )
+    creator = psycopg2.connect(make_dsn(target, user=names["creator"], password=creator_password))
+    try:
+        query(
+            creator,
+            "CREATE SCHEMA meta; "
+            "CREATE SCHEMA warehouse_source_stage; "
+            "CREATE TABLE meta.flat_file_loads(id bigint)",
+        )
+        yield admin, creator, target, names, runtime_password
+    finally:
+        creator.close()
+        admin.rollback()
+        query(
+            admin,
+            sql.SQL("DROP OWNED BY {} CASCADE").format(sql.Identifier(names["creator"])),
+        )
+        for role_name in (
+            names["refresher"],
+            names["publisher"],
+            names["runtime"],
+            names["bystander"],
+            names["parent"],
+            names["inherited"],
+            names["noadmin"],
+            names["setexact"],
+            names["creator"],
+        ):
+            query(admin, sql.SQL("DROP ROLE IF EXISTS {}").format(sql.Identifier(role_name)))
+
+
+def test_creator_admin_only_edges_pass_creation_revalidation_and_072_dependencies(
+    pg17_creator_db,
+):
+    _, creator, _, names, _ = pg17_creator_db
+    assert query(
+        creator,
+        "SELECT current_user=session_user,rolsuper,rolcreaterole,rolinherit "
+        "FROM pg_catalog.pg_roles WHERE rolname=current_user",
+    ) == [(True, False, True, True)]
+
+    query(creator, for_refresher(names["refresher"]))
+    assert role_memberships(creator, names["refresher"]) == bootstrap_creator_edge(
+        creator, names["refresher"], names["creator"]
+    )
+    query(creator, for_refresher(names["refresher"]))
+
+    with pytest.raises(psycopg2.Error, match="bounded NOLOGIN role"):
+        with creator.cursor() as cur:
+            cur.execute(for_publisher(DEPENDENCIES_072, names["publisher"]))
+    creator.rollback()
+
+    query(creator, for_publisher(ROLE_071, names["publisher"]))
+    assert role_memberships(creator, names["publisher"]) == bootstrap_creator_edge(
+        creator, names["publisher"], names["creator"]
+    )
+    query(creator, for_publisher(ROLE_071, names["publisher"]))
+    query(creator, for_publisher(DEPENDENCIES_072, names["publisher"]))
+
+
+def test_same_creator_can_enable_set_then_assume_role_and_guards_reject_activation(
+    pg17_creator_db,
+):
+    _, creator, _, names, _ = pg17_creator_db
+    query(creator, for_publisher(ROLE_071, names["publisher"]))
+    query(
+        creator,
+        sql.SQL("GRANT {} TO {} WITH INHERIT FALSE, SET TRUE").format(
+            sql.Identifier(names["publisher"]), sql.Identifier(names["creator"])
+        ),
+    )
+
+    assert role_memberships(creator, names["publisher"]) == [
+        (
+            names["publisher"],
+            names["creator"],
+            names["creator"],
+            False,
+            False,
+            True,
+        ),
+        *bootstrap_creator_edge(creator, names["publisher"], names["creator"]),
+    ]
+    assert set_role_identity(creator, names["publisher"]) == (
+        names["publisher"],
+        names["creator"],
+    )
+    rejected(creator, for_publisher(ROLE_071, names["publisher"]))
+    rejected(creator, for_publisher(DEPENDENCIES_072, names["publisher"]))
+
+
+def test_distinct_runtime_login_can_receive_set_only_membership_and_assume_role(
+    pg17_creator_db,
+):
+    _, creator, target, names, runtime_password = pg17_creator_db
+    query(creator, for_publisher(ROLE_071, names["publisher"]))
+    query(
+        creator,
+        sql.SQL(
+            "CREATE ROLE {} LOGIN NOINHERIT NOSUPERUSER NOCREATEDB NOCREATEROLE "
+            "NOREPLICATION NOBYPASSRLS PASSWORD {}"
+        ).format(sql.Identifier(names["runtime"]), sql.Literal(runtime_password)),
+    )
+    query(
+        creator,
+        sql.SQL("GRANT {} TO {} WITH ADMIN FALSE, INHERIT FALSE, SET TRUE").format(
+            sql.Identifier(names["publisher"]), sql.Identifier(names["runtime"])
+        ),
+    )
+
+    assert role_memberships(creator, names["publisher"]) == [
+        *bootstrap_creator_edge(creator, names["publisher"], names["creator"]),
+        (
+            names["publisher"],
+            names["runtime"],
+            names["creator"],
+            False,
+            False,
+            True,
+        ),
+    ]
+    runtime = psycopg2.connect(make_dsn(target, user=names["runtime"], password=runtime_password))
+    try:
+        assert set_role_identity(runtime, names["publisher"]) == (
+            names["publisher"],
+            names["runtime"],
+        )
+    finally:
+        runtime.close()
+
+    rejected(creator, for_publisher(ROLE_071, names["publisher"]))
+    rejected(creator, for_publisher(DEPENDENCIES_072, names["publisher"]))
+
+
+def test_guards_reject_outbound_unrelated_and_invalid_creator_edges(pg17_creator_db):
+    admin, creator, _, names, _ = pg17_creator_db
+
+    query(creator, for_refresher(names["refresher"]))
+    for options in (
+        {"admin": False, "inherit": False, "set_option": False},
+        {"admin": True, "inherit": True, "set_option": False},
+        {"admin": True, "inherit": False, "set_option": True},
+    ):
+        query(
+            admin,
+            sql.SQL("GRANT {} TO {} WITH ADMIN {}, INHERIT {}, SET {}").format(
+                sql.Identifier(names["refresher"]),
+                sql.Identifier(names["creator"]),
+                sql.SQL(str(options["admin"]).upper()),
+                sql.SQL(str(options["inherit"]).upper()),
+                sql.SQL(str(options["set_option"]).upper()),
+            ),
+        )
+        assert role_memberships(creator, names["refresher"]) == bootstrap_creator_edge(
+            creator, names["refresher"], names["creator"], **options
+        )
+        rejected(creator, for_refresher(names["refresher"]))
+    query(
+        admin,
+        sql.SQL("GRANT {} TO {} WITH ADMIN TRUE, INHERIT FALSE, SET FALSE").format(
+            sql.Identifier(names["refresher"]), sql.Identifier(names["creator"])
+        ),
+    )
+    query(creator, for_refresher(names["refresher"]))
+
+    query(
+        creator,
+        sql.SQL("CREATE ROLE {} NOLOGIN NOINHERIT").format(sql.Identifier(names["parent"])),
+    )
+    query(
+        creator,
+        sql.SQL("GRANT {} TO {} WITH ADMIN FALSE, INHERIT FALSE, SET TRUE").format(
+            sql.Identifier(names["parent"]), sql.Identifier(names["refresher"])
+        ),
+    )
+    rejected(creator, for_refresher(names["refresher"]))
+
+    query(creator, for_publisher(ROLE_071, names["publisher"]))
+    query(
+        creator,
+        sql.SQL("CREATE ROLE {} NOLOGIN NOINHERIT").format(sql.Identifier(names["bystander"])),
+    )
+    query(
+        creator,
+        sql.SQL("GRANT {} TO {} WITH ADMIN TRUE, INHERIT FALSE, SET FALSE").format(
+            sql.Identifier(names["publisher"]), sql.Identifier(names["bystander"])
+        ),
+    )
+    rejected(creator, for_publisher(ROLE_071, names["publisher"]))
+    rejected(creator, for_publisher(DEPENDENCIES_072, names["publisher"]))
+
+    inherited_role = names["inherited"]
+    query(creator, for_publisher(ROLE_071, inherited_role))
+    query(
+        admin,
+        sql.SQL("GRANT {} TO {} WITH ADMIN TRUE, INHERIT TRUE, SET FALSE").format(
+            sql.Identifier(inherited_role), sql.Identifier(names["creator"])
+        ),
+    )
+    assert role_memberships(creator, inherited_role) == bootstrap_creator_edge(
+        creator, inherited_role, names["creator"], inherit=True
+    )
+    rejected(creator, for_publisher(ROLE_071, inherited_role))
+    rejected(creator, for_publisher(DEPENDENCIES_072, inherited_role))
+
+    no_admin_role = names["noadmin"]
+    query(creator, for_publisher(ROLE_071, no_admin_role))
+    query(
+        admin,
+        sql.SQL("GRANT {} TO {} WITH ADMIN FALSE, INHERIT FALSE, SET FALSE").format(
+            sql.Identifier(no_admin_role), sql.Identifier(names["creator"])
+        ),
+    )
+    assert role_memberships(creator, no_admin_role) == bootstrap_creator_edge(
+        creator, no_admin_role, names["creator"], admin=False
+    )
+    rejected(creator, for_publisher(ROLE_071, no_admin_role))
+    rejected(creator, for_publisher(DEPENDENCIES_072, no_admin_role))
+
+    set_exact_role = names["setexact"]
+    query(creator, for_publisher(ROLE_071, set_exact_role))
+    query(
+        admin,
+        sql.SQL("GRANT {} TO {} WITH ADMIN TRUE, INHERIT FALSE, SET TRUE").format(
+            sql.Identifier(set_exact_role), sql.Identifier(names["creator"])
+        ),
+    )
+    assert role_memberships(creator, set_exact_role) == bootstrap_creator_edge(
+        creator, set_exact_role, names["creator"], set_option=True
+    )
+    rejected(creator, for_publisher(ROLE_071, set_exact_role))
+    rejected(creator, for_publisher(DEPENDENCIES_072, set_exact_role))


### PR DESCRIPTION
PostgreSQL 17 gives a non-superuser role creator an administration-only membership that migration 072 previously rejected. Permit only the current migration owner's ADMIN-only edge in 070/071/072, validate newly created roles immediately, and keep unrelated, outbound and activated memberships rejected. The production ledger was rechecked and still contains only the adoption root, so these pending migrations can be corrected before their first application.

Add explicit workflow-dispatch actions for managed production plan, upgrade and status. Each uses the fixed production manifest and step-scoped WAREHOUSE_DB_URL. Incompatible inputs and pushed managed manifests fail closed; the post-upgrade status step observes the ledger without retrying or masking a failed upgrade. The rollout guide covers locking, ambiguous commit outcomes and runtime role activation.

Validation: 4 focused SQL tests using real non-superuser PostgreSQL 17 connections; 175 migration, publication and freshness SQL regressions; 140 deployment/bootstrap CLI tests; 77 bootstrap/manifest unit tests (overlap with the CLI group); Ruff and formatting; YAML and Bash syntax; the exact managed workflow shell exercised with 3 valid actions and 10 invalid/injection inputs while database execution was stubbed. Independent review has no remaining correctness or access findings. The new role suite is mandatory in the existing PostgreSQL 17 CI job.

Production schema and runtime settings remain unchanged. Exact full-chain execution with Supabase's event-trigger privileges remains a deployment verification step; the stock PostgreSQL fixture proves the non-superuser role paths separately from full-chain superuser execution.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62606720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

No blocking issue was established; the managed deployment path is ready to merge, while PostgreSQL 17 behavior still requires execution in a stock PostgreSQL 17 environment before production rollout.

What we checked:
- Ran the general-contract-validation-proof against pg17-creator-membership to validate local runtime, locate SQL guards, and capture the focused suite's four precondition errors, with the before state exiting code 0 and the after state exiting code 1. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Validated upgrade capture and environment behavior with the second general-contract-validation-proof, observing that managed_upgrade was unavailable before capture and that after capture all three actions invoked only the fixed manifest; shim output shows WAREHOUSE_DB_URL=true while SUPABASE_DB_URL, DATABASE_URL, and DESTINATION__POSTGRES__CREDENTIALS are absent, and the forced exit-23 upgrade occurs once with the harness asserting the post-upgrade status. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<h3>Summary</h3>

- PostgreSQL 17 creator-membership behavior could not run because no disposable PostgreSQL 17 database URL was available, local PostgreSQL server binaries were unavailable, and the available PostgreSQL configuration reports version 15.5 rather than stock PostgreSQL 17.

<sub>Reviews (1) · Last reviewed commit: ["Support PG17 role creators and managed p..."](https://github.com/rstover-fo/cfb-database/commit/a8fa7bcc274d69d903d320a248874dc35882f5fb)</sub>

<!-- /greptile_comment -->