### PR TITLE
Schedule FPI receipt publication with scoped legacy exclusion

### DIFF
--- a/.github/workflows/backfill-sources.yml
+++ b/.github/workflows/backfill-sources.yml
@@ -64,6 +64,7 @@ on:
 # the same tables while the scheduled load is mid-run; it queues instead.
 concurrency:
   group: daily-season-load
+  queue: max # keep every pending shared writer while a long backfill holds the group
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/daily-load.yml
+++ b/.github/workflows/daily-load.yml
@@ -35,6 +35,7 @@ on:
 
 concurrency:
   group: daily-season-load
+  queue: max # keep every pending shared writer while a long run holds the group
   cancel-in-progress: false # never kill a mid-merge load; a queued run waits
 
 permissions:

--- a/.github/workflows/deploy-schema.yml
+++ b/.github/workflows/deploy-schema.yml
@@ -75,6 +75,7 @@ concurrency:
   # Recovery reads loaded inputs through several subprocesses. Serialize it
   # with ingestion and historical refresh for the whole run, not just dispatch.
   group: ${{ inputs.compute_script == 'recover_season_projections' && 'daily-season-load' || 'deploy-schema' }}
+  queue: max # preserve pending writers for whichever group this run selects
   cancel-in-progress: false # never kill a mid-deploy run; a queued run waits
 
 permissions:

--- a/.github/workflows/flat-files.yml
+++ b/.github/workflows/flat-files.yml
@@ -74,6 +74,7 @@ on:
 
 concurrency:
   group: flat-file-load
+  queue: max # preserve every pending flat-file writer instead of replacing one
   cancel-in-progress: false # never kill a mid-merge load; a queued run waits
 
 permissions:

--- a/.github/workflows/flat-files.yml
+++ b/.github/workflows/flat-files.yml
@@ -115,7 +115,12 @@ jobs:
         env:
           SOURCE_INPUT: ${{ inputs.source }}
           SEASONS_INPUT: ${{ inputs.seasons }}
+          SDV_FPI_RECEIPT_SEASON: ${{ vars.SDV_FPI_RECEIPT_SEASON }}
         run: |
+          due_exclusions=()
+          if [ "$SDV_FPI_RECEIPT_SEASON" = "2026" ]; then
+            due_exclusions+=(--exclude-source-season "sdv_fpi_weekly:2026")
+          fi
           if [ -n "$SEASONS_INPUT" ]; then
             # $SEASONS_INPUT is deliberately unquoted -- it is a
             # space-separated list of years and this loop relies on the
@@ -129,7 +134,7 @@ jobs:
                 # one becomes its own --source flag below.
                 python scripts/load_flat_files.py $(printf -- '--source %s ' $SOURCE_INPUT) --season "$season"
               else
-                python scripts/load_flat_files.py --due --season "$season"
+                python scripts/load_flat_files.py --due --season "$season" "${due_exclusions[@]}"
               fi
               echo "::endgroup::"
             done
@@ -139,7 +144,7 @@ jobs:
             # its own --source flag below.
             python scripts/load_flat_files.py $(printf -- '--source %s ' $SOURCE_INPUT)
           else
-            python scripts/load_flat_files.py --due
+            python scripts/load_flat_files.py --due "${due_exclusions[@]}"
           fi
       - name: Run source receipt canary
         id: receipt_canary

--- a/.github/workflows/historical-refresh.yml
+++ b/.github/workflows/historical-refresh.yml
@@ -67,6 +67,7 @@ on:
 
 concurrency:
   group: daily-season-load
+  queue: max # keep every pending shared writer while this long run holds the group
   cancel-in-progress: false # never kill a mid-merge load; this run waits its turn
 
 permissions:

--- a/.github/workflows/sdv-fpi-receipts.yml
+++ b/.github/workflows/sdv-fpi-receipts.yml
@@ -6,7 +6,10 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: flat-file-load
+  # Active receipt runs serialize outside the daily workflow, which owns this
+  # group while it calls the reusable flat-file workflow. Inactive runs are unique.
+  group: ${{ vars.SDV_FPI_RECEIPT_SEASON == '2026' && 'daily-season-load' || format('sdv-fpi-inactive-{0}', github.run_id) }}
+  queue: max
   cancel-in-progress: false
 
 permissions:
@@ -14,7 +17,6 @@ permissions:
 
 env:
   PYTHON_VERSION: "3.11"
-  SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
   SDV_FPI_RECEIPT_SEASON: ${{ vars.SDV_FPI_RECEIPT_SEASON }}
   EXPECTED_PROJECT_REF: "ibobsbwlewpqslkqbrjd"
 
