### PR TITLE
Preserve SDV ratings float precision through staging reads

### DIFF
--- a/src/pipelines/utils/sdv_ratings_publication.py
+++ b/src/pipelines/utils/sdv_ratings_publication.py
@@ -361,6 +361,11 @@ def _read_stage(dsn: str, table: str, expected_rows: int, artifact_origin: str) 
     conn = _connect(dsn)
     try:
         with conn.cursor() as cur:
+            # float8 arrives through psycopg's text protocol. A role/database
+            # default of zero rounds that output to 15 significant digits before
+            # Python builds the JSONB publication payload; positive mode is the
+            # shortest representation that round-trips the stored binary value.
+            cur.execute("SET LOCAL extra_float_digits = 1")
             cur.execute(
                 """
                 SELECT a.attname

--- a/tests/test_sdv_ratings_publication_sql.py
+++ b/tests/test_sdv_ratings_publication_sql.py
@@ -800,3 +800,80 @@ def test_real_python_adapter_stages_local_parquet_and_publishes_typed_nulls(
         conn,
         "SELECT source_url,status,row_count FROM meta.flat_file_loads",
     ) == [(None, "loaded", 1)]
+
+
+def test_real_python_adapter_preserves_staged_float8_bits_with_rounded_role_default(
+    sdv_db, monkeypatch, tmp_path
+):
+    from src.pipelines.sources.flat_files import REGISTRY
+    from src.pipelines.utils import sdv_ratings_publication as adapter
+
+    conn, target = sdv_db
+    expected_value = -0.030319570074811644
+    expected_hex = "bf9f0c17e799b2d7"
+    schema = pq.read_schema(ROOT / "tests/fixtures/flatfiles/sdv_ratings_weekly_sample.parquet")
+    raw_row = {name: None for name in schema.names}
+    raw_row.update(
+        season=2025,
+        through_week=1,
+        team_id="2",
+        adj_off_epa=expected_value,
+    )
+    local_file = tmp_path / "sdv-ratings-float8-precision.parquet"
+    pq.write_table(pa.Table.from_pylist([raw_row], schema=schema), local_file)
+    dsn = parse_dsn(target)
+    target_url = (
+        f"postgresql://{dsn['user']}:{dsn['password']}@{dsn['host']}:{dsn['port']}/{dsn['dbname']}"
+    )
+    monkeypatch.setattr(adapter, "get_db_url", lambda: target_url)
+
+    original_connect = adapter._connect
+
+    def connect_with_rounded_float_output(selected_dsn):
+        selected = original_connect(selected_dsn)
+        with selected.cursor() as cur:
+            cur.execute("SET extra_float_digits = 0")
+        selected.commit()
+        return selected
+
+    monkeypatch.setattr(adapter, "_connect", connect_with_rounded_float_output)
+    original_read_stage = adapter._read_stage
+    observed = {}
+
+    def read_stage_with_storage_check(selected_dsn, table, expected_rows, artifact_origin):
+        stage_conn = connect_with_rounded_float_output(selected_dsn)
+        try:
+            with stage_conn.cursor() as cur:
+                cur.execute(
+                    sql.SQL(
+                        "SELECT pg_catalog.encode(pg_catalog.float8send(adj_off_epa), 'hex') "
+                        "FROM {}.{}"
+                    ).format(
+                        sql.Identifier(adapter.STAGE_SCHEMA),
+                        sql.Identifier(table),
+                    )
+                )
+                observed["stage_hex"] = cur.fetchone()[0]
+            stage_conn.rollback()
+        finally:
+            stage_conn.close()
+        return original_read_stage(
+            selected_dsn,
+            table,
+            expected_rows,
+            artifact_origin,
+        )
+
+    monkeypatch.setattr(adapter, "_read_stage", read_stage_with_storage_check)
+
+    result = adapter.run_sdv_ratings_publication(
+        REGISTRY["sdv_ratings_weekly"], file_path=str(local_file), season=2025
+    )
+
+    assert result["status"] == "loaded"
+    assert observed["stage_hex"] == expected_hex
+    assert query(
+        conn,
+        "SELECT pg_catalog.encode(pg_catalog.float8send(adj_off_epa), 'hex') "
+        "FROM ratings.sdv_ratings_weekly WHERE season=2025 AND through_week=1 AND team_id=2",
+    ) == [(expected_hex,)]


### PR DESCRIPTION
When a database connection uses `extra_float_digits=0`, reading staged SDV ratings through PostgreSQL's text protocol rounds doubles to 15 significant digits before the publication payload is built. For example, a staged value of `-0.030319570074811644` becomes `-0.0303195700748116` in the final table.

Set shortest-roundtrip float output locally within the staging read transaction. The setting is rolled back when that read completes. Add an end-to-end PostgreSQL regression that forces the rounded connection default and checks the binary float representation in both the dlt stage and published target.

Validation: 30 ratings publication SQL tests passed on disposable PostgreSQL 17, including the new precision regression; 39 existing adapter tests passed. Ruff check/format and independent read-only review passed. No migration or grant change is required.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Fixes **loss of `float8` precision** when staged SDV ratings are read for the JSONB publication payload under PostgreSQL connections that default to **`extra_float_digits = 0`** (text output rounded to 15 significant digits).
> 
> `_read_stage` now runs **`SET LOCAL extra_float_digits = 1`** for the staging read transaction so doubles round-trip the stored binary value before Python serializes rows. A new **end-to-end adapter test** forces the rounded connection default and asserts the **`float8send` hex** matches in both the dlt stage and `ratings.sdv_ratings_weekly`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2aa3f64f1f6e0cdca580d73a33548054327a5ab. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63191980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge: no actionable issues were identified in the changed code.

What we checked:
- The base _read_stage performed the float8 SELECT without setting extra_float_digits. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- After capture, the disposable loopback PostgreSQL URL was unavailable, causing the run to not proceed. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Direct pytest run skipped one test, reported as 1 skipped in 0.36s. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- The evidence script and guarded-run outputs were inspected to verify the observed conditions. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<h3>Summary</h3>

- This change preserves float8 values while staged SDV ratings are read by using PostgreSQL’s shortest round-trip text representation within the read transaction. It also adds coverage that checks the stored float8 bits in both staging and the published table.
- ## T-Rex validation blocked The focused PostgreSQL check could not run because `F06_TEST_DB_URL` was not configured, and no disposable loopback PostgreSQL instance was available in this environment.

<sub>Reviews (1) · Last reviewed commit: ["Preserve SDV ratings float precision thr..."](https://github.com/rstover-fo/cfb-database/commit/c2aa3f64f1f6e0cdca580d73a33548054327a5ab)</sub>

<!-- /greptile_comment -->