### PR TITLE
Add checksum-pinned SDV FPI receipt canary

### DIFF
--- a/.github/workflows/flat-files.yml
+++ b/.github/workflows/flat-files.yml
@@ -23,6 +23,16 @@ on:
         required: false
         type: string
         default: ""
+      receipt_canary_action:
+        description: "Explicit FPI receipt canary action; none preserves the legacy loader"
+        required: false
+        type: string
+        default: "none"
+      receipt_expected_sha256:
+        description: "Required for a receipt canary; exact reviewed artifact SHA-256"
+        required: false
+        type: string
+        default: ""
     secrets:
       SUPABASE_DB_URL:
         required: true
@@ -46,6 +56,19 @@ on:
           request for a year a source hasn't published yet reports
           not_published (see probe_offseason_availability.py's distinction)
           and does not fail the run.
+        required: false
+        type: string
+      receipt_canary_action:
+        description: "Explicit FPI receipt canary action"
+        required: false
+        type: choice
+        default: "none"
+        options:
+          - none
+          - preflight
+          - publish
+      receipt_expected_sha256:
+        description: "Required for a receipt canary; exact reviewed artifact SHA-256"
         required: false
         type: string
 
@@ -83,6 +106,7 @@ jobs:
         run: echo "DESTINATION__POSTGRES__CREDENTIALS=$(printf '%s' "$SUPABASE_DB_URL" | sed 's/^postgresql:/postgres:/')" >> "$GITHUB_ENV"
       - name: Load flat-file sources
         id: load_flat_files
+        if: ${{ inputs.receipt_canary_action == 'none' }}
         # Hardening (PR #75 review finding C): route the workflow_dispatch
         # `source` input through a step-level env: var (probe-endpoints.yml's
         # pattern) instead of interpolating ${{ inputs.source }} directly
@@ -117,15 +141,30 @@ jobs:
           else
             python scripts/load_flat_files.py --due
           fi
+      - name: Run source receipt canary
+        id: receipt_canary
+        if: ${{ inputs.receipt_canary_action != 'none' }}
+        env:
+          RECEIPT_CANARY_ACTION: ${{ inputs.receipt_canary_action }}
+          RECEIPT_CANARY_SOURCE: ${{ inputs.source }}
+          RECEIPT_CANARY_SEASON: ${{ inputs.seasons }}
+          RECEIPT_EXPECTED_SHA256: ${{ inputs.receipt_expected_sha256 }}
+          RECEIPT_EXPECTED_PROJECT_REF: "ibobsbwlewpqslkqbrjd"
+        run: |
+          python scripts/run_source_receipt_canary.py "$RECEIPT_CANARY_ACTION" \
+            --source "$RECEIPT_CANARY_SOURCE" \
+            --season "$RECEIPT_CANARY_SEASON" \
+            --expected-sha256 "$RECEIPT_EXPECTED_SHA256" \
+            --expected-project-ref "$RECEIPT_EXPECTED_PROJECT_REF"
       - name: Refresh external-rating consumers
         # A failed multi-source load may still have committed new ratings.
         # Refresh those rows, but preserve the failed load/job status. Skip
         # cancellation and setup failures where the import step never ran.
-        if: ${{ !cancelled() && (steps.load_flat_files.outcome == 'success' || steps.load_flat_files.outcome == 'failure') }}
+        if: ${{ inputs.receipt_canary_action == 'none' && !cancelled() && (steps.load_flat_files.outcome == 'success' || steps.load_flat_files.outcome == 'failure') }}
         # Also retry after hash-skips or an empty due plan.
         run: python scripts/refresh_marts.py --views marts.epa_crossvalidation
       - name: Open or update failure issue
-        if: failure()
+        if: ${{ failure() && inputs.receipt_canary_action == 'none' }}
         uses: actions/github-script@v7
         with:
           script: |

--- a/scripts/run_source_receipt_canary.py
+++ b/scripts/run_source_receipt_canary.py
@@ -21,6 +21,7 @@ from datetime import date
 from pathlib import Path
 from typing import Any
 
+import httpx
 import psycopg2
 from psycopg2 import sql
 from psycopg2.extensions import parse_dsn
@@ -50,6 +51,14 @@ PRODUCTION_MANIFEST = ROOT / "src/schemas/production-manifest.json"
 
 class CanaryError(RuntimeError):
     """A known canary validation failure safe to report without a traceback."""
+
+
+class ArtifactFetchError(RuntimeError):
+    """A sanitized failure from the one bounded registered-artifact fetch."""
+
+    def __init__(self, **details: Any):
+        super().__init__("registered artifact fetch failed")
+        self.details = details
 
 
 @dataclass(frozen=True)
@@ -286,7 +295,30 @@ def _download_and_validate(source: str, season: int, expected_sha256: str) -> Ar
     url = resolve_fetch_url(spec, season)
     if url is None:
         raise CanaryError("registered canary source has no URL")
-    fetched: FetchedFile = fetch_file(url, timeout=30, retries=1)
+    try:
+        fetched: FetchedFile = fetch_file(url, timeout=30, retries=1)
+    except httpx.HTTPStatusError as error:
+        http_status = error.response.status_code
+        if http_status == 404:
+            raise ArtifactFetchError(
+                status="not_published",
+                outcome="deferred",
+                error_category="http_status",
+                http_status=http_status,
+            ) from None
+        raise ArtifactFetchError(
+            status="failed",
+            outcome="failed",
+            error_category="http_status",
+            http_status=http_status,
+        ) from None
+    except httpx.RequestError as error:
+        raise ArtifactFetchError(
+            status="failed",
+            outcome="failed",
+            error_category="transport",
+            transport_category=_transport_category(error),
+        ) from None
     computed_sha256 = hashlib.sha256(fetched.content).hexdigest()
     if fetched.sha256 != computed_sha256:
         raise CanaryError("fetcher SHA-256 does not match downloaded bytes")
@@ -371,18 +403,42 @@ def run_canary(args: argparse.Namespace) -> tuple[dict[str, Any], int]:
     return payload, 0
 
 
+def _failure_payload(args: argparse.Namespace, **details: Any) -> dict[str, Any]:
+    return {
+        "action": args.action,
+        "source": args.source,
+        "season": args.season,
+        **details,
+    }
+
+
+def _transport_category(error: httpx.RequestError) -> str:
+    if isinstance(error, httpx.TimeoutException):
+        return "timeout"
+    if isinstance(error, httpx.ProxyError):
+        return "proxy"
+    if isinstance(error, httpx.UnsupportedProtocol):
+        return "unsupported_protocol"
+    if isinstance(error, httpx.NetworkError):
+        return "network"
+    if isinstance(error, httpx.TooManyRedirects):
+        return "too_many_redirects"
+    return "request_error"
+
+
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     try:
         payload, status = run_canary(args)
+    except ArtifactFetchError as error:
+        payload = _failure_payload(args, **error.details)
+        status = 1
     except (CanaryError, publication.SourcePublicationError) as error:
-        payload = {
-            "action": args.action,
-            "source": args.source,
-            "season": args.season,
-            "status": "failed",
-            "error": str(error),
-        }
+        payload = _failure_payload(
+            args,
+            status="failed",
+            error=str(error),
+        )
         status = 1
     print(json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str))
     return status