@@ -24,6 +26,10 @@ jobs:
     if: ${{ vars.SDV_FPI_RECEIPT_SEASON == '2026' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    concurrency:
+      group: flat-file-load
+      queue: max
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -31,14 +37,16 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
       - run: pip install -e ".[flatfiles]"
-      - name: Set dlt destination credentials
-        run: echo "DESTINATION__POSTGRES__CREDENTIALS=$(printf '%s' "$SUPABASE_DB_URL" | sed 's/^postgresql:/postgres:/')" >> "$GITHUB_ENV"
       - name: Publish and verify FPI receipt
         id: publish_fpi
+        env:
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
         run: |
           python scripts/run_scheduled_fpi_receipts.py \
             --season "$SDV_FPI_RECEIPT_SEASON" \
             --expected-project-ref "$EXPECTED_PROJECT_REF"
       - name: Refresh external-rating consumers
         if: ${{ !cancelled() && steps.publish_fpi.outputs.publication_attempted == 'true' && (steps.publish_fpi.outcome == 'success' || steps.publish_fpi.outcome == 'failure') }}
+        env:
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
         run: python scripts/refresh_marts.py --views marts.epa_crossvalidation

--- a/.github/workflows/sdv-fpi-receipts.yml
+++ b/.github/workflows/sdv-fpi-receipts.yml
@@ -1,0 +1,44 @@
+name: SDV FPI Receipts
+
+on:
+  schedule:
+    - cron: "17 10 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: flat-file-load
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  PYTHON_VERSION: "3.11"
+  SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+  SDV_FPI_RECEIPT_SEASON: ${{ vars.SDV_FPI_RECEIPT_SEASON }}
+  EXPECTED_PROJECT_REF: "ibobsbwlewpqslkqbrjd"
+
+jobs:
+  publish:
+    name: Publish FPI receipt
+    if: ${{ vars.SDV_FPI_RECEIPT_SEASON == '2026' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+      - run: pip install -e ".[flatfiles]"
+      - name: Set dlt destination credentials
+        run: echo "DESTINATION__POSTGRES__CREDENTIALS=$(printf '%s' "$SUPABASE_DB_URL" | sed 's/^postgresql:/postgres:/')" >> "$GITHUB_ENV"
+      - name: Publish and verify FPI receipt
+        id: publish_fpi
+        run: |
+          python scripts/run_scheduled_fpi_receipts.py \
+            --season "$SDV_FPI_RECEIPT_SEASON" \
+            --expected-project-ref "$EXPECTED_PROJECT_REF"
+      - name: Refresh external-rating consumers
+        if: ${{ !cancelled() && steps.publish_fpi.outputs.publication_attempted == 'true' && (steps.publish_fpi.outcome == 'success' || steps.publish_fpi.outcome == 'failure') }}
+        run: python scripts/refresh_marts.py --views marts.epa_crossvalidation

--- a/docs/scheduled-fpi-receipts.md
+++ b/docs/scheduled-fpi-receipts.md
@@ -47,11 +47,22 @@ The receipt must have registered-URL provenance, in-file season evidence,
 the declared 36-hour interval, a successful latest attempt, and a non-stale
 current publication. Results include operation and generation IDs for recovery.
 
-The standalone workflow and legacy flat-file workflow share the
-`flat-file-load` concurrency group with cancellation disabled. The standalone
-job refreshes `marts.epa_crossvalidation` after an attempted publication, even
-if publication or verification failed, because a commit may already have
-happened. Refreshing does not erase the earlier failure status. The refresh
+The standalone workflow first acquires `daily-season-load`, then its publish
+job acquires `flat-file-load`. This matches the daily parent's order and
+serializes publication and refresh with daily, historical, backfill, recovery,
+and flat-file work. The FPI job can run after an unsuccessful daily workflow;
+it does not require that workflow to succeed. When activation is off, it uses
+a unique outer group and cannot delay the daily queue.
+
+All workflows sharing those groups use `queue: max` with cancellation disabled
+so a new arrival preserves existing pending runs. GitHub permits up to 100
+pending runs per group; excess runs are canceled. Long warehouse jobs can delay
+the requested 10:17 start and can make the publication exceed its declared age
+limit. See [GitHub's concurrency documentation](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency).
+
+The standalone job refreshes `marts.epa_crossvalidation` after an attempted
+publication, even if publication or verification failed, because a commit may
+already have happened. Refreshing does not erase the earlier failure status. The refresh
 uses the existing ordinary refresh mode.
 
 While the switch is active, both implicit-current-season and explicit-season
@@ -61,16 +72,18 @@ legacy `--due` commands receive:
 --exclude-source-season sdv_fpi_weekly:2026
 ```
 
-The exclusion applies only when the resolved load season is 2026. Other
-sources, historical 2025 FPI, and explicit manual `--source` commands retain
-their existing behavior. Direct/manual legacy FPI writes can still invalidate
-the current receipt pointer; operators must choose the receipt path when
+The exclusion is applied to the planned season before any fetch or fallback.
+When that planned season is 2026, the entire legacy FPI attempt is omitted,
+including its possible fallback to an older artifact. Explicit historical
+2025 due plans still include FPI. Other sources and explicit manual `--source`
+commands retain their existing behavior. Direct/manual legacy FPI writes can
+still invalidate the current receipt pointer; operators must choose the receipt path when
 current evidence is required. The exclusion option is restricted to `--due`.
 
 ## Rollout and recovery
 
-1. Review and merge the workflow, driver, and exclusion changes while the
-   repository activation variable is absent.
+1. Review and merge the workflow, driver, exclusion, and shared-queue changes
+   while the repository activation variable is absent.
 2. Pause competing flat-file producers and drain existing executions. Capture
    workflow states, target data, policy rows, and current receipt identities.
 3. Configure only the exact 36-hour FPI/2026 policy after validating the owner,

--- a/docs/scheduled-fpi-receipts.md
+++ b/docs/scheduled-fpi-receipts.md
@@ -1,0 +1,102 @@
+# Scheduled FPI publication receipts
+
+The `SDV FPI Receipts` workflow publishes the complete registered SDV FPI file
+for the explicitly enrolled 2026 season. It runs daily at 10:17 UTC and supports
+a manual dispatch of the same path. GitHub may delay scheduled jobs.
+
+## Activation contract
+
+The repository variable `SDV_FPI_RECEIPT_SEASON` is the shared activation switch.
+Only the exact value `2026` enables the workflow and its matching legacy-loader
+exclusion. A missing or different value leaves both inactive. The variable is
+not a credential and cannot grant database access.
+
+Activation also requires the deployed receipt schema, the existing loader's
+reviewed ability to assume `warehouse_source_publisher`, and one exact private
+policy row:
+
+| Asset | Coverage | Maximum publication age |
+| --- | --- | --- |
+| `ratings.espn_fpi_weekly` | `season:2026` | 36 hours |
+
+The daily interval leaves 12 hours for scheduling delays before a publication
+is stale. This is an explicit publication-age policy. A successful run fetches,
+validates, and republishes the artifact even if its bytes are unchanged. It
+does not prove when the provider last updated its values or that the provider
+has published every expected game/week.
+
+The driver checks the intended project, managed migration ledger, actual
+source-publisher role assumption, and exact policy before publication. The
+workflow does not create grants, configure policies, infer new season scopes,
+or opt into Elo publication, generation-enforced mart refresh, or CFBD quota
+admission.
+
+## Execution and coordination
+
+The driver selects exactly `sdv_fpi_weekly` and 2026 through the normal source
+publication adapter. It fetches the registered season URL, permits upstream
+corrections, and uses the adapter's complete-file validation and atomic
+publication. There is no older-season fallback or legacy hash skip. Missing
+artifacts remain deferred outcomes with a nonzero exit; other failures also
+fail the job. An uncertain commit must be reconciled by its operation and
+generation IDs before retrying.
+
+After success, the driver verifies the new generation and complete row counts
+through `public.get_source_freshness(2026)` as both `anon` and `authenticated`.
+The receipt must have registered-URL provenance, in-file season evidence,
+the declared 36-hour interval, a successful latest attempt, and a non-stale
+current publication. Results include operation and generation IDs for recovery.
+
+The standalone workflow and legacy flat-file workflow share the
+`flat-file-load` concurrency group with cancellation disabled. The standalone
+job refreshes `marts.epa_crossvalidation` after an attempted publication, even
+if publication or verification failed, because a commit may already have
+happened. Refreshing does not erase the earlier failure status. The refresh
+uses the existing ordinary refresh mode.
+
+While the switch is active, both implicit-current-season and explicit-season
+legacy `--due` commands receive:
+
+```text
+--exclude-source-season sdv_fpi_weekly:2026
+```
+
+The exclusion applies only when the resolved load season is 2026. Other
+sources, historical 2025 FPI, and explicit manual `--source` commands retain
+their existing behavior. Direct/manual legacy FPI writes can still invalidate
+the current receipt pointer; operators must choose the receipt path when
+current evidence is required. The exclusion option is restricted to `--due`.
+
+## Rollout and recovery
+
+1. Review and merge the workflow, driver, and exclusion changes while the
+   repository activation variable is absent.
+2. Pause competing flat-file producers and drain existing executions. Capture
+   workflow states, target data, policy rows, and current receipt identities.
+3. Configure only the exact 36-hour FPI/2026 policy after validating the owner,
+   deployed schema, active source-only role, and recent complete publication.
+   Reject a conflicting existing interval; preserve every other policy.
+4. Verify idempotence and actual `anon`/`authenticated` policy exposure. Set
+   `SDV_FPI_RECEIPT_SEASON=2026` and dispatch the standalone workflow once.
+5. Verify its exact receipt, current pointer, target rows and identifiers,
+   cleanup, refreshed consumer, private access restrictions, and preservation
+   of unrelated data. Restore the previous workflow states.
+
+For rollback, disable and drain the standalone job, clear the activation
+variable, and remove only this 36-hour policy if it still matches the approved
+value. Restore the recorded legacy workflow states. Keep receipt and operation
+history for diagnosis; a later legacy write can invalidate current evidence.
+Do not assume a failed workflow rolled back a successful publication.
+
+## Season boundary
+
+The driver uses the existing CFB ingest calendar: August through December maps
+to the calendar year, and January through July maps to the previous year.
+It therefore continues daily checks of 2026 through July 2027, including
+off-season corrections. Once that calendar resolves another season, it makes
+no provider or database calls and skips publication and refresh.
+
+Before that boundary, separately review and configure the next season or
+retire the 2026 activation and its policy. The old policy is not automatically
+changed, so its publication will eventually become stale if daily publication
+stops. No 2027 policy or publication is implied by this rollout.

--- a/scripts/load_flat_files.py
+++ b/scripts/load_flat_files.py
@@ -21,6 +21,9 @@ Usage:
                                                                   # non-manual source, cadence
                                                                   # gating off (hash-skip keeps
                                                                   # it cheap)
+    python scripts/load_flat_files.py --due \
+        --exclude-source-season sdv_fpi_weekly:2026              # leave this exact source/season
+                                                                  # out of the due plan
 
 Row counting (kind="dlt"): ``build_flat_file_source`` already materializes the
 parsed rows into in-memory list resources, so re-iterating those resources
@@ -444,6 +447,30 @@ def run_source(
     return result
 
 
+def _parse_excluded_source_season(value: str) -> tuple[str, int]:
+    """Parse one canonical ``SOURCE:SEASON`` exclusion for a due plan."""
+    if value.count(":") != 1:
+        raise argparse.ArgumentTypeError("expected SOURCE:SEASON with exactly one colon")
+
+    source, season_text = value.split(":")
+    if source not in REGISTRY:
+        raise argparse.ArgumentTypeError(
+            f"unknown source {source!r}; choose one of: {', '.join(sorted(REGISTRY))}"
+        )
+
+    try:
+        season = int(season_text)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "season must be a canonical integer from 1869 through 2200"
+        ) from exc
+    if season_text != str(season) or not 1869 <= season <= 2200:
+        raise argparse.ArgumentTypeError(
+            "season must be a canonical integer from 1869 through 2200"
+        )
+    return source, season
+
+
 def build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Fetch, parse, and load the flat-file sources (massey, nflverse, sbr, "
@@ -476,6 +503,14 @@ def build_arg_parser() -> argparse.ArgumentParser:
         "404 fallback -- a backfill request is never silently substituted.",
     )
     parser.add_argument(
+        "--exclude-source-season",
+        action="append",
+        type=_parse_excluded_source_season,
+        default=[],
+        metavar="SOURCE:SEASON",
+        help="Exclude this exact source and resolved season from a --due plan (repeatable)",
+    )
+    parser.add_argument(
         "--require-receipts",
         action="store_true",
         help="Publish each selected enrolled source/season atomically with a generation receipt; "
@@ -494,8 +529,8 @@ def _planned_sources(
     args: argparse.Namespace, today: date, season: int, *, season_explicit: bool
 ) -> list[str]:
     if args.source:
-        return list(args.source)
-    if args.due:
+        names = list(args.source)
+    elif args.due:
         if season_explicit:
             # An explicit --season is a backfill request: cadence freshness
             # describes only the current season's file, so gating a
@@ -503,13 +538,18 @@ def _planned_sources(
             # every weekly source off-season). Plan every non-manual source
             # instead -- the ledger hash-skip makes over-planning free, and
             # manual-cadence sources still need --file so they stay excluded.
-            return [name for name, spec in REGISTRY.items() if spec.cadence != "manual"]
-        return [
-            name
-            for name, spec in REGISTRY.items()
-            if is_due(spec, _cadence_last_checked(spec, season), today)
-        ]
-    return list(REGISTRY)
+            names = [name for name, spec in REGISTRY.items() if spec.cadence != "manual"]
+        else:
+            names = [
+                name
+                for name, spec in REGISTRY.items()
+                if is_due(spec, _cadence_last_checked(spec, season), today)
+            ]
+    else:
+        names = list(REGISTRY)
+
+    exclusions = set(args.exclude_source_season)
+    return [name for name in names if (name, season) not in exclusions]
 
 
 def _fetch_target_display(spec: FlatFileSpec, file_override: str | None, season: int) -> str:
@@ -526,6 +566,14 @@ def _fetch_target_display(spec: FlatFileSpec, file_override: str | None, season:
 def main(argv: list[str] | None = None) -> int:
     parser = build_arg_parser()
     args = parser.parse_args(argv)
+
+    if args.exclude_source_season:
+        if args.require_receipts:
+            parser.error("--exclude-source-season cannot be used with --require-receipts")
+        if args.source:
+            parser.error("--exclude-source-season cannot be used with explicit --source")
+        if not args.due:
+            parser.error("--exclude-source-season requires --due")
 
     if args.file is not None and (not args.source or len(args.source) != 1):
         parser.error("--file requires exactly one --source")

--- a/scripts/run_scheduled_fpi_receipts.py
+++ b/scripts/run_scheduled_fpi_receipts.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""Publish and verify the explicitly activated 2026 SDV FPI receipt."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import psycopg2
+from psycopg2 import sql
+
+from scripts import run_source_receipt_canary as canary
+from scripts.verify_load import SOURCE_FRESHNESS_FIELDS, _source_row_contract_error
+from src.pipelines.config.source_publication_assets import SDV_FPI_PUBLICATION
+from src.pipelines.sources.flat_files import REGISTRY, season_for_date
+from src.pipelines.utils import flat_file_publication as publication
+
+SOURCE = "sdv_fpi_weekly"
+SEASON = 2026
+PUBLIC_ROLES = ("anon", "authenticated")
+SHA256_RE = re.compile(r"[0-9a-f]{64}")
+
+
+class ScheduledFpiError(RuntimeError):
+    """A bounded scheduled-publication failure safe to report."""
+
+
+def _season(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("must be the activated season 2026") from error
+    if parsed != SEASON:
+        raise argparse.ArgumentTypeError("must be the activated season 2026")
+    return parsed
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Publish the activated 2026 SDV FPI receipt and verify freshness"
+    )
+    parser.add_argument("--season", type=_season, required=True)
+    parser.add_argument("--expected-project-ref", type=canary._project_ref, required=True)
+    return parser
+
+
+def _append_workflow_outputs(**values: str) -> None:
+    target = os.environ.get("GITHUB_OUTPUT")
+    if not target:
+        return
+    with Path(target).open("a", encoding="utf-8") as output:
+        for name, value in values.items():
+            output.write(f"{name}={value}\n")
+
+
+def _database_failure(error: psycopg2.Error, operation: str) -> ScheduledFpiError:
+    return ScheduledFpiError(
+        f"{operation} failed (type={type(error).__name__}, code={error.pgcode or 'none'})"
+    )
+
+
+def _require_policy(
+    dsn: str,
+    season: int,
+    *,
+    connector=psycopg2.connect,
+) -> None:
+    """Require the exact reviewed cadence without modifying policy state."""
+    try:
+        conn = connector(dsn, connect_timeout=10, application_name="scheduled-fpi-policy")
+        try:
+            conn.set_session(readonly=True, autocommit=False)
+            with conn.cursor() as cur:
+                cur.execute("SET LOCAL statement_timeout = '15s'")
+                cur.execute("SET LOCAL lock_timeout = '5s'")
+                cur.execute(
+                    """
+                    SELECT expected_refresh_interval = interval '36 hours'
+                    FROM meta.asset_freshness_policies
+                    WHERE asset_key = %s AND coverage_key = %s
+                    """,
+                    (SDV_FPI_PUBLICATION.asset_key, SDV_FPI_PUBLICATION.coverage_key(season)),
+                )
+                rows = cur.fetchall()
+            conn.rollback()
+        except BaseException:
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+            raise
+        finally:
+            conn.close()
+    except psycopg2.Error as error:
+        raise _database_failure(error, "freshness policy inspection") from None
+    if rows != [(True,)]:
+        raise ScheduledFpiError("FPI/2026 freshness policy must be exactly 36 hours")
+
+
+@contextmanager
+def _pinned_publication_connection(dsn: str) -> Iterator[None]:
+    original = publication.get_db_url
+    publication.get_db_url = lambda: dsn
+    try:
+        yield
+    finally:
+        publication.get_db_url = original
+
+
+def _require_publication_result(result: dict[str, Any]) -> None:
+    if result.get("source") != SOURCE or result.get("status") not in {
+        "loaded",
+        "not_published",
+        "blocked",
+        "failed",
+    }:
+        raise ScheduledFpiError("publisher returned an invalid publication status")
+    try:
+        run_id = str(result.get("run_id"))
+        generation_id = str(result.get("generation_id"))
+        if str(uuid.UUID(run_id)) != run_id or str(uuid.UUID(generation_id)) != generation_id:
+            raise ValueError
+    except (TypeError, ValueError, AttributeError) as error:
+        raise ScheduledFpiError("publisher returned invalid receipt identifiers") from error
+    rows = result.get("rows")
+    duration = result.get("duration_s")
+    sha256 = result.get("sha")
+    if (
+        type(rows) is not int
+        or rows < 0
+        or isinstance(duration, bool)
+        or not isinstance(duration, (int, float))
+        or not math.isfinite(duration)
+        or duration < 0
+        or (sha256 is not None and SHA256_RE.fullmatch(str(sha256)) is None)
+    ):
+        raise ScheduledFpiError("publisher returned invalid publication evidence")
+    if result.get("status") == "loaded" and (rows <= 0 or sha256 is None):
+        raise ScheduledFpiError("publisher returned incomplete publication evidence")
+
+
+def _verify_private_receipt(
+    dsn: str,
+    season: int,
+    result: dict[str, Any],
+    *,
+    connector=psycopg2.connect,
+) -> None:
+    """Match the returned identifiers, row count, and SHA to committed evidence."""
+    try:
+        conn = connector(dsn, connect_timeout=10, application_name="scheduled-fpi-receipt")
+        try:
+            conn.set_session(readonly=True, autocommit=False)
+            with conn.cursor() as cur:
+                cur.execute("SET LOCAL statement_timeout = '15s'")
+                cur.execute("SET LOCAL lock_timeout = '5s'")
+                cur.execute(
+                    """
+                    SELECT receipt.operation_run_id::text,
+                           receipt.generation_id::text,
+                           receipt.source_watermark,
+                           receipt.outcome,
+                           receipt.coverage,
+                           receipt.input_observations,
+                           receipt.row_delta,
+                           current_generation.generation_id::text
+                    FROM meta.asset_receipts AS receipt
+                    JOIN meta.asset_current_generations AS current_generation
+                      ON current_generation.asset_key = receipt.asset_key
+                     AND current_generation.coverage_key = receipt.coverage_key
+                    WHERE receipt.asset_key = %s
+                      AND receipt.coverage_key = %s
+                      AND receipt.generation_id = %s::uuid
+                    """,
+                    (
+                        SDV_FPI_PUBLICATION.asset_key,
+                        SDV_FPI_PUBLICATION.coverage_key(season),
+                        result["generation_id"],
+                    ),
+                )
+                rows = cur.fetchall()
+            conn.rollback()
+        except BaseException:
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+            raise
+        finally:
+            conn.close()
+    except psycopg2.Error as error:
+        raise _database_failure(error, "publication receipt verification") from None
+
+    if len(rows) != 1 or len(rows[0]) != 8:
+        raise ScheduledFpiError("committed publication receipt is missing or ambiguous")
+    run_id, generation_id, sha256, outcome, coverage, inputs, delta, current = rows[0]
+    expected_rows = result["rows"]
+    if (
+        run_id != result["run_id"]
+        or generation_id != result["generation_id"]
+        or current != result["generation_id"]
+        or sha256 != result["sha"]
+        or outcome != "succeeded"
+        or type(coverage) is not dict
+        or coverage.get("complete") is not True
+        or coverage.get("season") != season
+        or coverage.get("source_rows") != expected_rows
+        or coverage.get("published_rows") != expected_rows
+        or type(inputs) is not dict
+        or inputs.get("artifact_origin") != "registered_url"
+        or inputs.get("season_basis") != "artifact_field"
+        or type(delta) is not dict
+        or delta.get("published_rows") != expected_rows
+    ):
+        raise ScheduledFpiError("committed publication receipt does not match the result")
+
+
+def _read_public_freshness(
+    dsn: str,
+    role: str,
+    season: int,
+    *,
+    connector=psycopg2.connect,
+) -> tuple[dict[str, Any], bool]:
+    try:
+        conn = connector(dsn, connect_timeout=10, application_name="scheduled-fpi-freshness")
+        try:
+            conn.set_session(readonly=True, autocommit=False)
+            with conn.cursor() as cur:
+                cur.execute("SET LOCAL statement_timeout = '15s'")
+                cur.execute("SET LOCAL lock_timeout = '5s'")
+                cur.execute(sql.SQL("SET LOCAL ROLE {}").format(sql.Identifier(role)))
+                cur.execute("SELECT current_user::text")
+                identity = cur.fetchone()
+                if identity != (role,):
+                    raise ScheduledFpiError(
+                        f"freshness verification did not assume the {role} role"
+                    )
+                cur.execute(
+                    """
+                    SELECT to_jsonb(f),
+                           f.expected_refresh_interval = interval '36 hours'
+                    FROM public.get_source_freshness(%s) AS f
+                    WHERE f.source_name = %s
+                    """,
+                    (season, SOURCE),
+                )
+                rows = cur.fetchall()
+            conn.rollback()
+        except BaseException:
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+            raise
+        finally:
+            conn.close()
+    except ScheduledFpiError:
+        raise
+    except psycopg2.Error as error:
+        raise _database_failure(error, f"{role} freshness verification") from None
+    if len(rows) != 1 or len(rows[0]) != 2 or type(rows[0][0]) is not dict:
+        raise ScheduledFpiError(f"{role} freshness response is missing or ambiguous")
+    return rows[0]
+
+
+def _verify_public_freshness(dsn: str, season: int, result: dict[str, Any]) -> None:
+    for role in PUBLIC_ROLES:
+        row, interval_matches = _read_public_freshness(dsn, role, season)
+        if frozenset(row) != SOURCE_FRESHNESS_FIELDS:
+            raise ScheduledFpiError(f"{role} freshness response has an invalid shape")
+        contract_error = _source_row_contract_error(row, SOURCE)
+        if contract_error is not None:
+            raise ScheduledFpiError(f"{role} freshness response is invalid: {contract_error}")
+        if (
+            row["source_name"] != SOURCE
+            or row["asset_key"] != SDV_FPI_PUBLICATION.asset_key
+            or row["season"] != season
+            or row["coverage_key"] != SDV_FPI_PUBLICATION.coverage_key(season)
+            or str(row["generation_id"]) != result["generation_id"]
+            or row["publication_state"] != "current"
+            or row["current_outcome"] != "succeeded"
+            or row["is_complete"] is not True
+            or row["source_rows"] != result["rows"]
+            or row["published_rows"] != result["rows"]
+            or row["artifact_origin"] != "registered_url"
+            or row["season_basis"] != "artifact_field"
+            or row["latest_outcome"] != "succeeded"
+            or interval_matches is not True
+            or row["is_stale"] is not False
+        ):
+            raise ScheduledFpiError(f"{role} freshness response does not match publication")
+
+
+def _payload(status: str, season: int, result: dict[str, Any] | None = None) -> dict[str, Any]:
+    result = result or {}
+    return {
+        "status": status,
+        "source": SOURCE,
+        "season": season,
+        "run_id": result.get("run_id"),
+        "generation_id": result.get("generation_id"),
+        "rows": result.get("rows", 0),
+        "sha": result.get("sha"),
+        "duration_s": result.get("duration_s", 0.0),
+    }
+
+
+def _postpublication_failure(
+    season: int,
+    result: dict[str, Any],
+    error: Exception,
+) -> tuple[dict[str, Any], int]:
+    payload = _payload("verification_failed", season, result)
+    payload.update(
+        phase="post_publication_verification",
+        publication_status="loaded",
+    )
+    if isinstance(error, ScheduledFpiError):
+        payload["error"] = str(error)[:240]
+    elif isinstance(error, psycopg2.Error):
+        payload["error"] = str(_database_failure(error, "post-publication verification"))
+    else:
+        payload["error"] = f"unexpected verification failure ({type(error).__name__})"
+    return payload, 1
+
+
+def run_scheduled(
+    args: argparse.Namespace,
+    *,
+    today: date | None = None,
+) -> tuple[dict[str, Any], int]:
+    _append_workflow_outputs(active_season=str(args.season), publication_attempted="false")
+    current_season = season_for_date(today or date.today())
+    if current_season != SEASON:
+        payload = _payload("skipped", args.season)
+        payload["reason"] = "activated season is no longer current"
+        return payload, 0
+
+    dsn = publication.get_db_url()
+    identity, plan = canary._inspect_target(dsn, args.expected_project_ref, SOURCE, args.season)
+    if (
+        identity.get("can_set_role") is not True
+        or identity.get("assumed_role") != canary.PUBLISHER_ROLE
+        or plan is None
+    ):
+        raise ScheduledFpiError("bounded source publisher role is unavailable")
+    _require_policy(dsn, args.season)
+
+    _append_workflow_outputs(publication_attempted="true")
+    with _pinned_publication_connection(dsn):
+        result = publication.run_source_publication(REGISTRY[SOURCE], season=args.season)
+    _require_publication_result(result)
+    if result.get("status") != "loaded":
+        payload = _payload(str(result.get("status") or "failed"), args.season, result)
+        payload["error_category"] = "source_publication_failed"
+        return payload, 1
+
+    try:
+        _verify_private_receipt(dsn, args.season, result)
+        _verify_public_freshness(dsn, args.season, result)
+    except Exception as error:
+        return _postpublication_failure(args.season, result, error)
+    return _payload("loaded", args.season, result), 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        payload, status = run_scheduled(args)
+    except (ScheduledFpiError, canary.CanaryError) as error:
+        payload = _payload("failed", args.season)
+        payload["error"] = str(error)[:240]
+        status = 1
+    except publication.SourcePublicationError:
+        payload = _payload("failed", args.season)
+        payload["error"] = "source publication validation failed"
+        status = 1
+    except psycopg2.Error as error:
+        payload = _payload("failed", args.season)
+        payload["error"] = str(_database_failure(error, "database operation"))
+        status = 1
+    except Exception as error:
+        payload = _payload("failed", args.season)
+        payload["error"] = f"unexpected failure ({type(error).__name__})"
+        status = 1
+    print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+    return status
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_f10_flat_file_workflow.py
+++ b/tests/test_f10_flat_file_workflow.py
@@ -39,7 +39,11 @@ def test_flat_file_workflow_is_reusable_and_keeps_manual_backfills():
     assert triggers["workflow_call"]["secrets"]["SUPABASE_DB_URL"]["required"] is True
     # The caller owns daily-season-load for its entire run; reusing that group
     # here would make the called workflow wait for its own parent to finish.
-    assert workflow()["concurrency"]["group"] == "flat-file-load"
+    assert workflow()["concurrency"] == {
+        "group": "flat-file-load",
+        "queue": "max",
+        "cancel-in-progress": False,
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/test_f10_flat_file_workflow.py
+++ b/tests/test_f10_flat_file_workflow.py
@@ -67,6 +67,53 @@ def test_imports_finish_before_refresh(tmp_path, sources, seasons, expected):
 
 
 @pytest.mark.parametrize(
+    "sources,seasons,expected",
+    [
+        (
+            "",
+            "",
+            [["--due", "--exclude-source-season", "sdv_fpi_weekly:2026"]],
+        ),
+        (
+            "",
+            "2025 2026",
+            [
+                [
+                    "--due",
+                    "--season",
+                    season,
+                    "--exclude-source-season",
+                    "sdv_fpi_weekly:2026",
+                ]
+                for season in ("2025", "2026")
+            ],
+        ),
+        ("sdv_fpi_weekly", "", [["--source", "sdv_fpi_weekly"]]),
+        (
+            "sdv_fpi_weekly",
+            "2026",
+            [["--source", "sdv_fpi_weekly", "--season", "2026"]],
+        ),
+    ],
+)
+def test_receipt_activation_excludes_only_fpi_2026_from_due_routes(
+    tmp_path, sources, seasons, expected
+):
+    result, calls = run_steps(tmp_path, sources, seasons, activation="2026")
+    assert result == 0
+    assert calls == [["scripts/load_flat_files.py", *values] for values in expected] + [
+        ["scripts/refresh_marts.py", "--views", "marts.epa_crossvalidation"]
+    ]
+
+
+@pytest.mark.parametrize("activation", ["", "2025", "02026", "2026 "])
+def test_receipt_exclusion_is_off_unless_activation_is_exact(tmp_path, activation):
+    result, calls = run_steps(tmp_path, "", "", activation=activation)
+    assert result == 0
+    assert calls[0] == ["scripts/load_flat_files.py", "--due"]
+
+
+@pytest.mark.parametrize(
     "failed_script", ["scripts/load_flat_files.py", "scripts/refresh_marts.py"]
 )
 def test_workflow_propagates_failures(tmp_path, failed_script):
@@ -156,7 +203,7 @@ def test_canary_is_excluded_from_legacy_refresh_and_failure_issue():
     )
 
 
-def run_steps(tmp_path, sources, seasons, failed_script=""):
+def run_steps(tmp_path, sources, seasons, failed_script="", activation=""):
     """Run completed import and refresh commands while preserving failed status."""
     calls_path = tmp_path / "calls.jsonl"
     fake_python = tmp_path / "python"
@@ -193,6 +240,7 @@ def run_steps(tmp_path, sources, seasons, failed_script=""):
         "PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}",
         "SOURCE_INPUT": sources,
         "SEASONS_INPUT": seasons,
+        "SDV_FPI_RECEIPT_SEASON": activation,
         "TEST_CALLS": str(calls_path),
         "TEST_FAIL_SCRIPT": failed_script,
     }

--- a/tests/test_load_flat_files.py
+++ b/tests/test_load_flat_files.py
@@ -121,6 +121,68 @@ class TestArgParsing:
         with pytest.raises(SystemExit):
             load_flat_files.main(["--source", "not_a_real_source"])
 
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "sdv_fpi_weekly",
+            "sdv_fpi_weekly:2026:extra",
+            "not_a_real_source:2026",
+            "sdv_fpi_weekly:not-a-season",
+            "sdv_fpi_weekly:02026",
+            "sdv_fpi_weekly:+2026",
+            "sdv_fpi_weekly:1868",
+            "sdv_fpi_weekly:2201",
+        ],
+    )
+    def test_excluded_source_season_must_be_canonical_and_in_range(self, value):
+        with pytest.raises(SystemExit):
+            _parse(["--due", "--exclude-source-season", value])
+
+    @pytest.mark.parametrize(
+        "argv, message",
+        [
+            (
+                ["--exclude-source-season", "sdv_fpi_weekly:2026"],
+                "requires --due",
+            ),
+            (
+                [
+                    "--source",
+                    "sdv_fpi_weekly",
+                    "--exclude-source-season",
+                    "sdv_fpi_weekly:2026",
+                ],
+                "cannot be used with explicit --source",
+            ),
+            (
+                [
+                    "--source",
+                    "sdv_fpi_weekly",
+                    "--season",
+                    "2026",
+                    "--require-receipts",
+                    "--exclude-source-season",
+                    "sdv_fpi_weekly:2026",
+                ],
+                "cannot be used with --require-receipts",
+            ),
+        ],
+    )
+    def test_exclusions_reject_non_due_modes_before_planning_or_db(
+        self, monkeypatch, capsys, argv, message
+    ):
+        def boom(*args, **kwargs):
+            raise AssertionError("invalid exclusions must fail before planning or DB access")
+
+        monkeypatch.setattr(load_flat_files, "_planned_sources", boom)
+        monkeypatch.setattr(load_flat_files, "last_checked", boom)
+        monkeypatch.setattr(load_flat_files, "run_source", boom)
+
+        with pytest.raises(SystemExit):
+            load_flat_files.main(argv)
+
+        assert message in capsys.readouterr().err
+
 
 class TestDryRun:
     def test_dry_run_prints_all_registry_sources_and_exits_zero(self, monkeypatch, capsys):
@@ -156,6 +218,47 @@ class TestDryRun:
 
         rc = load_flat_files.main(["--dry-run"])
         assert rc == 0
+
+    def test_due_dry_run_excludes_only_current_matching_source_season(self, monkeypatch, capsys):
+        class Current2026(date):
+            @classmethod
+            def today(cls):
+                return cls(2026, 9, 10)
+
+        def boom(*args, **kwargs):
+            raise AssertionError("dry-run must not access files, providers, or production")
+
+        monkeypatch.setattr(load_flat_files, "date", Current2026)
+        monkeypatch.setattr(load_flat_files, "_cadence_last_checked", lambda *args: None)
+        monkeypatch.setattr(
+            load_flat_files,
+            "is_due",
+            lambda spec, last, today: (
+                spec.name in {"sdv_fpi_weekly", "sdv_team_xwalk", "sdv_ratings_weekly"}
+            ),
+        )
+        monkeypatch.setattr(load_flat_files, "fetch_file", boom)
+        monkeypatch.setattr(load_flat_files, "build_flat_file_source", boom)
+        monkeypatch.setattr(load_flat_files, "record_load", boom)
+        monkeypatch.setattr(load_flat_files, "run_source", boom)
+
+        rc = load_flat_files.main(
+            [
+                "--due",
+                "--dry-run",
+                "--exclude-source-season",
+                "sdv_fpi_weekly:2026",
+                "--exclude-source-season",
+                "sdv_team_xwalk:2026",
+            ]
+        )
+
+        assert rc == 0
+        output = capsys.readouterr().out
+        assert "[DRY RUN] 1 flat-file source(s) planned for season 2026" in output
+        assert "  sdv_fpi_weekly" not in output
+        assert "  sdv_team_xwalk" not in output
+        assert "  sdv_ratings_weekly" in output
 
 
 # ---------------------------------------------------------------------------
@@ -219,6 +322,48 @@ class TestPlannedSources:
         args = _parse(["--source", "massey", "--source", "sbr"])
         names = load_flat_files._planned_sources(args, IN_SEASON_DAY, 2025, season_explicit=False)
         assert names == ["massey", "sbr"]
+
+    def test_nonmatching_season_exclusion_preserves_current_source(self, monkeypatch):
+        monkeypatch.setattr(load_flat_files, "_cadence_last_checked", lambda *args: None)
+        monkeypatch.setattr(
+            load_flat_files,
+            "is_due",
+            lambda spec, last, today: spec.name in {"sdv_fpi_weekly", "sdv_ratings_weekly"},
+        )
+
+        args = _parse(["--due", "--exclude-source-season", "sdv_fpi_weekly:2025"])
+        names = load_flat_files._planned_sources(
+            args, date(2026, 9, 10), 2026, season_explicit=False
+        )
+
+        assert names == ["sdv_fpi_weekly", "sdv_ratings_weekly"]
+
+    @pytest.mark.parametrize(
+        "excluded_season, fpi_is_planned",
+        [(2025, False), (2026, True)],
+    )
+    def test_explicit_historical_due_exclusion_matches_resolved_season_only(
+        self, monkeypatch, excluded_season, fpi_is_planned
+    ):
+        def boom(*args, **kwargs):
+            raise AssertionError("historical --due planning must not consult cadence or DB")
+
+        monkeypatch.setattr(load_flat_files, "is_due", boom)
+        monkeypatch.setattr(load_flat_files, "_cadence_last_checked", boom)
+
+        args = _parse(
+            [
+                "--due",
+                "--season",
+                "2025",
+                "--exclude-source-season",
+                f"sdv_fpi_weekly:{excluded_season}",
+            ]
+        )
+        names = load_flat_files._planned_sources(args, OFF_SEASON_DAY, 2025, season_explicit=True)
+
+        assert ("sdv_fpi_weekly" in names) is fpi_is_planned
+        assert "sdv_ratings_weekly" in names
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scheduled_fpi_receipts.py
+++ b/tests/test_scheduled_fpi_receipts.py
@@ -22,6 +22,7 @@ RUN_ID = "1c74bd2a-c85f-4a28-bd5f-b5473ed30779"
 GENERATION_ID = "78699d90-51a8-4729-b41c-8232ed7c98f0"
 SHA256 = "a" * 64
 WORKFLOW = Path(__file__).resolve().parents[1] / ".github/workflows/sdv-fpi-receipts.yml"
+WORKFLOWS = WORKFLOW.parent
 
 
 def args() -> argparse.Namespace:
@@ -42,6 +43,10 @@ def loaded_result() -> dict:
 
 def workflow():
     return yaml.safe_load(WORKFLOW.read_text())
+
+
+def named_workflow(name: str):
+    return yaml.safe_load((WORKFLOWS / name).read_text())
 
 
 @pytest.mark.parametrize("season", ["2025", "2027", "2026 2027"])
@@ -524,21 +529,89 @@ def test_scheduled_workflow_is_daily_bounded_and_default_off():
     triggers = config[True]
     assert triggers == {"schedule": [{"cron": "17 10 * * *"}], "workflow_dispatch": None}
     assert config["concurrency"] == {
-        "group": "flat-file-load",
+        "group": "${{ vars.SDV_FPI_RECEIPT_SEASON == '2026' && 'daily-season-load' || "
+        "format('sdv-fpi-inactive-{0}', github.run_id) }}",
+        "queue": "max",
         "cancel-in-progress": False,
     }
     assert config["permissions"] == {"contents": "read"}
     job = config["jobs"]["publish"]
     assert job["if"] == "${{ vars.SDV_FPI_RECEIPT_SEASON == '2026' }}"
     assert job["timeout-minutes"] == 30
+    assert job["concurrency"] == {
+        "group": "flat-file-load",
+        "queue": "max",
+        "cancel-in-progress": False,
+    }
+    assert "SUPABASE_DB_URL" not in config["env"]
     assert config["env"]["SDV_FPI_RECEIPT_SEASON"] == ("${{ vars.SDV_FPI_RECEIPT_SEASON }}")
     steps = {step.get("name"): step for step in job["steps"]}
+    assert "Set dlt destination credentials" not in steps
     assert steps["Publish and verify FPI receipt"]["id"] == "publish_fpi"
     assert steps["Refresh external-rating consumers"]["if"] == (
         "${{ !cancelled() && steps.publish_fpi.outputs.publication_attempted == 'true' && "
         "(steps.publish_fpi.outcome == 'success' || steps.publish_fpi.outcome == 'failure') }}"
     )
     assert "${{" not in steps["Publish and verify FPI receipt"]["run"]
+
+
+def test_database_secret_is_scoped_only_to_operational_steps():
+    config = workflow()
+    steps = config["jobs"]["publish"]["steps"]
+    secret_reference = "${{ secrets.SUPABASE_DB_URL }}"
+    credential_steps = [
+        step.get("name")
+        for step in steps
+        if step.get("env", {}).get("SUPABASE_DB_URL") == secret_reference
+    ]
+
+    assert credential_steps == [
+        "Publish and verify FPI receipt",
+        "Refresh external-rating consumers",
+    ]
+    for step in steps:
+        if step.get("name") not in credential_steps:
+            assert secret_reference not in str(step)
+    assert "SUPABASE_DB_URL" not in config["env"]
+    assert "SUPABASE_DB_URL" not in config["jobs"]["publish"].get("env", {})
+    assert "DESTINATION__POSTGRES__CREDENTIALS" not in WORKFLOW.read_text()
+
+
+def test_every_shared_concurrency_holder_preserves_all_pending_runs():
+    expected_daily_groups = {
+        "daily-load.yml": "daily-season-load",
+        "historical-refresh.yml": "daily-season-load",
+        "backfill-sources.yml": "daily-season-load",
+        "deploy-schema.yml": (
+            "${{ inputs.compute_script == 'recover_season_projections' && "
+            "'daily-season-load' || 'deploy-schema' }}"
+        ),
+    }
+    for name, expected_group in expected_daily_groups.items():
+        assert named_workflow(name)["concurrency"] == {
+            "group": expected_group,
+            "queue": "max",
+            "cancel-in-progress": False,
+        }
+
+    assert named_workflow("flat-files.yml")["concurrency"] == {
+        "group": "flat-file-load",
+        "queue": "max",
+        "cancel-in-progress": False,
+    }
+
+
+def test_fpi_and_daily_acquire_shared_groups_in_the_same_order():
+    daily = named_workflow("daily-load.yml")
+    flat_files = named_workflow("flat-files.yml")
+    fpi = workflow()
+
+    assert daily["concurrency"]["group"] == "daily-season-load"
+    assert daily["jobs"]["flat_files"]["needs"] == "load"
+    assert daily["jobs"]["flat_files"]["uses"] == "./.github/workflows/flat-files.yml"
+    assert flat_files["concurrency"]["group"] == "flat-file-load"
+    assert "'daily-season-load'" in fpi["concurrency"]["group"]
+    assert fpi["jobs"]["publish"]["concurrency"]["group"] == "flat-file-load"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_scheduled_fpi_receipts.py
+++ b/tests/test_scheduled_fpi_receipts.py
@@ -1,0 +1,613 @@
+"""Bounded tests for the activated scheduled FPI receipt publisher."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import uuid
+from datetime import date
+from pathlib import Path
+
+import psycopg2
+import pytest
+import yaml
+
+from scripts import run_scheduled_fpi_receipts as scheduled
+
+PROJECT_REF = "ibobsbwlewpqslkqbrjd"
+RUN_ID = "1c74bd2a-c85f-4a28-bd5f-b5473ed30779"
+GENERATION_ID = "78699d90-51a8-4729-b41c-8232ed7c98f0"
+SHA256 = "a" * 64
+WORKFLOW = Path(__file__).resolve().parents[1] / ".github/workflows/sdv-fpi-receipts.yml"
+
+
+def args() -> argparse.Namespace:
+    return argparse.Namespace(season=2026, expected_project_ref=PROJECT_REF)
+
+
+def loaded_result() -> dict:
+    return {
+        "status": "loaded",
+        "source": scheduled.SOURCE,
+        "rows": 276,
+        "sha": SHA256,
+        "duration_s": 4.5,
+        "run_id": RUN_ID,
+        "generation_id": GENERATION_ID,
+    }
+
+
+def workflow():
+    return yaml.safe_load(WORKFLOW.read_text())
+
+
+@pytest.mark.parametrize("season", ["2025", "2027", "2026 2027"])
+def test_cli_accepts_only_the_explicitly_activated_2026_season(season):
+    with pytest.raises(SystemExit, match="2"):
+        scheduled.build_parser().parse_args(
+            ["--season", season, "--expected-project-ref", PROJECT_REF]
+        )
+
+
+def test_future_season_boundary_is_a_noop_before_database_or_provider(monkeypatch, tmp_path):
+    outputs = tmp_path / "outputs"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(outputs))
+    monkeypatch.setattr(
+        scheduled.publication,
+        "get_db_url",
+        lambda: pytest.fail("expired activation must not resolve a database"),
+    )
+    monkeypatch.setattr(
+        scheduled.canary,
+        "_inspect_target",
+        lambda *values: pytest.fail("expired activation must not inspect a database"),
+    )
+    monkeypatch.setattr(
+        scheduled.publication,
+        "run_source_publication",
+        lambda *values, **kwargs: pytest.fail("expired activation must not fetch or publish"),
+    )
+
+    payload, status = scheduled.run_scheduled(args(), today=date(2027, 8, 1))
+
+    assert status == 0
+    assert payload == {
+        "status": "skipped",
+        "source": "sdv_fpi_weekly",
+        "season": 2026,
+        "run_id": None,
+        "generation_id": None,
+        "rows": 0,
+        "sha": None,
+        "duration_s": 0.0,
+        "reason": "activated season is no longer current",
+    }
+    assert outputs.read_text().splitlines() == [
+        "active_season=2026",
+        "publication_attempted=false",
+    ]
+
+
+def test_active_run_checks_preconditions_pins_one_publication_and_verifies_result(
+    monkeypatch, tmp_path
+):
+    outputs = tmp_path / "outputs"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(outputs))
+    events = []
+    monkeypatch.setattr(scheduled.publication, "get_db_url", lambda: "resolved-dsn")
+
+    def inspect(dsn, project, source, season):
+        events.append(("inspect", dsn, project, source, season))
+        return {
+            "can_set_role": True,
+            "assumed_role": scheduled.canary.PUBLISHER_ROLE,
+        }, {"source_name": source}
+
+    monkeypatch.setattr(scheduled.canary, "_inspect_target", inspect)
+    monkeypatch.setattr(
+        scheduled,
+        "_require_policy",
+        lambda dsn, season: events.append(("policy", dsn, season)),
+    )
+
+    def publish(spec, **kwargs):
+        events.append(
+            (
+                "publish",
+                spec is scheduled.REGISTRY[scheduled.SOURCE],
+                kwargs,
+                scheduled.publication.get_db_url(),
+            )
+        )
+        return loaded_result()
+
+    monkeypatch.setattr(scheduled.publication, "run_source_publication", publish)
+    monkeypatch.setattr(
+        scheduled,
+        "_verify_private_receipt",
+        lambda dsn, season, result: events.append(
+            ("receipt", dsn, season, result["generation_id"], result["sha"])
+        ),
+    )
+    monkeypatch.setattr(
+        scheduled,
+        "_verify_public_freshness",
+        lambda dsn, season, result: events.append(
+            ("freshness", dsn, season, result["generation_id"], result["rows"])
+        ),
+    )
+
+    payload, status = scheduled.run_scheduled(args(), today=date(2026, 9, 10))
+
+    assert status == 0
+    assert payload == {
+        "status": "loaded",
+        "source": "sdv_fpi_weekly",
+        "season": 2026,
+        "run_id": RUN_ID,
+        "generation_id": GENERATION_ID,
+        "rows": 276,
+        "sha": SHA256,
+        "duration_s": 4.5,
+    }
+    assert events == [
+        ("inspect", "resolved-dsn", PROJECT_REF, "sdv_fpi_weekly", 2026),
+        ("policy", "resolved-dsn", 2026),
+        ("publish", True, {"season": 2026}, "resolved-dsn"),
+        ("receipt", "resolved-dsn", 2026, GENERATION_ID, SHA256),
+        ("freshness", "resolved-dsn", 2026, GENERATION_ID, 276),
+    ]
+    assert scheduled.publication.get_db_url() == "resolved-dsn"
+    assert outputs.read_text().splitlines()[-1] == "publication_attempted=true"
+
+
+@pytest.mark.parametrize("failure", ["role", "policy"])
+def test_precondition_failure_stops_before_publication(monkeypatch, failure):
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    monkeypatch.setattr(scheduled.publication, "get_db_url", lambda: "resolved-dsn")
+    identity = {
+        "can_set_role": failure != "role",
+        "assumed_role": scheduled.canary.PUBLISHER_ROLE if failure != "role" else None,
+    }
+    monkeypatch.setattr(scheduled.canary, "_inspect_target", lambda *values: (identity, {}))
+
+    def require_policy(*values):
+        if failure == "policy":
+            raise scheduled.ScheduledFpiError("policy missing")
+
+    monkeypatch.setattr(scheduled, "_require_policy", require_policy)
+    monkeypatch.setattr(
+        scheduled.publication,
+        "run_source_publication",
+        lambda *values, **kwargs: pytest.fail("precondition failure must not publish"),
+    )
+
+    with pytest.raises(scheduled.ScheduledFpiError):
+        scheduled.run_scheduled(args(), today=date(2026, 9, 10))
+
+
+@pytest.mark.parametrize(
+    ("policy_rows", "accepted"), [([(True,)], True), ([], False), ([(False,)], False)]
+)
+def test_policy_preflight_requires_one_exact_36_hour_row(policy_rows, accepted):
+    class Cursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *unused):
+            return False
+
+        def execute(self, statement, parameters=None):
+            if parameters is not None:
+                assert parameters == ("ratings.espn_fpi_weekly", "season:2026")
+                assert "interval '36 hours'" in statement
+
+        def fetchall(self):
+            return policy_rows
+
+    class Connection:
+        def set_session(self, **options):
+            assert options == {"readonly": True, "autocommit": False}
+
+        def cursor(self):
+            return Cursor()
+
+        def rollback(self):
+            pass
+
+        def close(self):
+            pass
+
+    if accepted:
+        scheduled._require_policy("dsn", 2026, connector=lambda *values, **options: Connection())
+    else:
+        with pytest.raises(scheduled.ScheduledFpiError, match="exactly 36 hours"):
+            scheduled._require_policy(
+                "dsn", 2026, connector=lambda *values, **options: Connection()
+            )
+
+
+@pytest.mark.parametrize("publication_status", ["failed", "not_published", "blocked"])
+def test_failed_deferred_or_uncertain_publication_is_not_retried_or_postverified(
+    monkeypatch, tmp_path, publication_status
+):
+    outputs = tmp_path / "outputs"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(outputs))
+    monkeypatch.setattr(scheduled.publication, "get_db_url", lambda: "resolved-dsn")
+    monkeypatch.setattr(
+        scheduled.canary,
+        "_inspect_target",
+        lambda *values: (
+            {"can_set_role": True, "assumed_role": scheduled.canary.PUBLISHER_ROLE},
+            {},
+        ),
+    )
+    monkeypatch.setattr(scheduled, "_require_policy", lambda *values: None)
+    calls = []
+    failed = {
+        **loaded_result(),
+        "status": publication_status,
+        "rows": 0,
+        "sha": None,
+        "duration_s": 1.0,
+    }
+
+    def publish(*values, **kwargs):
+        calls.append((values, kwargs))
+        return failed
+
+    monkeypatch.setattr(scheduled.publication, "run_source_publication", publish)
+    monkeypatch.setattr(
+        scheduled,
+        "_verify_private_receipt",
+        lambda *values: pytest.fail("failed publication must not be postverified"),
+    )
+    monkeypatch.setattr(
+        scheduled,
+        "_verify_public_freshness",
+        lambda *values: pytest.fail("failed publication must not be postverified"),
+    )
+
+    payload, status = scheduled.run_scheduled(args(), today=date(2026, 9, 10))
+
+    assert status == 1
+    assert payload["status"] == publication_status
+    assert payload["error_category"] == "source_publication_failed"
+    assert len(calls) == 1
+    assert outputs.read_text().splitlines()[-1] == "publication_attempted=true"
+
+
+def freshness_row(**overrides):
+    row = {
+        "source_name": "sdv_fpi_weekly",
+        "asset_key": "ratings.espn_fpi_weekly",
+        "season": 2026,
+        "coverage_key": "season:2026",
+        "generation_id": GENERATION_ID,
+        "published_at": "2026-09-10T15:00:00+00:00",
+        "age_seconds": 2,
+        "expected_refresh_interval": "1 day 12:00:00",
+        "is_stale": False,
+        "publication_state": "current",
+        "current_outcome": "succeeded",
+        "is_complete": True,
+        "source_rows": 276,
+        "published_rows": 276,
+        "artifact_origin": "registered_url",
+        "season_basis": "artifact_field",
+        "latest_outcome": "succeeded",
+        "latest_recorded_at": "2026-09-10T15:00:00+00:00",
+        "last_failure_outcome": None,
+        "last_failure_at": None,
+        "last_failure_category": None,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_postpublication_checks_exact_private_and_both_public_evidence(monkeypatch):
+    private = (
+        RUN_ID,
+        GENERATION_ID,
+        SHA256,
+        "succeeded",
+        {
+            "complete": True,
+            "season": 2026,
+            "source_rows": 276,
+            "published_rows": 276,
+        },
+        {"artifact_origin": "registered_url", "season_basis": "artifact_field"},
+        {"published_rows": 276},
+        GENERATION_ID,
+    )
+
+    class Cursor:
+        def __init__(self, result):
+            self.result = result
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *unused):
+            return False
+
+        def execute(self, statement, parameters=None):
+            pass
+
+        def fetchall(self):
+            return [self.result]
+
+    class Connection:
+        def __init__(self, result):
+            self.result = result
+
+        def set_session(self, **options):
+            assert options == {"readonly": True, "autocommit": False}
+
+        def cursor(self):
+            return Cursor(self.result)
+
+        def rollback(self):
+            pass
+
+        def close(self):
+            pass
+
+    scheduled._verify_private_receipt(
+        "dsn", 2026, loaded_result(), connector=lambda *args, **kwargs: Connection(private)
+    )
+    roles = []
+
+    def read_public(dsn, role, season):
+        roles.append((dsn, role, season))
+        return freshness_row(), True
+
+    monkeypatch.setattr(scheduled, "_read_public_freshness", read_public)
+    scheduled._verify_public_freshness("dsn", 2026, loaded_result())
+    assert roles == [("dsn", "anon", 2026), ("dsn", "authenticated", 2026)]
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        {"generation_id": str(uuid.uuid4())},
+        {"published_rows": 275},
+        {"artifact_origin": "local_file"},
+        {"latest_outcome": "failed"},
+        {"is_stale": True},
+    ],
+)
+def test_public_postcheck_rejects_mismatched_or_stale_evidence(monkeypatch, change):
+    monkeypatch.setattr(
+        scheduled,
+        "_read_public_freshness",
+        lambda *values: (freshness_row(**change), True),
+    )
+    with pytest.raises(scheduled.ScheduledFpiError):
+        scheduled._verify_public_freshness("dsn", 2026, loaded_result())
+
+
+def test_main_never_prints_unexpected_exception_details(monkeypatch, capsys):
+    monkeypatch.setattr(
+        scheduled,
+        "run_scheduled",
+        lambda selected: (_ for _ in ()).throw(
+            RuntimeError("postgresql://user:secret@private-host/database")
+        ),
+    )
+
+    status = scheduled.main(["--season", "2026", "--expected-project-ref", PROJECT_REF])
+    output = capsys.readouterr().out
+
+    assert status == 1
+    assert json.loads(output)["error"] == "unexpected failure (RuntimeError)"
+    assert "secret" not in output
+    assert "private-host" not in output
+
+
+@pytest.mark.parametrize(
+    ("failed_check", "error", "expected_error"),
+    [
+        (
+            "private",
+            scheduled.ScheduledFpiError("committed publication receipt does not match"),
+            "committed publication receipt does not match",
+        ),
+        (
+            "public",
+            psycopg2.OperationalError(
+                "password=do-not-print postgresql://user:secret@private-host/database"
+            ),
+            "post-publication verification failed (type=OperationalError, code=none)",
+        ),
+        (
+            "public",
+            RuntimeError("postgresql://user:secret@private-host/database"),
+            "unexpected verification failure (RuntimeError)",
+        ),
+    ],
+)
+def test_main_retains_loaded_evidence_when_postpublication_verification_fails(
+    monkeypatch, tmp_path, capsys, failed_check, error, expected_error
+):
+    outputs = tmp_path / "outputs"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(outputs))
+    monkeypatch.setattr(scheduled, "season_for_date", lambda selected_date: 2026)
+    monkeypatch.setattr(scheduled.publication, "get_db_url", lambda: "resolved-dsn")
+    monkeypatch.setattr(
+        scheduled.canary,
+        "_inspect_target",
+        lambda *values: (
+            {"can_set_role": True, "assumed_role": scheduled.canary.PUBLISHER_ROLE},
+            {},
+        ),
+    )
+    monkeypatch.setattr(scheduled, "_require_policy", lambda *values: None)
+    calls = []
+
+    def publish(*values, **kwargs):
+        calls.append((values, kwargs))
+        return loaded_result()
+
+    def private_check(*values):
+        if failed_check == "private":
+            raise error
+
+    def public_check(*values):
+        if failed_check == "public":
+            raise error
+
+    monkeypatch.setattr(scheduled.publication, "run_source_publication", publish)
+    monkeypatch.setattr(scheduled, "_verify_private_receipt", private_check)
+    monkeypatch.setattr(scheduled, "_verify_public_freshness", public_check)
+
+    status = scheduled.main(["--season", "2026", "--expected-project-ref", PROJECT_REF])
+    output = capsys.readouterr().out
+    payload = json.loads(output)
+
+    assert status == 1
+    assert payload == {
+        "status": "verification_failed",
+        "source": "sdv_fpi_weekly",
+        "season": 2026,
+        "run_id": RUN_ID,
+        "generation_id": GENERATION_ID,
+        "rows": 276,
+        "sha": SHA256,
+        "duration_s": 4.5,
+        "phase": "post_publication_verification",
+        "publication_status": "loaded",
+        "error": expected_error,
+    }
+    assert len(calls) == 1
+    assert outputs.read_text().splitlines()[-1] == "publication_attempted=true"
+    assert "do-not-print" not in output
+    assert "secret" not in output
+    assert "private-host" not in output
+
+
+def test_main_prepublication_failure_has_no_publication_evidence(monkeypatch, capsys):
+    monkeypatch.setattr(scheduled, "season_for_date", lambda selected_date: 2026)
+    monkeypatch.setattr(scheduled.publication, "get_db_url", lambda: "resolved-dsn")
+    monkeypatch.setattr(
+        scheduled.canary,
+        "_inspect_target",
+        lambda *values: (_ for _ in ()).throw(
+            scheduled.canary.CanaryError("database migration ledger did not match")
+        ),
+    )
+    monkeypatch.setattr(
+        scheduled.publication,
+        "run_source_publication",
+        lambda *values, **kwargs: pytest.fail("prepublication failure must not publish"),
+    )
+
+    status = scheduled.main(["--season", "2026", "--expected-project-ref", PROJECT_REF])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert status == 1
+    assert payload["status"] == "failed"
+    assert payload["run_id"] is None
+    assert payload["generation_id"] is None
+    assert payload["sha"] is None
+    assert payload["rows"] == 0
+    assert "publication_status" not in payload
+    assert "phase" not in payload
+
+
+def test_scheduled_workflow_is_daily_bounded_and_default_off():
+    config = workflow()
+    triggers = config[True]
+    assert triggers == {"schedule": [{"cron": "17 10 * * *"}], "workflow_dispatch": None}
+    assert config["concurrency"] == {
+        "group": "flat-file-load",
+        "cancel-in-progress": False,
+    }
+    assert config["permissions"] == {"contents": "read"}
+    job = config["jobs"]["publish"]
+    assert job["if"] == "${{ vars.SDV_FPI_RECEIPT_SEASON == '2026' }}"
+    assert job["timeout-minutes"] == 30
+    assert config["env"]["SDV_FPI_RECEIPT_SEASON"] == ("${{ vars.SDV_FPI_RECEIPT_SEASON }}")
+    steps = {step.get("name"): step for step in job["steps"]}
+    assert steps["Publish and verify FPI receipt"]["id"] == "publish_fpi"
+    assert steps["Refresh external-rating consumers"]["if"] == (
+        "${{ !cancelled() && steps.publish_fpi.outputs.publication_attempted == 'true' && "
+        "(steps.publish_fpi.outcome == 'success' || steps.publish_fpi.outcome == 'failure') }}"
+    )
+    assert "${{" not in steps["Publish and verify FPI receipt"]["run"]
+
+
+@pytest.mark.parametrize(
+    ("failed_script", "attempted", "expected_status", "expected_count"),
+    [
+        ("", True, 0, 2),
+        ("scripts/run_scheduled_fpi_receipts.py", True, 17, 2),
+        ("scripts/refresh_marts.py", True, 17, 2),
+        ("", False, 0, 1),
+    ],
+)
+def test_scheduled_workflow_routes_arguments_refreshes_attempts_and_propagates_failure(
+    tmp_path, failed_script, attempted, expected_status, expected_count
+):
+    calls_path = tmp_path / "calls.jsonl"
+    outputs = tmp_path / "outputs"
+    fake_python = tmp_path / "python"
+    fake_python.write_text(
+        f"#!{sys.executable}\n"
+        "import json, os, sys\n"
+        "with open(os.environ['TEST_CALLS'], 'a') as log:\n"
+        "    log.write(json.dumps(sys.argv[1:]) + '\\n')\n"
+        "if sys.argv[1] == 'scripts/run_scheduled_fpi_receipts.py':\n"
+        "    with open(os.environ['GITHUB_OUTPUT'], 'a') as output:\n"
+        "        output.write('publication_attempted=' + os.environ['TEST_ATTEMPTED'] + '\\n')\n"
+        "sys.exit(17 if sys.argv[1] == os.environ.get('TEST_FAIL_SCRIPT') else 0)\n"
+    )
+    fake_python.chmod(0o755)
+    steps = workflow()["jobs"]["publish"]["steps"]
+    publish = next(step for step in steps if step.get("id") == "publish_fpi")
+    refresh = next(
+        step for step in steps if step.get("name") == "Refresh external-rating consumers"
+    )
+    env = {
+        **os.environ,
+        "PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}",
+        "TEST_CALLS": str(calls_path),
+        "TEST_FAIL_SCRIPT": failed_script,
+        "TEST_ATTEMPTED": str(attempted).lower(),
+        "GITHUB_OUTPUT": str(outputs),
+        "SDV_FPI_RECEIPT_SEASON": "2026",
+        "EXPECTED_PROJECT_REF": PROJECT_REF,
+    }
+    first = subprocess.run(
+        ["bash", "--noprofile", "--norc", "-eo", "pipefail", "-c", publish["run"]],
+        env=env,
+        check=False,
+    )
+    status = first.returncode
+    if attempted:
+        second = subprocess.run(
+            ["bash", "--noprofile", "--norc", "-eo", "pipefail", "-c", refresh["run"]],
+            env=env,
+            check=False,
+        )
+        status = status or second.returncode
+    calls = [json.loads(line) for line in calls_path.read_text().splitlines()]
+    assert status == expected_status
+    assert len(calls) == expected_count
+    assert calls[0] == [
+        "scripts/run_scheduled_fpi_receipts.py",
+        "--season",
+        "2026",
+        "--expected-project-ref",
+        PROJECT_REF,
+    ]
+    if attempted:
+        assert calls[1] == [
+            "scripts/refresh_marts.py",
+            "--views",
+            "marts.epa_crossvalidation",
+        ]


### PR DESCRIPTION
Automatic FPI loads currently use the legacy flat-file path, which cannot maintain publication receipts. This adds a daily 10:17 UTC FPI/2026 receipt workflow and a shared, default-off `SDV_FPI_RECEIPT_SEASON=2026` activation switch. Activation removes the entire planned FPI/2026 attempt from legacy `--due` loads, including its older-season fallback. Explicit historical plans, other sources, and manual source commands keep their existing behavior.

The driver requires the intended database, reviewed migration ledger, publisher-role access, and an explicit 36-hour publication-age policy. It publishes the registered artifact through the atomic adapter and verifies the committed receipt and freshness using both public caller roles. Verification failures retain operation/generation IDs, SHA, and row counts for reconciliation. Database credentials are scoped to the publication and refresh steps. Publication stops at the existing calendar season boundary.

The workflow takes the daily warehouse lock before the flat-file lock, matching the daily parent's order. All shared-group workflows preserve pending runs with `queue: max`. The FPI consumer refresh runs after attempted publication even on failure, without clearing the failure status. The runbook explains queue delays, activation, and recovery.

Validation: 146 current scheduling and orchestration tests passed; the earlier 128 driver/exclusion/canary checks and 256 publication/orchestration regressions also passed (suites overlap). Ruff and formatting passed, as did all six affected workflow YAML files and 39 Bash steps. Independent review is clear after the recovery, concurrency, credential, and fallback-documentation fixes. Detailed production activation evidence is maintained separately from this code PR.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds a **default-off** scheduled path for **SDV FPI 2026** publication receipts, and keeps legacy flat-file `--due` loads from competing with it.
> 
> When the repo variable `SDV_FPI_RECEIPT_SEASON` is exactly `2026`, a new **SDV FPI Receipts** workflow runs daily (10:17 UTC). It publishes `sdv_fpi_weekly` for 2026 through the existing atomic publication adapter (`run_scheduled_fpi_receipts.py`), with preflight checks (project, publisher role, exact 36-hour freshness policy) and post-publish verification of private receipt rows and `get_source_freshness` as `anon` and `authenticated`. It still refreshes `marts.epa_crossvalidation` after any attempted publication so partial commits are not left stale.
> 
> Legacy coordination: `flat-files.yml` passes `--exclude-source-season sdv_fpi_weekly:2026` on `--due` invocations when that switch is on; `load_flat_files.py` implements repeatable `SOURCE:SEASON` exclusions on due plans only (not with explicit `--source` or `--require-receipts`). Explicit `--source` behavior is unchanged.
> 
> **Concurrency:** shared warehouse workflows (`daily-season-load`, `flat-file-load`, and related) now use `queue: max` with `cancel-in-progress: false` so pending runs are kept instead of dropped while a long job holds the group. The FPI workflow joins `daily-season-load` when active, then `flat-file-load` for the publish job.
> 
> Operator docs live in `docs/scheduled-fpi-receipts.md` (activation, exclusion semantics including no legacy fallback for FPI/2026 when excluded, rollout/rollback).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7b02ab111fd2daf1b20ec3a7af6c805c342f939. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62844021"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge.

What we checked:
- The authored offline contract checker completed with exit code 0 and reported each current queue: max occurrence as supported. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- An independent, reproducible copy of the same checker was executed, finished with exit code 0, and produced the identical set of supported results as the original run. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- The official GitHub Actions concurrency syntax was consulted to validate the contract-validation approach. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<h3>Summary</h3>

- Adds a default-off scheduled path for publishing and verifying 2026 FPI source receipts.
- Coordinates scheduled, daily, backfill, schema, historical-refresh, and flat-file warehouse writers while retaining pending work.
- The shared concurrency configuration accepts `queue: max` at both workflow and job scope.

<sub>Reviews (2) · Last reviewed commit: ["Serialize scheduled FPI publication and ..."](https://github.com/rstover-fo/cfb-database/commit/b7b02ab111fd2daf1b20ec3a7af6c805c342f939)</sub>

<!-- /greptile_comment -->