### PR TITLE
Publish remaining SDV sources with verified weekly receipts

### DIFF
--- a/.github/workflows/flat-files.yml
+++ b/.github/workflows/flat-files.yml
@@ -24,7 +24,7 @@ on:
         type: string
         default: ""
       receipt_canary_action:
-        description: "Explicit FPI receipt canary action; none preserves the legacy loader"
+        description: "Explicit SDV receipt canary action; none preserves the legacy loader"
         required: false
         type: string
         default: "none"
@@ -59,7 +59,7 @@ on:
         required: false
         type: string
       receipt_canary_action:
-        description: "Explicit FPI receipt canary action"
+        description: "Explicit SDV receipt canary action"
         required: false
         type: choice
         default: "none"
@@ -117,11 +117,31 @@ jobs:
           SOURCE_INPUT: ${{ inputs.source }}
           SEASONS_INPUT: ${{ inputs.seasons }}
           SDV_FPI_RECEIPT_SEASON: ${{ vars.SDV_FPI_RECEIPT_SEASON }}
+          SDV_RATINGS_RECEIPT_SEASON: ${{ vars.SDV_RATINGS_RECEIPT_SEASON }}
+          SDV_TEAM_XWALK_RECEIPT_SEASON: ${{ vars.SDV_TEAM_XWALK_RECEIPT_SEASON }}
+          SDV_GAME_XWALK_RECEIPT_SEASON: ${{ vars.SDV_GAME_XWALK_RECEIPT_SEASON }}
         run: |
           due_exclusions=()
           if [ "$SDV_FPI_RECEIPT_SEASON" = "2026" ]; then
             due_exclusions+=(--exclude-source-season "sdv_fpi_weekly:2026")
           fi
+          case "$SDV_RATINGS_RECEIPT_SEASON" in
+            2026) due_exclusions+=(--exclude-source-season "sdv_ratings_weekly:2026") ;;
+            "") ;;
+            *) echo "::error::SDV_RATINGS_RECEIPT_SEASON must be empty or 2026"; exit 2 ;;
+          esac
+          # The implicit 2026 fetch can fall back to 2025. Both planned
+          # attempts must yield ownership of the receipted 2025 partition.
+          case "$SDV_TEAM_XWALK_RECEIPT_SEASON" in
+            2025) due_exclusions+=(--exclude-source-season "sdv_team_xwalk:2025" --exclude-source-season "sdv_team_xwalk:2026") ;;
+            "") ;;
+            *) echo "::error::SDV_TEAM_XWALK_RECEIPT_SEASON must be empty or 2025"; exit 2 ;;
+          esac
+          case "$SDV_GAME_XWALK_RECEIPT_SEASON" in
+            2025) due_exclusions+=(--exclude-source-season "sdv_game_xwalk:2025" --exclude-source-season "sdv_game_xwalk:2026") ;;
+            "") ;;
+            *) echo "::error::SDV_GAME_XWALK_RECEIPT_SEASON must be empty or 2025"; exit 2 ;;
+          esac
           if [ -n "$SEASONS_INPUT" ]; then
             # $SEASONS_INPUT is deliberately unquoted -- it is a
             # space-separated list of years and this loop relies on the
@@ -162,6 +182,11 @@ jobs:
             --season "$RECEIPT_CANARY_SEASON" \
             --expected-sha256 "$RECEIPT_EXPECTED_SHA256" \
             --expected-project-ref "$RECEIPT_EXPECTED_PROJECT_REF"
+      - name: Refresh canary rating consumers
+        # Publication may commit before returning a failed verification or an
+        # uncertain result. Refresh those rows without clearing the failure.
+        if: ${{ !cancelled() && steps.receipt_canary.outputs.publication_source == 'sdv_ratings_weekly' && steps.receipt_canary.outputs.publication_attempted == 'true' && (steps.receipt_canary.outcome == 'success' || steps.receipt_canary.outcome == 'failure') }}
+        run: python scripts/refresh_marts.py --views marts.epa_crossvalidation
       - name: Refresh external-rating consumers
         # A failed multi-source load may still have committed new ratings.
         # Refresh those rows, but preserve the failed load/job status. Skip