--- a/scripts/run_source_receipt_canary.py
+++ b/scripts/run_source_receipt_canary.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""Run the explicitly selected FPI source-receipt canary.
+
+The canary is intentionally limited to one registered source and one explicit
+season.  Both modes inspect the actual publisher connection and validate the
+registered artifact.  ``publish`` additionally requires the runtime login to
+be able to assume the bounded publisher role, then publishes the already
+verified bytes through the normal receipt-backed adapter.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import tempfile
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import psycopg2
+from psycopg2 import sql
+from psycopg2.extensions import parse_dsn
+
+from src.pipelines.config.source_publication_assets import SDV_FPI_PUBLICATION
+from src.pipelines.sources.flat_files import (
+    REGISTRY,
+    ParseContext,
+    resolve_fetch_url,
+    resolve_parser,
+)
+from src.pipelines.utils import flat_file_publication as publication
+from src.pipelines.utils.file_fetcher import FetchedFile, fetch_file
+
+SOURCE = "sdv_fpi_weekly"
+PUBLISHER_ROLE = "warehouse_source_publisher"
+SHA256_RE = re.compile(r"[0-9a-f]{64}")
+PROJECT_REF_RE = re.compile(r"[a-z0-9]{20}")
+DIRECT_HOST_RE = re.compile(r"^db\.([a-z0-9]{20})\.supabase\.co$")
+POOLER_HOST_RE = re.compile(r"^[a-z0-9-]+(?:\.[a-z0-9-]+)*\.pooler\.supabase\.com$")
+POOLER_USER_RE = re.compile(r"^[^.]+\.([a-z0-9]{20})$")
+FORBIDDEN_DSN_ROUTING_PARAMETERS = frozenset({"hostaddr", "service", "servicefile"})
+FORBIDDEN_LIBPQ_ROUTING_ENV = ("PGHOSTADDR", "PGSERVICE", "PGSERVICEFILE")
+ROOT = Path(__file__).resolve().parents[1]
+PRODUCTION_MANIFEST = ROOT / "src/schemas/production-manifest.json"
+
+
+class CanaryError(RuntimeError):
+    """A known canary validation failure safe to report without a traceback."""
+
+
+@dataclass(frozen=True)
+class Artifact:
+    content: bytes
+    sha256: str
+    rows: int
+    weeks: tuple[int, ...]
+
+    def evidence(self) -> dict[str, Any]:
+        return {
+            "sha256": self.sha256,
+            "rows": self.rows,
+            "weeks": list(self.weeks),
+        }
+
+
+def _sha256(value: str) -> str:
+    if SHA256_RE.fullmatch(value) is None:
+        raise argparse.ArgumentTypeError("must be exactly 64 lowercase hexadecimal characters")
+    return value
+
+
+def _project_ref(value: str) -> str:
+    if PROJECT_REF_RE.fullmatch(value) is None:
+        raise argparse.ArgumentTypeError("must be a 20-character lowercase project reference")
+    return value
+
+
+def _season(value: str) -> int:
+    try:
+        season = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("must be one integer season") from error
+    try:
+        SDV_FPI_PUBLICATION.coverage_key(season)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(str(error)) from error
+    return season
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate or publish one checksum-pinned SDV FPI season receipt"
+    )
+    parser.add_argument("action", choices=("preflight", "publish"))
+    parser.add_argument("--source", choices=(SOURCE,), required=True)
+    parser.add_argument("--season", type=_season, required=True)
+    parser.add_argument("--expected-sha256", type=_sha256, required=True)
+    parser.add_argument("--expected-project-ref", type=_project_ref, required=True)
+    return parser
+
+
+def _expected_migrations() -> tuple[tuple[str, str, str, str, int], ...]:
+    manifest = json.loads(PRODUCTION_MANIFEST.read_text())
+    expected = []
+    for order, entry in enumerate(manifest["migrations"], start=1):
+        path = ROOT / entry["path"]
+        expected.append(
+            (
+                entry["id"],
+                entry["path"],
+                entry["kind"],
+                hashlib.sha256(path.read_bytes()).hexdigest(),
+                order,
+            )
+        )
+    return tuple(expected)
+
+
+def _dsn_project_evidence(dsn: str, expected_project_ref: str) -> list[str]:
+    ambient_routing = [name for name in FORBIDDEN_LIBPQ_ROUTING_ENV if os.environ.get(name)]
+    if ambient_routing:
+        raise CanaryError(
+            "ambient libpq routing overrides are forbidden: " + ", ".join(ambient_routing)
+        )
+    try:
+        parameters = parse_dsn(dsn)
+    except psycopg2.Error as error:
+        raise CanaryError(
+            f"database connection configuration is invalid "
+            f"(type={type(error).__name__}, code={error.pgcode or 'none'})"
+        ) from None
+
+    explicit_routing = sorted(FORBIDDEN_DSN_ROUTING_PARAMETERS.intersection(parameters))
+    if explicit_routing:
+        raise CanaryError(
+            "database connection contains forbidden routing parameters: "
+            + ", ".join(explicit_routing)
+        )
+
+    host = parameters.get("host", "")
+    user = parameters.get("user", "")
+    evidence = []
+    host_match = DIRECT_HOST_RE.fullmatch(host)
+    user_match = POOLER_USER_RE.fullmatch(user)
+    if host_match:
+        if host_match.group(1) != expected_project_ref:
+            raise CanaryError("database connection identifies a different Supabase project")
+        if user_match and user_match.group(1) != expected_project_ref:
+            raise CanaryError("database host and username identify different Supabase projects")
+        evidence.append("direct_host_project_ref")
+    elif POOLER_HOST_RE.fullmatch(host):
+        if user_match is None or user_match.group(1) != expected_project_ref:
+            raise CanaryError("database pooler connection does not identify the expected project")
+        evidence.append("pooler_user_project_ref")
+    else:
+        raise CanaryError("database connection does not identify the expected Supabase project")
+    return evidence
+
+
+def _inspect_target(
+    dsn: str,
+    expected_project_ref: str,
+    source: str,
+    season: int,
+    *,
+    connector=psycopg2.connect,
+) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    """Validate target identity and source plan in a read-only transaction."""
+    project_evidence = _dsn_project_evidence(dsn, expected_project_ref)
+    expected_migrations = _expected_migrations()
+    expected_by_id = {row[0]: row for row in expected_migrations}
+
+    try:
+        conn = connector(dsn, connect_timeout=10, application_name="source-receipt-canary")
+        try:
+            conn.set_session(readonly=True, autocommit=False)
+            with conn.cursor() as cur:
+                cur.execute("SET LOCAL statement_timeout = '15s'")
+                cur.execute("SET LOCAL lock_timeout = '5s'")
+                cur.execute(
+                    """
+                    SELECT current_database()::text, current_user::text, session_user::text,
+                           pg_catalog.pg_has_role(
+                               session_user, 'warehouse_source_publisher', 'SET'
+                           )
+                    """
+                )
+                identity_row = cur.fetchone()
+                if identity_row is None or len(identity_row) != 4:
+                    raise CanaryError("database returned incomplete runtime identity")
+                database, current_user, session_user, can_set_role = identity_row
+                if type(can_set_role) is not bool:
+                    raise CanaryError("database returned invalid role activation evidence")
+
+                cur.execute(
+                    """
+                    SELECT migration_id, path, kind, checksum, manifest_order
+                    FROM warehouse_control.schema_migrations
+                    ORDER BY manifest_order
+                    """
+                )
+                actual_migrations = tuple(cur.fetchall())
+                if actual_migrations != expected_migrations:
+                    actual_by_id = {row[0]: row for row in actual_migrations}
+                    expected_ids = set(expected_by_id)
+                    actual_ids = set(actual_by_id)
+                    missing = sorted(expected_ids - actual_ids)
+                    unexpected = sorted(actual_ids - expected_ids)
+                    changed = sorted(
+                        migration_id
+                        for migration_id, expected in expected_by_id.items()
+                        if migration_id in actual_by_id and actual_by_id[migration_id] != expected
+                    )
+                    differences = []
+                    if missing:
+                        differences.append("missing=" + ",".join(missing))
+                    if changed:
+                        differences.append("changed=" + ",".join(changed))
+                    if unexpected:
+                        differences.append("unexpected=" + ",".join(unexpected))
+                    raise CanaryError(
+                        "production migration ledger does not exactly match reviewed manifest: "
+                        + "; ".join(differences)
+                    )
+
+                plan = None
+                assumed_role = None
+                if can_set_role:
+                    cur.execute(sql.SQL("SET LOCAL ROLE {}").format(sql.Identifier(PUBLISHER_ROLE)))
+                    cur.execute("SELECT current_user::text")
+                    role_row = cur.fetchone()
+                    assumed_role = role_row[0] if role_row else None
+                    if assumed_role != PUBLISHER_ROLE:
+                        raise CanaryError("database did not assume the bounded publisher role")
+                    cur.execute(
+                        "SELECT warehouse_source_batch.get_source_plan(%s,%s)",
+                        (source, season),
+                    )
+                    plan_row = cur.fetchone()
+                    if plan_row is None:
+                        raise CanaryError("bounded publisher returned no source plan")
+                    plan = publication._validated_plan(plan_row[0], SDV_FPI_PUBLICATION, season)
+            conn.rollback()
+        except BaseException:
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+            raise
+        finally:
+            conn.close()
+    except CanaryError:
+        raise
+    except psycopg2.Error as error:
+        raise CanaryError(
+            f"database inspection failed "
+            f"(type={type(error).__name__}, code={error.pgcode or 'none'})"
+        ) from None
+
+    identity = {
+        "expected_project_ref": expected_project_ref,
+        "project_ref_evidence": project_evidence,
+        "database": database,
+        "current_user": current_user,
+        "session_user": session_user,
+        "can_set_role": can_set_role,
+        "assumed_role": assumed_role,
+        "activation_required": not can_set_role,
+        "migration_ledger": {
+            "verified": True,
+            "entries": [
+                {"id": migration_id, "checksum": checksum}
+                for migration_id, _, _, checksum, _ in expected_migrations
+            ],
+        },
+    }
+    return identity, plan
+
+
+def _download_and_validate(source: str, season: int, expected_sha256: str) -> Artifact:
+    spec = REGISTRY[source]
+    url = resolve_fetch_url(spec, season)
+    if url is None:
+        raise CanaryError("registered canary source has no URL")
+    fetched: FetchedFile = fetch_file(url, timeout=30, retries=1)
+    computed_sha256 = hashlib.sha256(fetched.content).hexdigest()
+    if fetched.sha256 != computed_sha256:
+        raise CanaryError("fetcher SHA-256 does not match downloaded bytes")
+    if computed_sha256 != expected_sha256:
+        raise CanaryError(
+            f"artifact SHA-256 mismatch: expected {expected_sha256}, got {computed_sha256}"
+        )
+
+    context = ParseContext(
+        source=source,
+        snapshot_date=date.today(),
+        season=season,
+        source_url=fetched.source_url,
+        file_name=os.path.basename(fetched.source_url),
+    )
+    raw_count = publication._raw_row_count(fetched.content, SDV_FPI_PUBLICATION, season)
+    rows = list(resolve_parser(spec.parser)(fetched.content, context))
+    publication._validate_parsed_rows(rows, raw_count, SDV_FPI_PUBLICATION, season)
+    weeks = tuple(sorted({row["week"] for row in rows}))
+    return Artifact(fetched.content, computed_sha256, len(rows), weeks)
+
+
+def _publish_pinned(
+    dsn: str,
+    source: str,
+    season: int,
+    artifact: Artifact,
+) -> dict[str, Any]:
+    """Publish once from a temporary copy of the already verified bytes."""
+    original_get_db_url = publication.get_db_url
+    try:
+        publication.get_db_url = lambda: dsn
+        with tempfile.TemporaryDirectory(prefix="sdv-fpi-receipt-canary-") as directory:
+            path = Path(directory) / f"cfb_fpi_weekly_{season}.parquet"
+            path.write_bytes(artifact.content)
+            result = publication.run_source_publication(
+                REGISTRY[source], file_path=str(path), season=season
+            )
+    finally:
+        publication.get_db_url = original_get_db_url
+    return result
+
+
+def run_canary(args: argparse.Namespace) -> tuple[dict[str, Any], int]:
+    dsn = publication.get_db_url()
+    identity, plan = _inspect_target(
+        dsn,
+        args.expected_project_ref,
+        args.source,
+        args.season,
+    )
+    if args.action == "publish" and not identity["can_set_role"]:
+        raise CanaryError("publisher role activation is required before publish")
+
+    artifact = _download_and_validate(args.source, args.season, args.expected_sha256)
+    payload: dict[str, Any] = {
+        "action": args.action,
+        "source": args.source,
+        "season": args.season,
+        "identity": identity,
+        "source_plan": plan,
+        "artifact": artifact.evidence(),
+    }
+    if args.action == "preflight":
+        payload["status"] = "ready" if plan is not None else "activation_required"
+        return payload, 0
+
+    result = _publish_pinned(dsn, args.source, args.season, artifact)
+    payload["publication"] = result
+    if result.get("status") != "loaded":
+        payload["status"] = "failed"
+        return payload, 1
+    if (
+        result.get("sha") != artifact.sha256
+        or result.get("rows") != artifact.rows
+        or not result.get("run_id")
+        or not result.get("generation_id")
+    ):
+        payload["status"] = "failed_result_validation"
+        return payload, 1
+    payload["status"] = "loaded"
+    return payload, 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        payload, status = run_canary(args)
+    except (CanaryError, publication.SourcePublicationError) as error:
+        payload = {
+            "action": args.action,
+            "source": args.source,
+            "season": args.season,
+            "status": "failed",
+            "error": str(error),
+        }
+        status = 1
+    print(json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str))
+    return status
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_f10_flat_file_workflow.py
+++ b/tests/test_f10_flat_file_workflow.py
@@ -24,6 +24,18 @@ def test_flat_file_workflow_is_reusable_and_keeps_manual_backfills():
         assert triggers["workflow_call"]["inputs"][name]["type"] == "string"
         assert triggers["workflow_call"]["inputs"][name]["default"] == ""
         assert triggers["workflow_dispatch"]["inputs"][name]["required"] is False
+    assert triggers["workflow_call"]["inputs"]["receipt_canary_action"] == {
+        "description": "Explicit FPI receipt canary action; none preserves the legacy loader",
+        "required": False,
+        "type": "string",
+        "default": "none",
+    }
+    assert triggers["workflow_call"]["inputs"]["receipt_expected_sha256"]["default"] == ""
+    dispatch_canary = triggers["workflow_dispatch"]["inputs"]["receipt_canary_action"]
+    assert dispatch_canary["type"] == "choice"
+    assert dispatch_canary["default"] == "none"
+    assert dispatch_canary["options"] == ["none", "preflight", "publish"]
+    assert triggers["workflow_dispatch"]["inputs"]["receipt_expected_sha256"]["type"] == ("string")
     assert triggers["workflow_call"]["secrets"]["SUPABASE_DB_URL"]["required"] is True
     # The caller owns daily-season-load for its entire run; reusing that group
     # here would make the called workflow wait for its own parent to finish.
@@ -70,6 +82,80 @@ def test_workflow_propagates_failures(tmp_path, failed_script):
         assert calls[-1][0] == "scripts/refresh_marts.py"
 
 
+@pytest.mark.parametrize("action", ["preflight", "publish"])
+def test_receipt_canary_routes_every_input_as_one_quoted_argument(tmp_path, action):
+    calls_path = tmp_path / "calls.jsonl"
+    fake_python = tmp_path / "python"
+    fake_python.write_text(
+        f"#!{sys.executable}\n"
+        "import json, os, sys\n"
+        "with open(os.environ['TEST_CALLS'], 'a') as log:\n"
+        "    log.write(json.dumps(sys.argv[1:]) + '\\n')\n"
+    )
+    fake_python.chmod(0o755)
+    canary_step = next(
+        step
+        for step in workflow()["jobs"]["load"]["steps"]
+        if step.get("name") == "Run source receipt canary"
+    )
+    source = "sdv_fpi_weekly --source injected"
+    season = "2026 2025"
+    sha = "a" * 64 + "; touch never"
+    env = {
+        **os.environ,
+        "PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}",
+        "TEST_CALLS": str(calls_path),
+        "RECEIPT_CANARY_ACTION": action,
+        "RECEIPT_CANARY_SOURCE": source,
+        "RECEIPT_CANARY_SEASON": season,
+        "RECEIPT_EXPECTED_SHA256": sha,
+        "RECEIPT_EXPECTED_PROJECT_REF": "ibobsbwlewpqslkqbrjd",
+    }
+    result = subprocess.run(
+        ["bash", "--noprofile", "--norc", "-eo", "pipefail", "-c", canary_step["run"]],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert [json.loads(line) for line in calls_path.read_text().splitlines()] == [
+        [
+            "scripts/run_source_receipt_canary.py",
+            action,
+            "--source",
+            source,
+            "--season",
+            season,
+            "--expected-sha256",
+            sha,
+            "--expected-project-ref",
+            "ibobsbwlewpqslkqbrjd",
+        ]
+    ]
+    assert "${{" not in canary_step["run"]
+
+
+def test_canary_is_excluded_from_legacy_refresh_and_failure_issue():
+    steps = workflow()["jobs"]["load"]["steps"]
+    by_name = {step.get("name"): step for step in steps}
+    assert by_name["Load flat-file sources"]["if"] == (
+        "${{ inputs.receipt_canary_action == 'none' }}"
+    )
+    assert by_name["Run source receipt canary"]["if"] == (
+        "${{ inputs.receipt_canary_action != 'none' }}"
+    )
+    assert by_name["Refresh external-rating consumers"]["if"] == (
+        "${{ inputs.receipt_canary_action == 'none' && !cancelled() && "
+        "(steps.load_flat_files.outcome == 'success' || "
+        "steps.load_flat_files.outcome == 'failure') }}"
+    )
+    assert by_name["Open or update failure issue"]["if"] == (
+        "${{ failure() && inputs.receipt_canary_action == 'none' }}"
+    )
+
+
 def run_steps(tmp_path, sources, seasons, failed_script=""):
     """Run completed import and refresh commands while preserving failed status."""
     calls_path = tmp_path / "calls.jsonl"
@@ -93,10 +179,11 @@ def run_steps(tmp_path, sources, seasons, failed_script=""):
         "Refresh external-rating consumers",
     ]
     assert selected[0]["id"] == "load_flat_files"