--- a/.github/workflows/flat-files.yml
+++ b/.github/workflows/flat-files.yml
@@ -96,8 +96,8 @@ jobs:
     # parquet load) across e.g. 12 seasons needs real headroom.
     timeout-minutes: 300
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
@@ -196,7 +196,7 @@ jobs:
         run: python scripts/refresh_marts.py --views marts.epa_crossvalidation
       - name: Open or update failure issue
         if: ${{ failure() && inputs.receipt_canary_action == 'none' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const title = "Flat-file load failures";

--- a/.github/workflows/sdv-source-receipts.yml
+++ b/.github/workflows/sdv-source-receipts.yml
@@ -35,8 +35,8 @@ jobs:
       queue: max
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip

--- a/.github/workflows/sdv-source-receipts.yml
+++ b/.github/workflows/sdv-source-receipts.yml
@@ -1,0 +1,55 @@
+name: SDV Source Receipts
+
+on:
+  schedule:
+    - cron: "29 10 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  # Preserve Daily's outer-then-inner lock order, shared with FPI. An inactive
+  # or invalid configuration cannot hold the daily writer's outer lock.
+  group: ${{ (vars.SDV_RATINGS_RECEIPT_SEASON == '2026' || vars.SDV_TEAM_XWALK_RECEIPT_SEASON == '2025' || vars.SDV_GAME_XWALK_RECEIPT_SEASON == '2025') && 'daily-season-load' || format('sdv-sources-inactive-{0}', github.run_id) }}
+  queue: max
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  PYTHON_VERSION: "3.11"
+  SDV_RATINGS_RECEIPT_SEASON: ${{ vars.SDV_RATINGS_RECEIPT_SEASON }}
+  SDV_TEAM_XWALK_RECEIPT_SEASON: ${{ vars.SDV_TEAM_XWALK_RECEIPT_SEASON }}
+  SDV_GAME_XWALK_RECEIPT_SEASON: ${{ vars.SDV_GAME_XWALK_RECEIPT_SEASON }}
+  EXPECTED_PROJECT_REF: "ibobsbwlewpqslkqbrjd"
+
+jobs:
+  publish:
+    name: Publish remaining SDV receipts
+    # Run invalid nonempty settings too, so the driver reports a configuration
+    # failure before database/provider access instead of silently skipping.
+    if: ${{ vars.SDV_RATINGS_RECEIPT_SEASON != '' || vars.SDV_TEAM_XWALK_RECEIPT_SEASON != '' || vars.SDV_GAME_XWALK_RECEIPT_SEASON != '' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency:
+      group: flat-file-load
+      queue: max
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+      - run: pip install -e ".[flatfiles]"
+      - name: Publish and verify SDV receipts
+        id: publish_sdv
+        env:
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+        run: |
+          python scripts/run_scheduled_sdv_receipts.py \
+            --expected-project-ref "$EXPECTED_PROJECT_REF"
+      - name: Refresh external-rating consumers
+        if: ${{ !cancelled() && steps.publish_sdv.outputs.ratings_publication_attempted == 'true' && (steps.publish_sdv.outcome == 'success' || steps.publish_sdv.outcome == 'failure') }}
+        env:
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+        run: python scripts/refresh_marts.py --views marts.epa_crossvalidation

--- a/docs/scheduled-sdv-receipts.md
+++ b/docs/scheduled-sdv-receipts.md
@@ -1,0 +1,144 @@
+# Scheduled SDV ratings and crosswalk receipts
+
+`SDV Source Receipts` publishes the explicitly activated SDV ratings and
+crosswalk scopes every Monday at 10:29 UTC. Each source has its own operation,
+receipt, current generation, and freshness policy. The separate
+[FPI publisher](scheduled-fpi-receipts.md) retains its daily schedule and
+36-hour policy.
+
+## Selected coverage and activation
+
+| Repository variable | Accepted active value | Published asset / coverage | Required policy |
+| --- | --- | --- | --- |
+| `SDV_RATINGS_RECEIPT_SEASON` | `2026` | `ratings.sdv_ratings_weekly` / `season:2026` | 8 days |
+| `SDV_TEAM_XWALK_RECEIPT_SEASON` | `2025` | `ref.team_id_xwalk` / `season:2025` | 8 days |
+| `SDV_GAME_XWALK_RECEIPT_SEASON` | `2025` | `ref.game_id_xwalk` / `season:2025` | 8 days |
+
+Unset variables leave their sources inactive. Unsupported nonempty values
+fail configuration validation. The driver distinguishes these publication
+seasons from the 2026 operating season and stops before database or provider
+access when that operating season ends, on August 1, 2027. Review the next
+scope or retire the variables and policies before then. A newly available
+crosswalk file for another season requires an explicit canary and coverage
+review; the scheduler never changes seasons or falls back automatically.
+
+An eight-day policy measures time since a successful complete publication.
+Weekly publication leaves one day for scheduling or warehouse delays before
+evidence becomes stale. It does not measure how recently the provider changed
+the file. Identical valid files are deliberately republished so both fetch
+evidence and upstream corrections remain reachable. The normal run fetches
+one artifact per active source, with the existing bounded fetch retries;
+redirects can add HTTP requests. These files do not consume CFBD API quota.
+
+Ratings use their in-file season. Registered crosswalk files have no season
+column, so scheduled receipts use the reviewed registered filename as their
+season basis. Publishing complete 2025 crosswalks does not satisfy freshness
+for 2026: a 2026 query continues reporting that coverage as unrecorded until
+genuine 2026 files are independently enrolled. Preserve unmatched provider IDs,
+NULL values, repeated team names, and repeated matchup keys distinguished by
+date. A complete receipt covers the validated file, not every possible team,
+game, or provider mapping.
+
+## Controlled activation
+
+1. Review and deploy the implementation with the new activation variables
+   unset. Verify the deployed revision and exact production migration manifest.
+2. Record and pause competing Daily, flat-file, and receipt workflows, then
+   drain their queued and active writers. The reusable canary workflow holds
+   only `flat-file-load`; it needs this temporary pause of outer-lock writers.
+3. Validate the registered artifact, review its business delta, and pin its SHA.
+   Run the canary's `preflight` through the actual publishing connection for
+   exactly one source and season. It verifies project routing, migration
+   checksums, actual runtime identity, bounded role access, and the source plan.
+4. Publish each selected canary separately. Reconcile a failure before starting
+   another canary. Check operation and generation IDs, complete coverage, SHA,
+   target keys and dlt lineage, unchanged unrelated rows, and actual `anon` and
+   `authenticated` freshness responses. Ratings also refresh
+   `marts.epa_crossvalidation` after a publication attempt, including failures
+   that may occur after commit. Preserve the original failure status.
+5. Configure only the selected policies through a guarded owner transaction,
+   requiring a recent complete current receipt and rejecting any conflicting
+   interval. Verify repeated application, public caller behavior, and denied
+   direct access to private policy data. A scheduler cannot create policies.
+6. Set each variable only after its corresponding canary and policy pass.
+   Verify legacy exclusions while writers remain paused, restore the recorded
+   workflow states, and dispatch `SDV Source Receipts`. Check all selected
+   outcomes and the ratings refresh. Observe a later automatic run separately
+   before claiming that cron execution is verified.
+
+The manual canary command is deliberately limited to one selection:
+
+```bash
+python scripts/run_source_receipt_canary.py preflight \
+  --source sdv_team_xwalk --season 2025 \
+  --expected-sha256 "$REVIEWED_SHA" \
+  --expected-project-ref "$EXPECTED_PROJECT_REF"
+```
+
+Use `publish` only after reviewing that same artifact and target. The canary
+fetches and validates the selected bytes, then publishes a pinned temporary
+copy. Its crosswalk receipt therefore honestly says `local_file` and
+`caller_declared`; keep the registered URL, filename season, and checksum in
+the associated operational evidence. The scheduled direct-URL path says
+`registered_url` and `registered_artifact_name`. Ratings retain `artifact_field`
+in both paths. A changed checksum requires a fresh artifact and delta review.
+
+## Scheduling, verification, and legacy ownership
+
+The new workflow takes `daily-season-load` first and `flat-file-load` second,
+using queued, non-cancelling concurrency in the same order as Daily and FPI.
+Inactive runs have a separate outer group. Database credentials are scoped to
+publication and refresh steps. Active sources run serially; a source failure
+does not prevent the other selected sources from being attempted, but any
+failure makes the whole run fail.
+
+Each source first checks the inspected connection, bounded publisher role,
+source plan, and exact policy. Publication uses that same connection for both
+the batch and dedicated ratings adapters. Verification matches the returned
+operation, new receipt, current generation, SHA, complete row counts, and
+source-specific provenance. Both public caller roles must return the new
+generation and a current, non-stale eight-day policy. An older current receipt
+cannot prove that this run succeeded.
+
+The legacy `Flat File Load` workflow excludes the following planned attempts
+when the corresponding variable is active:
+
+| Source | Excluded legacy source/season pairs |
+| --- | --- |
+| Ratings | `sdv_ratings_weekly:2026` |
+| Team crosswalk | `sdv_team_xwalk:2025`, `sdv_team_xwalk:2026` |
+| Game crosswalk | `sdv_game_xwalk:2025`, `sdv_game_xwalk:2026` |
+
+Both crosswalk pairs are necessary: legacy implicit-season fetching can try
+2026 and fall back to 2025 after planning. Excluding only the 2025 attempt would
+leave a path that overwrites receipted rows. These exclusions apply to implicit
+`--due` calls and explicit-season `--due` backfills. FPI retains its independent
+`sdv_fpi_weekly:2026` exclusion. Other source/seasons remain eligible.
+
+An explicit legacy `--source` invocation remains an intentional operator
+bypass. A local legacy loader invocation also has no repository-variable
+context unless exclusions are supplied. Such writes may invalidate a current
+receipt. Use the receipt publisher for maintained active scopes.
+
+## Failure recovery
+
+Retain each operation ID, generation ID, publication status, and failure phase.
+A failure in verification may follow a committed publication. Reconcile the
+exact operation, receipt, current pointer, and target rows before retrying;
+never automatically replay an uncertain commit. Source-specific transaction
+failures preserve the previous target/current generation and do not erase
+receipt history.
+
+Ratings consumer refresh runs after an attempted publication even when
+publication verification fails or another selected source fails. Crosswalk-only
+runs do not refresh that mart. A refresh failure makes the workflow fail without
+undoing the source publication. The mart remains an internal season-level
+comparison, excluded from as-of model inputs and shipping gates.
+
+To suspend scheduled retries during investigation, disable the dedicated
+workflow and retain activation variables so legacy exclusions still protect
+the receipted partitions. Evidence can become stale while publication is
+suspended. If a return to legacy ownership is deliberate, reconcile pending
+operations and retire its policy and activation variable together. Subsequent
+legacy writes may invalidate the old receipt; do not conceal that state by
+deleting history or changing a historical season label.

--- a/scripts/run_scheduled_sdv_receipts.py
+++ b/scripts/run_scheduled_sdv_receipts.py
@@ -1,0 +1,537 @@
+#!/usr/bin/env python3
+"""Publish and verify the explicitly activated remaining SDV receipts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import uuid
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import psycopg2
+from psycopg2 import sql
+
+from scripts import run_source_receipt_canary as canary
+from scripts.verify_load import SOURCE_FRESHNESS_FIELDS, _source_row_contract_error
+from src.pipelines.config.source_publication_assets import (
+    SOURCE_PUBLICATION_ASSETS,
+    SourcePublicationAsset,
+)
+from src.pipelines.sources.flat_files import REGISTRY, season_for_date
+from src.pipelines.utils import flat_file_publication as publication
+from src.pipelines.utils import sdv_ratings_publication
+
+OPERATING_SEASON = 2026
+PUBLIC_ROLES = ("anon", "authenticated")
+SHA256_RE = re.compile(r"[0-9a-f]{64}")
+
+
+@dataclass(frozen=True)
+class Activation:
+    source: str
+    variable: str
+    season: int
+
+    @property
+    def asset(self) -> SourcePublicationAsset:
+        return SOURCE_PUBLICATION_ASSETS[self.source]
+
+
+ACTIVATIONS = (
+    Activation("sdv_ratings_weekly", "SDV_RATINGS_RECEIPT_SEASON", 2026),
+    Activation("sdv_team_xwalk", "SDV_TEAM_XWALK_RECEIPT_SEASON", 2025),
+    Activation("sdv_game_xwalk", "SDV_GAME_XWALK_RECEIPT_SEASON", 2025),
+)
+
+
+class ScheduledSdvError(RuntimeError):
+    """A bounded scheduled-publication failure safe to report."""
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Publish activated SDV ratings and crosswalk receipts"
+    )
+    parser.add_argument(
+        "--expected-project-ref",
+        type=canary._project_ref,
+        required=True,
+        action=canary._StoreOnce,
+    )
+    return parser
+
+
+def _append_workflow_outputs(**values: str) -> None:
+    target = os.environ.get("GITHUB_OUTPUT")
+    if not target:
+        return
+    with Path(target).open("a", encoding="utf-8") as output:
+        for name, value in values.items():
+            output.write(f"{name}={value}\n")
+
+
+def _selected_activations(environ: Mapping[str, str]) -> list[Activation]:
+    selected = []
+    for activation in ACTIVATIONS:
+        value = environ.get(activation.variable)
+        if value in {None, ""}:
+            continue
+        if value != str(activation.season):
+            raise ScheduledSdvError(
+                f"{activation.variable} must be exactly {activation.season} when set"
+            )
+        selected.append(activation)
+    return selected
+
+
+def _database_failure(error: psycopg2.Error, operation: str) -> ScheduledSdvError:
+    return ScheduledSdvError(
+        f"{operation} failed (type={type(error).__name__}, code={error.pgcode or 'none'})"
+    )
+
+
+def _require_policy(
+    dsn: str,
+    activation: Activation,
+    *,
+    connector=psycopg2.connect,
+) -> None:
+    """Require one exact eight-day policy without modifying policy state."""
+    try:
+        conn = connector(dsn, connect_timeout=10, application_name="scheduled-sdv-policy")
+        try:
+            conn.set_session(readonly=True, autocommit=False)
+            with conn.cursor() as cur:
+                cur.execute("SET LOCAL statement_timeout = '15s'")
+                cur.execute("SET LOCAL lock_timeout = '5s'")
+                cur.execute(
+                    """
+                    SELECT expected_refresh_interval = interval '8 days'
+                    FROM meta.asset_freshness_policies
+                    WHERE asset_key = %s AND coverage_key = %s
+                    """,
+                    (
+                        activation.asset.asset_key,
+                        activation.asset.coverage_key(activation.season),
+                    ),
+                )
+                rows = cur.fetchall()
+            conn.rollback()
+        except BaseException:
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+            raise
+        finally:
+            conn.close()
+    except psycopg2.Error as error:
+        raise _database_failure(error, "freshness policy inspection") from None
+    if rows != [(True,)]:
+        raise ScheduledSdvError(
+            f"{activation.source}/{activation.season} freshness policy must be exactly 8 days"
+        )
+
+
+def _require_publication_result(source: str, result: dict[str, Any]) -> None:
+    if result.get("source") != source or result.get("status") not in {
+        "loaded",
+        "not_published",
+        "blocked",
+        "failed",
+    }:
+        raise ScheduledSdvError("publisher returned an invalid publication status")
+    try:
+        run_id = str(result.get("run_id"))
+        generation_id = str(result.get("generation_id"))
+        if str(uuid.UUID(run_id)) != run_id or str(uuid.UUID(generation_id)) != generation_id:
+            raise ValueError
+    except (TypeError, ValueError, AttributeError) as error:
+        raise ScheduledSdvError("publisher returned invalid receipt identifiers") from error
+    rows = result.get("rows")
+    duration = result.get("duration_s")
+    sha256 = result.get("sha")
+    if (
+        type(rows) is not int
+        or rows < 0
+        or isinstance(duration, bool)
+        or not isinstance(duration, (int, float))
+        or not math.isfinite(duration)
+        or duration < 0
+        or (sha256 is not None and SHA256_RE.fullmatch(str(sha256)) is None)
+    ):
+        raise ScheduledSdvError("publisher returned invalid publication evidence")
+    if result.get("status") == "loaded" and (rows <= 0 or sha256 is None):
+        raise ScheduledSdvError("publisher returned incomplete publication evidence")
+
+
+def _verify_private_receipt(
+    dsn: str,
+    activation: Activation,
+    result: dict[str, Any],
+    *,
+    connector=psycopg2.connect,
+) -> None:
+    """Match the returned operation and generation to committed receipt evidence."""
+    try:
+        conn = connector(dsn, connect_timeout=10, application_name="scheduled-sdv-receipt")
+        try:
+            conn.set_session(readonly=True, autocommit=False)
+            with conn.cursor() as cur:
+                cur.execute("SET LOCAL statement_timeout = '15s'")
+                cur.execute("SET LOCAL lock_timeout = '5s'")
+                cur.execute(
+                    """
+                    SELECT receipt.operation_run_id::text,
+                           receipt.generation_id::text,
+                           receipt.source_watermark,
+                           receipt.outcome,
+                           receipt.coverage,
+                           receipt.input_observations,
+                           receipt.row_delta,
+                           current_generation.generation_id::text
+                    FROM meta.asset_receipts AS receipt
+                    JOIN meta.asset_current_generations AS current_generation
+                      ON current_generation.asset_key = receipt.asset_key
+                     AND current_generation.coverage_key = receipt.coverage_key
+                    WHERE receipt.asset_key = %s
+                      AND receipt.coverage_key = %s
+                      AND receipt.generation_id = %s::uuid
+                    """,
+                    (
+                        activation.asset.asset_key,
+                        activation.asset.coverage_key(activation.season),
+                        result["generation_id"],
+                    ),
+                )
+                rows = cur.fetchall()
+            conn.rollback()
+        except BaseException:
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+            raise
+        finally:
+            conn.close()
+    except psycopg2.Error as error:
+        raise _database_failure(error, "publication receipt verification") from None
+
+    if len(rows) != 1 or len(rows[0]) != 8:
+        raise ScheduledSdvError("committed publication receipt is missing or ambiguous")
+    run_id, generation_id, sha256, outcome, coverage, inputs, delta, current = rows[0]
+    expected_rows = result["rows"]
+    if (
+        run_id != result["run_id"]
+        or generation_id != result["generation_id"]
+        or current != result["generation_id"]
+        or sha256 != result["sha"]
+        or outcome != "succeeded"
+        or type(coverage) is not dict
+        or coverage.get("complete") is not True
+        or coverage.get("scope") != "season"
+        or coverage.get("season") != activation.season
+        or coverage.get("mode") != "full_file_for_season"
+        or coverage.get("source_rows") != expected_rows
+        or coverage.get("published_rows") != expected_rows
+        or type(inputs) is not dict
+        or inputs.get("publisher") != "load_flat_files"
+        or inputs.get("protocol") != activation.asset.protocol
+        or inputs.get("parser_contract") != activation.asset.parser_contract
+        or inputs.get("stage_schema") != "warehouse_source_stage"
+        or inputs.get("artifact_origin") != "registered_url"
+        or type(delta) is not dict
+        or delta.get("published_rows") != expected_rows
+    ):
+        raise ScheduledSdvError("committed publication receipt does not match the result")
+    if activation.source != "sdv_ratings_weekly" and (
+        inputs.get("source_name") != activation.source
+        or inputs.get("season_basis") != "registered_artifact_name"
+    ):
+        raise ScheduledSdvError("committed publication provenance does not match the source")
+
+
+def _read_public_freshness(
+    dsn: str,
+    role: str,
+    activation: Activation,
+    *,
+    connector=psycopg2.connect,
+) -> tuple[dict[str, Any], bool]:
+    try:
+        conn = connector(dsn, connect_timeout=10, application_name="scheduled-sdv-freshness")
+        try:
+            conn.set_session(readonly=True, autocommit=False)
+            with conn.cursor() as cur:
+                cur.execute("SET LOCAL statement_timeout = '15s'")
+                cur.execute("SET LOCAL lock_timeout = '5s'")
+                cur.execute(sql.SQL("SET LOCAL ROLE {}").format(sql.Identifier(role)))
+                cur.execute("SELECT current_user::text")
+                identity = cur.fetchone()
+                if identity != (role,):
+                    raise ScheduledSdvError(
+                        f"freshness verification did not assume the {role} role"
+                    )
+                cur.execute(
+                    """
+                    SELECT to_jsonb(f),
+                           f.expected_refresh_interval = interval '8 days'
+                    FROM public.get_source_freshness(%s) AS f
+                    WHERE f.source_name = %s
+                    """,
+                    (activation.season, activation.source),
+                )
+                rows = cur.fetchall()
+            conn.rollback()
+        except BaseException:
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+            raise
+        finally:
+            conn.close()
+    except ScheduledSdvError:
+        raise
+    except psycopg2.Error as error:
+        raise _database_failure(error, f"{role} freshness verification") from None
+    if len(rows) != 1 or len(rows[0]) != 2 or type(rows[0][0]) is not dict:
+        raise ScheduledSdvError(f"{role} freshness response is missing or ambiguous")
+    return rows[0]
+
+
+def _verify_public_freshness(
+    dsn: str,
+    activation: Activation,
+    result: dict[str, Any],
+) -> None:
+    expected_basis = (
+        "artifact_field"
+        if activation.source == "sdv_ratings_weekly"
+        else "registered_artifact_name"
+    )
+    for role in PUBLIC_ROLES:
+        row, interval_matches = _read_public_freshness(dsn, role, activation)
+        if frozenset(row) != SOURCE_FRESHNESS_FIELDS:
+            raise ScheduledSdvError(f"{role} freshness response has an invalid shape")
+        contract_error = _source_row_contract_error(row, activation.source)
+        if contract_error is not None:
+            raise ScheduledSdvError(f"{role} freshness response is invalid: {contract_error}")
+        if (
+            row["source_name"] != activation.source
+            or row["asset_key"] != activation.asset.asset_key
+            or row["season"] != activation.season
+            or row["coverage_key"] != activation.asset.coverage_key(activation.season)
+            or str(row["generation_id"]) != result["generation_id"]
+            or row["publication_state"] != "current"
+            or row["current_outcome"] != "succeeded"
+            or row["is_complete"] is not True
+            or row["source_rows"] != result["rows"]
+            or row["published_rows"] != result["rows"]
+            or row["artifact_origin"] != "registered_url"
+            or row["season_basis"] != expected_basis
+            or row["latest_outcome"] != "succeeded"
+            or interval_matches is not True
+            or row["is_stale"] is not False
+        ):
+            raise ScheduledSdvError(f"{role} freshness response does not match publication")
+
+
+def _source_payload(
+    status: str,
+    activation: Activation,
+    result: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    result = result or {}
+    payload = {
+        "status": status,
+        "source": activation.source,
+        "season": activation.season,
+        "asset_key": activation.asset.asset_key,
+        "coverage_key": activation.asset.coverage_key(activation.season),
+        "run_id": result.get("run_id"),
+        "generation_id": result.get("generation_id"),
+        "rows": result.get("rows", 0),
+        "sha": result.get("sha"),
+        "duration_s": result.get("duration_s", 0.0),
+    }
+    if result.get("status") == "loaded":
+        payload.update(
+            artifact_origin="registered_url",
+            season_basis=(
+                "artifact_field"
+                if activation.source == "sdv_ratings_weekly"
+                else "registered_artifact_name"
+            ),
+        )
+    return payload
+
+
+def _safe_failure(
+    activation: Activation,
+    error: BaseException,
+    result: dict[str, Any] | None = None,
+    *,
+    phase: str,
+) -> dict[str, Any]:
+    payload = _source_payload("verification_failed" if result else "failed", activation, result)
+    payload["phase"] = phase
+    if isinstance(error, (ScheduledSdvError, canary.CanaryError)):
+        payload["error"] = str(error)[:240]
+    elif isinstance(error, psycopg2.Error):
+        payload["error"] = str(_database_failure(error, phase))
+    elif isinstance(error, publication.SourcePublicationError):
+        payload["error"] = "source publication validation failed"
+    else:
+        payload["error"] = f"unexpected failure ({type(error).__name__})"
+    return payload
+
+
+def _publish(activation: Activation) -> dict[str, Any]:
+    if activation.source == "sdv_ratings_weekly":
+        _append_workflow_outputs(ratings_publication_attempted="true")
+        return sdv_ratings_publication.run_sdv_ratings_publication(
+            REGISTRY[activation.source], season=activation.season
+        )
+    return publication.run_source_publication(REGISTRY[activation.source], season=activation.season)
+
+
+def _run_one(dsn: str, project_ref: str, activation: Activation) -> tuple[dict[str, Any], bool]:
+    try:
+        identity, plan = canary._inspect_target(
+            dsn,
+            project_ref,
+            activation.source,
+            activation.season,
+        )
+        if (
+            identity.get("can_set_role") is not True
+            or identity.get("assumed_role") != canary.PUBLISHER_ROLE
+            or plan is None
+        ):
+            raise ScheduledSdvError("bounded source publisher role is unavailable")
+        _require_policy(dsn, activation)
+    except BaseException as error:
+        if isinstance(error, (KeyboardInterrupt, SystemExit)):
+            raise
+        return _safe_failure(activation, error, phase="preflight"), False
+
+    try:
+        result = _publish(activation)
+    except BaseException as error:
+        if isinstance(error, (KeyboardInterrupt, SystemExit)):
+            raise
+        return _safe_failure(activation, error, phase="publication"), False
+
+    try:
+        _require_publication_result(activation.source, result)
+    except BaseException as error:
+        if isinstance(error, (KeyboardInterrupt, SystemExit)):
+            raise
+        retained_result = result if isinstance(result, dict) else None
+        return (
+            _safe_failure(
+                activation,
+                error,
+                retained_result,
+                phase="publication_result_validation",
+            ),
+            False,
+        )
+
+    if result["status"] != "loaded":
+        payload = _source_payload(str(result["status"]), activation, result)
+        payload["phase"] = "publication"
+        payload["error_category"] = "source_publication_failed"
+        return payload, False
+
+    try:
+        _verify_private_receipt(dsn, activation, result)
+        _verify_public_freshness(dsn, activation, result)
+    except BaseException as error:
+        if isinstance(error, (KeyboardInterrupt, SystemExit)):
+            raise
+        return (
+            _safe_failure(
+                activation,
+                error,
+                result,
+                phase="post_publication_verification",
+            ),
+            False,
+        )
+    return _source_payload("loaded", activation, result), True
+
+
+def run_scheduled(
+    args: argparse.Namespace,
+    *,
+    today: date | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> tuple[dict[str, Any], int]:
+    _append_workflow_outputs(ratings_publication_attempted="false")
+    selected = _selected_activations(os.environ if environ is None else environ)
+    current_season = season_for_date(today or date.today())
+    if current_season != OPERATING_SEASON:
+        return {
+            "status": "skipped",
+            "operating_season": current_season,
+            "reason": "remaining SDV receipt rollout is limited to operating season 2026",
+            "sources": [],
+        }, 0
+    if not selected:
+        return {
+            "status": "inactive",
+            "operating_season": current_season,
+            "sources": [],
+        }, 0
+
+    dsn = publication.get_db_url()
+    outcomes = []
+    all_succeeded = True
+    with canary.pinned_publication_connection(dsn):
+        for activation in selected:
+            outcome, succeeded = _run_one(dsn, args.expected_project_ref, activation)
+            outcomes.append(outcome)
+            all_succeeded = all_succeeded and succeeded
+    return {
+        "status": "loaded" if all_succeeded else "failed",
+        "operating_season": current_season,
+        "sources": outcomes,
+    }, 0 if all_succeeded else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        payload, status = run_scheduled(args)
+    except ScheduledSdvError as error:
+        payload = {"status": "failed", "error": str(error)[:240], "sources": []}
+        status = 1
+    except psycopg2.Error as error:
+        payload = {
+            "status": "failed",
+            "error": str(_database_failure(error, "database operation")),
+            "sources": [],
+        }
+        status = 1
+    except Exception as error:
+        payload = {
+            "status": "failed",
+            "error": f"unexpected failure ({type(error).__name__})",
+            "sources": [],
+        }
+        status = 1
+    print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+    return status
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_source_receipt_canary.py
+++ b/scripts/run_source_receipt_canary.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run the explicitly selected FPI source-receipt canary.
+"""Run one explicitly selected, checksum-pinned SDV source-receipt canary.
 
 The canary is intentionally limited to one registered source and one explicit
 season.  Both modes inspect the actual publisher connection and validate the
@@ -16,7 +16,9 @@ import json
 import os
 import re
 import tempfile
-from dataclasses import dataclass
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
 from datetime import date
 from pathlib import Path
 from typing import Any
@@ -26,7 +28,11 @@ import psycopg2
 from psycopg2 import sql
 from psycopg2.extensions import parse_dsn
 
-from src.pipelines.config.source_publication_assets import SDV_FPI_PUBLICATION
+from src.pipelines.config.source_publication_assets import (
+    SDV_FPI_PUBLICATION,
+    SOURCE_PUBLICATION_ASSETS,
+    SourcePublicationAsset,
+)
 from src.pipelines.sources.flat_files import (
     REGISTRY,
     ParseContext,
@@ -34,8 +40,16 @@ from src.pipelines.sources.flat_files import (
     resolve_parser,
 )
 from src.pipelines.utils import flat_file_publication as publication
+from src.pipelines.utils import sdv_ratings_publication
 from src.pipelines.utils.file_fetcher import FetchedFile, fetch_file
 
+SOURCES = (
+    "sdv_fpi_weekly",
+    "sdv_ratings_weekly",
+    "sdv_team_xwalk",
+    "sdv_game_xwalk",
+)
+# Retained for callers that imported the original single-source constant.
 SOURCE = "sdv_fpi_weekly"
 PUBLISHER_ROLE = "warehouse_source_publisher"
 SHA256_RE = re.compile(r"[0-9a-f]{64}")
@@ -61,19 +75,32 @@ class ArtifactFetchError(RuntimeError):
         self.details = details
 
 
+class _StoreOnce(argparse.Action):
+    """Reject repeated security-sensitive selectors instead of taking the last one."""
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        if getattr(namespace, self.dest, None) is not None:
+            parser.error(f"{option_string} must be provided exactly once")
+        setattr(namespace, self.dest, values)
+
+
 @dataclass(frozen=True)
 class Artifact:
     content: bytes
     sha256: str
     rows: int
-    weeks: tuple[int, ...]
+    weeks: tuple[int, ...] | None = None
+    summary: dict[str, Any] = field(default_factory=dict)
 
     def evidence(self) -> dict[str, Any]:
-        return {
+        evidence = {
             "sha256": self.sha256,
             "rows": self.rows,
-            "weeks": list(self.weeks),
         }
+        if self.weeks is not None:
+            evidence["weeks"] = list(self.weeks)
+        evidence.update(self.summary)
+        return evidence
 
 
 def _sha256(value: str) -> str:
@@ -102,13 +129,15 @@ def _season(value: str) -> int:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Validate or publish one checksum-pinned SDV FPI season receipt"
+        description="Validate or publish one checksum-pinned SDV season receipt"
     )
     parser.add_argument("action", choices=("preflight", "publish"))
-    parser.add_argument("--source", choices=(SOURCE,), required=True)
-    parser.add_argument("--season", type=_season, required=True)
-    parser.add_argument("--expected-sha256", type=_sha256, required=True)
-    parser.add_argument("--expected-project-ref", type=_project_ref, required=True)
+    parser.add_argument("--source", choices=SOURCES, required=True, action=_StoreOnce)
+    parser.add_argument("--season", type=_season, required=True, action=_StoreOnce)
+    parser.add_argument("--expected-sha256", type=_sha256, required=True, action=_StoreOnce)
+    parser.add_argument(
+        "--expected-project-ref", type=_project_ref, required=True, action=_StoreOnce
+    )
     return parser
 
 
@@ -179,6 +208,7 @@ def _inspect_target(
     connector=psycopg2.connect,
 ) -> tuple[dict[str, Any], dict[str, Any] | None]:
     """Validate target identity and source plan in a read-only transaction."""
+    asset = _asset(source)
     project_evidence = _dsn_project_evidence(dsn, expected_project_ref)
     expected_migrations = _expected_migrations()
     expected_by_id = {row[0]: row for row in expected_migrations}
@@ -245,14 +275,23 @@ def _inspect_target(
                     assumed_role = role_row[0] if role_row else None
                     if assumed_role != PUBLISHER_ROLE:
                         raise CanaryError("database did not assume the bounded publisher role")
-                    cur.execute(
-                        "SELECT warehouse_source_batch.get_source_plan(%s,%s)",
-                        (source, season),
-                    )
+                    if source == "sdv_ratings_weekly":
+                        cur.execute(
+                            "SELECT warehouse_source.get_sdv_ratings_plan(%s)",
+                            (season,),
+                        )
+                    else:
+                        cur.execute(
+                            "SELECT warehouse_source_batch.get_source_plan(%s,%s)",
+                            (source, season),
+                        )
                     plan_row = cur.fetchone()
                     if plan_row is None:
                         raise CanaryError("bounded publisher returned no source plan")
-                    plan = publication._validated_plan(plan_row[0], SDV_FPI_PUBLICATION, season)
+                    if source == "sdv_ratings_weekly":
+                        plan = sdv_ratings_publication._validated_plan(plan_row[0], season)
+                    else:
+                        plan = publication._validated_plan(plan_row[0], asset, season)
             conn.rollback()
         except BaseException:
             try:
@@ -291,6 +330,7 @@ def _inspect_target(
 
 
 def _download_and_validate(source: str, season: int, expected_sha256: str) -> Artifact:
+    asset = _asset(source)
     spec = REGISTRY[source]
     url = resolve_fetch_url(spec, season)
     if url is None:
@@ -334,11 +374,86 @@ def _download_and_validate(source: str, season: int, expected_sha256: str) -> Ar
         source_url=fetched.source_url,
         file_name=os.path.basename(fetched.source_url),
     )
-    raw_count = publication._raw_row_count(fetched.content, SDV_FPI_PUBLICATION, season)
+    if source == "sdv_ratings_weekly":
+        raw_count = sdv_ratings_publication._raw_row_count(fetched.content)
+    else:
+        raw_count = publication._raw_row_count(fetched.content, asset, season)
     rows = list(resolve_parser(spec.parser)(fetched.content, context))
-    publication._validate_parsed_rows(rows, raw_count, SDV_FPI_PUBLICATION, season)
-    weeks = tuple(sorted({row["week"] for row in rows}))
-    return Artifact(fetched.content, computed_sha256, len(rows), weeks)
+    if source == "sdv_ratings_weekly":
+        sdv_ratings_publication._validate_parsed_rows(rows, raw_count, season)
+    else:
+        publication._validate_parsed_rows(rows, raw_count, asset, season)
+    return _artifact(source, season, fetched, computed_sha256, rows)
+
+
+def _asset(source: str) -> SourcePublicationAsset:
+    try:
+        return SOURCE_PUBLICATION_ASSETS[source]
+    except KeyError:
+        raise CanaryError("source is not enrolled in the SDV receipt canary") from None
+
+
+def _artifact(
+    source: str,
+    season: int,
+    fetched: FetchedFile,
+    sha256: str,
+    rows: list[dict[str, Any]],
+) -> Artifact:
+    if source == "sdv_fpi_weekly":
+        return Artifact(
+            fetched.content,
+            sha256,
+            len(rows),
+            tuple(sorted({row["week"] for row in rows})),
+        )
+    if source == "sdv_ratings_weekly":
+        return Artifact(
+            fetched.content,
+            sha256,
+            len(rows),
+            summary={
+                "through_weeks": sorted({row["through_week"] for row in rows}),
+                "teams": len({row["team_id"] for row in rows}),
+            },
+        )
+
+    registered_url = resolve_fetch_url(REGISTRY[source], season)
+    common = {
+        "registered_url": registered_url,
+        "registered_file_name": os.path.basename(registered_url or fetched.source_url),
+        "publication_artifact_origin": "local_file",
+        "season_basis": "caller_declared",
+    }
+    if source == "sdv_team_xwalk":
+        common.update(
+            xwalk_keys=len({row["xwalk_key"] for row in rows}),
+            espn_team_ids=len(
+                {row["espn_team_id"] for row in rows if row["espn_team_id"] is not None}
+            ),
+        )
+    else:
+        common.update(
+            matchup_date_keys=len({(row["matchup_key"], row["yahoo_date"]) for row in rows}),
+            espn_game_ids=len(
+                {row["espn_game_id"] for row in rows if row["espn_game_id"] is not None}
+            ),
+        )
+    return Artifact(fetched.content, sha256, len(rows), summary=common)
+
+
+@contextmanager
+def pinned_publication_connection(dsn: str) -> Iterator[None]:
+    """Pin both publication adapters to the already inspected connection."""
+    original_batch = publication.get_db_url
+    original_ratings = sdv_ratings_publication.get_db_url
+    publication.get_db_url = lambda: dsn
+    sdv_ratings_publication.get_db_url = lambda: dsn
+    try:
+        yield
+    finally:
+        publication.get_db_url = original_batch
+        sdv_ratings_publication.get_db_url = original_ratings
 
 
 def _publish_pinned(
@@ -348,21 +463,37 @@ def _publish_pinned(
     artifact: Artifact,
 ) -> dict[str, Any]:
     """Publish once from a temporary copy of the already verified bytes."""
-    original_get_db_url = publication.get_db_url
-    try:
-        publication.get_db_url = lambda: dsn
-        with tempfile.TemporaryDirectory(prefix="sdv-fpi-receipt-canary-") as directory:
-            path = Path(directory) / f"cfb_fpi_weekly_{season}.parquet"
+    with pinned_publication_connection(dsn):
+        with tempfile.TemporaryDirectory(prefix="sdv-receipt-canary-") as directory:
+            registered_url = resolve_fetch_url(REGISTRY[source], season)
+            file_name = os.path.basename(registered_url or f"{source}_{season}.parquet")
+            path = Path(directory) / file_name
             path.write_bytes(artifact.content)
-            result = publication.run_source_publication(
-                REGISTRY[source], file_path=str(path), season=season
-            )
-    finally:
-        publication.get_db_url = original_get_db_url
+            if source == "sdv_ratings_weekly":
+                result = sdv_ratings_publication.run_sdv_ratings_publication(
+                    REGISTRY[source], file_path=str(path), season=season
+                )
+            else:
+                result = publication.run_source_publication(
+                    REGISTRY[source], file_path=str(path), season=season
+                )
     return result
 
 
+def _append_workflow_outputs(**values: str) -> None:
+    target = os.environ.get("GITHUB_OUTPUT")
+    if not target:
+        return
+    with Path(target).open("a", encoding="utf-8") as output:
+        for name, value in values.items():
+            output.write(f"{name}={value}\n")
+
+
 def run_canary(args: argparse.Namespace) -> tuple[dict[str, Any], int]:
+    _append_workflow_outputs(
+        publication_attempted="false",
+        publication_source=args.source,
+    )
     dsn = publication.get_db_url()
     identity, plan = _inspect_target(
         dsn,
@@ -386,6 +517,7 @@ def run_canary(args: argparse.Namespace) -> tuple[dict[str, Any], int]:
         payload["status"] = "ready" if plan is not None else "activation_required"
         return payload, 0
 
+    _append_workflow_outputs(publication_attempted="true")
     result = _publish_pinned(dsn, args.source, args.season, artifact)
     payload["publication"] = result
     if result.get("status") != "loaded":
@@ -433,7 +565,19 @@ def main(argv: list[str] | None = None) -> int:
     except ArtifactFetchError as error:
         payload = _failure_payload(args, **error.details)
         status = 1
-    except (CanaryError, publication.SourcePublicationError) as error:
+    except publication.SourcePublicationError as error:
+        message = (
+            "SDV ratings source publication validation failed"
+            if args.source == "sdv_ratings_weekly"
+            else str(error)
+        )
+        payload = _failure_payload(
+            args,
+            status="failed",
+            error=message,
+        )
+        status = 1
+    except CanaryError as error:
         payload = _failure_payload(
             args,
             status="failed",

--- a/tests/test_f10_flat_file_workflow.py
+++ b/tests/test_f10_flat_file_workflow.py
@@ -25,7 +25,7 @@ def test_flat_file_workflow_is_reusable_and_keeps_manual_backfills():
         assert triggers["workflow_call"]["inputs"][name]["default"] == ""
         assert triggers["workflow_dispatch"]["inputs"][name]["required"] is False
     assert triggers["workflow_call"]["inputs"]["receipt_canary_action"] == {
-        "description": "Explicit FPI receipt canary action; none preserves the legacy loader",
+        "description": "Explicit SDV receipt canary action; none preserves the legacy loader",
         "required": False,
         "type": "string",
         "default": "none",
@@ -207,7 +207,7 @@ def test_canary_is_excluded_from_legacy_refresh_and_failure_issue():
     )
 
 
-def run_steps(tmp_path, sources, seasons, failed_script="", activation=""):
+def run_steps(tmp_path, sources, seasons, failed_script="", activation="", sdv_activations=None):
     """Run completed import and refresh commands while preserving failed status."""
     calls_path = tmp_path / "calls.jsonl"
     fake_python = tmp_path / "python"
@@ -245,8 +245,12 @@ def run_steps(tmp_path, sources, seasons, failed_script="", activation=""):
         "SOURCE_INPUT": sources,
         "SEASONS_INPUT": seasons,
         "SDV_FPI_RECEIPT_SEASON": activation,
+        "SDV_RATINGS_RECEIPT_SEASON": "",
+        "SDV_TEAM_XWALK_RECEIPT_SEASON": "",
+        "SDV_GAME_XWALK_RECEIPT_SEASON": "",
         "TEST_CALLS": str(calls_path),
         "TEST_FAIL_SCRIPT": failed_script,
+        **(sdv_activations or {}),
     }
     status = 0
     for step in selected:

--- a/tests/test_scheduled_sdv_receipts.py
+++ b/tests/test_scheduled_sdv_receipts.py
@@ -1,0 +1,552 @@
+"""Behavioral coverage for the remaining SDV receipt scheduler."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import uuid
+from datetime import date
+
+import psycopg2
+import pytest
+
+from scripts import run_scheduled_sdv_receipts as scheduled
+
+PROJECT_REF = "ibobsbwlewpqslkqbrjd"
+SHA256 = "a" * 64
+
+
+def args() -> argparse.Namespace:
+    return argparse.Namespace(expected_project_ref=PROJECT_REF)
+
+
+def activation(source: str) -> scheduled.Activation:
+    return next(item for item in scheduled.ACTIVATIONS if item.source == source)
+
+
+def loaded_result(source: str, *, rows: int = 12) -> dict:
+    return {
+        "status": "loaded",
+        "source": source,
+        "rows": rows,
+        "sha": SHA256,
+        "duration_s": 1.25,
+        "run_id": str(uuid.uuid5(uuid.NAMESPACE_DNS, f"run-{source}")),
+        "generation_id": str(uuid.uuid5(uuid.NAMESPACE_DNS, f"generation-{source}")),
+    }
+
+
+def selected_environment(*sources: str) -> dict[str, str]:
+    selected = set(sources)
+    return {
+        item.variable: str(item.season) for item in scheduled.ACTIVATIONS if item.source in selected
+    }
+
+
+@pytest.mark.parametrize("source", [item.source for item in scheduled.ACTIVATIONS])
+def test_activation_selects_only_exact_nonempty_values(source):
+    assert scheduled._selected_activations(selected_environment(source)) == [activation(source)]
+
+
+@pytest.mark.parametrize("value", ["2024", "2026 ", "all"])
+def test_activation_rejects_wrong_nonempty_value(value):
+    with pytest.raises(scheduled.ScheduledSdvError, match="must be exactly 2026"):
+        scheduled._selected_activations({"SDV_RATINGS_RECEIPT_SEASON": value})
+
+
+def test_empty_activation_values_are_inactive():
+    assert (
+        scheduled._selected_activations({item.variable: "" for item in scheduled.ACTIVATIONS}) == []
+    )
+
+
+def test_cli_requires_exactly_one_project_reference():
+    parser = scheduled.build_parser()
+    with pytest.raises(SystemExit, match="2"):
+        parser.parse_args([])
+    with pytest.raises(SystemExit, match="2"):
+        parser.parse_args(
+            [
+                "--expected-project-ref",
+                PROJECT_REF,
+                "--expected-project-ref",
+                PROJECT_REF,
+            ]
+        )
+
+
+def test_rollover_stops_before_database_or_provider_io(monkeypatch, tmp_path):
+    outputs = tmp_path / "outputs"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(outputs))
+    monkeypatch.setattr(
+        scheduled.publication,
+        "get_db_url",
+        lambda: pytest.fail("rollover must stop before database resolution"),
+    )
+    monkeypatch.setattr(
+        scheduled,
+        "_run_one",
+        lambda *values: pytest.fail("rollover must stop before provider work"),
+    )
+
+    payload, status = scheduled.run_scheduled(
+        args(),
+        today=date(2027, 8, 1),
+        environ=selected_environment("sdv_ratings_weekly"),
+    )
+
+    assert status == 0
+    assert payload == {
+        "status": "skipped",
+        "operating_season": 2027,
+        "reason": "remaining SDV receipt rollout is limited to operating season 2026",
+        "sources": [],
+    }
+    assert outputs.read_text().splitlines() == ["ratings_publication_attempted=false"]
+
+
+def test_no_active_sources_stop_before_database_resolution(monkeypatch):
+    monkeypatch.setattr(
+        scheduled.publication,
+        "get_db_url",
+        lambda: pytest.fail("inactive scheduler must not resolve a database"),
+    )
+    payload, status = scheduled.run_scheduled(args(), today=date(2026, 9, 10), environ={})
+    assert status == 0
+    assert payload == {"status": "inactive", "operating_season": 2026, "sources": []}
+
+
+@pytest.mark.parametrize(
+    "policy_rows,accepted", [([(True,)], True), ([], False), ([(False,)], False)]
+)
+def test_policy_preflight_requires_one_exact_eight_day_row(policy_rows, accepted):
+    selected = activation("sdv_team_xwalk")
+
+    class Cursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *unused):
+            return False
+
+        def execute(self, statement, parameters=None):
+            if parameters is not None:
+                assert parameters == ("ref.team_id_xwalk", "season:2025")
+                assert "interval '8 days'" in statement
+
+        def fetchall(self):
+            return policy_rows
+
+    class Connection:
+        def set_session(self, **options):
+            assert options == {"readonly": True, "autocommit": False}
+
+        def cursor(self):
+            return Cursor()
+
+        def rollback(self):
+            pass
+
+        def close(self):
+            pass
+
+    def call(*values, **options):
+        return Connection()
+
+    if accepted:
+        scheduled._require_policy("dsn", selected, connector=call)
+    else:
+        with pytest.raises(scheduled.ScheduledSdvError, match="exactly 8 days"):
+            scheduled._require_policy("dsn", selected, connector=call)
+
+
+def test_all_selected_sources_run_serially_on_same_inspected_dsn(monkeypatch, tmp_path):
+    outputs = tmp_path / "outputs"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(outputs))
+    monkeypatch.setattr(scheduled.publication, "get_db_url", lambda: "inspected-dsn")
+    monkeypatch.setattr(
+        scheduled.sdv_ratings_publication,
+        "get_db_url",
+        lambda: "adversarial-ratings-dsn",
+    )
+    events = []
+
+    def inspect(dsn, project, source, season):
+        events.append(("inspect", source, season, dsn, project))
+        return {
+            "can_set_role": True,
+            "assumed_role": scheduled.canary.PUBLISHER_ROLE,
+        }, {"source": source}
+
+    monkeypatch.setattr(scheduled.canary, "_inspect_target", inspect)
+    monkeypatch.setattr(
+        scheduled,
+        "_require_policy",
+        lambda dsn, item: events.append(("policy", item.source, item.season, dsn)),
+    )
+
+    def ratings_publish(spec, *, season):
+        events.append(
+            (
+                "publish",
+                spec.name,
+                season,
+                scheduled.publication.get_db_url(),
+                scheduled.sdv_ratings_publication.get_db_url(),
+            )
+        )
+        return loaded_result(spec.name)
+
+    def batch_publish(spec, *, season):
+        events.append(
+            (
+                "publish",
+                spec.name,
+                season,
+                scheduled.publication.get_db_url(),
+                scheduled.sdv_ratings_publication.get_db_url(),
+            )
+        )
+        return loaded_result(spec.name)
+
+    monkeypatch.setattr(
+        scheduled.sdv_ratings_publication,
+        "run_sdv_ratings_publication",
+        ratings_publish,
+    )
+    monkeypatch.setattr(scheduled.publication, "run_source_publication", batch_publish)
+    monkeypatch.setattr(
+        scheduled,
+        "_verify_private_receipt",
+        lambda dsn, item, result: events.append(("private", item.source, dsn)),
+    )
+    monkeypatch.setattr(
+        scheduled,
+        "_verify_public_freshness",
+        lambda dsn, item, result: events.append(("public", item.source, dsn)),
+    )
+
+    payload, status = scheduled.run_scheduled(
+        args(),
+        today=date(2026, 9, 10),
+        environ=selected_environment(*(item.source for item in scheduled.ACTIVATIONS)),
+    )
+
+    assert status == 0
+    assert payload["status"] == "loaded"
+    assert [row["source"] for row in payload["sources"]] == [
+        item.source for item in scheduled.ACTIVATIONS
+    ]
+    assert [event[1] for event in events if event[0] == "publish"] == [
+        item.source for item in scheduled.ACTIVATIONS
+    ]
+    assert all(
+        event[3:] == ("inspected-dsn", "inspected-dsn") for event in events if event[0] == "publish"
+    )
+    assert scheduled.sdv_ratings_publication.get_db_url() == "adversarial-ratings-dsn"
+    assert outputs.read_text().splitlines() == [
+        "ratings_publication_attempted=false",
+        "ratings_publication_attempted=true",
+    ]
+
+
+def test_source_failures_do_not_suppress_later_selected_sources(monkeypatch):
+    monkeypatch.setattr(scheduled.publication, "get_db_url", lambda: "dsn")
+    attempted = []
+    monkeypatch.setattr(
+        scheduled.canary,
+        "_inspect_target",
+        lambda *values: (
+            {"can_set_role": True, "assumed_role": scheduled.canary.PUBLISHER_ROLE},
+            {},
+        ),
+    )
+    monkeypatch.setattr(scheduled, "_require_policy", lambda *values: None)
+
+    failed_ratings = {
+        **loaded_result("sdv_ratings_weekly"),
+        "status": "failed",
+        "rows": 0,
+        "sha": None,
+    }
+
+    def ratings_publish(spec, *, season):
+        attempted.append(spec.name)
+        return failed_ratings
+
+    def batch_publish(spec, *, season):
+        attempted.append(spec.name)
+        if spec.name == "sdv_team_xwalk":
+            raise scheduled.publication.SourcePublicationError("private detail")
+        return loaded_result(spec.name)
+
+    monkeypatch.setattr(
+        scheduled.sdv_ratings_publication,
+        "run_sdv_ratings_publication",
+        ratings_publish,
+    )
+    monkeypatch.setattr(scheduled.publication, "run_source_publication", batch_publish)
+    monkeypatch.setattr(scheduled, "_verify_private_receipt", lambda *values: None)
+    monkeypatch.setattr(scheduled, "_verify_public_freshness", lambda *values: None)
+
+    payload, status = scheduled.run_scheduled(
+        args(),
+        today=date(2026, 9, 10),
+        environ=selected_environment(*(item.source for item in scheduled.ACTIVATIONS)),
+    )
+
+    assert status == 1
+    assert payload["status"] == "failed"
+    assert attempted == [item.source for item in scheduled.ACTIVATIONS]
+    assert [item["status"] for item in payload["sources"]] == [
+        "failed",
+        "failed",
+        "loaded",
+    ]
+    assert payload["sources"][0]["run_id"] == failed_ratings["run_id"]
+    assert payload["sources"][1]["error"] == "source publication validation failed"
+
+
+def _receipt_row(item: scheduled.Activation, result: dict) -> tuple:
+    inputs = {
+        "publisher": "load_flat_files",
+        "protocol": item.asset.protocol,
+        "parser_contract": item.asset.parser_contract,
+        "stage_schema": "warehouse_source_stage",
+        "artifact_origin": "registered_url",
+    }
+    if item.source != "sdv_ratings_weekly":
+        inputs.update(
+            source_name=item.source,
+            season_basis="registered_artifact_name",
+        )
+    return (
+        result["run_id"],
+        result["generation_id"],
+        result["sha"],
+        "succeeded",
+        {
+            "complete": True,
+            "scope": "season",
+            "season": item.season,
+            "mode": "full_file_for_season",
+            "source_rows": result["rows"],
+            "published_rows": result["rows"],
+        },
+        inputs,
+        {"published_rows": result["rows"]},
+        result["generation_id"],
+    )
+
+
+@pytest.mark.parametrize("item", scheduled.ACTIVATIONS)
+def test_private_receipt_matches_source_operation_generation_and_provenance(item):
+    result = loaded_result(item.source)
+
+    class Cursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *unused):
+            return False
+
+        def execute(self, statement, parameters=None):
+            if parameters is not None:
+                assert parameters == (
+                    item.asset.asset_key,
+                    item.asset.coverage_key(item.season),
+                    result["generation_id"],
+                )
+
+        def fetchall(self):
+            return [_receipt_row(item, result)]
+
+    class Connection:
+        def set_session(self, **options):
+            assert options == {"readonly": True, "autocommit": False}
+
+        def cursor(self):
+            return Cursor()
+
+        def rollback(self):
+            pass
+
+        def close(self):
+            pass
+
+    scheduled._verify_private_receipt(
+        "dsn", item, result, connector=lambda *values, **options: Connection()
+    )
+
+
+def freshness_row(item: scheduled.Activation, result: dict, **overrides) -> dict:
+    basis = "artifact_field" if item.source == "sdv_ratings_weekly" else "registered_artifact_name"
+    row = {
+        "source_name": item.source,
+        "asset_key": item.asset.asset_key,
+        "season": item.season,
+        "coverage_key": item.asset.coverage_key(item.season),
+        "generation_id": result["generation_id"],
+        "published_at": "2026-09-10T15:00:00+00:00",
+        "age_seconds": 2,
+        "expected_refresh_interval": "8 days",
+        "is_stale": False,
+        "publication_state": "current",
+        "current_outcome": "succeeded",
+        "is_complete": True,
+        "source_rows": result["rows"],
+        "published_rows": result["rows"],
+        "artifact_origin": "registered_url",
+        "season_basis": basis,
+        "latest_outcome": "succeeded",
+        "latest_recorded_at": "2026-09-10T15:00:00+00:00",
+        "last_failure_outcome": None,
+        "last_failure_at": None,
+        "last_failure_category": None,
+    }
+    row.update(overrides)
+    return row
+
+
+@pytest.mark.parametrize("item", scheduled.ACTIVATIONS)
+def test_public_verification_checks_both_roles_and_source_specific_basis(monkeypatch, item):
+    result = loaded_result(item.source)
+    calls = []
+
+    def read(dsn, role, selected):
+        calls.append((dsn, role, selected))
+        return freshness_row(item, result), True
+
+    monkeypatch.setattr(scheduled, "_read_public_freshness", read)
+    scheduled._verify_public_freshness("dsn", item, result)
+    assert calls == [
+        ("dsn", "anon", item),
+        ("dsn", "authenticated", item),
+    ]
+
+
+def test_public_freshness_read_assumes_actual_role_and_exact_source_scope():
+    item = activation("sdv_team_xwalk")
+    result = loaded_result(item.source)
+
+    class Cursor:
+        def __init__(self):
+            self.statement = ""
+            self.calls = []
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *unused):
+            return False
+
+        def execute(self, statement, parameters=None):
+            self.statement = str(statement)
+            self.calls.append((self.statement, parameters))
+
+        def fetchone(self):
+            assert "current_user" in self.statement
+            return ("anon",)
+
+        def fetchall(self):
+            return [(freshness_row(item, result), True)]
+
+    class Connection:
+        def __init__(self):
+            self.cursor_object = Cursor()
+
+        def set_session(self, **options):
+            assert options == {"readonly": True, "autocommit": False}
+
+        def cursor(self):
+            return self.cursor_object
+
+        def rollback(self):
+            pass
+
+        def close(self):
+            pass
+
+    connection = Connection()
+    row, interval_matches = scheduled._read_public_freshness(
+        "dsn",
+        "anon",
+        item,
+        connector=lambda *values, **options: connection,
+    )
+
+    assert row["source_name"] == item.source
+    assert interval_matches is True
+    freshness_call = next(
+        call for call in connection.cursor_object.calls if "get_source_freshness" in call[0]
+    )
+    assert freshness_call[1] == (2025, "sdv_team_xwalk")
+    assert "interval '8 days'" in freshness_call[0]
+    assert any("SET LOCAL ROLE" in statement for statement, _ in connection.cursor_object.calls)
+
+
+@pytest.mark.parametrize("source", [item.source for item in scheduled.ACTIVATIONS])
+def test_public_verification_rejects_wrong_source_provenance(monkeypatch, source):
+    item = activation(source)
+    result = loaded_result(source)
+    wrong_basis = "registered_artifact_name" if source == "sdv_ratings_weekly" else "artifact_field"
+    monkeypatch.setattr(
+        scheduled,
+        "_read_public_freshness",
+        lambda *values: (freshness_row(item, result, season_basis=wrong_basis), True),
+    )
+    with pytest.raises(scheduled.ScheduledSdvError, match="invalid season evidence"):
+        scheduled._verify_public_freshness("dsn", item, result)
+
+
+def test_postpublication_failure_preserves_returned_identifiers(monkeypatch):
+    item = activation("sdv_game_xwalk")
+    result = loaded_result(item.source)
+    monkeypatch.setattr(
+        scheduled.canary,
+        "_inspect_target",
+        lambda *values: (
+            {"can_set_role": True, "assumed_role": scheduled.canary.PUBLISHER_ROLE},
+            {},
+        ),
+    )
+    monkeypatch.setattr(scheduled, "_require_policy", lambda *values: None)
+    monkeypatch.setattr(scheduled, "_publish", lambda selected: result)
+    monkeypatch.setattr(
+        scheduled,
+        "_verify_private_receipt",
+        lambda *values: (_ for _ in ()).throw(scheduled.ScheduledSdvError("receipt mismatch")),
+    )
+    monkeypatch.setattr(scheduled, "_verify_public_freshness", lambda *values: None)
+
+    payload, succeeded = scheduled._run_one("dsn", PROJECT_REF, item)
+
+    assert succeeded is False
+    assert payload["status"] == "verification_failed"
+    assert payload["run_id"] == result["run_id"]
+    assert payload["generation_id"] == result["generation_id"]
+    assert payload["sha"] == result["sha"]
+
+
+def test_main_sanitizes_unexpected_exception_details(monkeypatch, capsys):
+    monkeypatch.setattr(
+        scheduled,
+        "run_scheduled",
+        lambda selected: (_ for _ in ()).throw(
+            RuntimeError("postgresql://user:secret@private-host/database")
+        ),
+    )
+    status = scheduled.main(["--expected-project-ref", PROJECT_REF])
+    output = capsys.readouterr().out
+
+    assert status == 1
+    assert json.loads(output)["error"] == "unexpected failure (RuntimeError)"
+    assert "secret" not in output
+    assert "private-host" not in output
+
+
+def test_database_failure_is_sanitized():
+    error = psycopg2.OperationalError("password=secret host=private-host")
+    assert str(scheduled._database_failure(error, "receipt check")) == (
+        "receipt check failed (type=OperationalError, code=none)"
+    )

--- a/tests/test_sdv_receipt_workflows.py
+++ b/tests/test_sdv_receipt_workflows.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -112,6 +113,18 @@ def test_canary_refresh_handles_possible_ratings_commit_without_hiding_failure()
 
 def scheduled_workflow():
     return yaml.safe_load((ROOT / ".github/workflows/sdv-source-receipts.yml").read_text())
+
+
+@pytest.mark.parametrize("config", [workflow, scheduled_workflow])
+def test_receipt_workflow_actions_use_immutable_revisions(config):
+    references = [
+        step["uses"]
+        for job in config()["jobs"].values()
+        for step in job.get("steps", [])
+        if "uses" in step
+    ]
+    assert references
+    assert all(re.fullmatch(r"actions/[a-z-]+@[0-9a-f]{40}", ref) for ref in references)
 
 
 def test_schedule_uses_shared_lock_order_and_scopes_credentials_to_operations():

--- a/tests/test_sdv_receipt_workflows.py
+++ b/tests/test_sdv_receipt_workflows.py
@@ -1,0 +1,178 @@
+"""Exercise scheduled SDV routing and legacy fallback ownership."""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts import load_flat_files
+from tests.test_f10_flat_file_workflow import run_steps, workflow
+
+ROOT = Path(__file__).resolve().parents[1]
+ACTIVATIONS = {
+    "SDV_RATINGS_RECEIPT_SEASON": "2026",
+    "SDV_TEAM_XWALK_RECEIPT_SEASON": "2025",
+    "SDV_GAME_XWALK_RECEIPT_SEASON": "2025",
+}
+
+
+@pytest.mark.parametrize("seasons", ["", "2025 2026"])
+def test_active_scopes_exclude_fallback_and_preserve_fpi(tmp_path, seasons):
+    status, calls = run_steps(tmp_path, "", seasons, activation="2026", sdv_activations=ACTIVATIONS)
+    assert status == 0
+    excluded = [
+        "sdv_fpi_weekly:2026",
+        "sdv_ratings_weekly:2026",
+        "sdv_team_xwalk:2025",
+        "sdv_team_xwalk:2026",
+        "sdv_game_xwalk:2025",
+        "sdv_game_xwalk:2026",
+    ]
+    planned_seasons = seasons.split() if seasons else [None]
+    assert len(calls) == len(planned_seasons) + 1
+    for call, season in zip(calls, planned_seasons, strict=False):
+        prefix = ["scripts/load_flat_files.py", "--due"]
+        if season is not None:
+            prefix += ["--season", season]
+        expected = prefix + [arg for pair in excluded for arg in ("--exclude-source-season", pair)]
+        assert call == expected
+
+
+@pytest.mark.parametrize("season", [None, 2025])
+def test_receipted_crosswalk_never_reaches_legacy_fetch_or_fallback(tmp_path, monkeypatch, season):
+    """Execute workflow argv through the real loader planner, before any fetch."""
+    status, calls = run_steps(
+        tmp_path,
+        "",
+        str(season) if season else "",
+        sdv_activations={"SDV_TEAM_XWALK_RECEIPT_SEASON": "2025"},
+    )
+    assert status == 0
+    registry = {
+        name: load_flat_files.REGISTRY[name]
+        for name in ("sdv_team_xwalk", "sdv_game_xwalk", "sdv_ratings_weekly")
+    }
+    monkeypatch.setattr(load_flat_files, "REGISTRY", registry)
+    monkeypatch.setattr(load_flat_files, "season_for_date", lambda today: 2026)
+    monkeypatch.setattr(load_flat_files, "is_due", lambda *args: True)
+    monkeypatch.setattr(load_flat_files, "_cadence_last_checked", lambda *args: None)
+    executed = []
+
+    def legacy_run(spec, **kwargs):
+        if spec.name == "sdv_team_xwalk":
+            pytest.fail("receipted crosswalk reached the legacy path that can fall back to 2025")
+        executed.append((spec.name, kwargs["season"], kwargs["season_explicit"]))
+        return {"source": spec.name, "status": "skipped", "rows": 0, "duration_s": 0.0}
+
+    monkeypatch.setattr(load_flat_files, "run_source", legacy_run)
+    assert load_flat_files.main(calls[0][1:]) == 0
+    assert executed == [
+        ("sdv_game_xwalk", season or 2026, season is not None),
+        ("sdv_ratings_weekly", season or 2026, season is not None),
+    ]
+
+
+@pytest.mark.parametrize("variable", list(ACTIVATIONS))
+@pytest.mark.parametrize("bad_value", ["2027", "02025", "2025 ", "anything"])
+def test_bad_new_activation_stops_legacy_writes(tmp_path, variable, bad_value):
+    status, calls = run_steps(tmp_path, "", "", sdv_activations={variable: bad_value})
+    assert status == 2
+    assert calls == [["scripts/refresh_marts.py", "--views", "marts.epa_crossvalidation"]]
+
+
+def test_explicit_legacy_source_is_still_an_intentional_manual_bypass(tmp_path):
+    status, calls = run_steps(tmp_path, "sdv_team_xwalk", "2025", sdv_activations=ACTIVATIONS)
+    assert status == 0
+    assert calls[0] == [
+        "scripts/load_flat_files.py",
+        "--source",
+        "sdv_team_xwalk",
+        "--season",
+        "2025",
+    ]
+
+
+def test_canary_refresh_handles_possible_ratings_commit_without_hiding_failure():
+    steps = workflow()["jobs"]["load"]["steps"]
+    refresh = next(step for step in steps if step.get("name") == "Refresh canary rating consumers")
+    assert refresh["if"] == (
+        "${{ !cancelled() && steps.receipt_canary.outputs.publication_source "
+        "== 'sdv_ratings_weekly' "
+        "&& steps.receipt_canary.outputs.publication_attempted == 'true' "
+        "&& (steps.receipt_canary.outcome == 'success' "
+        "|| steps.receipt_canary.outcome == 'failure') }}"
+    )
+    assert refresh["run"] == "python scripts/refresh_marts.py --views marts.epa_crossvalidation"
+    assert not refresh.get("continue-on-error")
+
+
+def scheduled_workflow():
+    return yaml.safe_load((ROOT / ".github/workflows/sdv-source-receipts.yml").read_text())
+
+
+def test_schedule_uses_shared_lock_order_and_scopes_credentials_to_operations():
+    config = scheduled_workflow()
+    assert config[True]["schedule"] == [{"cron": "29 10 * * 1"}]
+    assert config["permissions"] == {"contents": "read"}
+    assert "daily-season-load" in config["concurrency"]["group"]
+    assert "sdv-sources-inactive-" in config["concurrency"]["group"]
+    assert config["concurrency"]["queue"] == "max"
+    assert config["concurrency"]["cancel-in-progress"] is False
+    job = config["jobs"]["publish"]
+    assert job["concurrency"] == {
+        "group": "flat-file-load",
+        "queue": "max",
+        "cancel-in-progress": False,
+    }
+    assert "SUPABASE_DB_URL" not in config["env"]
+    assert "env" not in job
+    for variable in ACTIVATIONS:
+        assert f"vars.{variable} != ''" in job["if"]
+    for step in job["steps"]:
+        operational = step.get("name") in {
+            "Publish and verify SDV receipts",
+            "Refresh external-rating consumers",
+        }
+        assert ("SUPABASE_DB_URL" in step.get("env", {})) == operational
+    refresh = job["steps"][-1]
+    assert refresh["if"] == (
+        "${{ !cancelled() && steps.publish_sdv.outputs.ratings_publication_attempted == 'true' "
+        "&& (steps.publish_sdv.outcome == 'success' || steps.publish_sdv.outcome == 'failure') }}"
+    )
+    assert all(not step.get("continue-on-error") for step in job["steps"])
+
+
+def test_scheduled_command_passes_project_reference_as_one_argument(tmp_path):
+    command = next(
+        step["run"]
+        for step in scheduled_workflow()["jobs"]["publish"]["steps"]
+        if step.get("id") == "publish_sdv"
+    )
+    fake_python = tmp_path / "python"
+    fake_python.write_text(
+        f"#!{sys.executable}\nimport json, sys\nprint(json.dumps(sys.argv[1:]))\n"
+    )
+    fake_python.chmod(0o755)
+    project = "reviewed-project; touch never"
+    result = subprocess.run(
+        ["bash", "--noprofile", "--norc", "-eo", "pipefail", "-c", command],
+        env={
+            **os.environ,
+            "PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}",
+            "EXPECTED_PROJECT_REF": project,
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert json.loads(result.stdout) == [
+        "scripts/run_scheduled_sdv_receipts.py",
+        "--expected-project-ref",
+        project,
+    ]
+    assert "${{" not in command

--- a/tests/test_source_freshness_sql.py
+++ b/tests/test_source_freshness_sql.py
@@ -204,6 +204,58 @@ def record_failure(conn, source, *, season=2025, outcome="failed"):
     return generation_id
 
 
+@pytest.mark.parametrize(
+    "source,season",
+    [("sdv_ratings_weekly", 2026), ("sdv_team_xwalk", 2025), ("sdv_game_xwalk", 2025)],
+)
+def test_scheduled_verifier_matches_executed_receipts_and_actual_callers(
+    source_freshness_db, source, season
+):
+    from scripts import run_scheduled_sdv_receipts as scheduled
+
+    conn, target = source_freshness_db
+    activation = next(item for item in scheduled.ACTIVATIONS if item.source == source)
+    first = publish_source(conn, source, season=season)
+    result = {
+        "source": source,
+        "status": "loaded",
+        "run_id": first[0],
+        "generation_id": first[1],
+        "sha": first[2],
+        "rows": len(json.loads(first[3])),
+        "duration_s": 0.0,
+    }
+    scheduled._require_publication_result(source, result)
+    scheduled._verify_private_receipt(target, activation, result)
+    with pytest.raises(scheduled.ScheduledSdvError, match="exactly 8 days"):
+        scheduled._require_policy(target, activation)
+    query(
+        conn,
+        "INSERT INTO meta.asset_freshness_policies "
+        "(asset_key,coverage_key,expected_refresh_interval) VALUES (%s,%s,interval '8 days')",
+        (activation.asset.asset_key, activation.asset.coverage_key(season)),
+    )
+    scheduled._require_policy(target, activation)
+    scheduled._verify_public_freshness(target, activation, result)
+
+    # A replacement makes the previous result invalid even though its receipt
+    # remains successful in history and both artifact row counts are equal.
+    newer = publish_source(conn, source, season=season, suffix="b")
+    with pytest.raises(scheduled.ScheduledSdvError, match="does not match"):
+        scheduled._verify_private_receipt(target, activation, result)
+    with pytest.raises(scheduled.ScheduledSdvError, match="does not match"):
+        scheduled._verify_public_freshness(target, activation, result)
+    result.update(run_id=newer[0], generation_id=newer[1], sha=newer[2])
+    scheduled._verify_private_receipt(target, activation, result)
+    scheduled._verify_public_freshness(target, activation, result)
+
+    # A later failed attempt must not be accepted just because the successful
+    # current pointer, artifact, and policy remain in place.
+    record_failure(conn, source, season=season)
+    with pytest.raises(scheduled.ScheduledSdvError, match="does not match"):
+        scheduled._verify_public_freshness(target, activation, result)
+
+
 def test_rpc_has_exact_typed_four_row_missing_contract(source_freshness_db):
     conn, _ = source_freshness_db
     for role in ("anon", "authenticated"):

--- a/tests/test_source_receipt_canary.py
+++ b/tests/test_source_receipt_canary.py
@@ -57,6 +57,17 @@ def source_plan():
     }
 
 
+def ratings_plan():
+    return {
+        "protocol": "sdv-ratings-season-v1",
+        "asset_key": "ratings.sdv_ratings_weekly",
+        "coverage_key": "season:2026",
+        "season": 2026,
+        "expected_generation_id": None,
+        "parser_contract": "sdv-ratings-v1",
+    }
+
+
 class FakeCursor:
     def __init__(self, *, can_set_role, migrations=None):
         self.can_set_role = can_set_role
@@ -81,6 +92,8 @@ class FakeCursor:
             return (canary.PUBLISHER_ROLE,)
         if "get_source_plan" in self.statement:
             return (source_plan(),)
+        if "get_sdv_ratings_plan" in self.statement:
+            return (ratings_plan(),)
         raise AssertionError(f"unexpected fetchone for {self.statement}")
 
     def fetchall(self):
@@ -189,6 +202,29 @@ def test_preflight_accepts_unactivated_login_without_attempting_set_role():
     statements = [statement for statement, _ in connection.cursor_object.calls]
     assert not any("SET LOCAL ROLE" in statement for statement in statements)
     assert not any("get_source_plan" in statement for statement in statements)
+
+
+def test_ratings_inspection_uses_dedicated_plan_rpc_and_validator():
+    dsn = f"postgresql://postgres.{PROJECT_REF}:secret@aws.pooler.supabase.com/postgres"
+    connection = FakeConnection(can_set_role=True)
+
+    _, plan = canary._inspect_target(
+        dsn,
+        PROJECT_REF,
+        "sdv_ratings_weekly",
+        2026,
+        connector=lambda *args, **kwargs: connection,
+    )
+
+    assert plan == ratings_plan()
+    plan_calls = [
+        call for call in connection.cursor_object.calls if "get_sdv_ratings_plan" in call[0]
+    ]
+    assert plan_calls == [("SELECT warehouse_source.get_sdv_ratings_plan(%s)", (2026,))]
+    assert not any(
+        "warehouse_source_batch.get_source_plan" in statement
+        for statement, _ in connection.cursor_object.calls
+    )
 
 
 @pytest.mark.parametrize(
@@ -508,6 +544,26 @@ def test_main_does_not_misclassify_http_error_outside_artifact_fetch(monkeypatch
         canary.main(cli_args("publish"))
 
 
+def test_main_sanitizes_ratings_publication_validation_error(monkeypatch, capsys):
+    monkeypatch.setattr(
+        canary,
+        "run_canary",
+        lambda selected: (_ for _ in ()).throw(
+            canary.sdv_ratings_publication.SourcePublicationError(
+                "postgresql://user:secret@private-host/database"
+            )
+        ),
+    )
+    argv = cli_args("publish")
+    argv[2] = "sdv_ratings_weekly"
+
+    assert canary.main(argv) == 1
+    output = capsys.readouterr().out
+    assert json.loads(output)["error"] == "SDV ratings source publication validation failed"
+    assert "secret" not in output
+    assert "private-host" not in output
+
+
 def _fpi_parquet_bytes() -> bytes:
     fixture = Path(__file__).parent / "fixtures/flatfiles/sdv_fpi_weekly_sample.parquet"
     schema = pq.read_schema(fixture)
@@ -550,6 +606,36 @@ def test_download_uses_canonical_parser_and_reports_rows_and_weeks(monkeypatch):
     assert seen[0][1:] == (30, 1)
 
 
+@pytest.mark.parametrize(
+    "source,summary_keys",
+    [
+        ("sdv_ratings_weekly", {"through_weeks", "teams"}),
+        ("sdv_team_xwalk", {"xwalk_keys", "espn_team_ids"}),
+        ("sdv_game_xwalk", {"matchup_date_keys", "espn_game_ids"}),
+    ],
+)
+def test_download_uses_source_parser_and_source_specific_summary(monkeypatch, source, summary_keys):
+    fixture = Path(__file__).parent / f"fixtures/flatfiles/{source}_sample.parquet"
+    raw = fixture.read_bytes()
+    sha = hashlib.sha256(raw).hexdigest()
+
+    def fetch(url, *, timeout, retries):
+        return FetchedFile(raw, sha, url)
+
+    monkeypatch.setattr(canary, "fetch_file", fetch)
+    artifact = canary._download_and_validate(source, 2025, sha)
+    evidence = artifact.evidence()
+
+    assert artifact.rows == pq.read_metadata(fixture).num_rows
+    assert summary_keys <= evidence.keys()
+    assert "weeks" not in evidence
+    if source.endswith("xwalk"):
+        assert evidence["publication_artifact_origin"] == "local_file"
+        assert evidence["season_basis"] == "caller_declared"
+        assert evidence["registered_url"].endswith("_2025.parquet")
+        assert evidence["registered_file_name"].endswith("_2025.parquet")
+
+
 def test_publish_pins_verified_bytes_uses_same_dsn_and_cleans_up(monkeypatch):
     artifact = canary.Artifact(b"exact reviewed bytes", EXPECTED_SHA, 2, (0, 1))
     observed = {}
@@ -586,6 +672,81 @@ def test_publish_pins_verified_bytes_uses_same_dsn_and_cleans_up(monkeypatch):
     }
     assert observed["path"].exists() is False
     assert canary.publication.get_db_url is original_resolver
+
+
+def test_ratings_publish_pins_both_resolvers_and_restores_after_failure(monkeypatch):
+    artifact = canary.Artifact(b"exact reviewed bytes", EXPECTED_SHA, 2)
+    original_batch = canary.publication.get_db_url
+    original_ratings = canary.sdv_ratings_publication.get_db_url
+    observed = {}
+
+    def publish(spec, *, file_path, season):
+        observed.update(
+            source=spec.name,
+            batch_dsn=canary.publication.get_db_url(),
+            ratings_dsn=canary.sdv_ratings_publication.get_db_url(),
+            bytes=Path(file_path).read_bytes(),
+        )
+        raise canary.sdv_ratings_publication.SourcePublicationError("bounded failure")
+
+    monkeypatch.setattr(
+        canary.sdv_ratings_publication,
+        "get_db_url",
+        lambda: "adversarial-ambient-ratings-dsn",
+    )
+    adversarial_resolver = canary.sdv_ratings_publication.get_db_url
+    monkeypatch.setattr(
+        canary.sdv_ratings_publication,
+        "run_sdv_ratings_publication",
+        publish,
+    )
+
+    with pytest.raises(canary.publication.SourcePublicationError, match="bounded failure"):
+        canary._publish_pinned("inspected-dsn", "sdv_ratings_weekly", 2026, artifact)
+
+    assert observed == {
+        "source": "sdv_ratings_weekly",
+        "batch_dsn": "inspected-dsn",
+        "ratings_dsn": "inspected-dsn",
+        "bytes": b"exact reviewed bytes",
+    }
+    assert canary.publication.get_db_url is original_batch
+    assert canary.sdv_ratings_publication.get_db_url is adversarial_resolver
+    assert original_ratings is not adversarial_resolver
+
+
+def test_publish_output_marks_attempt_immediately_before_publication(monkeypatch, tmp_path):
+    output = tmp_path / "github-output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+    monkeypatch.setattr(canary.publication, "get_db_url", lambda: "dsn")
+    monkeypatch.setattr(
+        canary,
+        "_inspect_target",
+        lambda *values: ({"can_set_role": True, "activation_required": False}, source_plan()),
+    )
+    monkeypatch.setattr(
+        canary,
+        "_download_and_validate",
+        lambda *values: canary.Artifact(b"pinned", EXPECTED_SHA, 2, (0, 1)),
+    )
+
+    def publish(*values):
+        assert output.read_text().splitlines() == [
+            "publication_attempted=false",
+            "publication_source=sdv_fpi_weekly",
+            "publication_attempted=true",
+        ]
+        return {
+            "status": "loaded",
+            "sha": EXPECTED_SHA,
+            "rows": 2,
+            "run_id": "run",
+            "generation_id": "generation",
+        }
+
+    monkeypatch.setattr(canary, "_publish_pinned", publish)
+
+    assert canary.main(cli_args("publish")) == 0
 
 
 def test_failed_or_uncertain_publication_is_not_retried(monkeypatch):
@@ -626,6 +787,8 @@ def test_failed_or_uncertain_publication_is_not_retried(monkeypatch):
         [
             "preflight",
             "--source",
+            "sdv_fpi_weekly",
+            "--source",
             "sdv_ratings_weekly",
             "--season",
             "2026",
@@ -661,3 +824,21 @@ def test_failed_or_uncertain_publication_is_not_retried(monkeypatch):
 def test_cli_rejects_any_source_set_season_set_or_unpinned_sha(argv):
     with pytest.raises(SystemExit, match="2"):
         canary.build_parser().parse_args(argv)
+
+
+@pytest.mark.parametrize("source", canary.SOURCES)
+def test_cli_accepts_each_enrolled_source_with_one_explicit_scope(source):
+    parsed = canary.build_parser().parse_args(
+        [
+            "preflight",
+            "--source",
+            source,
+            "--season",
+            "2026",
+            "--expected-sha256",
+            EXPECTED_SHA,
+            "--expected-project-ref",
+            PROJECT_REF,
+        ]
+    )
+    assert parsed.source == source


### PR DESCRIPTION
The remaining SDV sources still use legacy flat-file loads, which do not maintain publication receipts. Add weekly publication for explicitly activated 2026 ratings and 2025 team/game crosswalks, with exact eight-day freshness policies and verification of each new receipt under both public caller roles.

Generalize the checksum-pinned canary while preserving FPI behavior and pinning both publisher adapters to the inspected database. Exclude each active historical crosswalk from both the 2025 legacy attempt and the 2026 fallback attempt. The new workflow uses the existing Daily/flat-file lock order, continues independent sources after a failure, preserves publication identifiers, and refreshes rating consumers after a possible commit.

Validation:
- 130 canary, scheduler, FPI compatibility, and publication-plan tests passed.
- 38 workflow and legacy-exclusion tests passed.
- 134 publication/freshness SQL tests plus 3 new scheduled-verifier tests passed against disposable Postgres 17.
- Ruff, both workflow YAML files, and all nine embedded Bash steps passed checks.
- Independent read-only review found no substantive defects.

The new activation variables default to unset. Production canaries and guarded policy configuration follow deployment; no schema migration or new grant is included.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds **weekly receipt-backed publication** for the remaining SDV sources (2026 ratings, 2025 team/game crosswalks), controlled by new repo variables and an **`SDV Source Receipts`** workflow (Monday cron + dispatch).
> 
> **`run_scheduled_sdv_receipts.py`** publishes each activated source serially, requires an exact **8-day** freshness policy, verifies committed receipts and **`anon`/`authenticated`** freshness, pins both batch and ratings publishers to the inspected DB connection, and refreshes **`marts.epa_crossvalidation`** after a ratings attempt even when verification fails.
> 
> **`run_source_receipt_canary.py`** is generalized from FPI-only to all four SDV sources (checksum-pinned preflight/publish, source-specific validation, workflow outputs for ratings refresh). **`flat-files.yml`** excludes legacy `--due` plans for receipt-owned source/season pairs (including **both** crosswalk 2025 and 2026 so implicit fallback cannot overwrite receipts) and adds a canary ratings refresh step.
> 
> Docs (`scheduled-sdv-receipts.md`) describe activation, lock order, and legacy ownership. Broad workflow, scheduler, canary, and SQL verifier tests accompany the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51c772492aa86ae3242512351ac408ccfb88db54. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63172234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge.

<h3>Summary</h3>

- Introduces a scheduled workflow with shared writer-lock ordering, exact eight-day policy checks, committed-receipt verification, and public-role freshness validation.
- Generalizes the checksum-pinned canary across four SDV sources and pins both publication adapters to the inspected database.
- Excludes receipt-owned source/season pairs from legacy due-load planning and refreshes rating consumers after possible commits.
- Pins credential-adjacent GitHub Actions to immutable revisions, resolving the previous review concern.
- Adds scheduler, workflow, canary, legacy-exclusion, and database-backed freshness tests.

<sub>Reviews (2) · Last reviewed commit: ["Pin receipt workflow actions to verified..."](https://github.com/rstover-fo/cfb-database/commit/aacb40dee55b60cb09292e646f1927ef42609d83)</sub>

<!-- /greptile_comment -->