-    assert "if" not in selected[0]
+    assert selected[0]["if"] == "${{ inputs.receipt_canary_action == 'none' }}"
     assert selected[1]["if"] == (
-        "${{ !cancelled() && (steps.load_flat_files.outcome == 'success' "
-        "|| steps.load_flat_files.outcome == 'failure') }}"
+        "${{ inputs.receipt_canary_action == 'none' && !cancelled() && "
+        "(steps.load_flat_files.outcome == 'success' || "
+        "steps.load_flat_files.outcome == 'failure') }}"
     )
     # Refresh can recover committed rows after a partial import failure, but
     # neither step may mask a failure from the reusable job's caller.

--- a/tests/test_source_receipt_canary.py
+++ b/tests/test_source_receipt_canary.py
@@ -1,0 +1,496 @@
+"""Unit coverage for the explicit SDV FPI receipt canary."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+from pathlib import Path
+
+import psycopg2
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from scripts import run_source_receipt_canary as canary
+from src.pipelines.utils.file_fetcher import FetchedFile
+
+PROJECT_REF = "ibobsbwlewpqslkqbrjd"
+EXPECTED_SHA = "a" * 64
+
+
+def args(action="preflight"):
+    return argparse.Namespace(
+        action=action,
+        source="sdv_fpi_weekly",
+        season=2026,
+        expected_sha256=EXPECTED_SHA,
+        expected_project_ref=PROJECT_REF,
+    )
+
+
+def source_plan():
+    return {
+        "protocol": "sdv-season-file-v1",
+        "source_name": "sdv_fpi_weekly",
+        "asset_key": "ratings.espn_fpi_weekly",
+        "coverage_key": "season:2026",
+        "season": 2026,
+        "expected_generation_id": None,
+        "parser_contract": "sdv-fpi-v1",
+    }
+
+
+class FakeCursor:
+    def __init__(self, *, can_set_role, migrations=None):
+        self.can_set_role = can_set_role
+        self.migrations = migrations
+        self.statement = ""
+        self.calls = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *unused):
+        return False
+
+    def execute(self, statement, parameters=None):
+        self.statement = str(statement)
+        self.calls.append((self.statement, parameters))
+
+    def fetchone(self):
+        if "current_database()" in self.statement:
+            return ("postgres", "runtime_login", "runtime_login", self.can_set_role)
+        if "SELECT current_user::text" in self.statement:
+            return (canary.PUBLISHER_ROLE,)
+        if "get_source_plan" in self.statement:
+            return (source_plan(),)
+        raise AssertionError(f"unexpected fetchone for {self.statement}")
+
+    def fetchall(self):
+        if "warehouse_control.schema_migrations" in self.statement:
+            return list(self.migrations or canary._expected_migrations())
+        raise AssertionError(f"unexpected fetchall for {self.statement}")
+
+
+class FakeConnection:
+    def __init__(self, *, can_set_role, migrations=None):
+        self.cursor_object = FakeCursor(can_set_role=can_set_role, migrations=migrations)
+        self.session_calls = []
+        self.rollbacks = 0
+        self.commits = 0
+        self.closed = False
+
+    def set_session(self, **kwargs):
+        self.session_calls.append(kwargs)
+
+    def cursor(self):
+        return self.cursor_object
+
+    def rollback(self):
+        self.rollbacks += 1
+
+    def commit(self):
+        self.commits += 1
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.mark.parametrize(
+    "dsn,evidence",
+    [
+        (
+            f"postgresql://postgres:secret@db.{PROJECT_REF}.supabase.co/postgres",
+            ["direct_host_project_ref"],
+        ),
+        (
+            f"postgresql://postgres.{PROJECT_REF}:secret@aws-0-us-east-1.pooler.supabase.com/postgres",
+            ["pooler_user_project_ref"],
+        ),
+    ],
+)
+def test_read_only_inspection_verifies_runtime_target_and_bounded_plan(dsn, evidence):
+    connection = FakeConnection(can_set_role=True)
+    connect_calls = []
+
+    def connect(*values, **options):
+        connect_calls.append((values, options))
+        return connection
+
+    identity, plan = canary._inspect_target(
+        dsn,
+        PROJECT_REF,
+        "sdv_fpi_weekly",
+        2026,
+        connector=connect,
+    )
+
+    assert connect_calls == [
+        ((dsn,), {"connect_timeout": 10, "application_name": "source-receipt-canary"})
+    ]
+    assert connection.session_calls == [{"readonly": True, "autocommit": False}]
+    assert connection.commits == 0
+    assert connection.rollbacks == 1
+    assert connection.closed is True
+    assert identity["project_ref_evidence"] == evidence
+    assert identity["database"] == "postgres"
+    assert identity["current_user"] == identity["session_user"] == "runtime_login"
+    assert identity["can_set_role"] is True
+    assert identity["assumed_role"] == canary.PUBLISHER_ROLE
+    assert identity["activation_required"] is False
+    assert identity["migration_ledger"]["verified"] is True
+    assert [entry["id"] for entry in identity["migration_ledger"]["entries"]] == [
+        row[0] for row in canary._expected_migrations()
+    ]
+    assert plan == source_plan()
+    statements = [statement for statement, _ in connection.cursor_object.calls]
+    assert any("SET LOCAL ROLE" in statement for statement in statements)
+    assert any("get_source_plan" in statement for statement in statements)
+    ledger_statement, ledger_parameters = next(
+        call
+        for call in connection.cursor_object.calls
+        if "warehouse_control.schema_migrations" in call[0]
+    )
+    assert "WHERE" not in ledger_statement
+    assert ledger_parameters is None
+
+
+def test_preflight_accepts_unactivated_login_without_attempting_set_role():
+    dsn = f"postgresql://postgres.{PROJECT_REF}:secret@aws-0-us-east-1.pooler.supabase.com/postgres"
+    connection = FakeConnection(can_set_role=False)
+    identity, plan = canary._inspect_target(
+        dsn,
+        PROJECT_REF,
+        "sdv_fpi_weekly",
+        2026,
+        connector=lambda *args, **kwargs: connection,
+    )
+
+    assert plan is None
+    assert identity["activation_required"] is True
+    assert connection.commits == 0
+    statements = [statement for statement, _ in connection.cursor_object.calls]
+    assert not any("SET LOCAL ROLE" in statement for statement in statements)
+    assert not any("get_source_plan" in statement for statement in statements)
+
+
+@pytest.mark.parametrize(
+    "dsn,message",
+    [
+        (
+            f"postgresql://postgres.{PROJECT_REF}:secret@db."
+            "aaaaaaaaaaaaaaaaaaaa.supabase.co/postgres",
+            "different Supabase project",
+        ),
+        (
+            f"postgresql://postgres.aaaaaaaaaaaaaaaaaaaa:secret@db.{PROJECT_REF}."
+            "supabase.co/postgres",
+            "host and username identify different Supabase projects",
+        ),
+        (
+            f"postgresql://postgres.{PROJECT_REF}:secret@pooler.example/postgres",
+            "does not identify the expected Supabase project",
+        ),
+    ],
+)
+def test_project_identity_rejects_conflicting_or_unrecognized_dsn(dsn, message):
+    with pytest.raises(canary.CanaryError, match=message):
+        canary._inspect_target(
+            dsn,
+            PROJECT_REF,
+            "sdv_fpi_weekly",
+            2026,
+            connector=lambda *args, **kwargs: pytest.fail("invalid target must not connect"),
+        )
+
+
+def test_project_identity_rejects_explicit_hostaddr_before_connect():
+    dsn = (
+        f"postgresql://postgres.{PROJECT_REF}:secret@"
+        "aws-0-us-east-1.pooler.supabase.com/postgres?hostaddr=192.0.2.10"
+    )
+    with pytest.raises(canary.CanaryError, match="forbidden routing parameters: hostaddr"):
+        canary._inspect_target(
+            dsn,
+            PROJECT_REF,
+            "sdv_fpi_weekly",
+            2026,
+            connector=lambda *args, **kwargs: pytest.fail("hostaddr must fail before connect"),
+        )
+
+
+@pytest.mark.parametrize("variable", ["PGHOSTADDR", "PGSERVICE", "PGSERVICEFILE"])
+def test_project_identity_rejects_ambient_libpq_routing_before_connect(monkeypatch, variable):
+    dsn = f"postgresql://postgres.{PROJECT_REF}:secret@aws-0-us-east-1.pooler.supabase.com/postgres"
+    monkeypatch.setenv(variable, "untrusted-routing-value")
+    with pytest.raises(canary.CanaryError, match=variable):
+        canary._inspect_target(
+            dsn,
+            PROJECT_REF,
+            "sdv_fpi_weekly",
+            2026,
+            connector=lambda *args, **kwargs: pytest.fail(
+                "ambient routing must fail before connect"
+            ),
+        )
+
+
+def test_target_inspection_rejects_unexpected_applied_migration():
+    dsn = f"postgresql://postgres.{PROJECT_REF}:secret@aws-0-us-east-1.pooler.supabase.com/postgres"
+    migrations = (
+        *canary._expected_migrations(),
+        ("warehouse.future.074", "future.sql", "immutable", "f" * 64, 10),
+    )
+    connection = FakeConnection(can_set_role=False, migrations=migrations)
+
+    with pytest.raises(canary.CanaryError, match=r"unexpected=warehouse\.future\.074"):
+        canary._inspect_target(
+            dsn,
+            PROJECT_REF,
+            "sdv_fpi_weekly",
+            2026,
+            connector=lambda *args, **kwargs: connection,
+        )
+
+
+def test_connection_errors_report_only_type_and_code():
+    dsn = f"postgresql://postgres.{PROJECT_REF}:secret@aws-0-us-east-1.pooler.supabase.com/postgres"
+
+    def fail_connect(*args, **kwargs):
+        raise psycopg2.OperationalError("password=do-not-print host=private-host")
+
+    with pytest.raises(canary.CanaryError) as raised:
+        canary._inspect_target(
+            dsn,
+            PROJECT_REF,
+            "sdv_fpi_weekly",
+            2026,
+            connector=fail_connect,
+        )
+
+    assert str(raised.value) == ("database inspection failed (type=OperationalError, code=none)")
+
+
+def test_preflight_validates_artifact_without_publication(monkeypatch):
+    identity = {"can_set_role": False, "activation_required": True}
+    artifact = canary.Artifact(b"pinned", EXPECTED_SHA, 2, (0, 1))
+    monkeypatch.setattr(canary.publication, "get_db_url", lambda: "dsn")
+    monkeypatch.setattr(canary, "_inspect_target", lambda *values: (identity, None))
+    monkeypatch.setattr(canary, "_download_and_validate", lambda *values: artifact)
+    monkeypatch.setattr(
+        canary,
+        "_publish_pinned",
+        lambda *values: pytest.fail("preflight must never publish"),
+    )
+
+    payload, status = canary.run_canary(args())
+
+    assert status == 0
+    assert payload["status"] == "activation_required"
+    assert payload["artifact"] == {"sha256": EXPECTED_SHA, "rows": 2, "weeks": [0, 1]}
+
+
+def test_publish_requires_activation_before_fetch_or_publication(monkeypatch):
+    monkeypatch.setattr(canary.publication, "get_db_url", lambda: "dsn")
+    monkeypatch.setattr(
+        canary,
+        "_inspect_target",
+        lambda *values: ({"can_set_role": False, "activation_required": True}, None),
+    )
+    monkeypatch.setattr(
+        canary,
+        "_download_and_validate",
+        lambda *values: pytest.fail("inactive publisher must not fetch"),
+    )
+    monkeypatch.setattr(
+        canary,
+        "_publish_pinned",
+        lambda *values: pytest.fail("inactive publisher must not publish"),
+    )
+
+    with pytest.raises(canary.CanaryError, match="activation is required"):
+        canary.run_canary(args("publish"))
+
+
+def test_wrong_sha_stops_before_parser_and_publication(monkeypatch):
+    calls = []
+    raw = b"changed upstream bytes"
+    actual_sha = hashlib.sha256(raw).hexdigest()
+
+    def fetch(url, *, timeout, retries):
+        calls.append((url, timeout, retries))
+        return FetchedFile(raw, actual_sha, url)
+
+    monkeypatch.setattr(canary, "fetch_file", fetch)
+    monkeypatch.setattr(
+        canary,
+        "resolve_parser",
+        lambda parser: pytest.fail("wrong SHA must not parse"),
+    )
+    with pytest.raises(canary.CanaryError, match="artifact SHA-256 mismatch"):
+        canary._download_and_validate("sdv_fpi_weekly", 2026, EXPECTED_SHA)
+
+    assert calls == [
+        (
+            "https://github.com/sportsdataverse/sportsdataverse-data/releases/download/"
+            "cfb_fpi_weekly/cfb_fpi_weekly_2026.parquet",
+            30,
+            1,
+        )
+    ]
+
+
+def _fpi_parquet_bytes() -> bytes:
+    fixture = Path(__file__).parent / "fixtures/flatfiles/sdv_fpi_weekly_sample.parquet"
+    schema = pq.read_schema(fixture)
+    rows = []
+    for week, team_id in ((0, 333), (1, 2483)):
+        row = {name: None for name in schema.names}
+        row.update(
+            season=2026,
+            season_type=2,
+            week=week,
+            team_id=team_id,
+            last_updated="2026-08-20T12:30:00Z",
+            run_date_time_key=20260820123000 + week,
+            snapshot_out_of_sequence=False,
+            snapshot_is_contemporaneous=True,
+            fpi=18.25 - week,
+        )
+        rows.append(row)
+    buffer = io.BytesIO()
+    pq.write_table(pa.Table.from_pylist(rows, schema=schema), buffer)
+    return buffer.getvalue()
+
+
+def test_download_uses_canonical_parser_and_reports_rows_and_weeks(monkeypatch):
+    raw = _fpi_parquet_bytes()
+    sha = hashlib.sha256(raw).hexdigest()
+    seen = []
+
+    def fetch(url, *, timeout, retries):
+        seen.append((url, timeout, retries))
+        return FetchedFile(raw, sha, url)
+
+    monkeypatch.setattr(canary, "fetch_file", fetch)
+    artifact = canary._download_and_validate("sdv_fpi_weekly", 2026, sha)
+
+    assert artifact.content == raw
+    assert artifact.sha256 == sha
+    assert artifact.rows == 2
+    assert artifact.weeks == (0, 1)
+    assert seen[0][1:] == (30, 1)
+
+
+def test_publish_pins_verified_bytes_uses_same_dsn_and_cleans_up(monkeypatch):
+    artifact = canary.Artifact(b"exact reviewed bytes", EXPECTED_SHA, 2, (0, 1))
+    observed = {}
+    original_resolver = canary.publication.get_db_url
+
+    def publish(spec, *, file_path, season):
+        path = Path(file_path)
+        observed.update(
+            source=spec.name,
+            season=season,
+            bytes=path.read_bytes(),
+            path=path,
+            dsn=canary.publication.get_db_url(),
+        )
+        return {
+            "status": "loaded",
+            "sha": EXPECTED_SHA,
+            "rows": 2,
+            "run_id": "run",
+            "generation_id": "generation",
+            "duration_s": 1.25,
+        }
+
+    monkeypatch.setattr(canary.publication, "run_source_publication", publish)
+    result = canary._publish_pinned("inspected-dsn", "sdv_fpi_weekly", 2026, artifact)
+
+    assert result["status"] == "loaded"
+    assert observed == {
+        "source": "sdv_fpi_weekly",
+        "season": 2026,
+        "bytes": b"exact reviewed bytes",
+        "path": observed["path"],
+        "dsn": "inspected-dsn",
+    }
+    assert observed["path"].exists() is False
+    assert canary.publication.get_db_url is original_resolver
+
+
+def test_failed_or_uncertain_publication_is_not_retried(monkeypatch):
+    artifact = canary.Artifact(b"pinned", EXPECTED_SHA, 2, (0, 1))
+    calls = []
+    monkeypatch.setattr(canary.publication, "get_db_url", lambda: "dsn")
+    monkeypatch.setattr(
+        canary,
+        "_inspect_target",
+        lambda *values: ({"can_set_role": True, "activation_required": False}, source_plan()),
+    )
+    monkeypatch.setattr(canary, "_download_and_validate", lambda *values: artifact)
+
+    def publish(*values):
+        calls.append(values)
+        return {
+            "status": "failed",
+            "error": "source publication RPC commit outcome is uncertain",
+            "run_id": "run",
+            "generation_id": "generation",
+            "sha": EXPECTED_SHA,
+            "rows": 0,
+            "duration_s": 0.5,
+        }
+
+    monkeypatch.setattr(canary, "_publish_pinned", publish)
+    payload, status = canary.run_canary(args("publish"))
+
+    assert status == 1
+    assert payload["status"] == "failed"
+    assert payload["publication"]["run_id"] == "run"
+    assert len(calls) == 1
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        [
+            "preflight",
+            "--source",
+            "sdv_ratings_weekly",
+            "--season",
+            "2026",
+            "--expected-sha256",
+            EXPECTED_SHA,
+            "--expected-project-ref",
+            PROJECT_REF,
+        ],
+        [
+            "preflight",
+            "--source",
+            "sdv_fpi_weekly",
+            "--season",
+            "2026 2025",
+            "--expected-sha256",
+            EXPECTED_SHA,
+            "--expected-project-ref",
+            PROJECT_REF,
+        ],
+        [
+            "publish",
+            "--source",
+            "sdv_fpi_weekly",
+            "--season",
+            "2026",
+            "--expected-sha256",
+            EXPECTED_SHA.upper(),
+            "--expected-project-ref",
+            PROJECT_REF,
+        ],
+    ],
+)
+def test_cli_rejects_any_source_set_season_set_or_unpinned_sha(argv):
+    with pytest.raises(SystemExit, match="2"):
+        canary.build_parser().parse_args(argv)

--- a/tests/test_source_receipt_canary.py
+++ b/tests/test_source_receipt_canary.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import argparse
 import hashlib
 import io
+import json
 from pathlib import Path
 
+import httpx
 import psycopg2
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -27,6 +29,20 @@ def args(action="preflight"):
         expected_sha256=EXPECTED_SHA,
         expected_project_ref=PROJECT_REF,
     )
+
+
+def cli_args(action):
+    return [
+        action,
+        "--source",
+        "sdv_fpi_weekly",
+        "--season",
+        "2026",
+        "--expected-sha256",
+        EXPECTED_SHA,
+        "--expected-project-ref",
+        PROJECT_REF,
+    ]
 
 
 def source_plan():
@@ -339,6 +355,157 @@ def test_wrong_sha_stops_before_parser_and_publication(monkeypatch):
             1,
         )
     ]
+
+
+@pytest.mark.parametrize("action", ["preflight", "publish"])
+@pytest.mark.parametrize(
+    "http_status,expected",
+    [
+        (
+            404,
+            {
+                "status": "not_published",
+                "outcome": "deferred",
+                "error_category": "http_status",
+                "http_status": 404,
+            },
+        ),
+        (
+            503,
+            {
+                "status": "failed",
+                "outcome": "failed",
+                "error_category": "http_status",
+                "http_status": 503,
+            },
+        ),
+    ],
+)
+def test_http_fetch_failures_are_sanitized_json_before_publication(
+    monkeypatch, capsys, action, http_status, expected
+):
+    calls = []
+    request = httpx.Request("GET", "https://user:secret@example.test/artifact?token=private")
+    response = httpx.Response(http_status, request=request)
+    failure = httpx.HTTPStatusError(
+        f"unsafe request detail token=private status={http_status}",
+        request=request,
+        response=response,
+    )
+    monkeypatch.setattr(canary.publication, "get_db_url", lambda: "dsn")
+    monkeypatch.setattr(
+        canary,
+        "_inspect_target",
+        lambda *values: ({"can_set_role": True, "activation_required": False}, source_plan()),
+    )
+
+    def fetch(url, *, timeout, retries):
+        calls.append((url, timeout, retries))
+        raise failure
+
+    monkeypatch.setattr(canary, "fetch_file", fetch)
+    monkeypatch.setattr(
+        canary,
+        "_publish_pinned",
+        lambda *values: pytest.fail("fetch failure must not start publication or records"),
+    )
+
+    status = canary.main(cli_args(action))
+    output = capsys.readouterr().out
+    payload = json.loads(output)
+
+    assert status == 1
+    assert payload == {
+        "action": action,
+        "season": 2026,
+        "source": "sdv_fpi_weekly",
+        **expected,
+    }
+    assert "secret" not in output
+    assert "private" not in output
+    assert calls == [
+        (
+            "https://github.com/sportsdataverse/sportsdataverse-data/releases/download/"
+            "cfb_fpi_weekly/cfb_fpi_weekly_2026.parquet",
+            30,
+            1,
+        )
+    ]
+
+
+@pytest.mark.parametrize("action", ["preflight", "publish"])
+@pytest.mark.parametrize(
+    "failure_type,transport_category",
+    [(httpx.ConnectError, "network"), (httpx.ReadTimeout, "timeout")],
+)
+def test_transport_fetch_failures_are_sanitized_json_before_publication(
+    monkeypatch, capsys, action, failure_type, transport_category
+):
+    calls = []
+    request = httpx.Request("GET", "https://user:secret@example.test/artifact?token=private")
+    failure = failure_type("unsafe transport detail token=private", request=request)
+    monkeypatch.setattr(canary.publication, "get_db_url", lambda: "dsn")
+    monkeypatch.setattr(
+        canary,
+        "_inspect_target",
+        lambda *values: ({"can_set_role": True, "activation_required": False}, source_plan()),
+    )
+
+    def fetch(url, *, timeout, retries):
+        calls.append((url, timeout, retries))
+        raise failure
+
+    monkeypatch.setattr(canary, "fetch_file", fetch)
+    monkeypatch.setattr(
+        canary,
+        "_publish_pinned",
+        lambda *values: pytest.fail("fetch failure must not start publication or records"),
+    )
+
+    status = canary.main(cli_args(action))
+    output = capsys.readouterr().out
+    payload = json.loads(output)
+
+    assert status == 1
+    assert payload == {
+        "action": action,
+        "error_category": "transport",
+        "outcome": "failed",
+        "season": 2026,
+        "source": "sdv_fpi_weekly",
+        "status": "failed",
+        "transport_category": transport_category,
+    }
+    assert "secret" not in output
+    assert "private" not in output
+    assert len(calls) == 1
+    assert calls[0][1:] == (30, 1)
+
+
+def test_main_preserves_unexpected_exception_visibility(monkeypatch):
+    monkeypatch.setattr(
+        canary,
+        "run_canary",
+        lambda selected: (_ for _ in ()).throw(RuntimeError("unexpected implementation bug")),
+    )
+    with pytest.raises(RuntimeError, match="unexpected implementation bug"):
+        canary.main(cli_args("preflight"))
+
+
+def test_main_does_not_misclassify_http_error_outside_artifact_fetch(monkeypatch):
+    request = httpx.Request("GET", "https://example.test/unrelated")
+    failure = httpx.HTTPStatusError(
+        "unexpected later HTTP error",
+        request=request,
+        response=httpx.Response(502, request=request),
+    )
+    monkeypatch.setattr(
+        canary,
+        "run_canary",
+        lambda selected: (_ for _ in ()).throw(failure),
+    )
+    with pytest.raises(httpx.HTTPStatusError, match="unexpected later HTTP error"):
+        canary.main(cli_args("publish"))
 
 
 def _fpi_parquet_bytes() -> bytes:


### PR DESCRIPTION
The flat-file workflow could only run legacy loads, so it could not perform an explicit receipt-backed canary using its existing database secret. This adds default-off `preflight` and `publish` actions for one SDV FPI source and one season, while preserving the normal loader, refresh, and failure-issue behavior.

The driver verifies the expected Supabase connection and entire production migration ledger, rejects libpq routing overrides, and requires an actual source-publisher role assumption before publication. It validates the registered artifact against an operator-supplied SHA256 and publishes a temporary copy of those exact bytes through the existing adapter. Canary results include the operation and generation IDs for reconciliation. Missing artifacts report a deferred result; HTTP and transport failures emit sanitized JSON with a nonzero exit before publication. The driver adds no runtime grants, retries of uncertain commits, downstream refreshes, or scheduling changes.

Validation: 41 focused canary/workflow tests and 131 existing loader/orchestration tests passed. Ruff, formatting, workflow YAML, Bash syntax, and diff checks passed. Independent review found no remaining correctness or access issues. Production catalog snapshots and detailed rollout evidence are retained locally and are not included in this PR.




<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62712150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge; no blocking issues remain.

<h3>Summary</h3>

- Separates preflight and publication modes from the legacy loader, refresh, and failure-issue paths.
- Verifies the Supabase target, migration ledger, publisher-role activation, source plan, artifact checksum, and parsed contents before publication.
- Converts expected artifact HTTP and transport failures into sanitized structured results.
- Adds focused workflow, identity, validation, publication, and failure-handling tests.

<sub>Reviews (2) · Last reviewed commit: ["Handle canary artifact fetch failures wi..."](https://github.com/rstover-fo/cfb-database/commit/1847cb4aa61d5e4338d0698b7814c9445712fbfa)</sub>

<!-- /greptile_comment -->